### PR TITLE
fix: Encrypt all password fields

### DIFF
--- a/backend/app/services/datasources.py
+++ b/backend/app/services/datasources.py
@@ -27,6 +27,9 @@ class DataSourceService:
         "refresh_token",
         "password",
         "api_token",
+        "private_key_passphrase",
+        "smb_password",
+        "connectionstring",
     ]
 
     def __init__(self, repository: DataSourcesRepository):

--- a/backend/app/services/llm_providers.py
+++ b/backend/app/services/llm_providers.py
@@ -22,7 +22,11 @@ llm_provider_all_key_builder = make_key_builder("-")
 
 @inject
 class LlmProviderService:
-    encrypted_fields = ["api_key"]
+    encrypted_fields = [
+        "api_key",
+        "aws_access_key_id",
+        "aws_secret_access_key",
+    ]
 
     def __init__(self, repository: LlmProviderRepository):
         self.repository = repository

--- a/frontend/src/views/DataSources/components/DataSourceDialog.tsx
+++ b/frontend/src/views/DataSources/components/DataSourceDialog.tsx
@@ -315,7 +315,12 @@ export function DataSourceDialog({
 
   const isOAuthType = ["gmail", "o365"].includes(sourceType);
   const schema = dataSourceSchemas[sourceType];
-  const hasAdvancedFields = schema?.fields.some((f) => !f.required) ?? false;
+  const hasAdvancedFields =
+    schema?.fields.some((f) => {
+      if (f.required) return false;
+      if (!f.conditional) return true;
+      return connectionData[f.conditional.field] === f.conditional.value;
+    }) ?? false;
   const hasChangedSinceTest =
     testStatus !== null &&
     testedConnectionData !== null &&


### PR DESCRIPTION
## Description

All fields that are of type password in frontend are now encrypted before stored in database.
Extra: refine condition when to show Advanced toggle (fields that have a condition which isn't met should be filtered out).

## Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [X] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release