### PR TITLE
fix: Add localhost:8022 to CORS origins in agent_security_utils and middleware

### DIFF
--- a/backend/app/core/agent_security_utils.py
+++ b/backend/app/core/agent_security_utils.py
@@ -18,8 +18,10 @@ def get_agent_cors_origins(agent_security_settings) -> list[str]:
     default_origins = [
         "http://localhost:8080",
         "http://localhost:3000",
+        "http://localhost:8022",  # plugin-js example widget
         "http://127.0.0.1:8080",
         "http://127.0.0.1:3000",
+        "http://127.0.0.1:8022",
     ]
 
     # Start with default origins

--- a/backend/app/middlewares/_middleware.py
+++ b/backend/app/middlewares/_middleware.py
@@ -35,8 +35,10 @@ def get_allowed_origins() -> list[str]:
     default_origins = [
         "http://localhost:8080",
         "http://localhost:3000",
+        "http://localhost:8022",  # plugin-js example widget
         "http://127.0.0.1:8080",
         "http://127.0.0.1:3000",
+        "http://127.0.0.1:8022",
     ]
 
     # Start with default origins


### PR DESCRIPTION
## Description

- Running Plugin JS locally has a CORS issue blocker.
- Added port 8022 to the allowed list of default_origins.
<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release



---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
