### PR TITLE
fix: update date format to date-time in API schema and filters

### DIFF
--- a/backend/app/schemas/filter.py
+++ b/backend/app/schemas/filter.py
@@ -1,30 +1,35 @@
-from fastapi import Query
-from pydantic import BaseModel, Field
-from typing import Optional
 from datetime import date, datetime
+from typing import Optional
 from uuid import UUID
 
+from fastapi import Query
+from pydantic import BaseModel, Field
+
+from app.core.utils.enums.conversation_status_enum import ConversationStatus
 from app.core.utils.enums.conversation_topic_enum import ConversationTopic
 from app.core.utils.enums.sentiment_enum import Sentiment
 from app.core.utils.enums.sort_direction_enum import SortDirection
 from app.core.utils.enums.sort_field_enum import SortField
-from app.core.utils.enums.conversation_status_enum import ConversationStatus
 
 
 class BaseFilterModel(BaseModel):
     skip: int = Field(0, ge=0, description="The number of rows to skip before returning results")
     limit: int = Field(20, ge=1, le=100, description="The number of rows to return per page")
     from_date: Optional[date] = Field(None, description="Start date (YYYY-MM-DD)")
-    to_date: Optional[date] = Field(None, description="End date (YYYY-MM-DD)")
+    to_date: Optional[datetime] = Field(None, description="End datetime (YYYY-MM-DD 23:59)")
     operator_id: Optional[UUID] = Field(None, description="Operator who made the conversation")
     order_by: Optional[SortField] = Field(SortField.CREATED_AT, description="Order by column name")
     sort_direction: Optional[SortDirection] = Field(SortDirection.DESC, description="Order by direction")
 
+
 class ConversationFilter(BaseFilterModel):
-    conversation_status: Optional[list[ConversationStatus]] = Field (Query(None,
-                                                                           description='Conversation statuses'))
-    conversation_topics: Optional[list[ConversationTopic]] = Field (Query(None,),
-                                                                    description='Conversation topics decided by llm')
+    conversation_status: Optional[list[ConversationStatus]] = Field(Query(None, description="Conversation statuses"))
+    conversation_topics: Optional[list[ConversationTopic]] = Field(
+        Query(
+            None,
+        ),
+        description="Conversation topics decided by llm",
+    )
     sentiment: Optional[Sentiment] = Field(None, description="Sentiment of the conversation")
     agent_id: Optional[UUID] = Field(None, description="Filter by agent ID")
     customer_satisfaction_min: Optional[int] = Field(None, ge=0, le=10, description="Min customer satisfaction score")
@@ -36,15 +41,19 @@ class ConversationFilter(BaseFilterModel):
     efficiency_min: Optional[int] = Field(None, ge=0, le=10, description="Min efficiency score")
     efficiency_max: Optional[int] = Field(None, ge=0, le=10, description="Max efficiency score")
     hostility_positive_max: Optional[int] = Field(
-            None, ge=0, le=30, description="Sentiment intervals to decide based on hostility score if a live "
-                                          "conversation should be considered neutral, positive or negative"
-
-            )
+        None,
+        ge=0,
+        le=30,
+        description="Sentiment intervals to decide based on hostility score if a live "
+        "conversation should be considered neutral, positive or negative",
+    )
     hostility_neutral_max: Optional[int] = Field(
-            None, ge=0, le=49, description="Sentiment intervals to decide based on hostility score if a live "
-                                           "conversation should be considered neutral, positive or negative"
-
-            )
+        None,
+        ge=0,
+        le=49,
+        description="Sentiment intervals to decide based on hostility score if a live "
+        "conversation should be considered neutral, positive or negative",
+    )
 
     minimum_hostility_score: Optional[int] = None
     include_messages: Optional[bool] = Field(True)
@@ -57,8 +66,7 @@ class ConversationFilter(BaseFilterModel):
 class ApiKeysFilter(BaseFilterModel):
     user_id: Optional[UUID] = Field(None, description="Agent who's user owns the api key")
 
-    
-    
+
 class RecordingFilter(BaseFilterModel):
     operator_id: Optional[UUID] = None
 
@@ -66,4 +74,3 @@ class RecordingFilter(BaseFilterModel):
 class AgentResponseLogFilter(BaseModel):
     conversation_id: UUID
     node_type: Optional[str] = Field(None, description="Filter by node type found in state.nodeExecutionStatus[*].type")
-

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -266,7 +266,7 @@
               "anyOf": [
                 {
                   "type": "string",
-                  "format": "date"
+                  "format": "date-time"
                 },
                 {
                   "type": "null"
@@ -774,7 +774,7 @@
               "anyOf": [
                 {
                   "type": "string",
-                  "format": "date"
+                  "format": "date-time"
                 },
                 {
                   "type": "null"
@@ -1185,7 +1185,7 @@
               "anyOf": [
                 {
                   "type": "string",
-                  "format": "date"
+                  "format": "date-time"
                 },
                 {
                   "type": "null"
@@ -1564,7 +1564,7 @@
               "anyOf": [
                 {
                   "type": "string",
-                  "format": "date"
+                  "format": "date-time"
                 },
                 {
                   "type": "null"
@@ -4381,7 +4381,7 @@
               "anyOf": [
                 {
                   "type": "string",
-                  "format": "date"
+                  "format": "date-time"
                 },
                 {
                   "type": "null"
@@ -5221,7 +5221,7 @@
               "anyOf": [
                 {
                   "type": "string",
-                  "format": "date"
+                  "format": "date-time"
                 },
                 {
                   "type": "null"
@@ -5724,7 +5724,7 @@
               "anyOf": [
                 {
                   "type": "string",
-                  "format": "date"
+                  "format": "date-time"
                 },
                 {
                   "type": "null"
@@ -7213,7 +7213,7 @@
               "anyOf": [
                 {
                   "type": "string",
-                  "format": "date"
+                  "format": "date-time"
                 },
                 {
                   "type": "null"

--- a/frontend/src/views/Transcripts/hooks/useTranscriptData.ts
+++ b/frontend/src/views/Transcripts/hooks/useTranscriptData.ts
@@ -72,11 +72,13 @@ export const useTranscriptData = (options: UseTranscriptDataOptions = {}) => {
     } else {
       try {
         setLoading(true);
-        const { items: backendData, total: backendTotal } = await fetchTranscripts({
+        const params = {
           limit, skip, sentiment, hostility_neutral_max, hostility_positive_max,
           include_feedback, conversation_status, order_by, sort_direction,
           agent_id, scoreFilters, from_date, to_date, exclude_empty,
-        });
+        };
+
+        const { items: backendData, total: backendTotal } = await fetchTranscripts(params);
 
         if (!backendData || !Array.isArray(backendData)) {
           throw new Error("Invalid backend data format");

--- a/frontend/src/views/Transcripts/pages/Transcripts.tsx
+++ b/frontend/src/views/Transcripts/pages/Transcripts.tsx
@@ -193,7 +193,7 @@ const Transcripts = () => {
     agent_id: selectedAgentId !== "all" ? selectedAgentId : undefined,
     scoreFilters,
     from_date: dateRange?.from ? format(dateRange.from, "yyyy-MM-dd") : undefined,
-    to_date: dateRange?.to ? format(dateRange.to, "yyyy-MM-dd") : undefined,
+    to_date: dateRange?.to ? format(dateRange.to, "yyyy-MM-dd 23:59:59") : undefined,
     exclude_empty: hideEmpty || undefined,
   });
 


### PR DESCRIPTION
## Description
- Changed date format from "date" to "date-time" in openapi.json for better precision.
- Updated filter.py to reflect the change in to_date from date to datetime.
- Adjusted useTranscriptData and Transcripts components to handle the new datetime format for to_date.


<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
