### PR TITLE
feat: add heartbeat polling configuration and integrate into chat components

### DIFF
--- a/frontend/.env.template
+++ b/frontend/.env.template
@@ -56,3 +56,7 @@ VITE_ONBOARDING_CHAT_APIKEY=onboarding_apikey_example
 # Used to automatically log in the user and create the Agent from the onboarding agent
 VITE_ONBOARDING_USERNAME=username
 VITE_ONBOARDING_PASSWORD=password
+
+# Enable Heartbeat polling for real-time chat updates and streaming responses
+# Set to "false" to fall back to WebSocket connections
+VITE_USE_POLL=false

--- a/frontend/src/components/GlobalChat.tsx
+++ b/frontend/src/components/GlobalChat.tsx
@@ -1,12 +1,12 @@
 import { GenAgentChat } from "genassist-chat-react";
 import { useEffect, useState } from "react";
 import { getApiUrl } from "@/config/api";
-import { isWsEnabled } from "@/config/api";
+import { isWsEnabled, isPollEnabled } from "@/config/api";
 
 export const GlobalChat = () => {
   const [baseUrl, setBaseUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const genassistApiKey = import.meta.env.VITE_GENASSIST_CHAT_APIKEY;  
+  const genassistApiKey = import.meta.env.VITE_GENASSIST_CHAT_APIKEY;
 
   useEffect(() => {
     (async () => {
@@ -46,6 +46,7 @@ export const GlobalChat = () => {
         position: "bottom-right",
       }}
       useFile={true}
+      usePoll={isPollEnabled}
     />
   );
 };

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -227,3 +227,8 @@ export const probeApiHealth = async (): Promise<boolean> => {
   setServerDown();
   return false;
 };
+
+/** Whether Heartbeat polling is enabled (VITE_USE_POLL=true/false). Defaults to true when unset.
+ *  Note: Vite reads env at dev server start / build time; restart the dev server after changing .env. */
+export const isPollEnabled =
+  (import.meta.env.VITE_USE_POLL ?? "true").toString().toLowerCase() === "true" && !isWsEnabled;

--- a/frontend/src/views/AIAgents/components/Customer/ChatAsCustomer.tsx
+++ b/frontend/src/views/AIAgents/components/Customer/ChatAsCustomer.tsx
@@ -9,7 +9,7 @@ import {
   type FeatureFlags,
 } from "genassist-chat-react";
 import { getAgentIntegrationKey } from "@/services/api";
-import { getApiUrl, isWsEnabled } from "@/config/api";
+import { getApiUrl, isWsEnabled, isPollEnabled } from "@/config/api";
 import { Button } from "@/components/button";
 import { ArrowLeft } from "lucide-react";
 import IntegrationCodePanel from "@/views/AIAgents/components/Customer/IntegrationCodePanel";
@@ -33,13 +33,15 @@ export default function ChatAsCustomer() {
   const [chatSettings, setChatSettings] = useState<ChatSettingsConfig>({
     name: "Genassist",
     description: "Support",
+    agentName: "Genassist",
   });
   const [metadata, setMetadata] = useState<Record<string, any>>({});
   const [agentChatInputMetadata, setAgentChatInputMetadata] = useState<Record<string, any>>({});
   const [featureFlags, setFeatureFlags] = useState<FeatureFlags>({
     useAudio: false,
     useFile: false,
-    useWs: false,
+    useWs: isWsEnabled,
+    usePoll: isPollEnabled,
   });
 
   // Restore persisted metadata on mount
@@ -132,6 +134,7 @@ export default function ChatAsCustomer() {
           >
             <ArrowLeft />
           </Button>
+
           <GenAgentConfigPanel
             theme={theme}
             onThemeChange={setTheme}
@@ -173,7 +176,8 @@ export default function ChatAsCustomer() {
             theme={theme}
             headerTitle="Chat as Customer"
             placeholder="Ask a question..."
-            useWs={isWsEnabled}
+            useWs={featureFlags.useWs}
+            usePoll={featureFlags.usePoll}
             onError={(error) => {
               // ignore
             }}

--- a/plugins/react/src/components/GenAgentConfigPanel.tsx
+++ b/plugins/react/src/components/GenAgentConfigPanel.tsx
@@ -567,6 +567,15 @@ export const GenAgentConfigPanel: React.FC<GenAgentConfigPanelProps> = ({
                   style={{ width: 20, height: 20, cursor: 'pointer' }}
                 />
               </div>
+              <div style={formGroupStyle}>
+                <label style={labelStyle}>Use Heartbeat Polling</label>
+                <input
+                  type="checkbox"
+                  checked={!!featureFlags.usePoll}
+                  onChange={(e) => handleFeatureFlagChange('usePoll', e.target.checked)}
+                  style={{ width: 20, height: 20, cursor: 'pointer' }}
+                />
+              </div>
             </div>
           </>
         )}


### PR DESCRIPTION
## Description
- Added VITE_USE_POLL environment variable to control heartbeat polling for real-time chat updates.
- Updated GlobalChat and ChatAsCustomer components to utilize polling based on the new configuration.
- Enhanced GenAgentConfigPanel to include a checkbox for enabling/disabling heartbeat polling.
- Introduced the isPollEnabled utility to determine polling status based on environment settings.
<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test update



---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.

