### PR TITLE
feat: add conversation cache invalidation functionality

### DIFF
--- a/backend/app/cache/redis_cache.py
+++ b/backend/app/cache/redis_cache.py
@@ -168,6 +168,10 @@ async def invalidate_agent_cache(agent_id: UUID, user_id: UUID):
     await invalidate_cache("agents:get_by_id_full", agent_id)
     await invalidate_cache("agents:get_by_user_id", user_id)
 
+async def invalidate_conversation_cache(conversation_id: UUID):
+    await invalidate_cache("conversations:get_conversation_by_id_with_operator_agent", conversation_id)
+    await invalidate_cache("conversations:in_progress_poll", conversation_id)
+
 async def invalidate_llm_provider_cache(provider_id: UUID | None):
     if provider_id:
         await invalidate_cache("llm_providers:get_by_id", str(provider_id))

--- a/backend/app/services/conversations.py
+++ b/backend/app/services/conversations.py
@@ -18,7 +18,7 @@ from app.core.utils.bi_utils import (
     calculate_duration_from_transcript,
     calculate_incremental_word_counts,
 )
-from app.cache.redis_cache import make_key_builder
+from app.cache.redis_cache import make_key_builder, invalidate_conversation_cache
 from fastapi_cache.coder import PickleCoder
 from fastapi_cache.decorator import cache
 from app.core.utils.enums.conversation_status_enum import ConversationStatus
@@ -524,7 +524,8 @@ class ConversationService:
         for conversation in stale_conversations:
             if len(conversation.messages) < 3:
                 # soft delete the conversation
-                await self.update_conversation(conversation, is_deleted=True)
+                conversation.is_deleted = True
+                await self.update_conversation(conversation)
                 deleted_count += 1
                 logger.info(
                     f"Deleted stale conversation {conversation.id} (last updated: {conversation.updated_at})"
@@ -545,6 +546,8 @@ class ConversationService:
                         f"Failed to finalize conversation {conversation.id}: {str(e)}"
                     )
                     failed_count += 1
+
+            await invalidate_conversation_cache(conversation.id)
 
         return {
             "deleted_count": deleted_count,


### PR DESCRIPTION
## Description

- Updated the `ConversationService` to call this new function when deleting stale conversations, ensuring cache consistency.
- Introduced a new function `invalidate_conversation_cache` to handle cache invalidation for conversation-related data.


This enhancement improves cache management for conversation data.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
