### PR TITLE
fix: Normalize source type to lowercase in DataSourceDialog component

### DIFF
--- a/frontend/src/views/DataSources/components/DataSourceDialog.tsx
+++ b/frontend/src/views/DataSources/components/DataSourceDialog.tsx
@@ -92,7 +92,7 @@ export function DataSourceDialog({
       if (isOpen) {
         resetForm();
         if (mode === "create" && defaultSourceType) {
-          setSourceType(defaultSourceType);
+          setSourceType(defaultSourceType.toLowerCase() as string);
         }
         if (dataSourceToEdit && mode === "edit") {
           if (
@@ -138,7 +138,7 @@ export function DataSourceDialog({
   const populateFormWithDataSource = (dataSource: DataSource) => {
     setDataSourceId(dataSource.id);
     setName(dataSource.name);
-    setSourceType(dataSource.source_type);
+    setSourceType(dataSource.source_type.toLowerCase() as string);
     setConnectionData(dataSource.connection_data);
     setIsActive(dataSource.is_active === 1);
     setTestStatus(dataSource.connection_status ?? null);
@@ -340,7 +340,7 @@ export function DataSourceDialog({
                 <Select
                   value={sourceType}
                   onValueChange={(value) => {
-                    setSourceType(value);
+                    setSourceType(value.toLowerCase() as string);
                     setConnectionData(getSchemaDefaults(value));
                     setTestStatus(null);
                     setShowAdvanced(false);


### PR DESCRIPTION
## Description

- Updated the DataSourceDialog component to ensure that the source type is consistently set to lowercase when creating or editing data sources. This change improves data consistency and prevents potential issues with case sensitivity.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
