### PR TITLE
(fix) - Add parameter to enable/disable Rate Limit

### DIFF
--- a/backend/app/middlewares/rate_limit_middleware.py
+++ b/backend/app/middlewares/rate_limit_middleware.py
@@ -51,6 +51,7 @@ def get_conversation_identifier(request: Request) -> str:
 limiter = Limiter(
     key_func=get_user_identifier,
     default_limits=[RATE_LIMIT_GLOBAL_MINUTE, RATE_LIMIT_GLOBAL_HOUR],
+    enabled=settings.RATE_LIMIT_ENABLED,
 )
 
 


### PR DESCRIPTION
## Description

Added fix to consider the flag to control the state of rate limit.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update

## Changes Made

<!-- Describe the changes in detail -->

- [ ] rate_limit_middleware.py

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.

