### PR TITLE
fix: prevent event propagation in TranslationDialog submit handler

### DIFF
--- a/frontend/src/views/Settings/components/TranslationDialog.tsx
+++ b/frontend/src/views/Settings/components/TranslationDialog.tsx
@@ -215,6 +215,8 @@ export function TranslationDialog({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    e.stopPropagation();
+
     setError("");
 
     if (!key.trim()) {


### PR DESCRIPTION
## Description
- Added `e.stopPropagation()` to the `handleSubmit` function in the TranslationDialog component to prevent event bubbling during form submission.


<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
