### PR TITLE
feat: add modes to SQL node

### DIFF
--- a/backend/app/modules/workflow/engine/nodes/sql_node.py
+++ b/backend/app/modules/workflow/engine/nodes/sql_node.py
@@ -2,19 +2,20 @@
 SQL node implementation using the BaseNode class.
 """
 
-from typing import Dict, Any
 import logging
+from typing import Any, Dict
 
 from injector import inject
-from app.modules.workflow.engine.base_node import BaseNode
-from app.modules.integration.database import translate_to_query, db_provider_manager
+
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.dependencies.injector import injector
+from app.modules.integration.database import db_provider_manager, translate_to_query
+from app.modules.workflow.engine.base_node import BaseNode
 from app.modules.workflow.llm.provider import LLMProvider
 
-
 logger = logging.getLogger(__name__)
+
 
 @inject
 class SQLNode(BaseNode):
@@ -30,18 +31,34 @@ class SQLNode(BaseNode):
         Returns:
             Dictionary with SQL query response and execution steps
         """
-        provider_id = config.get("providerId")
+        mode = config.get("mode")
         datasource_id = config.get("dataSourceId")
-        query = config.get("query", "What information do you have?")
+        sql_query = config.get("sqlQuery", "")
+        human_query = config.get("humanQuery", "")
+        provider_id = config.get("providerId")
         system_prompt = config.get("systemPrompt", "")
         node_parameters = config.get("parameters", {})
-        if not provider_id:
-            raise AppException(error_key=ErrorKey.MISSING_PARAMETER)
+
+        # Validate required fields
         if not datasource_id:
             raise AppException(error_key=ErrorKey.DATASOURCE_NOT_FOUND)
 
-        llm_provider = injector.get(LLMProvider)
-        llm_model = await llm_provider.get_model(provider_id)
+        if not mode:
+            raise AppException(error_key=ErrorKey.MISSING_PARAMETER)
+
+        # Validate mode-specific required fields
+        if mode == "humanQuery":
+            if not provider_id:
+                raise AppException(error_key=ErrorKey.MISSING_PARAMETER)
+            if not human_query:
+                raise AppException(error_key=ErrorKey.MISSING_PARAMETER)
+        elif mode == "sqlQuery":
+            if not sql_query:
+                raise AppException(error_key=ErrorKey.MISSING_PARAMETER)
+        else:
+            raise AppException(error_key=ErrorKey.MISSING_PARAMETER)
+
+        # Get database manager
         db_manager = await db_provider_manager.get_database_manager(datasource_id)
 
         if not db_manager:
@@ -66,37 +83,47 @@ class SQLNode(BaseNode):
             logger.info("Node parameters: %s", node_parameters)
 
         try:
-            # Inject node parameters into the query if they exist
-            if node_parameters:
-                # Create a parameter context string to append to the query
-                param_context = " Use these specific values: "
-                for key, value in node_parameters.items():
-                    param_context += f"{key} = {value}, "
-                param_context = param_context.rstrip(", ") + "."
-                query = query + param_context
-                logger.info(f"Enhanced query with parameters: {query}")
-            
-            db_query = await translate_to_query(
-                db_manager,
-                llm_model=llm_model,
-                natural_language_query=query,
-                system_prompt=system_prompt,
-            )
+            # Prepare query based on mode
+            if mode == "humanQuery":
+                llm_provider = injector.get(LLMProvider)
+                llm_model = await llm_provider.get_model(provider_id)
+
+                query_text = human_query
+                if node_parameters:
+                    param_context = " Use these specific values: "
+                    for key, value in node_parameters.items():
+                        param_context += f"{key} = {value}, "
+                    param_context = param_context.rstrip(", ") + "."
+                    query_text = query_text + param_context
+                    logger.info(f"Enhanced human query with parameters: {query_text}")
+
+                db_query = await translate_to_query(
+                    db_manager,
+                    llm_model=llm_model,
+                    natural_language_query=query_text,
+                    system_prompt=system_prompt,
+                )
+            else:
+                if node_parameters:
+                    logger.info(
+                        "Node parameters provided but not used in manual SQL mode: %s",
+                        node_parameters,
+                    )
+
+                db_query = {
+                    "formatted_query": sql_query,
+                }
 
             results, error_msg = await db_manager.execute_query(
                 db_query["formatted_query"]
             )
 
             if error_msg:
-                logger.error(
-                    "Database query execution failed: %s", error_msg
-                )
+                logger.error("Database query execution failed: %s", error_msg)
                 return {
                     "status": 500,
                     "data": {
-                        "error": (
-                            f"Database query execution failed: {error_msg}"
-                        )
+                        "error": (f"Database query execution failed: {error_msg}")
                     },
                     "query": db_query,
                     "parameters": {
@@ -114,7 +141,7 @@ class SQLNode(BaseNode):
                         "datasource_id": datasource_id,
                     },
                 }
-                
+
         except Exception as e:
             logger.error("SQL node execution failed: %s", e)
             return {

--- a/backend/app/schemas/dynamic_form_schemas/nodes/sql_schema.py
+++ b/backend/app/schemas/dynamic_form_schemas/nodes/sql_schema.py
@@ -1,35 +1,46 @@
 from typing import List
-from ..base import FieldSchema
+
+from ..base import ConditionalField, FieldSchema
 
 SQL_NODE_DIALOG_SCHEMA: List[FieldSchema] = [
+    FieldSchema(name="name", type="text", label="Node Name", required=False),
+    FieldSchema(name="dataSourceId", type="select", label="Data Source", required=True),
     FieldSchema(
-        name="name",
+        name="mode",
+        type="select",
+        label="Mode",
+        required=True,
+        options=[
+            {"label": "Write SQL Manually", "value": "sqlQuery"},
+            {"label": "Generate SQL from Text", "value": "humanQuery"},
+        ],
+    ),
+    FieldSchema(
+        name="sqlQuery",
         type="text",
-        label="Node Name",
-        required=False
+        label="SQL Query",
+        required=True,
+        conditional=ConditionalField(field="mode", value="sqlQuery"),
     ),
     FieldSchema(
         name="providerId",
         type="select",
         label="LLM Provider",
-        required=True
-    ),
-    FieldSchema(
-        name="dataSourceId",
-        type="select",
-        label="Data Source",
-        required=True
+        required=True,
+        conditional=ConditionalField(field="mode", value="humanQuery"),
     ),
     FieldSchema(
         name="systemPrompt",
         type="text",
         label="System Prompt",
-        required=False
+        required=False,
+        conditional=ConditionalField(field="mode", value="humanQuery"),
     ),
     FieldSchema(
-        name="query",
+        name="humanQuery",
         type="text",
-        label="Human Query",
-        required=True
-    )
+        label="Query in Plain English",
+        required=True,
+        conditional=ConditionalField(field="mode", value="humanQuery"),
+    ),
 ]

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/SQLDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/SQLDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { SQLNodeData } from "../types/nodes";
+import { SQLNodeData, SQLMode } from "../types/nodes";
 import { Button } from "@/components/button";
 import { Input } from "@/components/input";
 import { Label } from "@/components/label";
@@ -10,7 +10,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/select";
-import { Textarea } from "@/components/textarea";
 import { DataSource } from "@/interfaces/dataSource.interface";
 import { LLMProvider } from "@/interfaces/llmProvider.interface";
 import { getAllDataSources } from "@/services/dataSources";
@@ -31,15 +30,17 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
   const { isOpen, onClose, data, onUpdate } = props;
 
   const [name, setName] = useState(data.name || "");
-  const [providerId, setProviderId] = useState(data.providerId || "");
   const [dataSourceId, setDatasourceId] = useState(data.dataSourceId || "");
-  const [query, setQuery] = useState(data.query || "");
+  const [mode, setMode] = useState<SQLMode | undefined>(undefined);
+  const [sqlQuery, setSqlQuery] = useState("");
+  const [providerId, setProviderId] = useState(data.providerId || "");
   const [systemPrompt, setSystemPrompt] = useState(data.systemPrompt || "");
+  const [humanQuery, setHumanQuery] = useState("");
   const [parameters, setParameters] = useState<Record<string, string>>(
-    data.parameters || {}
+    data.parameters || {},
   );
   const [availableProviders, setAvailableProviders] = useState<LLMProvider[]>(
-    []
+    [],
   );
   const [availableDataSources, setAvailableDataSources] = useState<
     DataSource[]
@@ -51,16 +52,18 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
   useEffect(() => {
     if (isOpen) {
       setName(data.name || "");
-      setProviderId(data.providerId || "");
       setDatasourceId(data.dataSourceId || "");
-      setQuery(data.query || "");
+      setMode(data.mode || undefined);
+      setSqlQuery(data.sqlQuery || "");
+      setProviderId(data.providerId || "");
       setSystemPrompt(data.systemPrompt || "");
+      setHumanQuery(data.humanQuery || "");
       setParameters(data.parameters || {});
 
       loadProviders();
       loadDataSources();
     }
-  }, [isOpen, data, toast]);
+  }, [isOpen, data]);
 
   const loadProviders = async () => {
     try {
@@ -86,7 +89,7 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
           ds.source_type.toLowerCase().includes("mysql") ||
           ds.source_type.toLowerCase().includes("postgres") ||
           ds.source_type.toLowerCase().includes("sqlite") ||
-          ds.source_type.toLowerCase().includes("snowflake")
+          ds.source_type.toLowerCase().includes("snowflake"),
       );
       setAvailableDataSources(dbDataSources);
     } catch (err) {
@@ -102,10 +105,12 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
     onUpdate({
       ...data,
       name,
-      providerId,
       dataSourceId,
-      query,
+      mode,
+      sqlQuery,
+      providerId,
       systemPrompt,
+      humanQuery,
       parameters,
     });
     onClose();
@@ -131,10 +136,12 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
         data={{
           ...data,
           name,
-          providerId,
           dataSourceId,
-          query,
+          mode,
+          sqlQuery,
+          providerId,
           systemPrompt,
+          humanQuery,
           parameters,
         }}
       >
@@ -149,34 +156,7 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
               className="w-full"
             />
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="provider">LLM Provider</Label>
-            <Select
-              value={providerId || ""}
-              onValueChange={(value) => {
-                if (value === "__create__") {
-                  setIsCreateProviderOpen(true);
-                  return;
-                }
-                setProviderId(value);
-              }}
-            >
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder="Select an LLM provider" />
-              </SelectTrigger>
-              <SelectContent>
-                {availableProviders.map((provider) => (
-                  <SelectItem key={provider.id} value={provider.id!}>
-                    {provider.name}
-                  </SelectItem>
-                ))}
-                <CreateNewSelectItem />
-              </SelectContent>
-            </Select>
-            <p className="text-xs text-gray-500">
-              Select the LLM provider to use for query processing
-            </p>
-          </div>
+
           <div className="space-y-2">
             <Label htmlFor="datasource">Data Source</Label>
             <Select
@@ -205,91 +185,167 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
               Select the database data source to query
             </p>
           </div>
+
           <div className="space-y-2">
-            <Label htmlFor="systemPrompt">System Prompt</Label>
-            <DraggableTextArea
-              id="systemPrompt"
-              value={systemPrompt}
-              onChange={(e) => setSystemPrompt(e.target.value)}
-              placeholder="Enter system prompt for the SQL generator"
-              className="w-full min-h-[100px] font-mono text-sm"
-            />
+            <Label htmlFor="mode">Mode</Label>
+            <Select
+              value={mode || ""}
+              onValueChange={(value) => setMode(value as SQLMode)}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select mode" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="sqlQuery">Write SQL Manually</SelectItem>
+                <SelectItem value="humanQuery">
+                  Generate SQL from Text
+                </SelectItem>
+              </SelectContent>
+            </Select>
             <p className="text-xs text-gray-500">
-              Optional system prompt to guide the SQL generation behavior
+              Choose how you want to provide the query
             </p>
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="query">Human Query</Label>
-            <DraggableTextArea
-              id="query"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Ask a question to DB"
-              className="w-full min-h-[100px] font-mono text-sm"
-            />
-            <p className="text-xs text-gray-500">
-              Human to SQL generator. Use variables from previous nodes if
-              needed.
-            </p>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="parameters">Parameters</Label>
+
+          {mode === "sqlQuery" && (
             <div className="space-y-2">
-              {Object.entries(parameters).map(([key, value], index) => (
-                <div key={index} className="flex gap-2">
-                  <DraggableInput
-                    placeholder="Parameter name"
-                    value={key}
-                    onChange={(e) => {
-                      const newParameters = { ...parameters };
-                      delete newParameters[key];
-                      newParameters[e.target.value] = value;
-                      setParameters(newParameters);
-                    }}
-                    className="flex-1"
-                  />
-                  <DraggableInput
-                    placeholder="Parameter value"
-                    value={value}
-                    onChange={(e) => {
-                      setParameters({
-                        ...parameters,
-                        [key]: e.target.value,
-                      });
-                    }}
-                    className="flex-1"
-                  />
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => {
-                      const newParameters = { ...parameters };
-                      delete newParameters[key];
-                      setParameters(newParameters);
-                    }}
-                  >
-                    Remove
-                  </Button>
-                </div>
-              ))}
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  setParameters({
-                    ...parameters,
-                    "": "",
-                  });
-                }}
-              >
-                Add Parameter
-              </Button>
+              <Label htmlFor="sqlQuery">SQL Query</Label>
+              <DraggableTextArea
+                id="sqlQuery"
+                value={sqlQuery}
+                onChange={(e) => setSqlQuery(e.target.value)}
+                placeholder="Enter or drag and drop your SQL query here"
+                className="w-full min-h-[150px] font-mono text-sm"
+              />
+              <p className="text-xs text-gray-500">
+                Enter the SQL query to execute. Use variables from previous
+                nodes if needed.
+              </p>
             </div>
-            <p className="text-xs text-gray-500">
-              Optional parameters that can be used in the SQL query. These will
-              be passed to the backend for processing.
-            </p>
-          </div>
+          )}
+
+          {mode === "humanQuery" && (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="provider">LLM Provider</Label>
+                <Select
+                  value={providerId || ""}
+                  onValueChange={(value) => {
+                    if (value === "__create__") {
+                      setIsCreateProviderOpen(true);
+                      return;
+                    }
+                    setProviderId(value);
+                  }}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select an LLM provider" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableProviders.map((provider) => (
+                      <SelectItem key={provider.id} value={provider.id!}>
+                        {provider.name}
+                      </SelectItem>
+                    ))}
+                    <CreateNewSelectItem />
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-gray-500">
+                  Select the LLM provider to generate SQL from your text
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="systemPrompt">System Prompt</Label>
+                <DraggableTextArea
+                  id="systemPrompt"
+                  value={systemPrompt}
+                  onChange={(e) => setSystemPrompt(e.target.value)}
+                  placeholder="Enter system prompt for the SQL generator"
+                  className="w-full min-h-[100px] text-sm"
+                />
+                <p className="text-xs text-gray-500">
+                  Optional system prompt to guide the SQL generation behavior
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="humanQuery">Query in Plain English</Label>
+                <DraggableTextArea
+                  id="humanQuery"
+                  value={humanQuery}
+                  onChange={(e) => setHumanQuery(e.target.value)}
+                  placeholder="e.g., Show me all customers who made purchases last month"
+                  className="w-full min-h-[100px] text-sm"
+                />
+                <p className="text-xs text-gray-500">
+                  Describe what you want to query in plain English. AI will
+                  convert it to SQL.
+                </p>
+              </div>
+            </>
+          )}
+
+          {mode && (
+            <div className="space-y-2">
+              <Label htmlFor="parameters">Parameters</Label>
+              <div className="space-y-2">
+                {Object.entries(parameters).map(([key, value], index) => (
+                  <div key={index} className="flex gap-2">
+                    <DraggableInput
+                      placeholder="Parameter name"
+                      value={key}
+                      onChange={(e) => {
+                        const newParameters = { ...parameters };
+                        delete newParameters[key];
+                        newParameters[e.target.value] = value;
+                        setParameters(newParameters);
+                      }}
+                      className="flex-1"
+                    />
+                    <DraggableInput
+                      placeholder="Parameter value"
+                      value={value}
+                      onChange={(e) => {
+                        setParameters({
+                          ...parameters,
+                          [key]: e.target.value,
+                        });
+                      }}
+                      className="flex-1"
+                    />
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        const newParameters = { ...parameters };
+                        delete newParameters[key];
+                        setParameters(newParameters);
+                      }}
+                    >
+                      Remove
+                    </Button>
+                  </div>
+                ))}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setParameters({
+                      ...parameters,
+                      "": "",
+                    });
+                  }}
+                >
+                  Add Parameter
+                </Button>
+              </div>
+              <p className="text-xs text-gray-500">
+                Optional parameters that can be used in the SQL query. These
+                will be passed to the backend for processing.
+              </p>
+            </div>
+          )}
         </div>
       </NodeConfigDialog>
       <LLMProviderDialog

--- a/frontend/src/views/AIAgents/Workflows/nodeTypes/tools/definitions.ts
+++ b/frontend/src/views/AIAgents/Workflows/nodeTypes/tools/definitions.ts
@@ -204,20 +204,22 @@ def executable_function(params):
 
 export const SQL_NODE_DEFINITION: NodeTypeDefinition<SQLNodeData> = {
   type: "sqlNode",
-  label: "SQL Generator",
+  label: "SQL Executor",
   description:
-    "Generates SQL queries using an AI model to retrieve structured data.",
-  shortDescription: "Generate SQL queries",
+    "Executes SQL queries on a configured database. Write SQL manually or generate it from text.",
+  shortDescription: "Execute SQL queries",
   configSubtitle:
     "Configure SQL generation settings, including model provider, data source, and prompts.",
   category: "tools",
   icon: "Database",
   defaultData: {
-    name: "SQL Generator",
-    providerId: "",
+    name: "SQL Executor",
     dataSourceId: "",
-    query: "",
+    mode: undefined,
+    sqlQuery: "",
+    providerId: "",
     systemPrompt: "",
+    humanQuery: "",
     handlers: [
       {
         id: "input",

--- a/frontend/src/views/AIAgents/Workflows/types/nodes.ts
+++ b/frontend/src/views/AIAgents/Workflows/types/nodes.ts
@@ -22,7 +22,7 @@ export interface BaseNodeData {
   unwrap?: boolean;
   updateNodeData?: <T extends BaseNodeData>(
     nodeId: string,
-    data: Partial<T>
+    data: Partial<T>,
   ) => void;
 }
 
@@ -169,11 +169,15 @@ export interface KnowledgeBaseNodeData extends BaseNodeData {
 }
 
 // SQL Node Data
+export type SQLMode = "sqlQuery" | "humanQuery";
+
 export interface SQLNodeData extends BaseNodeData {
-  providerId: string;
   dataSourceId: string;
-  query: string;
+  mode?: SQLMode;
+  sqlQuery?: string;
+  providerId?: string;
   systemPrompt?: string;
+  humanQuery?: string;
   parameters?: Record<string, string>;
 }
 
@@ -361,7 +365,7 @@ export const createNode = <T extends NodeData>(
   type: string,
   id: string,
   position: { x: number; y: number },
-  data: T
+  data: T,
 ): Node => {
   return {
     id,
@@ -374,7 +378,7 @@ export const createNode = <T extends NodeData>(
 export const createEdge = (
   source: string,
   target: string,
-  data: Record<string, unknown>
+  data: Record<string, unknown>,
 ): Edge => {
   return {
     id: `${source}-${target}`,

--- a/frontend/src/views/AIAgents/Workflows/utils/nodeValidation.ts
+++ b/frontend/src/views/AIAgents/Workflows/utils/nodeValidation.ts
@@ -7,16 +7,27 @@ function isEmptyValue(value: unknown): boolean {
   return false;
 }
 
+function shouldShowConditionalField(
+  field: FieldSchema,
+  data: Record<string, any>,
+): boolean {
+  if (!field.conditional) return true;
+
+  const conditionalFieldValue = data[field.conditional.field];
+  return conditionalFieldValue === field.conditional.value;
+}
+
 export function getEmptyRequiredFields(
   data: Record<string, any>,
-  schemas: FieldSchema[]
+  schemas: FieldSchema[],
 ): string[] {
   if (!schemas || schemas.length === 0) return [];
 
   const missingFields: string[] = [];
 
   for (const field of schemas) {
-    if (field.required) {
+    // Only validate required fields that should be shown based on conditionals
+    if (field.required && shouldShowConditionalField(field, data)) {
       const value = data[field.name];
       if (isEmptyValue(value)) {
         missingFields.push(field.label);


### PR DESCRIPTION
## Description

The SQL node can be used in two different modes:
1. Write SQL Manually: node expects as input a properly formatted SQL query
2. Generate SQL from Text: node expects as input a query in plain English, which is then turned into an equivalent SQL query using an LLM. (this was the only functionality the node had before)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [X] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update