### PR TITLE
feat: adjusted frontend, enhanced permission button visibility based on role restrictions

### DIFF
--- a/backend/app/api/v1/routes/permissions.py
+++ b/backend/app/api/v1/routes/permissions.py
@@ -1,17 +1,22 @@
-from fastapi import APIRouter, Depends, Request
 from typing import List
 from uuid import UUID
-from app.core.permissions.constants import Permissions as P
+
+from fastapi import APIRouter, Depends, Request
 from fastapi_injector import Injected
 
 from app.auth.dependencies import auth, permissions
-from app.schemas.filter import BaseFilterModel
-from app.schemas.permission import PermissionRead, PermissionCreate, PermissionUpdate
+from app.core.permissions.constants import Permissions as P
+from app.schemas.permission import (
+    PermissionCreate,
+    PermissionQueryParams,
+    PermissionRead,
+    PermissionUpdate,
+)
 from app.services.permissions import PermissionsService
 
 router = APIRouter()
 
-
+# Query params + filters
 @router.post(
     "",
     response_model=PermissionRead,
@@ -31,12 +36,12 @@ async def create(
     dependencies=[Depends(auth), Depends(permissions(P.Permission.READ))],
 )
 async def get_all(
-    filter: BaseFilterModel = Depends(),
+    query_params: PermissionQueryParams = Depends(),
     service: PermissionsService = Injected(PermissionsService),
 ):
-    filter.limit = 1000 if filter.limit == 20 else filter.limit
+    query_params.filter.limit = 1000 if query_params.filter.limit == 20 else query_params.filter.limit
 
-    return await service.get_all(filter)
+    return await service.get_all(query_params.filter, mode=query_params.mode)
 
 
 @router.get(

--- a/backend/app/api/v1/routes/permissions.py
+++ b/backend/app/api/v1/routes/permissions.py
@@ -6,9 +6,9 @@ from fastapi_injector import Injected
 
 from app.auth.dependencies import auth, permissions
 from app.core.permissions.constants import Permissions as P
+from app.schemas.filter import BaseFilterModel
 from app.schemas.permission import (
     PermissionCreate,
-    PermissionQueryParams,
     PermissionRead,
     PermissionUpdate,
 )
@@ -36,13 +36,11 @@ async def create(
     dependencies=[Depends(auth), Depends(permissions(P.Permission.READ))],
 )
 async def get_all(
-    query_params: PermissionQueryParams = Depends(),
+    filter: BaseFilterModel = Depends(),
     service: PermissionsService = Injected(PermissionsService),
 ):
-    query_params.filter.limit = 1000 if query_params.filter.limit == 20 else query_params.filter.limit
-
-    return await service.get_all(query_params.filter, mode=query_params.mode)
-
+    filter.limit = 1000 if filter.limit == 20 else filter.limit
+    return await service.get_all(filter)
 
 @router.get(
     "/{permission_id}",

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -166,7 +166,7 @@ def socket_auth(required_permissions: list[str]):
             else:
                 raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION, reason="Missing credentials")
 
-            if not set(required_permissions).issubset(set(perms)):
+            if "*" not in perms and not set(required_permissions).issubset(set(perms)):
                 raise WebSocketException(code=4403, reason="Invalid permissions")
 
             return SocketPrincipal(principal, user_id, perms, resolved_tenant_id)

--- a/backend/app/schemas/permission.py
+++ b/backend/app/schemas/permission.py
@@ -1,8 +1,10 @@
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel, Field, ConfigDict
 from uuid import UUID
 
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.filter import BaseFilterModel
 
 
 class PermissionBase(BaseModel):
@@ -41,3 +43,7 @@ class PermissionRead(PermissionBase):
     model_config = ConfigDict(
         from_attributes = True
     )
+
+class PermissionQueryParams(BaseModel):
+    mode: str = Field(..., description="Mode of the permission")
+    filter: BaseFilterModel = Field(..., description="Filter for the permissions")

--- a/backend/app/schemas/permission.py
+++ b/backend/app/schemas/permission.py
@@ -4,8 +4,6 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from app.schemas.filter import BaseFilterModel
-
 
 class PermissionBase(BaseModel):
     """
@@ -43,7 +41,3 @@ class PermissionRead(PermissionBase):
     model_config = ConfigDict(
         from_attributes = True
     )
-
-class PermissionQueryParams(BaseModel):
-    mode: str = Field(..., description="Mode of the permission")
-    filter: BaseFilterModel = Field(..., description="Filter for the permissions")

--- a/backend/app/services/permissions.py
+++ b/backend/app/services/permissions.py
@@ -29,13 +29,10 @@ class PermissionsService:
             raise AppException(error_key=ErrorKey.PERMISSION_NOT_FOUND, status_code=404)
         return model
 
-    async def get_all(self, filter: BaseFilterModel, mode: str) -> list[PermissionModel]:
-        permissions = await self.repository.get_all(filter_obj=filter)
-
-        if mode == "create":
-            # avoid returning the wildcard permission here
-            permissions = [permission for permission in permissions if permission.name != "*"]
-
+    async def get_all(self, filter: BaseFilterModel) -> list[PermissionModel]:
+        permissions = await self.repository.get_all(filter_obj=filter or {})
+        # avoid returning the wildcard permission here
+        permissions = [permission for permission in permissions if permission.name != "*"]
         return permissions
 
     async def delete(self, permission_id: UUID):

--- a/backend/app/services/permissions.py
+++ b/backend/app/services/permissions.py
@@ -1,11 +1,14 @@
 from uuid import UUID
+
 from injector import inject
+
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.db.models import PermissionModel
 from app.repositories.permissions import PermissionsRepository
 from app.schemas.filter import BaseFilterModel
 from app.schemas.permission import PermissionCreate, PermissionUpdate
+
 
 @inject
 class PermissionsService:
@@ -26,9 +29,14 @@ class PermissionsService:
             raise AppException(error_key=ErrorKey.PERMISSION_NOT_FOUND, status_code=404)
         return model
 
-    async def get_all(self, filter: BaseFilterModel) -> list[PermissionModel]:
-        models = await self.repository.get_all(filter_obj=filter)
-        return models
+    async def get_all(self, filter: BaseFilterModel, mode: str) -> list[PermissionModel]:
+        permissions = await self.repository.get_all(filter_obj=filter)
+
+        if mode == "create":
+            # avoid returning the wildcard permission here
+            permissions = [permission for permission in permissions if permission.name != "*"]
+
+        return permissions
 
     async def delete(self, permission_id: UUID):
         model = await self.get_by_id(permission_id)

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1517,6 +1517,15 @@
         ],
         "parameters": [
           {
+            "name": "mode",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Mode"
+            }
+          },
+          {
             "name": "skip",
             "in": "query",
             "required": false,

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1517,15 +1517,6 @@
         ],
         "parameters": [
           {
-            "name": "mode",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Mode"
-            }
-          },
-          {
             "name": "skip",
             "in": "query",
             "required": false,

--- a/frontend/src/components/ActionButtons.tsx
+++ b/frontend/src/components/ActionButtons.tsx
@@ -6,6 +6,8 @@ interface ActionButtonsProps {
   onDelete: () => void;
   editTitle?: string;
   deleteTitle?: string;
+  canEdit?: boolean;
+  canDelete?: boolean;
 }
 
 export function ActionButtons({
@@ -13,15 +15,21 @@ export function ActionButtons({
   onDelete,
   editTitle = "Edit",
   deleteTitle = "Delete",
+  canEdit = true,
+  canDelete = true,
 }: ActionButtonsProps) {
   return (
     <div className="flex flex-wrap gap-2">
-      <Button variant="ghost" size="sm" onClick={onEdit} title={editTitle}>
-        <Pencil className="w-4 h-4 text-black" />
-      </Button>
-      <Button variant="ghost" size="sm" onClick={onDelete} title={deleteTitle}>
-        <Trash2 className="w-4 h-4 text-red-500" />
-      </Button>
+      {canEdit && (
+        <Button variant="ghost" size="sm" onClick={onEdit} title={editTitle}>
+          <Pencil className="w-4 h-4 text-black" />
+        </Button>
+      )}
+      {canDelete && (
+        <Button variant="ghost" size="sm" onClick={onDelete} title={deleteTitle}>
+          <Trash2 className="w-4 h-4 text-red-500" />
+        </Button>
+      )}
     </div>
   );
 }

--- a/frontend/src/services/permission.ts
+++ b/frontend/src/services/permission.ts
@@ -2,10 +2,11 @@ import { apiRequest } from "@/config/api";
 import { Permission } from "@/interfaces/permission.interface";
 import toast from "react-hot-toast";
 
-export const getAllPermissions = async (): Promise<Permission[]> => {
+export const getAllPermissions = async (dialogMode: "create" | "edit"): Promise<Permission[]> => {
   // eslint-disable-next-line no-useless-catch
   try {
-    const data = await apiRequest<Permission[]>("GET", "/permissions/");
+    const mode = dialogMode === "create" ? "create" : "edit";
+    const data = await apiRequest<Permission[]>("GET", "/permissions?mode=" + mode);
     return data || [];
   } catch (error) {
     throw error;

--- a/frontend/src/services/permission.ts
+++ b/frontend/src/services/permission.ts
@@ -5,8 +5,7 @@ import toast from "react-hot-toast";
 export const getAllPermissions = async (dialogMode: "create" | "edit"): Promise<Permission[]> => {
   // eslint-disable-next-line no-useless-catch
   try {
-    const mode = dialogMode === "create" ? "create" : "edit";
-    const data = await apiRequest<Permission[]>("GET", "/permissions?mode=" + mode);
+    const data = await apiRequest<Permission[]>("GET", "/permissions");
     return data || [];
   } catch (error) {
     throw error;

--- a/frontend/src/views/Roles/components/RoleDialog.tsx
+++ b/frontend/src/views/Roles/components/RoleDialog.tsx
@@ -88,7 +88,7 @@ export function RoleDialog({
   const fetchPermissions = async () => {
     setPermissionsLoading(true);
     try {
-      const permissions = await getAllPermissions();
+      const permissions = await getAllPermissions(dialogMode);
       setAllPermissions(permissions);
 
       if (roleToEdit && roleToEdit.id) {

--- a/frontend/src/views/Roles/components/RoleDialog.tsx
+++ b/frontend/src/views/Roles/components/RoleDialog.tsx
@@ -47,7 +47,6 @@ export function RoleDialog({
   const [roleId, setRoleId] = useState<string | undefined>("");
   const [dialogMode, setDialogMode] = useState<"create" | "edit">(mode);
   const [allPermissions, setAllPermissions] = useState<Permission[]>([]);
-  const [rolePermissions, setRolePermissions] = useState<Permission[]>([]);
   const [selectedPermissionIds, setSelectedPermissionIds] = useState<string[]>(
     []
   );
@@ -74,7 +73,6 @@ export function RoleDialog({
       resetForm();
 
       setAllPermissions([]);
-      setRolePermissions([]);
       setSelectedPermissionIds([]);
       setSearchQuery("");
 
@@ -93,12 +91,6 @@ export function RoleDialog({
 
       if (roleToEdit && roleToEdit.id) {
         const rolePermissionIds = await getPermissionsByRoleId(roleToEdit.id);
-
-        const rolePermissionObjects = permissions.filter((permission) =>
-          rolePermissionIds.includes(permission.id)
-        );
-
-        setRolePermissions(rolePermissionObjects);
         setSelectedPermissionIds(rolePermissionIds);
       }
     } catch (error) {
@@ -210,6 +202,13 @@ export function RoleDialog({
               />
             </div>
 
+            {/* Permissions */}
+            {permissionsLoading ? (
+              <div className="flex flex-col gap-4 items-center justify-center p-4">
+                <Loader2 className="w-6 h-6 animate-spin" />
+                <span className="text-sm text-muted-foreground font-medium">Loading permissions...</span>
+              </div>
+            ) : (
             <div className="space-y-4">
               <div className="mb-3">
                 <Label className="mt-2 mb-0.5" htmlFor="permission-search">
@@ -281,8 +280,9 @@ export function RoleDialog({
                           </label>
                         </div>
                       ))}
+                </div>
               </div>
-            </div>
+            )}
 
             <div className="flex items-center gap-2">
               <Label htmlFor="is-active">Active</Label>

--- a/frontend/src/views/Roles/components/RolesCard.tsx
+++ b/frontend/src/views/Roles/components/RolesCard.tsx
@@ -33,6 +33,9 @@ export function RolesCard({
   const [isDeleting, setIsDeleting] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
 
+  // roles that cannot be edited
+  const restrictedRoles = new Set(["admin", "superadmin"]);
+
   useEffect(() => {
     fetchRoles();
   }, [refreshKey]);
@@ -117,6 +120,8 @@ export function RolesCard({
       <TableCell className="truncate">{formatDate(role.updated_at)}</TableCell>
       <TableCell>
         <ActionButtons
+          canEdit={!restrictedRoles.has(role.name)}
+          canDelete={!restrictedRoles.has(role.name)}
           onEdit={() => onEditRole(role)}
           onDelete={() => handleDeleteClick(role)}
           editTitle="Edit Role"

--- a/frontend/src/views/Roles/pages/Roles.tsx
+++ b/frontend/src/views/Roles/pages/Roles.tsx
@@ -26,7 +26,7 @@ export default function Roles() {
     setRoleToEdit(null);
     setIsDialogOpen(true);
   };
-  
+
   const handleEditRole = (role: Role) => {
     setDialogMode('edit');
     setRoleToEdit(role);
@@ -44,7 +44,7 @@ export default function Roles() {
         actionButtonText="Add New Role"
         onActionClick={handleCreateRole}
       />
-      
+
       <RolesCard
         searchQuery={searchQuery}
         refreshKey={refreshKey}
@@ -62,4 +62,4 @@ export default function Roles() {
       />
     </PageLayout>
   );
-} 
+}


### PR DESCRIPTION
## Description

refactor: remove mode parameter from permissions API and streamline query handling
- Eliminated the `mode` parameter from the permissions API to simplify query management.
- Refactored the `get_all` function in the permissions service to directly utilize the filter object without the mode distinction.
- Updated the permissions schema by removing `PermissionQueryParams` and integrating `BaseFilterModel` for cleaner query handling.
- Adjusted frontend components to reflect the removal of the mode parameter in API requests and enhanced permission button visibility based on role restrictions.

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release



---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
