### PR TITLE
fix: token refresh flow: add tenant header and refresh token rotation

### DIFF
--- a/backend/app/api/v1/routes/auth.py
+++ b/backend/app/api/v1/routes/auth.py
@@ -56,11 +56,11 @@ async def refresh_token(
     
     user = await auth_service.decode_jwt(refresh_token)  # Decode user
     tenant_id = get_tenant_context()
-    access_token = auth_service.create_access_token(
-        data={"sub": user.username, "user_id": str(user.id), "tenant_id": tenant_id}
-    )
+    token_data = {"sub": user.username, "user_id": str(user.id), "tenant_id": tenant_id}
+    access_token = auth_service.create_access_token(data=token_data)
+    new_refresh_token = auth_service.create_refresh_token(data=token_data)
 
-    return {"access_token": access_token, "token_type": "bearer"}
+    return {"access_token": access_token, "refresh_token": new_refresh_token, "token_type": "bearer"}
 
 
 @router.get("/me", summary="Returns current user details", dependencies=[Depends(auth)])


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

- Add missing x-tenant-id header to refresh token request to prevent 401 errors in multi-tenant environments
- Return and store new refresh token on each refresh call (token rotation)
- Extract clearAuthStorage helper to deduplicate localStorage cleanup


## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update

## Changes Made

<!-- Describe the changes in detail -->

- [ ] Change 1
- [ ] Change 2
- [ ] Change 3

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.

