### PR TITLE
feat: enhance NodeConfigPanel with icon rendering and layout adjustments

### DIFF
--- a/frontend/src/views/AIAgents/Workflows/components/NodeConfigPanel.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/NodeConfigPanel.tsx
@@ -31,6 +31,7 @@ import {
   AlertDialogCancel,
 } from "@/components/alert-dialog";
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+import { renderIcon } from "../utils/iconUtils";
 
 const DEFAULT_SHEET_WIDTH_PX = 896;
 const MIN_SHEET_WIDTH_PX = 480;
@@ -489,8 +490,9 @@ export const NodeConfigPanel: React.FC<WorkflowNodesPanelProps> = ({
           </div>
 
           {/* Sticky Footer with Action Buttons */}
-          <div className="shrink-0 border-t bg-background px-6 py-4 flex justify-end gap-3">
-            {footer}
+          <div className="shrink-0 border-t bg-background px-6 py-4 flex justify-end gap-3 items-center justify-between">
+            <div className="text-xs text-gray-400 flex items-center gap-2">{nodeDefinition?.icon && renderIcon(nodeDefinition?.icon, "w-4 h-4 text-gray-500")} {nodeDefinition?.type} </div>
+            <div className="flex justify-end gap-2">{footer}</div>
           </div>
           </div>
           {/* Lock toggle */}


### PR DESCRIPTION
## Description
- Added icon rendering functionality to display node icons alongside their types in the footer.
- Adjusted the layout of the footer to improve the alignment and spacing of action buttons and node information.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update

## Screenshots (if applicable)

<img width="690" height="703" alt="image" src="https://github.com/user-attachments/assets/ed45a306-8e4f-47f6-8a5d-e4e29a38d0d4" />


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.

