### PR TITLE
refactor: reorganize imports and enhance Celery configuration

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,25 +1,25 @@
 import json
 import logging
 import os
-from pathlib import Path
 from contextlib import asynccontextmanager
+from pathlib import Path
+
+from celery import Celery
+from celery.schedules import crontab
 from fastapi import FastAPI
 from fastapi_injector import InjectorMiddleware, RequestScopeOptions, attach_injector
-from app.core.config.logging import init_logging
+
 from app.api.v1.routes._routes import register_routers
+from app.cache.redis_cache import init_fastapi_cache_with_redis
+from app.core.config.logging import init_logging
 from app.core.config.settings import settings
 from app.core.exceptions.exception_handler import init_error_handlers
+from app.db.multi_tenant_session import multi_tenant_manager
 from app.dependencies.injector import injector
-from app.cache.redis_cache import init_fastapi_cache_with_redis
 from app.dependencies.tenant_dependencies import pre_wormup_tenant_singleton
 from app.file_system.file_system import ensure_directories
 from app.middlewares._middleware import build_middlewares
 from app.middlewares.rate_limit_middleware import init_rate_limiter
-from app.db.multi_tenant_session import multi_tenant_manager
-
-from celery.schedules import crontab
-from celery import Celery
-
 
 init_logging()
 logger = logging.getLogger(__name__)
@@ -85,7 +85,8 @@ async def _initialize_redis_services(app: FastAPI):
         Tuple of (redis_string, redis_binary) clients
     """
     from redis.asyncio import Redis
-    from app.dependencies.dependency_injection import RedisString, RedisBinary
+
+    from app.dependencies.dependency_injection import RedisBinary, RedisString
 
     logger.info("Initializing Redis services...")
 
@@ -256,7 +257,7 @@ def create_celery():
             "app.tasks.share_folder_tasks",
             "app.tasks.ml_model_pipeline_tasks",
             "app.tasks.kb_batch_tasks",
-            "app.tasks.analytics_aggregation_tasks"
+            "app.tasks.analytics_aggregation_tasks",
         ],
     )
 
@@ -289,6 +290,8 @@ def create_celery():
         worker_pool=settings.CELERY_WORKER_POOL,
         worker_log_format="[%(asctime)s: %(levelname)s/%(processName)s] %(message)s",
         worker_task_log_format="[%(asctime)s: %(levelname)s/%(processName)s][%(task_name)s(%(task_id)s)] %(message)s",
+        # Prevent Celery from hijacking root logger and writing to stderr (Datadog-friendly)
+        worker_hijack_root_logger=False,
     )
 
     # Configure periodic tasks (conditionally enabled via settings)
@@ -306,7 +309,7 @@ def create_celery():
         beat_schedule["cleanup-stale-conversations"] = {
             "task": "app.tasks.conversations_tasks.cleanup_stale_conversations",
             # Run at 2 minutes past every 10 minutes
-             "schedule": crontab(minute="2-59/10"),
+            "schedule": crontab(minute="2-59/10"),
             "options": {"expires": 3600},  # Task expires after 1 hour
         }
 
@@ -316,7 +319,7 @@ def create_celery():
             # Run at 3 minutes past every 10 minutes
             "schedule": crontab(minute="3-59/10"),
             "options": {"expires": 3600},  # Task expires after 1 hour
-            }
+        }
 
     if settings.CELERY_ENABLE_IMPORT_S3_FILES_TASK:
         beat_schedule["import-s3-files"] = {


### PR DESCRIPTION
## Description
- By default, Celery "hijacks" the Python root logger to ensure that all log messages follow the Celery log format and are redirected to the appropriate destinations (like a log file or stdout).
- Moved and cleaned up import statements for better organization.
- Added a new option to prevent Celery from hijacking the root logger.
- Adjusted the formatting of the Celery beat schedule for consistency.


<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release



---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
