### PR TITLE
fix: multi-tenant KB sync and pgvector delete parameter limit

### DIFF
--- a/backend/app/api/v1/routes/agent_knowledge.py
+++ b/backend/app/api/v1/routes/agent_knowledge.py
@@ -27,6 +27,7 @@ from app.services.agent_knowledge_utils import (
     populate_remote_file_metadata,
     schedule_rag_load,
 )
+from app.core.tenant_scope import get_tenant_context
 from app.tasks.kb_batch_tasks import batch_process_files_kb_async_with_scope
 from app.tasks.s3_tasks import import_s3_files_to_kb_async
 from app.core.project_path import DATA_VOLUME
@@ -547,9 +548,13 @@ async def summarize_files_from_azure(
         logger.warning("Attempting to run KB batch processing without specifying a KB ID.")
         return {"status": "error", "message": "kb_id is required"}
 
+    # Capture current tenant context
+    tenant_id = get_tenant_context()
+
     background_tasks.add_task(
         batch_process_files_kb_async_with_scope,
-        kb_id
+        kb_id,
+        tenant_id
     )
 
     return {"status": "started"}

--- a/backend/app/modules/data/providers/vector/db/base.py
+++ b/backend/app/modules/data/providers/vector/db/base.py
@@ -184,15 +184,7 @@ class BaseVectorDB(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def     1. API Endpoints / Tasks
-       ↓
-    2. AgentRAGServiceManager.delete_document(kb_obj, doc_id)
-       ↓
-    3. AgentRAGService.delete_document(doc_id)
-       ↓
-    4. VectorProvider.delete_document(doc_id)  ← Calls get_all_ids() first
-       ↓
-    5. vector_db.delete_vectors(all_ids)       ← DIRECT CALL HEREdelete_vectors(self, ids: List[str]) -> bool:
+    async def delete_vectors(self, ids: List[str]) -> bool:
         """
         Delete vectors by IDs
 

--- a/backend/app/modules/data/providers/vector/db/base.py
+++ b/backend/app/modules/data/providers/vector/db/base.py
@@ -184,12 +184,33 @@ class BaseVectorDB(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def delete_vectors(self, ids: List[str]) -> bool:
+    async def     1. API Endpoints / Tasks
+       ↓
+    2. AgentRAGServiceManager.delete_document(kb_obj, doc_id)
+       ↓
+    3. AgentRAGService.delete_document(doc_id)
+       ↓
+    4. VectorProvider.delete_document(doc_id)  ← Calls get_all_ids() first
+       ↓
+    5. vector_db.delete_vectors(all_ids)       ← DIRECT CALL HEREdelete_vectors(self, ids: List[str]) -> bool:
         """
         Delete vectors by IDs
 
         Args:
             ids: List of document IDs to delete
+
+        Returns:
+            Success status
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def delete_vectors_by_metadata(self, filter_dict: Dict[str, Any]) -> bool:
+        """
+        Delete vectors by metadata filters (more efficient for bulk operations)
+
+        Args:
+            filter_dict: Dictionary of metadata field-value pairs to filter by
 
         Returns:
             Success status

--- a/backend/app/modules/data/providers/vector/db/chroma.py
+++ b/backend/app/modules/data/providers/vector/db/chroma.py
@@ -156,6 +156,35 @@ class ChromaVectorDB(BaseVectorDB):
             logger.error(f"Failed to delete vectors from ChromaDB: {e}")
             return False
 
+    async def delete_vectors_by_metadata(self, filter_dict: Dict[str, Any]) -> bool:
+        """
+        Delete vectors by metadata filters (ChromaDB implementation)
+        
+        Args:
+            filter_dict: Dictionary of metadata field-value pairs to filter by
+            
+        Returns:
+            Success status
+        """
+        try:
+            if not self.collection:
+                logger.error("Collection not initialized")
+                return False
+
+            if not filter_dict:
+                logger.warning("No metadata filters provided for deletion")
+                return True
+
+            # ChromaDB supports metadata filtering directly
+            await self.collection.delete(where=filter_dict)
+
+            logger.info(f"Deleted vectors from ChromaDB using metadata filters: {filter_dict}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to delete vectors by metadata from ChromaDB: {e}")
+            return False
+
     async def search(
         self,
         query_vector: List[float],

--- a/backend/app/modules/data/providers/vector/db/faiss.py
+++ b/backend/app/modules/data/providers/vector/db/faiss.py
@@ -197,7 +197,44 @@ class FaissVectorDB(BaseVectorDB):
         except Exception as e:
             logger.error(f"Failed to delete vectors from FAISS: {e}")
             return False
-    
+
+    async def delete_vectors_by_metadata(self, filter_dict: Dict[str, Any]) -> bool:
+        """
+        Delete vectors by metadata filters (FAISS implementation)
+        
+        Args:
+            filter_dict: Dictionary of metadata field-value pairs to filter by
+            
+        Returns:
+            Success status
+        """
+        try:
+            if not filter_dict:
+                logger.warning("No metadata filters provided for deletion")
+                return True
+
+            # Find IDs that match the metadata filters
+            ids_to_delete = []
+            for doc_id, metadata in self.metadata_map.items():
+                if metadata:
+                    matches = True
+                    for key, value in filter_dict.items():
+                        if metadata.get(key) != value:
+                            matches = False
+                            break
+                    if matches:
+                        ids_to_delete.append(doc_id)
+
+            if ids_to_delete:
+                return await self.delete_vectors(ids_to_delete)
+            else:
+                logger.info("No vectors found matching metadata filters")
+                return True
+
+        except Exception as e:
+            logger.error(f"Failed to delete vectors by metadata from FAISS: {e}")
+            return False
+
     async def search(
         self, 
         query_vector: List[float], 

--- a/backend/app/modules/data/providers/vector/db/pgvector.py
+++ b/backend/app/modules/data/providers/vector/db/pgvector.py
@@ -294,6 +294,59 @@ class PgVectorDB(BaseVectorDB):
             logger.error(f"Failed to delete vectors from pgvector: {e}")
             return False
 
+    async def delete_vectors_by_metadata(self, filter_dict: Dict[str, Any]) -> bool:
+        """
+        Delete vectors by metadata filters (efficient for bulk operations)
+        
+        Args:
+            filter_dict: Dictionary of metadata field-value pairs to filter by
+            
+        Returns:
+            Success status
+        """
+        try:
+            if not self.engine:
+                logger.error("Engine not initialized")
+                return False
+
+            if not self.table_name:
+                logger.error("Collection not initialized. Call create_collection() first.")
+                return False
+
+            if not filter_dict:
+                logger.warning("No metadata filters provided for deletion")
+                return True
+
+            async with self.engine.begin() as conn:
+                # Build WHERE clause for metadata filtering
+                where_conditions = []
+                params = {}
+                
+                for key, value in filter_dict.items():
+                    param_key = f"filter_{key}"
+                    where_conditions.append(f"metadata->>'{key}' = :{param_key}")
+                    params[param_key] = str(value)
+
+                if not where_conditions:
+                    logger.warning("No valid filter conditions generated")
+                    return True
+
+                where_clause = " AND ".join(where_conditions)
+                delete_sql = text(f"""
+                    DELETE FROM {self.table_name}
+                    WHERE {where_clause}
+                """)
+
+                result = await conn.execute(delete_sql, params)
+                deleted_count = result.rowcount
+
+            logger.info(f"Deleted {deleted_count} vectors from pgvector table using metadata filters: {filter_dict}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to delete vectors by metadata from pgvector: {e}")
+            return False
+
     async def search(
         self,
         query_vector: List[float],

--- a/backend/app/modules/data/providers/vector/db/qdrant.py
+++ b/backend/app/modules/data/providers/vector/db/qdrant.py
@@ -276,6 +276,40 @@ class QdrantVectorDB(BaseVectorDB):
             logger.error(f"Failed to delete vectors from Qdrant: {e}")
             return False
 
+    async def delete_vectors_by_metadata(self, filter_dict: Dict[str, Any]) -> bool:
+        """
+        Delete vectors by metadata filters (Qdrant implementation)
+        
+        Args:
+            filter_dict: Dictionary of metadata field-value pairs to filter by
+            
+        Returns:
+            Success status
+        """
+        try:
+            if not self.client:
+                logger.error("Client not initialized")
+                return False
+
+            if not filter_dict:
+                logger.warning("No metadata filters provided for deletion")
+                return True
+
+            # Build Qdrant filter from metadata filters
+            qdrant_filter = self._build_qdrant_filter(filter_dict)
+
+            await self.client.delete(
+                collection_name=self.collection_name,
+                points_selector=FilterSelector(filter=qdrant_filter)
+            )
+
+            logger.info(f"Deleted vectors from Qdrant collection using metadata filters: {filter_dict}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to delete vectors by metadata from Qdrant: {e}")
+            return False
+
     def _build_qdrant_filter(
         self, filter_dict: Optional[Dict[str, Any]]
     ) -> Optional[Filter]:

--- a/backend/app/modules/data/providers/vector/provider.py
+++ b/backend/app/modules/data/providers/vector/provider.py
@@ -165,18 +165,14 @@ class VectorProvider(BaseDataProvider):
                 if not await self.initialize():
                     return False
 
-            # Get all chunk IDs for this document
-            all_ids = await self.vector_db.get_all_ids({"doc_id": doc_id})
+            # Use conditional delete by metadata for efficiency
+            # This avoids the parameter limit issue with large documents
+            filter_dict = {"doc_id": doc_id}
+            success = await self.vector_db.delete_vectors_by_metadata(filter_dict)
 
-            if all_ids:
-                success = await self.vector_db.delete_vectors(all_ids)
-                if success:
-                    logger.info(
-                        f"Deleted document {doc_id} with {len(all_ids)} chunks")
-                return success
-            else:
-                logger.info(f"No chunks found for document {doc_id}")
-                return True
+            if success:
+                logger.info(f"Deleted document {doc_id} from vector store")
+            return success
 
         except Exception as e:
             logger.error(f"Failed to delete document {doc_id}: {e}")

--- a/backend/app/tasks/kb_batch_tasks.py
+++ b/backend/app/tasks/kb_batch_tasks.py
@@ -42,14 +42,31 @@ def batch_process_files_kb(kb_id: Optional[str] = None):
 
 
 async def batch_process_files_kb_async_with_scope(
-    kb_id: Optional[str] = None
+    kb_id: Optional[str] = None,
+    tenant_id: Optional[str] = None
 ):
-    """Wrapper to run KB batch processing for all tenants"""
+    """
+    Wrapper to run KB batch processing.
+
+    Args:
+        kb_id: Specific KB ID to process.
+        tenant_id: Tenant context for manual sync. If provided with kb_id,
+            processing runs only for that tenant.
+    """
     from app.tasks.base import run_task_with_tenant_support
+    from app.core.tenant_scope import set_tenant_context, clear_tenant_context
+
+    if kb_id and tenant_id:
+        try:
+            set_tenant_context(tenant_id)
+            return await batch_process_files_kb_async(kb_id=kb_id)
+        finally:
+            clear_tenant_context()
+
     return await run_task_with_tenant_support(
         batch_process_files_kb_async,
         "KB batch processing",
-        kb_id=kb_id,
+        kb_id=kb_id
     )
 
 


### PR DESCRIPTION
Bug #1: Multi-tenant execution during KB sync
- Modified agent_knowledge.py endpoint to capture tenant context and pass tenant_id to background tasks
- Updated kb_batch_tasks.py wrapper to conditionally execute for single tenant vs all tenants
- Ensures KB sync runs only for the current tenant instead of all tenants

Bug #2: pgvector delete parameter limit error
- Added delete_vectors_by_metadata abstract method to vector database base class
- Implemented efficient conditional delete in pgvector provider using metadata filters
- Modified vector provider to use metadata-based deletion instead of ID batching
- Prevents PostgreSQL parameter limit errors when deleting large documents
- Added implementations for all vector providers (FAISS, ChromaDB, Qdrant)

Both fixes maintain backward compatibility and don't break existing Celery tasks or cron jobs.