### PR TITLE
fix: file manager routes, add operation id

### DIFF
--- a/backend/app/api/v1/routes/file_manager.py
+++ b/backend/app/api/v1/routes/file_manager.py
@@ -130,7 +130,7 @@ async def get_file(
         )
 
 
-@router.api_route("/files/{file_id}/download", methods=["GET", "HEAD"])
+@router.api_route("/files/{file_id}/download", methods=["GET", "HEAD"], operation_id="download_file")
 async def download_file(
     file_id: UUID,
     repository: FileManagerRepository = Injected(FileManagerRepository),
@@ -161,7 +161,7 @@ async def download_file(
             detail=f"File not found: {str(e)}"
         )
 
-@router.api_route("/files/{file_id}/source", methods=["GET", "HEAD"])
+@router.api_route("/files/{file_id}/source", methods=["GET", "HEAD"], operation_id="get_file_source")
 async def get_file_source(
     file_id: UUID,
     request: Request,

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8415,14 +8415,14 @@
       }
     },
     "/api/file-manager/files/{file_id}/download": {
-      "get": {
+      "head": {
         "tags": [
           "v1",
           "FileManager"
         ],
         "summary": "Download File",
         "description": "Download a file by ID.",
-        "operationId": "download_file_api_file_manager_files__file_id__download_get",
+        "operationId": "download_file",
         "parameters": [
           {
             "name": "file_id",
@@ -8456,14 +8456,14 @@
           }
         }
       },
-      "head": {
+      "get": {
         "tags": [
           "v1",
           "FileManager"
         ],
         "summary": "Download File",
         "description": "Download a file by ID.",
-        "operationId": "download_file_api_file_manager_files__file_id__download_get",
+        "operationId": "download_file",
         "parameters": [
           {
             "name": "file_id",
@@ -8499,13 +8499,13 @@
       }
     },
     "/api/file-manager/files/{file_id}/source": {
-      "get": {
+      "head": {
         "tags": [
           "v1",
           "FileManager"
         ],
         "summary": "Get File Source",
-        "operationId": "get_file_source_api_file_manager_files__file_id__source_get",
+        "operationId": "get_file_source",
         "parameters": [
           {
             "name": "file_id",
@@ -8539,13 +8539,13 @@
           }
         }
       },
-      "head": {
+      "get": {
         "tags": [
           "v1",
           "FileManager"
         ],
         "summary": "Get File Source",
-        "operationId": "get_file_source_api_file_manager_files__file_id__source_get",
+        "operationId": "get_file_source",
         "parameters": [
           {
             "name": "file_id",
@@ -14919,7 +14919,6 @@
           },
           "password": {
             "type": "string",
-            "format": "password",
             "title": "Password"
           },
           "scope": {
@@ -14947,7 +14946,6 @@
                 "type": "null"
               }
             ],
-            "format": "password",
             "title": "Client Secret"
           }
         },


### PR DESCRIPTION
## Description

This PR solves the warning when starting the app and showing the duplicate operation id for two endpoints used on the file manager routes.

Original Warning:
```code
UserWarning: Duplicate Operation ID
```

```code
genassist_env/lib/python3.12/site-packages/fastapi/openapi/utils.py:225: UserWarning: Duplicate Operation ID get_file_source_api_file_manager_files__file_id__source_get for function get_file_source at genassist/backend/app/api/v1/routes/file_manager.py
```

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update

