### PR TITLE
fix: update subdomain handling in connection tester

### DIFF
--- a/backend/app/services/connection_tester.py
+++ b/backend/app/services/connection_tester.py
@@ -3,8 +3,16 @@ import httpx
 
 async def test_zendesk(cd: dict) -> dict:
     async with httpx.AsyncClient() as client:
+        # check if subdomain has also the zendesk.com domain
+        if not cd["subdomain"].endswith(".zendesk.com"):
+            cd["subdomain"] = f"{cd['subdomain']}.zendesk.com"
+        else:
+            cd["subdomain"] = cd["subdomain"]
+
+        url = f"https://{cd['subdomain']}/api/v2/users/me.json"
+
         response = await client.get(
-            f"https://{cd['subdomain']}.zendesk.com/api/v2/users/me.json",
+            url,
             auth=(f"{cd['email']}/token", cd["api_token"]),
             timeout=10.0,
         )


### PR DESCRIPTION
## Description

- Ensure the subdomain is correctly formatted to include the zendesk.com domain if not already present. This change simplifies the URL construction for the API request to fetch user data.

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
