### PR TITLE
chore: update websocket service configuration in docker-compose files

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -301,15 +301,14 @@ services:
     container_name: genassist-ws-dev
     ports:
       - "8002:8002"
+    env_file:
+      - ./websocket/.env
     environment:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD}
       - BACKEND_URL=http://app:8000
-      - WS_INTERNAL_SECRET=${WS_INTERNAL_SECRET}
-      - WS_PORT=8002
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - LOG_LEVEL=debug
     depends_on:
       redis:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,15 +236,14 @@ services:
     container_name: genassist-ws
     ports:
       - "8002:8002"
+    env_file:
+      - ./websocket/.env
     environment:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD}
       - BACKEND_URL=http://app:8000
-      - WS_INTERNAL_SECRET=${WS_INTERNAL_SECRET}
-      - WS_PORT=8002
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - LOG_LEVEL=debug
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
## Description
- Added `env_file` reference to load environment variables from the `.env` file for the websocket service in both `docker-compose.dev.yml` and `docker-compose.yml`.
- Removed `WS_INTERNAL_SECRET` and `WS_PORT` from the environment variables for the websocket service to streamline configuration.

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
