### PR TITLE
[frontend] Fix input api key visibility toggle

### DIFF
--- a/frontend/src/views/AIAgents/components/Keys/ApiKeyForm.tsx
+++ b/frontend/src/views/AIAgents/components/Keys/ApiKeyForm.tsx
@@ -15,6 +15,7 @@ import { createApiKey, updateApiKey } from "@/services/apiKeys";
 import { ApiKey } from "@/interfaces/api-key.interface";
 import toast from "react-hot-toast";
 import { Copy, Eye, EyeOff } from "lucide-react";
+import { maskInput } from "@/helpers/utils";
 
 interface Props {
   agentId: string;
@@ -124,18 +125,18 @@ export default function ApiKeyForm({
             {existingKey?.key_val && (
               <div className="space-y-2">
                 <Label htmlFor="api_key">API Key</Label>
-                <div className="relative">
+                <div className="relative flex flex-row items-center">
                   <Input
                     id="api_key"
                     readOnly
-                    className="pr-20"
+                    className="w-full z-10"
                     value={
                       isKeyVisible
                         ? existingKey.key_val
-                        : existingKey.key_val.replace(/./g, "•")
+                        : maskInput(existingKey.key_val || "")
                     }
                   />
-                  <div className="absolute right-2 top-1/2 -translate-y-1/2 flex gap-2">
+                  <div className="absolute right-2 flex gap-1 elevation-1 z-20">
                     <Button
                       type="button"
                       variant="ghost"


### PR DESCRIPTION
## Description

This PR fixed a bug with toggle button on the ApiKeyForm.tsx component.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update

## Changes Made

Used tailwind classes and re-used the maskInput fn to hide the real text content.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #[BUG 62108]

## Screenshots (if applicable)

previous version:
<img width="903" height="476" alt="image" src="https://github.com/user-attachments/assets/fafe30fe-def4-40c8-bbb7-bdaaf9f0d249" />

fixed version:
<img width="902" height="452" alt="image" src="https://github.com/user-attachments/assets/794c7b5a-5dc6-47d4-b41f-686bf32074d8" />



