### PR TITLE
fix: prevent closing NodeConfigPanel when test dialog is open

### DIFF
--- a/frontend/src/views/AIAgents/Workflows/components/GenericTestDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/GenericTestDialog.tsx
@@ -280,7 +280,7 @@ export const GenericTestDialog: React.FC<GenericTestDialogProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-2xl max-h-[85vh] w-full overflow-hidden">
+      <DialogContent className="max-w-2xl max-h-[85vh] w-full overflow-hidden" style={{ zIndex: 1201 }}>
         <DialogHeader>
           <DialogTitle>{`Test ${nodeName}`}</DialogTitle>
           <p className="text-sm text-gray-500">

--- a/frontend/src/views/AIAgents/Workflows/components/NodeConfigPanel.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/NodeConfigPanel.tsx
@@ -143,7 +143,7 @@ export const NodeConfigPanel: React.FC<WorkflowNodesPanelProps> = ({
   const handleSheetOpenChange = useCallback(
     (open: boolean) => {
       if (!open) {
-        if (isPinned) return; // Pinned panels don't close
+        if (isPinned || isTestDialogOpen) return; // Don't close while pinned or testing
         if (isDirty && onUpdate) {
           setShowUnsavedDialog(true);
           return; // Block close, show confirmation
@@ -152,7 +152,7 @@ export const NodeConfigPanel: React.FC<WorkflowNodesPanelProps> = ({
         onClose();
       }
     },
-    [isPinned, isDirty, onUpdate, onClose]
+    [isPinned, isTestDialogOpen, isDirty, onUpdate, onClose]
   );
 
   // Confirmation dialog handlers


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update

## Changes Made

<!-- Describe the changes in detail -->

- [ ] Change 1
- [ ] Change 2
- [ ] Change 3

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.

