### PR TITLE
feat: zendesk data source + fetch articles from category id 

### DIFF
--- a/backend/app/modules/integration/zendesk.py
+++ b/backend/app/modules/integration/zendesk.py
@@ -264,12 +264,14 @@ class ZendeskConnector:
     async def fetch_articles(
         self,
         locale: Optional[str] = None,
+        category_id: Optional[int] = None,
         section_id: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """
         Fetch all articles from Zendesk Help Center.
         Args:
             locale: Optional locale filter (e.g., "en-us")
+            category_id: Optional category ID to filter articles
             section_id: Optional section ID to filter articles
         Returns:
             List of article dictionaries
@@ -277,8 +279,13 @@ class ZendeskConnector:
         all_articles = []
         url: Optional[str] = f"{self.help_center_url}/articles.json"
 
+        if category_id:
+            url = f"{self.help_center_url}/categories/{category_id}/articles.json"
+            logger.info("Fetching articles from category ID", extra={"category_id": category_id})
+
         if section_id:
             url = f"{self.help_center_url}/sections/{section_id}/articles.json"
+            logger.info("Fetching articles from section ID", extra={"section_id": section_id})
 
         params = {}
         if locale:

--- a/backend/app/schemas/dynamic_form_schemas/data_source_schemas.py
+++ b/backend/app/schemas/dynamic_form_schemas/data_source_schemas.py
@@ -284,6 +284,14 @@ DATA_SOURCE_SCHEMAS: Dict[str, TypeSchema] = {
                 advanced=True,
             ),
             FieldSchema(
+                name="category_id",
+                type="number",
+                label="Category ID",
+                required=False,
+                description="Optional: Only sync articles from a specific category. Leave empty to sync all categories.",
+                advanced=True,
+            ),
+            FieldSchema(
                 name="section_id",
                 type="number",
                 label="Section ID",

--- a/frontend/src/views/DataSources/components/DataSourceDialog.tsx
+++ b/frontend/src/views/DataSources/components/DataSourceDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import {
   Dialog,
   DialogContent,
@@ -73,7 +73,13 @@ export function DataSourceDialog({
     staleTime: 3000,
   });
 
-  const dataSourceSchemas = data ?? {};
+  const dataSourceSchemas = useMemo(() => {
+    if (!data) return {};
+
+    return Object.fromEntries(
+      Object.entries(data).map(([key, value]) => [key.toLowerCase(), value]),
+    );
+  }, [data]);
 
   useEffect(() => {
     const initializeForm = async () => {

--- a/frontend/src/views/KnowledgeBase/components/KnowledgeBaseManager.tsx
+++ b/frontend/src/views/KnowledgeBase/components/KnowledgeBaseManager.tsx
@@ -180,7 +180,7 @@ const KnowledgeBaseManager: React.FC = () => {
 
   /* File types that are supported by the file extractor */
   const acceptedFileTypes = [".pdf", ".docx", ".doc", ".txt", ".csv", ".xls", ".xlsx", ".pptx", ".ppt", ".html", ".htm", ".yaml", ".yml", ".json", ".jsonl", ".md"];
-  
+
   useEffect(() => {
     fetchItems();
   }, []);
@@ -251,7 +251,7 @@ const KnowledgeBaseManager: React.FC = () => {
 
     fetchLLMAnalysts();
   }, []);
-  
+
   const fetchSources = useCallback(async () => {
     if (formData.type && formData.type in targetTypes) {
       const allSources = await getAllDataSources();
@@ -313,7 +313,7 @@ const KnowledgeBaseManager: React.FC = () => {
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     // get the files
     const files = e.target.files ? Array.from(e.target.files) : [];
-    
+
     // set the selected files
     setSelectedFiles([...files]);
 
@@ -1136,7 +1136,7 @@ const KnowledgeBaseManager: React.FC = () => {
                                   multiple
                                   onChange={handleFileChange}
                                   disabled={isUploading}
-                                  accept={acceptedFileTypes.join(",")}  
+                                  accept={acceptedFileTypes.join(",")}
                                   className="hidden"
                                 />
                               </label>


### PR DESCRIPTION
## Description

- Enhanced the `fetch_articles` method in `ZendeskConnector` to support an optional `category_id` parameter for filtering articles by category.
- Updated the documentation to reflect the new parameter and its usage.
- Added logging to track article fetching by category and section.
- Introduced useMemo to memoize the transformation of data source schemas, ensuring efficient updates and preventing unnecessary recalculations.
- Cleaned up whitespace in KnowledgeBaseManager for improved code readability.
This update improves the flexibility of article retrieval from Zendesk.
<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
