### PR TITLE
refactor: update AgentUpdate schema to allow additional properties and improve agent settings handling

### DIFF
--- a/backend/app/api/v1/routes/agents.py
+++ b/backend/app/api/v1/routes/agents.py
@@ -94,7 +94,7 @@ async def run_query_agent_logic(
                 "agent_id": agent_id,
                 "thread_id": metadata.get("thread_id"),
                 "rag_used": False,
-                "row_agent_response": result        
+                "row_agent_response": result
 
     }
     logger.debug(f"Result: {result}")

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -54,12 +54,12 @@ class AgentUpdate(BaseModel):
     thinking_phrase_delay: Optional[int] = None
     workflow_id: Optional[UUID] = None
     security_settings: Optional[AgentSecuritySettingsUpdate] = None
-    model_config = ConfigDict(extra='forbid', from_attributes=True)
+
+    model_config = ConfigDict(extra='ignore', from_attributes=True)
 
 
 class AgentRead(AgentBase):
     id: UUID
-    model_config = ConfigDict(extra='ignore')  # shared rules
     user_id: Optional[UUID] = None
     operator_id: UUID
     operator: Optional[OperatorReadMinimal] = None
@@ -71,6 +71,8 @@ class AgentRead(AgentBase):
     welcome_image: Optional[bytes] = Field(None, exclude=True)
     # Flag to indicate if agent has a welcome image (avoids unnecessary fetch)
     has_welcome_image: bool = False
+
+    model_config = ConfigDict(extra='ignore')  # shared rules
 
     @model_validator(mode='before')
     @classmethod

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -15086,7 +15086,6 @@
             ]
           }
         },
-        "additionalProperties": false,
         "type": "object",
         "title": "AgentUpdate"
       },

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -116,14 +116,32 @@ export async function getRagFromSchema(): Promise<DynamicFormSchema> {
   );
 }
 
+/** Fields the PUT /configs/{id} endpoint accepts (AgentUpdate schema). Extra fields cause 422. */
+const AGENT_UPDATE_ALLOWED_KEYS = [
+  "name",
+  "description",
+  "is_active",
+  "welcome_message",
+  "welcome_image",
+  "welcome_title",
+  "possible_queries",
+  "thinking_phrases",
+  "thinking_phrase_delay",
+  "workflow_id",
+  "security_settings",
+] as const;
+
 export async function updateAgentConfig(
   id: string,
   config: AgentConfigUpdate
 ): Promise<AgentConfig> {
+  const payload = Object.fromEntries(
+    AGENT_UPDATE_ALLOWED_KEYS.filter((k) => k in config).map((k) => [k, config[k]])
+  );
   return apiRequest<AgentConfig>(
     "PUT",
     `genagent/agents/configs/${id}`,
-    config
+    payload
   );
 }
 

--- a/frontend/src/views/AIAgents/components/AgentForm.tsx
+++ b/frontend/src/views/AIAgents/components/AgentForm.tsx
@@ -395,13 +395,13 @@ const AgentForm: React.FC<AgentFormProps> = ({
                       >
                         {/* Background decoration */}
                         <div className="absolute inset-0 bg-grid-pattern opacity-[0.02]"></div>
-                        
+
                         <div className="relative flex flex-col items-center justify-center z-10">
                           {/* Upload icon with cloud */}
                           <div
                             className={`relative w-16 h-16 rounded-2xl flex items-center justify-center mb-4 transition-all duration-300 ${
-                              isDragOver 
-                                ? "bg-primary/20 scale-110 shadow-lg shadow-primary/30" 
+                              isDragOver
+                                ? "bg-primary/20 scale-110 shadow-lg shadow-primary/30"
                                 : "bg-primary/10 group-hover:bg-primary/15 group-hover:scale-105"
                             }`}
                           >
@@ -479,7 +479,7 @@ const AgentForm: React.FC<AgentFormProps> = ({
                               )}
                             </Button>
                           </div>
-                          
+
                           {/* File info */}
                           <div className="flex-1 min-w-0">
                             <div className="flex items-start justify-between gap-2">
@@ -538,7 +538,7 @@ const AgentForm: React.FC<AgentFormProps> = ({
                       </div>
                     </div>
                   )}
-                  
+
                   {/* Loading state */}
                   {imageLoading && (
                     <div className="flex items-center justify-center gap-3 p-4 rounded-lg bg-primary/5 border border-primary/20">
@@ -825,6 +825,7 @@ export const AgentFormDialog = ({
 }: AgentDialogProps) => {
   const formId = "agent-form-dialog";
   const isEditMode = !!data?.id;
+  console.log('iEditMode', isEditMode);
 
   // Prevent body scroll when dialog is open
   React.useEffect(() => {
@@ -832,7 +833,7 @@ export const AgentFormDialog = ({
       // Save the current overflow state
       const previousOverflow = document.body.style.overflow;
       document.body.style.overflow = 'hidden';
-      
+
       // Restore previous overflow state on cleanup
       return () => {
         document.body.style.overflow = previousOverflow;
@@ -841,7 +842,7 @@ export const AgentFormDialog = ({
   }, [isOpen]);
 
   return (
-    <Sheet open={isOpen} onOpenChange={onClose} modal={false}>
+    <Sheet open={isOpen} modal={false}>
       <SheetContent hideOverlay={true} className="sm:max-w-lg w-full flex flex-col p-0 top-2 right-2 h-[calc(100vh-1rem)] rounded-2xl border-2 shadow-2xl data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-right-full">
         <SheetHeader className="p-6 pb-4 border-b shrink-0">
           <SheetTitle className="text-xl font-semibold">

--- a/frontend/src/views/AIAgents/components/AgentForm.tsx
+++ b/frontend/src/views/AIAgents/components/AgentForm.tsx
@@ -11,9 +11,8 @@ import {
 } from "@/services/api";
 import { Button } from "@/components/button";
 import { Input } from "@/components/input";
-import { Switch } from "@/components/switch";
 import { Label } from "@/components/label";
-import { ChevronLeft, CheckCircle2, Trash2, Plus, HelpCircle, MessageSquare } from "lucide-react";
+import { ChevronLeft, CheckCircle2, Trash2, Plus, HelpCircle, MessageSquare, X } from "lucide-react";
 // import { createWorkflow, updateWorkflow } from "@/services/workflows";
 import {
   Sheet,
@@ -21,6 +20,7 @@ import {
   SheetHeader,
   SheetTitle,
   SheetDescription,
+  SheetClose,
 } from "@/components/sheet";
 import { Textarea } from "@/components/textarea";
 
@@ -825,7 +825,6 @@ export const AgentFormDialog = ({
 }: AgentDialogProps) => {
   const formId = "agent-form-dialog";
   const isEditMode = !!data?.id;
-  console.log('iEditMode', isEditMode);
 
   // Prevent body scroll when dialog is open
   React.useEffect(() => {
@@ -843,16 +842,20 @@ export const AgentFormDialog = ({
 
   return (
     <Sheet open={isOpen} modal={false}>
-      <SheetContent hideOverlay={true} className="sm:max-w-lg w-full flex flex-col p-0 top-2 right-2 h-[calc(100vh-1rem)] rounded-2xl border-2 shadow-2xl data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-right-full">
-        <SheetHeader className="p-6 pb-4 border-b shrink-0">
+      <SheetContent hideOverlay={true} hideDefaultClose={true} className="sm:max-w-lg w-full flex flex-col p-0 top-2 right-2 h-[calc(100vh-1rem)] rounded-2xl border-2 shadow-2xl data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-right-full">
+        <SheetHeader className="p-6 pb-4 border-b shrink-0 flex flex-row">
           <SheetTitle className="text-xl font-semibold">
             {data?.id ? "Edit Agent" : "Create New Agent"}
-          </SheetTitle>
+
           <SheetDescription>
             {data?.id
               ? "Update your agent's configuration and settings."
               : "Configure your new AI agent with a name, description, and welcome settings."}
           </SheetDescription>
+          </SheetTitle>
+          <SheetClose className="ml-auto self-start" onClick={onClose}>
+            <X className="h-4 w-4" />
+          </SheetClose>
         </SheetHeader>
         <div className="flex-1 overflow-y-auto overflow-x-hidden px-6 pt-4 pb-6">
           <AgentForm

--- a/frontend/src/views/AIAgents/components/AgentList.tsx
+++ b/frontend/src/views/AIAgents/components/AgentList.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { AgentListItem } from "@/interfaces/ai-agent.interface";
+import { AgentListItem, AgentConfig } from "@/interfaces/ai-agent.interface";
 import { Button } from "@/components/button";
 import {
   Plus,
@@ -12,6 +12,7 @@ import {
   KeyRoundIcon,
   Shield,
   Loader2,
+  Workflow,
 } from "lucide-react";
 import { Switch } from "@/components/switch";
 import {
@@ -23,6 +24,8 @@ import {
 } from "@/components/dropdown-menu";
 import { AgentFormDialog } from "./AgentForm";
 import { SearchInput } from "@/components/SearchInput";
+import { getAgentConfig } from "@/services/api";
+import { toast } from "react-hot-toast";
 
 interface AgentListProps {
   agents: AgentListItem[];
@@ -79,9 +82,60 @@ const AgentList: React.FC<AgentListProps> = ({
   });
 
   const [openAgentForm, setOpenAgentForm] = useState(false);
+  const [settingsDialogOpen, setSettingsDialogOpen] = useState(false);
+  const [settingsFormData, setSettingsFormData] = useState<{
+    id: string;
+    name: string;
+    description: string;
+    welcome_message?: string;
+    welcome_title?: string;
+    thinking_phrase_delay?: number;
+    possible_queries?: string[];
+    thinking_phrases?: string[];
+    is_active?: boolean;
+    workflow_id?: string;
+    has_welcome_image?: boolean;
+  } | null>(null);
+  const [settingsLoadingAgentId, setSettingsLoadingAgentId] = useState<string | null>(null);
 
   const handleOpenWorkflow = (agentId: string) => {
     navigate(`/ai-agents/workflow/${agentId}`);
+  };
+
+  const handleOpenAgentSettings = async (agentId: string) => {
+    setSettingsLoadingAgentId(agentId);
+    try {
+      const config: AgentConfig = await getAgentConfig(agentId);
+      const formData = {
+        id: config.id,
+        name: config.name,
+        description: config.description ?? "",
+        welcome_message: config.welcome_message ?? "",
+        welcome_title: config.welcome_title ?? "",
+        thinking_phrase_delay: config.thinking_phrase_delay ?? 0,
+        possible_queries: config.possible_queries ?? [],
+        thinking_phrases: config.thinking_phrases ?? [],
+        is_active: config.is_active,
+        // workflow_id: config.workflow_id,
+        // has_welcome_image: (config as { has_welcome_image?: boolean }).has_welcome_image,
+      };
+      setSettingsFormData(formData);
+      // Defer opening so the dropdown fully closes first; avoids Radix
+      // interpreting the dropdown close as an outside click that closes the Sheet
+      setSettingsDialogOpen(true);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to load agent settings"
+      );
+    } finally {
+      // setSettingsLoadingAgentId(null);
+    }
+  };
+
+  const handleSettingsDialogClose = () => {
+    setSettingsDialogOpen(false);
+    setSettingsFormData(null);
+    onRefresh();
   };
 
   if (!agents || agents.length === 0) {
@@ -165,8 +219,8 @@ const AgentList: React.FC<AgentListProps> = ({
                 <DropdownMenuContent align="end">
                   <DropdownMenuItem asChild>
                     <Link to={`/ai-agents/workflow/${agent.id}`}>
-                      <Pencil className="mr-2 h-4 w-4" />
-                      <span>Edit</span>
+                      <Workflow className="mr-2 h-4 w-4" />
+                      <span>Edit Workflow</span>
                     </Link>
                   </DropdownMenuItem>
                   <DropdownMenuItem
@@ -191,6 +245,21 @@ const AgentList: React.FC<AgentListProps> = ({
                     </Link>
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      handleOpenAgentSettings(agent.id);
+                    }}
+                    disabled={settingsLoadingAgentId === agent.id}
+                  >
+                    {settingsLoadingAgentId === agent.id ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <Pencil className="mr-2 h-4 w-4" />
+                    )}
+                    <span>Edit Agent</span>
+                  </DropdownMenuItem>
                   <DropdownMenuItem
                     className="text-destructive focus:text-destructive"
                     onClick={() => onDelete(agent.id)}
@@ -259,6 +328,13 @@ const AgentList: React.FC<AgentListProps> = ({
         isOpen={openAgentForm}
         onClose={handleFormClose}
         data={null}
+      />
+      <AgentFormDialog
+        isOpen={settingsDialogOpen}
+        onClose={handleSettingsDialogClose}
+        data={settingsFormData}
+        redirectOnCreate={false}
+        onCreated={() => handleSettingsDialogClose()}
       />
     </div>
   );

--- a/frontend/src/views/AIAgents/components/AgentList.tsx
+++ b/frontend/src/views/AIAgents/components/AgentList.tsx
@@ -168,11 +168,15 @@ const AgentList: React.FC<AgentListProps> = ({
     const agentName = agent.name;
     const isActive = !!agent.is_active;
     const truncatedPrompt = agent.possible_queries?.join(" ") ?? "";
+    const isAgentModalOpen =
+      settingsLoadingAgentId === agent.id && settingsDialogOpen;
 
     return (
       <div
         key={agent.id}
-        className={`px-6 py-4 hover:bg-muted/50 cursor-pointer`}
+        className={`px-6 py-4 hover:bg-muted/50 cursor-pointer ${
+          settingsDialogOpen && !isAgentModalOpen ? "blur-sm" : ""
+        }`}
         onClick={() => {
           handleOpenWorkflow(agent.id);
         }}


### PR DESCRIPTION
## Description

- Removed `additionalProperties: false` from the AgentUpdate schema in openapi.json to permit extra fields.
- Changed model configuration in AgentUpdate to `extra='ignore'` to allow input flexibility.
- Enhanced the updateAgentConfig function to filter allowed keys for the PUT /configs/{id} endpoint.
- Added settings dialog functionality in AgentList for editing agent configurations, including loading state management.
- Cleaned up formatting in various components for better readability.

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
