### PR TITLE
refactor: update conversation cleanup settings and schedule in Celery tasks

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -130,5 +130,5 @@ FILE_MANAGER_ENABLED=false
 # File Manager Provider -> local, s3, azure, gcs, sharepoint
 FILE_MANAGER_PROVIDER=local
 
-# Celery cleanup stale conversations cron (Run at 2 minutes past every 30 minutes)
-CELERY_CLEANUP_STALE_CONVERSATIONS_CRON=2-59/30
+# Conversation cleanup stale minutes
+CONVERSATION_CLEANUP_STALE_MINUTES=30

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -295,8 +295,8 @@ def create_celery():
         },
         "cleanup-stale-conversations": {
             "task": "app.tasks.conversations_tasks.cleanup_stale_conversations",
-            # Run every 30 minutes (at :00 and :30)
-            "schedule": crontab(minute=str(settings.CELERY_CLEANUP_STALE_CONVERSATIONS_CRON)),
+            # Run at 2 minutes past every 5 minutes
+             "schedule": crontab(minute="2-59/5"),
             "options": {"expires": 3600},  # Task expires after 1 hour
         },
         "import-s3-files": {

--- a/backend/app/core/config/settings.py
+++ b/backend/app/core/config/settings.py
@@ -45,7 +45,8 @@ class ProjectSettings(BaseSettings):
     # Use "prefork" only if you run workers that do not import ML libs; set CELERY_WORKER_POOL=prefork.
     CELERY_WORKER_POOL: str = "solo"
 
-    CELERY_CLEANUP_STALE_CONVERSATIONS_CRON: str = "*/30"
+    # === Conversation Cleanup Settings ===
+    CONVERSATION_CLEANUP_STALE_MINUTES: int = 30
 
     FERNET_KEY: Optional[str]
 

--- a/backend/app/tasks/conversations_tasks.py
+++ b/backend/app/tasks/conversations_tasks.py
@@ -4,6 +4,7 @@ from app.dependencies.injector import injector
 from datetime import datetime, timedelta, timezone
 import logging
 from app.services.conversations import ConversationService
+from app.core.config.settings import settings
 
 logger = logging.getLogger(__name__)
 
@@ -28,8 +29,10 @@ async def cleanup_stale_conversations_async():
     logger.info("Starting cleanup of stale conversations")
     conversation_srv = injector.get(ConversationService)
 
+    # get the time cutoff from the settings
+    time_cutoff = settings.CONVERSATION_CLEANUP_STALE_MINUTES or 30
 
-    cutoff_time = datetime.now(timezone.utc) - timedelta(minutes=5)
+    cutoff_time = datetime.now(timezone.utc) - timedelta(minutes=time_cutoff)
     cleanup_result = await conversation_srv.cleanup_stale_conversations(cutoff_time)
 
     result = {


### PR DESCRIPTION
## Description
- Changed environment variable from CELERY_CLEANUP_STALE_CONVERSATIONS_CRON to CONVERSATION_CLEANUP_STALE_MINUTES.
- Updated Celery task schedule to run every 5 minutes at 2 minutes past the hour.
- Adjusted conversation cleanup logic to use the new settings value for determining the cutoff time.

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
