### PR TITLE
[frontend] fix: unauthenticated calls for authenticated users

### DIFF
--- a/frontend/src/context/FeatureFlagContext.tsx
+++ b/frontend/src/context/FeatureFlagContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useState, useEffect, ReactNode, useMe
 import { getFeatureFlags } from '@/services/featureFlags';
 import { FeatureFlag, ParsedFeatureFlag } from '@/interfaces/featureFlag.interface';
 import { parseFeatureFlags, isFeatureEnabled as checkFeatureEnabled, getFeatureValue as getFeatureValueHelper } from '@/helpers/featureFlag';
+import { isAuthenticated } from '@/services/auth';
 
 interface FeatureFlagContextType {
   flags: FeatureFlag[];
@@ -39,7 +40,10 @@ export const FeatureFlagProvider: React.FC<FeatureFlagProviderProps> = ({ childr
   };
 
   useEffect(() => {
-    fetchFlags();
+    // check if the user is authenticated
+    if (isAuthenticated()) {
+      fetchFlags();
+    }
   }, []);
 
   const isEnabled = (key: string): boolean => {

--- a/frontend/src/context/NodeSchemaContext.tsx
+++ b/frontend/src/context/NodeSchemaContext.tsx
@@ -7,6 +7,7 @@ import React, {
 } from "react";
 import { FieldSchema } from "@/interfaces/dynamicFormSchemas.interface";
 import { getAllNodeSchemas } from "@/services/workflows";
+import { isAuthenticated } from "@/services/auth";
 
 interface NodeSchemaContextType {
   schemas: Map<string, FieldSchema[]>;
@@ -51,7 +52,10 @@ export const NodeSchemaProvider: React.FC<NodeSchemaProviderProps> = ({
   };
 
   useEffect(() => {
-    fetchSchemas();
+    // check if the user is authenticated
+    if (isAuthenticated()) {
+      fetchSchemas();
+    }
   }, []);
 
   const getSchema = (nodeType: string): FieldSchema[] | null => {


### PR DESCRIPTION
## Description
This PR solves a small issue with some endpoints that calls the backend before user is authenticated.

## Type of Change
Applied code change on the frontend.

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update

## Changes Made
Added a check if user is authenticated before executing the request to the server.

## Testing
Visit the app without being authenticated and you will see two endpoints calls and response 401 from the server.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #62118

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.

