### PR TITLE
[backend] fix: Enhance ProjectSettings with Chroma configuration 

### DIFF
--- a/backend/app/core/config/settings.py
+++ b/backend/app/core/config/settings.py
@@ -1,5 +1,5 @@
 from typing import Optional, Tuple
-from pydantic import computed_field, ConfigDict
+from pydantic import computed_field, ConfigDict, Field
 from pydantic_settings import BaseSettings
 
 from app.core.project_path import DATA_VOLUME
@@ -24,6 +24,7 @@ class ProjectSettings(BaseSettings):
     REDIS_MAX_CONNECTIONS: int = 20  # Max connections in pool
     REDIS_SOCKET_TIMEOUT: int = 5  # Socket timeout in seconds
     REDIS_HEALTH_CHECK_INTERVAL: int = 30  # Health check interval in seconds
+    
     FERNET_KEY: Optional[str]
 
     # === LLM Keys ===
@@ -122,6 +123,10 @@ class ProjectSettings(BaseSettings):
 
     # === CORS Configuration ===
     CORS_ALLOWED_ORIGINS: Optional[str] = None  # Comma-separated list of additional allowed origins
+
+    # === Chroma Configuration ===
+    CHROMA_HOST: Field(default="localhost", description="Database host")
+    CHROMA_PORT: Field(default=8005, description="Database port")
 
     @property
     def _zendesk_base(self) -> str:

--- a/backend/app/modules/data/providers/vector/db/base.py
+++ b/backend/app/modules/data/providers/vector/db/base.py
@@ -1,17 +1,13 @@
 """
 Base vector database interface
 """
-import os
 from abc import ABC, abstractmethod
 from typing import List, Dict, Any, Optional
 from pydantic import BaseModel, Field, field_validator, model_validator
 from app.core.tenant_scope import get_tenant_context
+from app.core.config.settings import settings
 
 from ....schema_utils import VECTOR_DEFAULTS
-
-DEFAULT_HOST = os.getenv("CHROMA_HOST", "localhost")
-DEFAULT_PORT = int(os.getenv("CHROMA_PORT", 8005))
-
 
 class VectorDBConfig(BaseModel):
     """Configuration for vector database"""
@@ -21,9 +17,9 @@ class VectorDBConfig(BaseModel):
     persist_directory: Optional[str] = Field(
         default=None, description="Directory for data persistence")
     host: Optional[str] = Field(
-        default=DEFAULT_HOST, description="Database host")
+        default=settings.CHROMA_HOST, description="Database host")
     port: Optional[int] = Field(
-        default=DEFAULT_PORT, description="Database port")
+        default=settings.CHROMA_PORT, description="Database port")
     distance_metric: str = Field(
         default="cosine", description="Distance metric (cosine, euclidean, dot_product)")
     index_type: str = Field(


### PR DESCRIPTION
## Description
This PR includes work progress to centralize the Chroma configuration by adding CHROMA_HOST and CHROMA_PORT to ProjectSettings and updating VectorDBConfig to use these settings instead of reading environment variables directly.

<!-- Provide a clear and concise description of your changes -->


## Type of Change
Backend/ code changes

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update

## Changes Made
<!-- Describe the changes in detail -->
- [ ] core app settings / added read variables for CHROMA
- [ ] use on vector db values from the settings

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #62125



