### PR TITLE
fix: resolve Celery ClusterCrossSlotError on Redis Cluster startup

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -268,8 +268,13 @@ def create_celery():
             "fanout_prefix": True,
             "fanout_patterns": True,
             "max_connections": settings.CELERY_REDIS_MAX_CONNECTIONS,  # Limit broker connection pool
+            "global_keyprefix": "{celery}",  # Force all keys to same Redis Cluster hash slot
+        },
+        result_backend_transport_options={
+            "global_keyprefix": "{celery}",  # Force all keys to same Redis Cluster hash slot
         },
         redis_max_connections=settings.CELERY_REDIS_MAX_CONNECTIONS,  # Limit result backend connection pool
+        worker_enable_mingle=False,  # Disable mingle to avoid cross-slot errors on startup
         task_serializer="json",
         accept_content=["json"],
         result_serializer="json",

--- a/backend/app/services/smb_share_service.py
+++ b/backend/app/services/smb_share_service.py
@@ -119,7 +119,7 @@ class SMBShareFSService:
         return resolved_path
 
     def _smb_abspath(self, subpath: str) -> str:
-        """
+        r"""
         Build a UNC path like: \host\share\sub\path
         Use smbclient.path.join to be safe across OSes.
         """


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

Add global_keyprefix with hash tag to force all Celery broker and
result backend keys to the same Redis Cluster slot. Disable mingle
to prevent cross-slot pipeline transactions during worker startup.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
