### PR TITLE
refactor: update file path handling in agent knowledge

### DIFF
--- a/backend/app/api/v1/routes/agent_knowledge.py
+++ b/backend/app/api/v1/routes/agent_knowledge.py
@@ -29,8 +29,6 @@ from app.modules.workflow.agents.rag import ThreadScopedRAG
 from app.schemas.dynamic_form_schemas import AGENT_RAG_FORM_SCHEMAS_DICT
 # File manager service
 from app.services.file_manager import FileManagerService
-from app.modules.filemanager.providers.local.provider import LocalFileSystemProvider
-from app.modules.filemanager.providers.s3.provider import S3StorageProvider
 from app.schemas.file import FileBase, FileUploadResponse
 from app.core.config.settings import file_storage_settings
 
@@ -230,7 +228,7 @@ async def upload_file(
             }
             
             # create the file path where the file will be saved
-            file_path = os.path.join(UPLOAD_DIR, unique_filename)
+            file_path = os.path.join(str(DATA_VOLUME), unique_filename)
 
             # check if the file manager is enabled
             use_file_manager = file_storage_settings.FILE_MANAGER_ENABLED

--- a/backend/app/modules/filemanager/providers/local/provider.py
+++ b/backend/app/modules/filemanager/providers/local/provider.py
@@ -24,7 +24,7 @@ class LocalFileSystemProvider(BaseStorageProvider):
 
     name: str = "local"
     provider_type: str = "local"
-    tmp_folder: str = str(DATA_VOLUME / "uploads")
+    tmp_folder: str = str(DATA_VOLUME)
 
     def __init__(self, config: Dict[str, Any]):
         """


### PR DESCRIPTION
## Description

- Changed the file path in agent_knowledge.py to use DATA_VOLUME for file uploads.
- Updated the temporary folder path in LocalFileSystemProvider to point to DATA_VOLUME instead of a subdirectory.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update

## Changes Made

<!-- Describe the changes in detail -->

- [ ] Change 1
- [ ] Change 2
- [ ] Change 3

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.

