### PR TITLE
refactor: rename chat reset method for clarity

### DIFF
--- a/frontend/src/views/Onboarding/hooks/useOnboardingChat.ts
+++ b/frontend/src/views/Onboarding/hooks/useOnboardingChat.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChatService, type AgentWelcomeData, type ChatMessage } from "genassist-chat-react";
-import { type RegistrationStatus } from "@/context/RoutesContext";  
+import { type RegistrationStatus } from "@/context/RoutesContext";
 
 export const useOnboardingChat = ({ registrationStatus }: { registrationStatus: RegistrationStatus }) => {
   const [error, setError] = useState<string | null>(null);
@@ -34,7 +34,7 @@ export const useOnboardingChat = ({ registrationStatus }: { registrationStatus: 
 
     const chat = new ChatService(onboardingBaseUrl, onboardingApiKey, undefined, tenant);
     chatRef.current = chat;
-    chat.resetConversation();
+    chat.resetChatConversation();
     setIsChatReady(true);
 
     const handleWelcomeData = (data: AgentWelcomeData) => {


### PR DESCRIPTION
## Description
- Updated the method name from `resetConversation` to `resetChatConversation` in the `useOnboardingChat` hook to improve code readability and better reflect its functionality.


<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
