### PR TITLE
enhancement: Add "Require all inputs to finish" toggle to aggregator node

### DIFF
--- a/backend/app/schemas/dynamic_form_schemas/nodes/aggregator_schema.py
+++ b/backend/app/schemas/dynamic_form_schemas/nodes/aggregator_schema.py
@@ -25,5 +25,11 @@ AGGREGATOR_NODE_DIALOG_SCHEMA: List[FieldSchema] = [
         type="text",
         label="Forward Template",
         required=False
+    ),
+    FieldSchema(
+        name="requireAllInputs",
+        type="boolean",
+        label="Require All Inputs",
+        required=False
     )
 ]

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -15666,7 +15666,6 @@
           },
           "password": {
             "type": "string",
-            "format": "password",
             "title": "Password"
           },
           "scope": {
@@ -15694,7 +15693,6 @@
                 "type": "null"
               }
             ],
-            "format": "password",
             "title": "Client Secret"
           }
         },

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/AggregatorDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/AggregatorDialog.tsx
@@ -3,7 +3,7 @@ import { AggregatorNodeData } from "../types/nodes";
 import { Button } from "@/components/button";
 import { Input } from "@/components/input";
 import { Label } from "@/components/label";
-import { Save } from "lucide-react";
+import { Save, Info } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -11,6 +11,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/select";
+import { Switch } from "@/components/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/RadixTooltip";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { DraggableInput } from "../components/custom/DraggableInput";
 import { useWorkflowExecution } from "../context/WorkflowExecutionContext";
@@ -39,6 +46,7 @@ export const AggregatorDialog: React.FC<AggregatorDialogProps> = (props) => {
     useState<AggregationStrategyType>("list");
   const [timeoutSeconds, setTimeoutSeconds] = useState(15);
   const [forwardTemplate, setForwardTemplate] = useState("");
+  const [requireAllInputs, setRequireAllInputs] = useState(true);
 
   useEffect(() => {
     if (isOpen) {
@@ -47,6 +55,7 @@ export const AggregatorDialog: React.FC<AggregatorDialogProps> = (props) => {
         (data.aggregationStrategy as AggregationStrategyType) ?? "list"
       );
       setTimeoutSeconds(data.timeoutSeconds ?? 15);
+      setRequireAllInputs(data.requireAllInputs ?? true);
 
       // Auto-generate default forward template from direct predecessor nodes
       const directSources =
@@ -68,6 +77,7 @@ export const AggregatorDialog: React.FC<AggregatorDialogProps> = (props) => {
       aggregationStrategy,
       timeoutSeconds,
       forwardTemplate,
+      requireAllInputs,
     });
     onClose();
   };
@@ -92,6 +102,7 @@ export const AggregatorDialog: React.FC<AggregatorDialogProps> = (props) => {
         aggregationStrategy,
         timeoutSeconds,
         forwardTemplate,
+        requireAllInputs,
       }}
     >
       <div className="space-y-2">
@@ -104,6 +115,33 @@ export const AggregatorDialog: React.FC<AggregatorDialogProps> = (props) => {
           className="w-full"
         />
       </div>
+
+      <TooltipProvider>
+        <div className="space-y-2 flex items-center gap-2 w-full">
+          <Label htmlFor="require-all-inputs">Require all inputs to finish</Label>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="inline-flex rounded-full text-muted-foreground hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+              >
+                <Info className="h-4 w-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs text-balance">
+              When enabled, the node waits for every connected input branch to
+              complete before merging results. Disable to proceed as soon as any
+              input is available, returning only the results that have finished.
+            </TooltipContent>
+          </Tooltip>
+          <div className="flex-1" />
+          <Switch
+            id="require-all-inputs"
+            checked={requireAllInputs}
+            onCheckedChange={setRequireAllInputs}
+          />
+        </div>
+      </TooltipProvider>
 
       <div className="space-y-2">
         <Label htmlFor="aggregation-strategy">Aggregation Strategy</Label>

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/AggregatorDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/AggregatorDialog.tsx
@@ -116,33 +116,6 @@ export const AggregatorDialog: React.FC<AggregatorDialogProps> = (props) => {
         />
       </div>
 
-      <TooltipProvider>
-        <div className="space-y-2 flex items-center gap-2 w-full">
-          <Label htmlFor="require-all-inputs">Require all inputs to finish</Label>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                className="inline-flex rounded-full text-muted-foreground hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-              >
-                <Info className="h-4 w-4" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent className="max-w-xs text-balance">
-              When enabled, the node waits for every connected input branch to
-              complete before merging results. Disable to proceed as soon as any
-              input is available, returning only the results that have finished.
-            </TooltipContent>
-          </Tooltip>
-          <div className="flex-1" />
-          <Switch
-            id="require-all-inputs"
-            checked={requireAllInputs}
-            onCheckedChange={setRequireAllInputs}
-          />
-        </div>
-      </TooltipProvider>
-
       <div className="space-y-2">
         <Label htmlFor="aggregation-strategy">Aggregation Strategy</Label>
         <Select
@@ -201,6 +174,34 @@ export const AggregatorDialog: React.FC<AggregatorDialogProps> = (props) => {
           Template for forwarding aggregated results to downstream nodes
         </p>
       </div>
+
+      <TooltipProvider>
+        <div className="flex items-center gap-2 w-full !mt-6">
+          <Label htmlFor="require-all-inputs">Require all inputs to finish</Label>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="inline-flex rounded-full text-muted-foreground hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+              >
+                <Info className="h-4 w-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs text-balance">
+              When enabled, the node waits for every connected input branch to
+              complete before merging results. Disable to proceed as soon as any
+              input is available, returning only the results that have finished.
+            </TooltipContent>
+          </Tooltip>
+          <div className="flex-1" />
+          <Switch
+            id="require-all-inputs"
+            checked={requireAllInputs}
+            onCheckedChange={setRequireAllInputs}
+          />
+        </div>
+      </TooltipProvider>
+
     </NodeConfigPanel>
   );
 };

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/AggregatorDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/AggregatorDialog.tsx
@@ -177,7 +177,7 @@ export const AggregatorDialog: React.FC<AggregatorDialogProps> = (props) => {
 
       <TooltipProvider>
         <div className="flex items-center gap-2 w-full !mt-6">
-          <Label htmlFor="require-all-inputs">Require all inputs to finish</Label>
+          <Label htmlFor="require-all-inputs">Require complete results</Label>
           <Tooltip>
             <TooltipTrigger asChild>
               <button
@@ -188,9 +188,9 @@ export const AggregatorDialog: React.FC<AggregatorDialogProps> = (props) => {
               </button>
             </TooltipTrigger>
             <TooltipContent className="max-w-xs text-balance">
-              When enabled, the node waits for every connected input branch to
-              complete before merging results. Disable to proceed as soon as any
-              input is available, returning only the results that have finished.
+              When enabled, all connected branches must complete before results
+              are merged. When disabled, available results are merged immediately
+              without waiting for remaining branches.
             </TooltipContent>
           </Tooltip>
           <div className="flex-1" />

--- a/frontend/src/views/AIAgents/Workflows/nodeTypes/router/aggregatorNode.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeTypes/router/aggregatorNode.tsx
@@ -29,10 +29,17 @@ const AggregatorNode: React.FC<NodeProps<AggregatorNodeData>> = ({
 
   const timeout = data.timeoutSeconds ? data.timeoutSeconds : 0;
 
+  const requireAllInputs = data.requireAllInputs ?? true;
+
   const nodeContent: NodeContentRow[] = [
     {
       label: "Strategy",
       value: data.aggregationStrategy,
+      isSelection: true,
+    },
+    {
+      label: "Require All Inputs",
+      value: requireAllInputs ? "Yes" : "No",
       isSelection: true,
     },
     {

--- a/frontend/src/views/AIAgents/Workflows/nodeTypes/router/definitions.ts
+++ b/frontend/src/views/AIAgents/Workflows/nodeTypes/router/definitions.ts
@@ -71,6 +71,7 @@ export const AGGREGATOR_NODE_DEFINITION: NodeTypeDefinition<AggregatorNodeData> 
       aggregationStrategy: "list",
       forwardTemplate: "",
       timeoutSeconds: 15,
+      requireAllInputs: true,
       handlers: [
         {
           id: "input",

--- a/frontend/src/views/AIAgents/Workflows/types/nodes.ts
+++ b/frontend/src/views/AIAgents/Workflows/types/nodes.ts
@@ -80,6 +80,7 @@ export interface AggregatorNodeData extends BaseNodeData {
   aggregationStrategy?: "list" | "merge" | "first" | "last";
   timeoutSeconds?: number;
   forwardTemplate?: string;
+  requireAllInputs?: boolean;
 }
 
 export interface ZendeskTicketNodeData extends BaseNodeData {


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

- Adds a configurable "Require all inputs to finish" toggle (with tooltip) to the aggregator node settings panel
- When enabled (default), the node behaves as before — waits for every connected input branch to complete before merging
- When disabled, the node proceeds as soon as at least one input is available and only includes finished results in the output


## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update

## Changes Made

<!-- Describe the changes in detail -->

- [ ] Change 1
- [ ] Change 2
- [ ] Change 3

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.

