### PR TITLE
fix: Do not use connection data stored in DB

### DIFF
--- a/backend/app/services/datasources.py
+++ b/backend/app/services/datasources.py
@@ -196,14 +196,14 @@ class DataSourceService:
         if datasource_id:
             # stored_raw = await self.repository.get_by_id(datasource_id)
             # raw_conn = dict((stored_raw.connection_data if stored_raw else None) or {})
-            raw_conn = dict(connection_data or {})
-            decrypted_conn = await self.decrypt_connection_data_fields(dict(raw_conn))
+            # decrypted_conn = await self.decrypt_connection_data_fields(dict(raw_conn))
+            decrypted_conn = await self.decrypt_connection_data_fields(cd)
 
             base = dict(decrypted_conn)
             for k, v in cd.items():
                 if v is None or v == "":
                     continue
-                if k in self.encrypted_fields and v == raw_conn.get(k):
+                if k in self.encrypted_fields and v == cd.get(k):
                     pass  # unchanged encrypted field — keep stored decrypted value
                 else:
                     base[k] = v  # new plaintext value from user

--- a/backend/app/services/llm_providers.py
+++ b/backend/app/services/llm_providers.py
@@ -151,15 +151,16 @@ class LlmProviderService:
         cd = dict(connection_data or {})
 
         if provider_id:
-            stored_raw = await self.repository.get_by_id(provider_id)
-            raw_conn = dict((stored_raw.connection_data if stored_raw else None) or {})
-            decrypted_conn = await self.decrypt_connection_data_fields(dict(raw_conn), provider_id)
+            # stored_raw = await self.repository.get_by_id(provider_id)
+            # raw_conn = dict((stored_raw.connection_data if stored_raw else None) or {})
+            # decrypted_conn = await self.decrypt_connection_data_fields(dict(raw_conn), provider_id)
+            decrypted_conn = await self.decrypt_connection_data_fields(cd)
 
             base = dict(decrypted_conn)
             for k, v in cd.items():
                 if v is None or v == "":
                     continue
-                if k in self.encrypted_fields and v == raw_conn.get(k):
+                if k in self.encrypted_fields and v == cd.get(k):
                     pass  # unchanged encrypted field — keep stored decrypted value
                 else:
                     base[k] = v  # new plaintext value from user


### PR DESCRIPTION
## Description

For both data sources and LLM providers, do not use connection data stored in DB (if it exists) when testing the connection.
Always use the values inputted by the user.

## Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release