### PR TITLE
fix: case in-sensitivity headers check

### DIFF
--- a/backend/app/api/v1/routes/webhook.py
+++ b/backend/app/api/v1/routes/webhook.py
@@ -39,8 +39,11 @@ async def create_webhook(
             )
         )
 
+    # lowercase the tenant header name to make the check case-insensitive
+    looking_tenant_header = settings.TENANT_HEADER_NAME.lower()
+
     # Add tenant ID as query parameter so middleware can detect it
-    query_params = {settings.TENANT_HEADER_NAME: tenant_id}
+    query_params = {f"{looking_tenant_header}": tenant_id}
     execution_url = f"{url}?{urlencode(query_params)}"
 
     # Create webhook with auto-generated URL

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -100,6 +100,9 @@ def socket_auth(required_permissions: list[str]):
             # Extract tenant information from WebSocket (priority: query param > header > subdomain)
             resolved_tenant_id = None
             tenant_slug = None
+            
+            # lowercase the tenant header name to make the check case-insensitive
+            tenant_header_name = settings.TENANT_HEADER_NAME.lower()
 
             if settings.MULTI_TENANT_ENABLED:
                 # Method 1: Extract from query parameter (highest priority)
@@ -109,7 +112,7 @@ def socket_auth(required_permissions: list[str]):
                     query_params = parse_qs(websocket.url.query)
                     # parse_qs returns lists, so get first item if exists
                     tenant_query_param = (
-                        query_params.get(settings.TENANT_HEADER_NAME, [None])[0] or
+                        query_params.get(tenant_header_name, [None])[0] or
                         query_params.get("tenant_id", [None])[0] or
                         query_params.get("tenant", [None])[0]
                     )
@@ -119,8 +122,8 @@ def socket_auth(required_permissions: list[str]):
                         logger.debug(f"WebSocket tenant resolved from query parameter: {tenant_slug}")
 
                 # Method 2: Extract from header (only if not found in query)
-                if not resolved_tenant_id and settings.TENANT_HEADER_NAME in websocket.headers:
-                    tenant_slug = websocket.headers[settings.TENANT_HEADER_NAME]
+                if not resolved_tenant_id and tenant_header_name in websocket.headers:
+                    tenant_slug = websocket.headers[tenant_header_name]
                     resolved_tenant_id = tenant_slug
                     logger.debug(f"WebSocket tenant resolved from header: {tenant_slug}")
 

--- a/backend/app/middlewares/tenant_middleware.py
+++ b/backend/app/middlewares/tenant_middleware.py
@@ -11,16 +11,15 @@ class TenantMiddleware(BaseHTTPMiddleware):
     """Middleware to extract tenant information from requests"""
 
     def get_tenant_slug(self, source_data: dict) -> str:
-        looking_tenant_header = settings.TENANT_HEADER_NAME
+        tenant_header_name = settings.TENANT_HEADER_NAME.lower()
+
+        # lowercase the keys of the source data to make the check case-insensitive
+        source_data_lower = {k.lower(): v for k, v in source_data.items()}
+
         # check for multiple cases of the tenant header name
-        if looking_tenant_header in source_data:
-            return source_data[looking_tenant_header]
-        elif looking_tenant_header.lower() in source_data:
-            return source_data[looking_tenant_header.lower()]
-        elif looking_tenant_header.upper() in source_data:
-            return source_data[looking_tenant_header.upper()]
-        elif looking_tenant_header.title() in source_data:
-            return source_data[looking_tenant_header.title()]
+        if tenant_header_name in source_data_lower:
+            return source_data_lower[tenant_header_name]
+        return None
 
     async def dispatch(self, request: Request, call_next):
         if not settings.MULTI_TENANT_ENABLED:


### PR DESCRIPTION
## Description
This PR solves some issues with headers comparison checks with case sensitivity, used on the query parameters way:
?x-Tenant-ID=xx


<!-- Provide a clear and concise description of your changes -->

## Type of Change
Backend/code changes

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update

## Changes Made
tenant-middleware.py
auth/dependencies.py
webhook.py


<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.

