### PR TITLE
refactor: update permission constants for websocket endpoints

### DIFF
--- a/backend/app/api/v1/routes/conversations.py
+++ b/backend/app/api/v1/routes/conversations.py
@@ -652,7 +652,7 @@ async def get_agent_response_log_by_message(
 async def websocket_endpoint(
     websocket: WebSocket,
     conversation_id: UUID,
-    principal: SocketPrincipal = socket_auth(["read:in_progress_conversation"]),
+    principal: SocketPrincipal = socket_auth([P.Conversation.READ_IN_PROGRESS]),
     lang: Optional[str] = Query(default="en"),
     topics: list[str] = Query(default=["message"]),
     socket_connection_manager: SocketConnectionManager = Injected(
@@ -697,7 +697,7 @@ async def websocket_endpoint(
 @router.websocket("/ws/dashboard/list")
 async def websocket_dashboard_endpoint(
     websocket: WebSocket,
-    principal: SocketPrincipal = socket_auth(["read:in_progress_conversation"]),
+    principal: SocketPrincipal = socket_auth([P.Dashboard.READ]),
     lang: Optional[str] = Query(default="en"),
     topics: list[str] = Query(default=["message"]),
     socket_connection_manager: SocketConnectionManager = Injected(

--- a/backend/app/core/permissions/constants.py
+++ b/backend/app/core/permissions/constants.py
@@ -46,6 +46,7 @@ class ConversationPermissions:
     CREATE_IN_PROGRESS = "create:in_progress_conversation"
     UPDATE_IN_PROGRESS = "update:in_progress_conversation"
     TAKEOVER_IN_PROGRESS = "takeover_in_progress_conversation"
+    READ_IN_PROGRESS = "read:in_progress_conversation"
 
 
 class DataSourcePermissions:


### PR DESCRIPTION
## Description

- Replaced string literals with constants for permission checks in websocket endpoints.
- Added READ_IN_PROGRESS constant to enhance code readability and maintainability.
<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
