### PR TITLE
feat: truncate output arrays to a default of 4 items in WorkflowTe…

### DIFF
--- a/frontend/src/views/AIAgents/Workflows/components/WorkflowTestDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/WorkflowTestDialog.tsx
@@ -23,7 +23,7 @@ import { testWorkflow, WorkflowTestResponse } from "@/services/workflows";
 import { Workflow } from "@/interfaces/workflow.interface";
 import { NodeSchema, SchemaField } from "../types/schemas";
 import { useWorkflowExecution } from "../context/WorkflowExecutionContext";
-import { getValueFromPath, parseInputValue, valueToString } from "../utils/helpers";
+import { getValueFromPath, parseInputValue, truncateNodeOutput, valueToString } from "../utils/helpers";
 import JsonViewer from "@/components/JsonViewer";
 
 interface WorkflowTestDialogProps {
@@ -170,7 +170,12 @@ const WorkflowTestDialog: React.FC<WorkflowTestDialogProps> = ({
         input_data: parsedInputs,
         workflow: workflow,
       });
-      setResponse(response);
+      // Truncate arrays in the output to a default of 4 items
+      const truncatedResponse = {
+        ...response,
+        output: truncateNodeOutput(response.output),
+      };
+      setResponse(truncatedResponse as WorkflowTestResponse);
       // Update workflow.testInput with the latest changes
       if (onUpdateWorkflowTestInputs) {
         onUpdateWorkflowTestInputs(testInput);


### PR DESCRIPTION
…stDialog

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update

## Changes Made

<!-- Describe the changes in detail -->

- [ ] Change 1
- [ ] Change 2
- [ ] Change 3

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.

