### PR TITLE
security: replace realistic credential placeholders with explicit dummy values

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,17 +1,19 @@
 ENV=dev
 
-OPENAI_API_KEY=OAIKEY
-GOOGLE_API_KEY=GOOGLEKEY
-HUGGINGFACE_TOKEN=HFTOKEN
+# API Keys - Replace with your actual keys
+OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+GOOGLE_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+HUGGINGFACE_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 DB_HOST=localhost
 DB_USER=postgres
-DB_PASS=postgres
+DB_PASS=change-this-password-in-production
 DB_NAME=core_db
 DB_PORT=5432
 
-JWT_SECRET_KEY=CHANGE_THIS_TO_A_SECURE_JWT_KEY
-FERNET_KEY=FERNET_KEY_VALUE
+# Security - Generate strong random values for production
+JWT_SECRET_KEY=replace-with-32-char-random-string-here
+FERNET_KEY=replace-with-fernet-key-from-generate-key
 USE_SSL=false
 
 # Enable/disable WebSocket backend (connect, broadcast, rooms)
@@ -44,12 +46,13 @@ RATE_LIMIT_CONVERSATION_UPDATE_PER_MINUTE=30
 # 500 conversation updates per hour per conversation (agent)
 RATE_LIMIT_CONVERSATION_UPDATE_PER_HOUR=500
 
-AWS_ACCOUNT_ID=AWS_ACCOUNT
+# AWS Credentials - Replace with your actual credentials
+AWS_ACCOUNT_ID=xxxxxxxxxxxx
 AWS_REGION=us-east-1
-AWS_ACCESS_KEY_ID=AWS_KEY
-AWS_SECRET_ACCESS_KEY=AWS_SECRET
-AWS_RECORDINGS_BUCKET=AWSRECORDINGBUCKET
-#AWS_S3_TEST_BUCKET=TEMP_BUCKET
+AWS_ACCESS_KEY_ID=AKIAxxxxxxxxxxxxxxxx
+AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+AWS_RECORDINGS_BUCKET=your-recordings-bucket-name
+#AWS_S3_TEST_BUCKET=your-test-bucket-name
 
 REDIS_HOST=redis
 REDIS_PORT=6379
@@ -67,47 +70,52 @@ REDIS_SOCKET_CONNECT_TIMEOUT=15 # seconds
 
 PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
 
-USE_OPIK=TRUE
+# Opik Configuration
+USE_OPIK=FALSE
 OPIK_URL_OVERRIDE=https://www.comet.com/opik/api
-OPIK_WORKSPACE=CHANGE_THIS_TO_YOUR_WORKSPACE
-OPIK_API_KEY=CHANGE_THIS_TO_YOUR_COMET_API_KEY
-OPIK_PROJECT_NAME=CHANGE_THIS_TO_YOUR_PROJECT_NAME_INSIDE_THE_WORKSPACE
+OPIK_WORKSPACE=your-workspace-name
+OPIK_API_KEY=your-comet-api-key
+OPIK_PROJECT_NAME=your-project-name
 
-ZENDESK_SUBDOMAIN=ZDSUBDOMAIN
-ZENDESK_EMAIL=ZDEMAIL
-ZENDESK_API_TOKEN=ZENDESKTOKEN
+# Zendesk Configuration
+ZENDESK_SUBDOMAIN=your-subdomain
+ZENDESK_EMAIL=your-email@example.com
+ZENDESK_API_TOKEN=your-zendesk-api-token
 ZENDESK_CUSTOM_FIELD_CONVERSATION_ID=0
 
 WHISPER_TRANSCRIBE_SERVICE=http://localhost:8001/transcribe
 
-GOOGLE_API_KEY=YOUR_GOOGLE_API_KEY
-MICROSOFT_CLIENT_ID=YOUR_MICROSOFT_CLIENT_ID
-MICROSOFT_CLIENT_SECRET=YOUR_MICROSOFT_CLIENT_SECRET
-MICROSOFT_TENANT_ID=YOUR_MICROSOFT_TENANT_ID
+# Google/Microsoft API Keys
+GOOGLE_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+MICROSOFT_CLIENT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+MICROSOFT_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxx
+MICROSOFT_TENANT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
+# Vector Database Configuration
 CHROMA_HOST=localhost # if in development with backend running inside IDE(non docker) otherwise remove this variable
 CHROMA_PORT=8005 # if in development with backend running inside IDE(non docker) otherwise remove this variable
 QDRANT_HOST=http://localhost
 QDRANT_PORT=6333
 
-
+# Multi-tenant Configuration
 MULTI_TENANT_ENABLED=true
 TENANT_HEADER_NAME=x-tenant-id
 TENANT_SUBDOMAIN_ENABLED=False
 
 CORS_ALLOWED_ORIGINS=*
 
+# reCAPTCHA Configuration
 RECAPTCHA_ENABLED=False
-RECAPTCHA_PROJECT_ID=YOUR_PROJECT_ID
-RECAPTCHA_SITE_KEY=YOUR_SITE_KEY
-RECAPTCHA_MIN_SCORE=YOUR_MINIMUM_PASSING_SCORE # 0.0 - 1.0
-GCP_SVC_ACCOUNT=CONTENTS_OF_YOUR_CREDENTIAL_JSON_FILE_IN_BASE64
+RECAPTCHA_PROJECT_ID=your-project-id
+RECAPTCHA_SITE_KEY=your-site-key
+RECAPTCHA_MIN_SCORE=0.5 # 0.0 - 1.0
+GCP_SVC_ACCOUNT=your-base64-encoded-credentials
 
 # Azure Blob Storage
-AZURE_CONNECTION_STRING=DefaultEndpointsProtocol=
-AZURE_ACCOUNT_NAME=
-AZURE_ACCOUNT_KEY=
-AZURE_CONTAINER_NAME=
+AZURE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=your-account;AccountKey=your-key;EndpointSuffix=core.windows.net
+AZURE_ACCOUNT_NAME=your-account-name
+AZURE_ACCOUNT_KEY=your-account-key
+AZURE_CONTAINER_NAME=your-container-name
 
 MSSQL_DRIVER=ODBC+Driver+18+for+SQL+Server
 
@@ -116,7 +124,7 @@ BEDROCK_MAX_RETRY_QUERY_EMBEDDING=3
 BEDROCK_TIMEOUT_QUERY_EMBEDDING_SECONDS=8
 
 # S3 Storage Bucket Name -> Files
-AWS_BUCKET_NAME=CHANGE_THIS_TO_YOUR_S3_BUCKET_NAME
+AWS_BUCKET_NAME=your-s3-bucket-name
 # File Manager
 FILE_MANAGER_ENABLED=false
 # File Manager Provider -> local, s3, azure, gcs, sharepoint


### PR DESCRIPTION
The current `.env.example` contains placeholder values that look like real credentials (e.g., `OAIKEY`, `GOOGLEKEY`). This creates two risks:

1. Developers might mistake them for working values and not change them
2. Real credentials could be accidentally committed if they follow the same pattern

## Changes

- Replace API key placeholders with clearly fake values (`sk-xxx...`, `hf_xxx...`)
- Add descriptive comments indicating values must be replaced
- Use consistent placeholder patterns (`xxx...`, `your-...`)
- Disable optional services by default (`USE_OPIK=FALSE`)
- Add section headers for better organization

## Security Impact

Fixes potential security issue where developers might commit real credentials following the same pattern as the placeholders. The new format makes it obvious these are dummy values that must be replaced.

## Testing

- [x] Verified no actual secrets were used
- [x] Placeholders follow industry standard patterns (OpenAI keys start with `sk-`, HuggingFace with `hf_`)
- [x] Application will fail to authenticate with dummy values (expected behavior)