### PR TITLE
fix: fronted response server error codes

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,14 +1,51 @@
 import "ace-builds/src-noconflict/ace";
 import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
 import App from './App.tsx'
 import './index.css'
+
+// Network error codes that indicate server is unreachable
+const NETWORK_ERROR_CODES = new Set([
+  "ERR_NETWORK",
+  "ECONNABORTED",
+  "ERR_CONNECTION_REFUSED",
+  "ERR_CONNECTION_RESET",
+  "ERR_SOCKET_NOT_CONNECTED",
+  "ENOTFOUND",
+]);
+
+// Custom retry function that limits retries on server/network errors
+const shouldRetry = (failureCount: number, error: unknown): boolean => {
+  const maxRetries = 2;
+
+  if (failureCount >= maxRetries) {
+    return false;
+  }
+
+  if (error instanceof AxiosError) {
+    const status = error.response?.status;
+    const code = error.code;
+
+    // Don't retry on server errors (5xx)
+    if (status && status >= 500) {
+      return false;
+    }
+
+    // Don't retry on network errors (server unreachable)
+    if (NETWORK_ERROR_CODES.has(code ?? "")) {
+      return false;
+    }
+  }
+
+  return true;
+};
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 1000 * 60 * 5, // 5 minutes
-      retry: 1,
+      retry: shouldRetry,
     },
   },
 })


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
- Implement custom retry logic for network errors in main.tsx, limiting retries to 2 and avoiding retries on server errors (5xx) and specific network error codes.
- Update api.ts to mark the server as down for any 5xx errors and improve health check logic to handle network errors more gracefully.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update

