### PR TITLE
fix: add fastapi cache init in celery

### DIFF
--- a/backend/run_celery.py
+++ b/backend/run_celery.py
@@ -1,11 +1,22 @@
-import os
 import logging
+from celery.signals import worker_process_init
 from app import create_app
 from app.core.config.settings import settings
 
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
+
+
+@worker_process_init.connect
+def init_worker_cache(**kwargs):
+    from redis.asyncio import Redis as AsyncRedis
+    from fastapi_cache import FastAPICache
+    from fastapi_cache.backends.redis import RedisBackend
+    redis = AsyncRedis.from_url(settings.REDIS_URL, decode_responses=False)
+    FastAPICache.init(RedisBackend(redis), prefix="auth")
+    logger.info("FastAPICache initialized for Celery worker process")
+
 
 # Create the FastAPI app to get the Celery app instance
 app = create_app()


### PR DESCRIPTION
## Description

add fastapi cache initialisation in celery
<!-- Mark the relevant option with an 'x' -->

- [x 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release
