### PR TITLE
feat: add has_welcome_image property and enhance AgentForm functionality

### DIFF
--- a/backend/app/cache/redis_cache.py
+++ b/backend/app/cache/redis_cache.py
@@ -168,6 +168,9 @@ async def invalidate_agent_cache(agent_id: UUID, user_id: UUID):
     await invalidate_cache("agents:get_by_id_full", agent_id)
     await invalidate_cache("agents:get_by_user_id", user_id)
 
+async def invalidate_only_agent_cache(agent_id: UUID):
+    await invalidate_cache("agents:get_by_id_full", agent_id)
+
 async def clear_conversation_memory_cache(conversation_id: UUID) -> None:
     """
     Delete the Redis keys written by RedisConversationMemory for a conversation.

--- a/backend/app/services/agent_config.py
+++ b/backend/app/services/agent_config.py
@@ -323,12 +323,15 @@ class AgentConfigService:
         self, agent_id: UUID, image_data: bytes
     ) -> AgentModel:
         """Upload welcome image for an agent"""
-        agent = await self.repository.get_by_id(agent_id)
+        agent = await self.repository.get_by_id_full(agent_id)
         if not agent:
             raise AppException(ErrorKey.AGENT_NOT_FOUND, status_code=404)
 
+        user_id = agent.operator.user.id
         agent.welcome_image = image_data
-        return await self.repository.update(agent)
+        updated = await self.repository.update(agent)
+        await invalidate_agent_cache(agent_id, user_id)
+        return updated
 
     async def get_welcome_image(self, agent_id: UUID) -> Optional[bytes]:
         """Get welcome image for an agent"""
@@ -339,12 +342,15 @@ class AgentConfigService:
 
     async def delete_welcome_image(self, agent_id: UUID) -> AgentModel:
         """Delete welcome image for an agent"""
-        agent = await self.repository.get_by_id(agent_id)
+        agent = await self.repository.get_by_id_full(agent_id)
         if not agent:
             raise AppException(ErrorKey.AGENT_NOT_FOUND, status_code=404)
 
+        user_id = agent.operator.user.id
         agent.welcome_image = None
-        return await self.repository.update(agent)
+        updated = await self.repository.update(agent)
+        await invalidate_agent_cache(agent_id, user_id)
+        return updated
 
     async def get_by_operator_id(self, operator_id: UUID) -> AgentModel:
         """Get agent by operator ID with security_settings eagerly loaded."""

--- a/backend/app/services/agent_config.py
+++ b/backend/app/services/agent_config.py
@@ -6,26 +6,25 @@ from fastapi_cache.coder import PickleCoder
 from fastapi_cache.decorator import cache
 from injector import inject
 from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.auth.utils import generate_password
-from app.cache.redis_cache import invalidate_agent_cache, make_key_builder
+from app.cache.redis_cache import invalidate_agent_cache, invalidate_only_agent_cache, make_key_builder
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
-from app.db.models import AgentModel
+from app.db.models import AgentModel, AgentSecuritySettingsModel
 from app.db.utils.sql_alchemy_utils import null_unloaded_attributes
 from app.repositories.agent import AgentRepository
 from app.repositories.user_types import UserTypesRepository
 from app.schemas.agent import AgentCreate, AgentListItem, AgentRead, AgentUpdate
-from app.schemas.common import PaginatedResponse
-from app.schemas.filter import BaseFilterModel
 from app.schemas.agent_security_settings import (
     AgentSecuritySettingsCreate,
     AgentSecuritySettingsUpdate,
 )
-from app.db.models import AgentSecuritySettingsModel
+from app.schemas.common import PaginatedResponse
+from app.schemas.filter import BaseFilterModel
 from app.schemas.workflow import WorkflowUpdate, get_base_workflow
 from app.services.operators import OperatorService
 from app.services.workflow import WorkflowService
-
 
 logger = logging.getLogger(__name__)
 
@@ -323,14 +322,13 @@ class AgentConfigService:
         self, agent_id: UUID, image_data: bytes
     ) -> AgentModel:
         """Upload welcome image for an agent"""
-        agent = await self.repository.get_by_id_full(agent_id)
+        agent = await self.repository.get_by_id(agent_id)
         if not agent:
             raise AppException(ErrorKey.AGENT_NOT_FOUND, status_code=404)
 
-        user_id = agent.operator.user.id
         agent.welcome_image = image_data
         updated = await self.repository.update(agent)
-        await invalidate_agent_cache(agent_id, user_id)
+        await invalidate_only_agent_cache(agent_id)
         return updated
 
     async def get_welcome_image(self, agent_id: UUID) -> Optional[bytes]:
@@ -342,14 +340,13 @@ class AgentConfigService:
 
     async def delete_welcome_image(self, agent_id: UUID) -> AgentModel:
         """Delete welcome image for an agent"""
-        agent = await self.repository.get_by_id_full(agent_id)
+        agent = await self.repository.get_by_id(agent_id)
         if not agent:
             raise AppException(ErrorKey.AGENT_NOT_FOUND, status_code=404)
 
-        user_id = agent.operator.user.id
         agent.welcome_image = None
         updated = await self.repository.update(agent)
-        await invalidate_agent_cache(agent_id, user_id)
+        await invalidate_only_agent_cache(agent_id)
         return updated
 
     async def get_by_operator_id(self, operator_id: UUID) -> AgentModel:

--- a/frontend/src/interfaces/ai-agent.interface.ts
+++ b/frontend/src/interfaces/ai-agent.interface.ts
@@ -51,6 +51,7 @@ export interface AgentConfig {
   user_id: string;
   llm_analyst_id?: string | null;
   security_settings?: AgentSecuritySettings | null;
+  has_welcome_image?: boolean;
   [key: string]: unknown;
 }
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -169,11 +169,16 @@ export async function uploadWelcomeImage(
 
 export async function getWelcomeImage(agentId: string): Promise<Blob> {
   const baseURL = await getApiUrl();
-  const fullUrl = `${baseURL}genagent/agents/configs/${agentId}/welcome-image`;
+  // Bust caches so a replaced image is not shown as the previous blob.
+  const fullUrl = `${baseURL}genagent/agents/configs/${agentId}/welcome-image?_=${Date.now()}`;
 
   try {
     const response = await api.get(fullUrl, {
       responseType: "blob",
+      headers: {
+        "Cache-Control": "no-cache",
+        Pragma: "no-cache",
+      },
     });
     return response.data;
   } catch (error: unknown) {

--- a/frontend/src/views/AIAgents/components/AgentForm.tsx
+++ b/frontend/src/views/AIAgents/components/AgentForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { toast } from "react-hot-toast";
 import {
@@ -38,11 +38,10 @@ import {
 import { Textarea } from "@/components/textarea";
 import { TranslationDialog } from "@/views/Settings/components/TranslationDialog";
 import { DisclaimerEditor } from "@/components/DisclaimerEditor";
-import { getTranslationByKey } from "@/services/translations";
+import { getTranslationByKey, getLanguages } from "@/services/translations";
+import { Language, Translation } from "@/interfaces/translation.interface";
 import { getTranslationCount } from "../utils";
 import { Toggle } from "@/components/toggle";
-
-type RequiredFieldId = "name" | "description" | "welcome_message";
 
 interface AgentFormData {
   id?: string;
@@ -60,14 +59,8 @@ interface AgentFormData {
   llm_analyst_id?: string | null;
 }
 
-/** Input placeholders only; new "+ Add" rows start empty until the user types. */
-const PLACEHOLDER_POSSIBLE_QUERY = "Enter a sample query";
-const PLACEHOLDER_THINKING_PHRASE = "I think...|Getting the data...";
-
-function nonEmptyTrimmedStrings(items: string[] | undefined): string[] {
-  return (items ?? [])
-    .map((s) => s.trim())
-    .filter((s) => s !== "");
+function omitEmptyStrings(items: string[] | undefined): string[] {
+  return (items ?? []).map((s) => s.trim()).filter((s) => s !== "");
 }
 
 interface AgentFormProps {
@@ -88,14 +81,17 @@ interface AgentFormProps {
 interface TranslationTriggerProps {
   translationKey: string;
   currentValue: string;
-  /** Sync the agent field to the translation row marked as default after save. */
-  onApplySavedDefault?: (value: string) => void;
+  /** Shared list from the form so each dialog does not call getLanguages. */
+  languages: Language[];
+  /** Sync parent field to the saved translation default. */
+  onTranslationDefaultSaved?: (defaultText: string) => void;
 }
 
 const TranslationTrigger: React.FC<TranslationTriggerProps> = ({
   translationKey,
   currentValue,
-  onApplySavedDefault,
+  languages,
+  onTranslationDefaultSaved,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [refreshCounter, setRefreshCounter] = useState(0);
@@ -128,11 +124,9 @@ const TranslationTrigger: React.FC<TranslationTriggerProps> = ({
     setIsOpen(true);
   };
 
-  const handleTranslationSaved = (savedDefault?: string | null) => {
+  const handleSaved = (translation: Translation) => {
     setRefreshCounter((prev) => prev + 1);
-    if (onApplySavedDefault && savedDefault != null) {
-      onApplySavedDefault(savedDefault);
-    }
+    onTranslationDefaultSaved?.(translation.default ?? "");
   };
 
   const hasTranslations = translationCount > 0;
@@ -169,7 +163,8 @@ const TranslationTrigger: React.FC<TranslationTriggerProps> = ({
         translationToEdit={null}
         initialKey={translationKey}
         initialDefaultValue={currentValue}
-        onTranslationSaved={handleTranslationSaved}
+        onTranslationSaved={handleSaved}
+        languages={languages}
       />
     </>
   );
@@ -212,12 +207,20 @@ const AgentForm: React.FC<AgentFormProps> = ({
   });
 
   const [llmAnalysts, setLlmAnalysts] = useState<LLMAnalyst[]>([]);
+  const [editFormLanguages, setEditFormLanguages] = useState<Language[]>([]);
 
   useEffect(() => {
     getAllLLMAnalysts()
       .then(setLlmAnalysts)
       .catch(() => {});
   }, []);
+
+  useEffect(() => {
+    if (!isEditMode || !id) return;
+    getLanguages()
+      .then(setEditFormLanguages)
+      .catch(() => toast.error("Failed to load languages."));
+  }, [isEditMode, id]);
 
   const [loading, setLoading] = useState<boolean>(false);
   const [success, setSuccess] = useState<boolean>(false);
@@ -227,40 +230,40 @@ const AgentForm: React.FC<AgentFormProps> = ({
   const [imageDeleting, setImageDeleting] = useState<boolean>(false);
   const [isDragOver, setIsDragOver] = useState<boolean>(false);
   const [showAdvanced, setShowAdvanced] = useState<boolean>(data?.llm_analyst_id ? true : false);
-  const [fieldErrors, setFieldErrors] = useState<
-    Partial<Record<RequiredFieldId, boolean>>
-  >({});
 
-  const clearFieldError = (field: RequiredFieldId) => {
-    setFieldErrors((prev) => {
-      if (!prev[field]) return prev;
-      const next = { ...prev };
-      delete next[field];
-      return next;
-    });
-  };
-
-  const invalidFieldClass =
-    "border-destructive focus-visible:ring-destructive aria-invalid:border-destructive";
+  /** Avoids a slow GET welcome-image finishing after the user picked a replacement and overwriting preview/state. */
+  const imageFileRef = useRef<File | null>(null);
+  useEffect(() => {
+    imageFileRef.current = imageFile;
+  }, [imageFile]);
 
   // Load existing image when editing (only if agent has one)
-  React.useEffect(() => {
+  useEffect(() => {
     let objectUrl: string | null = null;
+    let cancelled = false;
 
     const loadExistingImage = async () => {
-      // Only fetch if agent has a welcome image
-      if (isEditMode && id && data?.has_welcome_image) {
-        try {
-          const imageBlob = await getWelcomeImage(id);
-          objectUrl = URL.createObjectURL(imageBlob);
-          setImagePreview(objectUrl);
-        } catch (error) {
-          // Image failed to load
+      if (!(isEditMode && id && data?.has_welcome_image)) return;
+      try {
+        const imageBlob = await getWelcomeImage(id);
+        if (cancelled) return;
+        const newUrl = URL.createObjectURL(imageBlob);
+        if (cancelled) {
+          URL.revokeObjectURL(newUrl);
+          return;
         }
+        if (imageFileRef.current) {
+          URL.revokeObjectURL(newUrl);
+          return;
+        }
+        objectUrl = newUrl;
+        setImagePreview(newUrl);
+      } catch (error) {
+        // Image failed to load
       }
     };
 
-    loadExistingImage();
+    void loadExistingImage();
 
     // load advanced settings
     if (isEditMode && !!formData.llm_analyst_id) {
@@ -268,6 +271,7 @@ const AgentForm: React.FC<AgentFormProps> = ({
     }
 
     return () => {
+      cancelled = true;
       if (objectUrl) {
         URL.revokeObjectURL(objectUrl);
       }
@@ -278,13 +282,6 @@ const AgentForm: React.FC<AgentFormProps> = ({
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
     const { name, value } = e.target;
-    if (
-      name === "name" ||
-      name === "description" ||
-      name === "welcome_message"
-    ) {
-      clearFieldError(name);
-    }
     setFormData((prev) => ({
       ...prev,
       [name]: name === "thinking_phrase_delay" ? Number(value) || 0 : value,
@@ -354,6 +351,7 @@ const AgentForm: React.FC<AgentFormProps> = ({
     if (file) {
       processFile(file);
     }
+    e.target.value = "";
   };
 
   const handleRemoveImage = async () => {
@@ -421,72 +419,55 @@ const AgentForm: React.FC<AgentFormProps> = ({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    const requiredChecks: {
-      id: RequiredFieldId;
-      label: string;
-      isEmpty: boolean;
-    }[] = [
-      {
-        id: "name",
-        label: "Name",
-        isEmpty: !String(formData.name ?? "").trim(),
-      },
-      {
-        id: "description",
-        label: "Description",
-        isEmpty: !String(formData.description ?? "").trim(),
-      },
-      {
-        id: "welcome_message",
-        label: "Welcome Message",
-        isEmpty: !String(formData.welcome_message ?? "").trim(),
-      },
+    const requiredFields = [
+      { label: "Name", isEmpty: !formData.name },
+      { label: "Description", isEmpty: !formData.description },
+      { label: "Welcome Message", isEmpty: !formData.welcome_message },
     ];
 
-    const missing = requiredChecks.filter((f) => f.isEmpty);
-    if (missing.length > 0) {
-      const nextErrors: Partial<Record<RequiredFieldId, boolean>> = {};
-      for (const f of missing) nextErrors[f.id] = true;
-      setFieldErrors(nextErrors);
+    const missingFields = requiredFields
+      .filter((field) => field.isEmpty)
+      .map((field) => field.label);
 
-      const missingLabels = missing.map((f) => f.label);
-      if (missingLabels.length === 1) {
-        toast.error(`${missingLabels[0]} is required.`);
+    if (missingFields.length > 0) {
+      if (missingFields.length === 1) {
+        toast.error(`${missingFields[0]} is required.`);
       } else {
-        toast.error(`Please fill in: ${missingLabels.join(", ")}.`);
+        toast.error(`Please provide: ${missingFields.join(", ")}.`);
       }
-
-      requestAnimationFrame(() => {
-        const first = missing[0]?.id;
-        if (first) document.getElementById(first)?.focus();
-      });
       return;
     }
-
-    setFieldErrors({});
 
     try {
       setLoading(true);
       let agentId: string;
 
       if (isEditMode) {
+        if (imageFile) {
+          setImageLoading(true);
+          try {
+            await uploadWelcomeImage(id, imageFile);
+            toast.success("Welcome image uploaded successfully.");
+          } catch (error) {
+            toast.error("Failed to upload welcome image.");
+          } finally {
+            setImageLoading(false);
+          }
+        }
         const { id: _, ...rest } = formData;
         const dataToSubmit = {
           ...rest,
-          possible_queries: nonEmptyTrimmedStrings(rest.possible_queries),
-          thinking_phrases: nonEmptyTrimmedStrings(rest.thinking_phrases),
+          possible_queries: omitEmptyStrings(rest.possible_queries),
+          thinking_phrases: omitEmptyStrings(rest.thinking_phrases),
         };
         await updateAgentConfig(id, dataToSubmit);
         agentId = id;
-        setSuccess(true);
-        onSaved?.();
-        onClose?.();
       } else {
         const { id: _, ...rest } = formData;
         const dataToSubmit = {
           ...rest,
-          possible_queries: nonEmptyTrimmedStrings(rest.possible_queries),
-          thinking_phrases: nonEmptyTrimmedStrings(rest.thinking_phrases),
+          possible_queries: omitEmptyStrings(rest.possible_queries),
+          thinking_phrases: omitEmptyStrings(rest.thinking_phrases),
         };
         const agentConfig = await createAgentConfig({
           ...dataToSubmit,
@@ -495,19 +476,10 @@ const AgentForm: React.FC<AgentFormProps> = ({
 
         // Notify parent about the newly created agent
         onCreated?.(agentId);
-
-        if (redirectOnCreate) {
-          navigate(`/ai-agents/workflow/${agentConfig.id}`);
-        } else {
-          // When redirect is disabled, mark success and let the parent handle next steps.
-          setSuccess(true);
-          onSaved?.();
-          onClose?.();
-        }
       }
 
-      // Upload image if provided
-      if (imageFile && agentId) {
+      // Create flow: upload after we have an id. Edit flow uploads above before PUT.
+      if (!isEditMode && imageFile && agentId) {
         setImageLoading(true);
         try {
           await uploadWelcomeImage(agentId, imageFile);
@@ -517,6 +489,14 @@ const AgentForm: React.FC<AgentFormProps> = ({
         } finally {
           setImageLoading(false);
         }
+      }
+
+      if (!isEditMode && redirectOnCreate) {
+        navigate(`/ai-agents/workflow/${agentId}`);
+      } else {
+        setSuccess(true);
+        onSaved?.();
+        onClose?.();
       }
 
       toast.success(
@@ -563,8 +543,6 @@ const AgentForm: React.FC<AgentFormProps> = ({
                   value={formData.name}
                   onChange={handleInputChange}
                   placeholder="Enter agent name"
-                  aria-invalid={fieldErrors.name ? true : undefined}
-                  className={fieldErrors.name ? invalidFieldClass : undefined}
                 />
               </div>
 
@@ -576,10 +554,6 @@ const AgentForm: React.FC<AgentFormProps> = ({
                   value={formData.description}
                   onChange={handleInputChange}
                   placeholder="Enter agent description"
-                  aria-invalid={fieldErrors.description ? true : undefined}
-                  className={
-                    fieldErrors.description ? invalidFieldClass : undefined
-                  }
                 />
               </div>
 
@@ -782,11 +756,9 @@ const AgentForm: React.FC<AgentFormProps> = ({
                     <TranslationTrigger
                       translationKey={`agent.${id}.welcome_title`}
                       currentValue={formData.welcome_title || ""}
-                      onApplySavedDefault={(value) =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          welcome_title: value,
-                        }))
+                      languages={editFormLanguages}
+                      onTranslationDefaultSaved={(text) =>
+                        setFormData((prev) => ({ ...prev, welcome_title: text }))
                       }
                     />
                   )}
@@ -806,10 +778,11 @@ const AgentForm: React.FC<AgentFormProps> = ({
                     <TranslationTrigger
                       translationKey={`agent.${id}.welcome_message`}
                       currentValue={formData.welcome_message || ""}
-                      onApplySavedDefault={(value) =>
+                      languages={editFormLanguages}
+                      onTranslationDefaultSaved={(text) =>
                         setFormData((prev) => ({
                           ...prev,
-                          welcome_message: value,
+                          welcome_message: text,
                         }))
                       }
                     />
@@ -821,10 +794,6 @@ const AgentForm: React.FC<AgentFormProps> = ({
                   value={formData.welcome_message}
                   onChange={handleInputChange}
                   placeholder="Enter welcome message"
-                  aria-invalid={fieldErrors.welcome_message ? true : undefined}
-                  className={
-                    fieldErrors.welcome_message ? invalidFieldClass : undefined
-                  }
                 />
               </div>
               <div className="border border-border rounded-lg overflow-hidden">
@@ -863,15 +832,16 @@ const AgentForm: React.FC<AgentFormProps> = ({
                           onChange={(e) =>
                             handlePossibleQueryChange(index, e.target.value)
                           }
-                          placeholder={PLACEHOLDER_POSSIBLE_QUERY}
+                          placeholder="Enter a sample query"
                           className="flex-1 placeholder:text-muted-foreground"
                         />
                         {isEditMode && (
                           <TranslationTrigger
                             translationKey={`agent.${id}.possible_queries.${index}`}
                             currentValue={query}
-                            onApplySavedDefault={(value) =>
-                              handlePossibleQueryChange(index, value)
+                            languages={editFormLanguages}
+                            onTranslationDefaultSaved={(text) =>
+                              handlePossibleQueryChange(index, text)
                             }
                           />
                         )}
@@ -936,15 +906,16 @@ const AgentForm: React.FC<AgentFormProps> = ({
                           onChange={(e) =>
                             handleThinkingPhraseChange(index, e.target.value)
                           }
-                          placeholder={PLACEHOLDER_THINKING_PHRASE}
+                          placeholder='e.g. Thinking...|Processing...'
                           className="flex-1 placeholder:text-muted-foreground"
                         />
                         {isEditMode && (
                           <TranslationTrigger
                             translationKey={`agent.${id}.thinking_phrases.${index}`}
                             currentValue={phrase}
-                            onApplySavedDefault={(value) =>
-                              handleThinkingPhraseChange(index, value)
+                            languages={editFormLanguages}
+                            onTranslationDefaultSaved={(text) =>
+                              handleThinkingPhraseChange(index, text)
                             }
                           />
                         )}
@@ -994,10 +965,11 @@ const AgentForm: React.FC<AgentFormProps> = ({
                     <TranslationTrigger
                       translationKey={`agent.${id}.input_disclaimer_html`}
                       currentValue={formData.input_disclaimer_html || ""}
-                      onApplySavedDefault={(value) =>
+                      languages={editFormLanguages}
+                      onTranslationDefaultSaved={(text) =>
                         setFormData((prev) => ({
                           ...prev,
-                          input_disclaimer_html: value,
+                          input_disclaimer_html: text,
                         }))
                       }
                     />

--- a/frontend/src/views/AIAgents/components/AgentForm.tsx
+++ b/frontend/src/views/AIAgents/components/AgentForm.tsx
@@ -42,6 +42,8 @@ import { getTranslationByKey } from "@/services/translations";
 import { getTranslationCount } from "../utils";
 import { Toggle } from "@/components/toggle";
 
+type RequiredFieldId = "name" | "description" | "welcome_message";
+
 interface AgentFormData {
   id?: string;
   name: string;
@@ -58,17 +60,14 @@ interface AgentFormData {
   llm_analyst_id?: string | null;
 }
 
-/** Matches list Input placeholders; new "+ Add" rows start with this until the user edits. */
-const DEFAULT_NEW_POSSIBLE_QUERY = "Enter a sample query";
-const DEFAULT_NEW_THINKING_PHRASE = "I think...|Getting the data...";
+/** Input placeholders only; new "+ Add" rows start empty until the user types. */
+const PLACEHOLDER_POSSIBLE_QUERY = "Enter a sample query";
+const PLACEHOLDER_THINKING_PHRASE = "I think...|Getting the data...";
 
-function omitUneditedTemplateRows(
-  items: string[] | undefined,
-  template: string,
-): string[] {
+function nonEmptyTrimmedStrings(items: string[] | undefined): string[] {
   return (items ?? [])
     .map((s) => s.trim())
-    .filter((s) => s !== "" && s !== template);
+    .filter((s) => s !== "");
 }
 
 interface AgentFormProps {
@@ -89,11 +88,14 @@ interface AgentFormProps {
 interface TranslationTriggerProps {
   translationKey: string;
   currentValue: string;
+  /** Sync the agent field to the translation row marked as default after save. */
+  onApplySavedDefault?: (value: string) => void;
 }
 
 const TranslationTrigger: React.FC<TranslationTriggerProps> = ({
   translationKey,
   currentValue,
+  onApplySavedDefault,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [refreshCounter, setRefreshCounter] = useState(0);
@@ -126,9 +128,11 @@ const TranslationTrigger: React.FC<TranslationTriggerProps> = ({
     setIsOpen(true);
   };
 
-  const handleSaved = () => {
-    // trigger any external refresh logic in future if needed
+  const handleTranslationSaved = (savedDefault?: string | null) => {
     setRefreshCounter((prev) => prev + 1);
+    if (onApplySavedDefault && savedDefault != null) {
+      onApplySavedDefault(savedDefault);
+    }
   };
 
   const hasTranslations = translationCount > 0;
@@ -165,7 +169,7 @@ const TranslationTrigger: React.FC<TranslationTriggerProps> = ({
         translationToEdit={null}
         initialKey={translationKey}
         initialDefaultValue={currentValue}
-        onTranslationSaved={handleSaved}
+        onTranslationSaved={handleTranslationSaved}
       />
     </>
   );
@@ -223,6 +227,21 @@ const AgentForm: React.FC<AgentFormProps> = ({
   const [imageDeleting, setImageDeleting] = useState<boolean>(false);
   const [isDragOver, setIsDragOver] = useState<boolean>(false);
   const [showAdvanced, setShowAdvanced] = useState<boolean>(data?.llm_analyst_id ? true : false);
+  const [fieldErrors, setFieldErrors] = useState<
+    Partial<Record<RequiredFieldId, boolean>>
+  >({});
+
+  const clearFieldError = (field: RequiredFieldId) => {
+    setFieldErrors((prev) => {
+      if (!prev[field]) return prev;
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
+  };
+
+  const invalidFieldClass =
+    "border-destructive focus-visible:ring-destructive aria-invalid:border-destructive";
 
   // Load existing image when editing (only if agent has one)
   React.useEffect(() => {
@@ -259,6 +278,13 @@ const AgentForm: React.FC<AgentFormProps> = ({
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
     const { name, value } = e.target;
+    if (
+      name === "name" ||
+      name === "description" ||
+      name === "welcome_message"
+    ) {
+      clearFieldError(name);
+    }
     setFormData((prev) => ({
       ...prev,
       [name]: name === "thinking_phrase_delay" ? Number(value) || 0 : value,
@@ -279,10 +305,7 @@ const AgentForm: React.FC<AgentFormProps> = ({
   const addPossibleQuery = () => {
     setFormData((prev) => ({
       ...prev,
-      possible_queries: [
-        ...prev.possible_queries,
-        DEFAULT_NEW_POSSIBLE_QUERY,
-      ],
+      possible_queries: [...prev.possible_queries, ""],
     }));
   };
 
@@ -311,10 +334,7 @@ const AgentForm: React.FC<AgentFormProps> = ({
   const addThinkingPhrase = () => {
     setFormData((prev) => ({
       ...prev,
-      thinking_phrases: [
-        ...prev.thinking_phrases,
-        DEFAULT_NEW_THINKING_PHRASE,
-      ],
+      thinking_phrases: [...prev.thinking_phrases, ""],
     }));
   };
 
@@ -401,24 +421,49 @@ const AgentForm: React.FC<AgentFormProps> = ({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    const requiredFields = [
-      { label: "Name", isEmpty: !formData.name },
-      { label: "Description", isEmpty: !formData.description },
-      { label: "Welcome Message", isEmpty: !formData.welcome_message },
+    const requiredChecks: {
+      id: RequiredFieldId;
+      label: string;
+      isEmpty: boolean;
+    }[] = [
+      {
+        id: "name",
+        label: "Name",
+        isEmpty: !String(formData.name ?? "").trim(),
+      },
+      {
+        id: "description",
+        label: "Description",
+        isEmpty: !String(formData.description ?? "").trim(),
+      },
+      {
+        id: "welcome_message",
+        label: "Welcome Message",
+        isEmpty: !String(formData.welcome_message ?? "").trim(),
+      },
     ];
 
-    const missingFields = requiredFields
-      .filter((field) => field.isEmpty)
-      .map((field) => field.label);
+    const missing = requiredChecks.filter((f) => f.isEmpty);
+    if (missing.length > 0) {
+      const nextErrors: Partial<Record<RequiredFieldId, boolean>> = {};
+      for (const f of missing) nextErrors[f.id] = true;
+      setFieldErrors(nextErrors);
 
-    if (missingFields.length > 0) {
-      if (missingFields.length === 1) {
-        toast.error(`${missingFields[0]} is required.`);
+      const missingLabels = missing.map((f) => f.label);
+      if (missingLabels.length === 1) {
+        toast.error(`${missingLabels[0]} is required.`);
       } else {
-        toast.error(`Please provide: ${missingFields.join(", ")}.`);
+        toast.error(`Please fill in: ${missingLabels.join(", ")}.`);
       }
+
+      requestAnimationFrame(() => {
+        const first = missing[0]?.id;
+        if (first) document.getElementById(first)?.focus();
+      });
       return;
     }
+
+    setFieldErrors({});
 
     try {
       setLoading(true);
@@ -428,14 +473,8 @@ const AgentForm: React.FC<AgentFormProps> = ({
         const { id: _, ...rest } = formData;
         const dataToSubmit = {
           ...rest,
-          possible_queries: omitUneditedTemplateRows(
-            rest.possible_queries,
-            DEFAULT_NEW_POSSIBLE_QUERY,
-          ),
-          thinking_phrases: omitUneditedTemplateRows(
-            rest.thinking_phrases,
-            DEFAULT_NEW_THINKING_PHRASE,
-          ),
+          possible_queries: nonEmptyTrimmedStrings(rest.possible_queries),
+          thinking_phrases: nonEmptyTrimmedStrings(rest.thinking_phrases),
         };
         await updateAgentConfig(id, dataToSubmit);
         agentId = id;
@@ -446,14 +485,8 @@ const AgentForm: React.FC<AgentFormProps> = ({
         const { id: _, ...rest } = formData;
         const dataToSubmit = {
           ...rest,
-          possible_queries: omitUneditedTemplateRows(
-            rest.possible_queries,
-            DEFAULT_NEW_POSSIBLE_QUERY,
-          ),
-          thinking_phrases: omitUneditedTemplateRows(
-            rest.thinking_phrases,
-            DEFAULT_NEW_THINKING_PHRASE,
-          ),
+          possible_queries: nonEmptyTrimmedStrings(rest.possible_queries),
+          thinking_phrases: nonEmptyTrimmedStrings(rest.thinking_phrases),
         };
         const agentConfig = await createAgentConfig({
           ...dataToSubmit,
@@ -530,6 +563,8 @@ const AgentForm: React.FC<AgentFormProps> = ({
                   value={formData.name}
                   onChange={handleInputChange}
                   placeholder="Enter agent name"
+                  aria-invalid={fieldErrors.name ? true : undefined}
+                  className={fieldErrors.name ? invalidFieldClass : undefined}
                 />
               </div>
 
@@ -541,6 +576,10 @@ const AgentForm: React.FC<AgentFormProps> = ({
                   value={formData.description}
                   onChange={handleInputChange}
                   placeholder="Enter agent description"
+                  aria-invalid={fieldErrors.description ? true : undefined}
+                  className={
+                    fieldErrors.description ? invalidFieldClass : undefined
+                  }
                 />
               </div>
 
@@ -743,6 +782,12 @@ const AgentForm: React.FC<AgentFormProps> = ({
                     <TranslationTrigger
                       translationKey={`agent.${id}.welcome_title`}
                       currentValue={formData.welcome_title || ""}
+                      onApplySavedDefault={(value) =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          welcome_title: value,
+                        }))
+                      }
                     />
                   )}
                 </div>
@@ -761,6 +806,12 @@ const AgentForm: React.FC<AgentFormProps> = ({
                     <TranslationTrigger
                       translationKey={`agent.${id}.welcome_message`}
                       currentValue={formData.welcome_message || ""}
+                      onApplySavedDefault={(value) =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          welcome_message: value,
+                        }))
+                      }
                     />
                   )}
                 </div>
@@ -770,6 +821,10 @@ const AgentForm: React.FC<AgentFormProps> = ({
                   value={formData.welcome_message}
                   onChange={handleInputChange}
                   placeholder="Enter welcome message"
+                  aria-invalid={fieldErrors.welcome_message ? true : undefined}
+                  className={
+                    fieldErrors.welcome_message ? invalidFieldClass : undefined
+                  }
                 />
               </div>
               <div className="border border-border rounded-lg overflow-hidden">
@@ -808,13 +863,16 @@ const AgentForm: React.FC<AgentFormProps> = ({
                           onChange={(e) =>
                             handlePossibleQueryChange(index, e.target.value)
                           }
-                          placeholder={DEFAULT_NEW_POSSIBLE_QUERY}
-                          className={"flex-1 placeholder:text-muted-foreground" + (isEditMode && query === DEFAULT_NEW_POSSIBLE_QUERY ? " text-muted-foreground italic" : "")}
+                          placeholder={PLACEHOLDER_POSSIBLE_QUERY}
+                          className="flex-1 placeholder:text-muted-foreground"
                         />
                         {isEditMode && (
                           <TranslationTrigger
                             translationKey={`agent.${id}.possible_queries.${index}`}
                             currentValue={query}
+                            onApplySavedDefault={(value) =>
+                              handlePossibleQueryChange(index, value)
+                            }
                           />
                         )}
                         <Button
@@ -878,13 +936,16 @@ const AgentForm: React.FC<AgentFormProps> = ({
                           onChange={(e) =>
                             handleThinkingPhraseChange(index, e.target.value)
                           }
-                          placeholder={DEFAULT_NEW_THINKING_PHRASE}
-                          className={"flex-1 placeholder:text-muted-foreground" + (isEditMode && phrase === DEFAULT_NEW_THINKING_PHRASE ? " text-muted-foreground italic" : "")}
+                          placeholder={PLACEHOLDER_THINKING_PHRASE}
+                          className="flex-1 placeholder:text-muted-foreground"
                         />
                         {isEditMode && (
                           <TranslationTrigger
                             translationKey={`agent.${id}.thinking_phrases.${index}`}
                             currentValue={phrase}
+                            onApplySavedDefault={(value) =>
+                              handleThinkingPhraseChange(index, value)
+                            }
                           />
                         )}
                         <Button
@@ -933,6 +994,12 @@ const AgentForm: React.FC<AgentFormProps> = ({
                     <TranslationTrigger
                       translationKey={`agent.${id}.input_disclaimer_html`}
                       currentValue={formData.input_disclaimer_html || ""}
+                      onApplySavedDefault={(value) =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          input_disclaimer_html: value,
+                        }))
+                      }
                     />
                   )}
                 </div>

--- a/frontend/src/views/AIAgents/components/AgentForm.tsx
+++ b/frontend/src/views/AIAgents/components/AgentForm.tsx
@@ -58,6 +58,19 @@ interface AgentFormData {
   llm_analyst_id?: string | null;
 }
 
+/** Matches list Input placeholders; new "+ Add" rows start with this until the user edits. */
+const DEFAULT_NEW_POSSIBLE_QUERY = "Enter a sample query";
+const DEFAULT_NEW_THINKING_PHRASE = "I think...|Getting the data...";
+
+function omitUneditedTemplateRows(
+  items: string[] | undefined,
+  template: string,
+): string[] {
+  return (items ?? [])
+    .map((s) => s.trim())
+    .filter((s) => s !== "" && s !== template);
+}
+
 interface AgentFormProps {
   data?: AgentFormData;
   plain?: boolean;
@@ -186,6 +199,8 @@ const AgentForm: React.FC<AgentFormProps> = ({
       thinking_phrase_delay: 0,
       possible_queries: [],
       thinking_phrases: [],
+      has_welcome_image: data?.has_welcome_image || false,
+      llm_analyst_id: null,
     }),
     possible_queries: cleanedQueries.length > 0 ? cleanedQueries : [],
     thinking_phrases:
@@ -207,7 +222,7 @@ const AgentForm: React.FC<AgentFormProps> = ({
   const [imageLoading, setImageLoading] = useState<boolean>(false);
   const [imageDeleting, setImageDeleting] = useState<boolean>(false);
   const [isDragOver, setIsDragOver] = useState<boolean>(false);
-  const [showAdvanced, setShowAdvanced] = useState<boolean>(false);
+  const [showAdvanced, setShowAdvanced] = useState<boolean>(data?.llm_analyst_id ? true : false);
 
   // Load existing image when editing (only if agent has one)
   React.useEffect(() => {
@@ -264,7 +279,10 @@ const AgentForm: React.FC<AgentFormProps> = ({
   const addPossibleQuery = () => {
     setFormData((prev) => ({
       ...prev,
-      possible_queries: [...prev.possible_queries, ""],
+      possible_queries: [
+        ...prev.possible_queries,
+        DEFAULT_NEW_POSSIBLE_QUERY,
+      ],
     }));
   };
 
@@ -293,7 +311,10 @@ const AgentForm: React.FC<AgentFormProps> = ({
   const addThinkingPhrase = () => {
     setFormData((prev) => ({
       ...prev,
-      thinking_phrases: [...prev.thinking_phrases, ""],
+      thinking_phrases: [
+        ...prev.thinking_phrases,
+        DEFAULT_NEW_THINKING_PHRASE,
+      ],
     }));
   };
 
@@ -404,14 +425,36 @@ const AgentForm: React.FC<AgentFormProps> = ({
       let agentId: string;
 
       if (isEditMode) {
-        const { id: _, ...dataToSubmit } = formData;
+        const { id: _, ...rest } = formData;
+        const dataToSubmit = {
+          ...rest,
+          possible_queries: omitUneditedTemplateRows(
+            rest.possible_queries,
+            DEFAULT_NEW_POSSIBLE_QUERY,
+          ),
+          thinking_phrases: omitUneditedTemplateRows(
+            rest.thinking_phrases,
+            DEFAULT_NEW_THINKING_PHRASE,
+          ),
+        };
         await updateAgentConfig(id, dataToSubmit);
         agentId = id;
         setSuccess(true);
         onSaved?.();
         onClose?.();
       } else {
-        const { id: _, ...dataToSubmit } = formData;
+        const { id: _, ...rest } = formData;
+        const dataToSubmit = {
+          ...rest,
+          possible_queries: omitUneditedTemplateRows(
+            rest.possible_queries,
+            DEFAULT_NEW_POSSIBLE_QUERY,
+          ),
+          thinking_phrases: omitUneditedTemplateRows(
+            rest.thinking_phrases,
+            DEFAULT_NEW_THINKING_PHRASE,
+          ),
+        };
         const agentConfig = await createAgentConfig({
           ...dataToSubmit,
         });
@@ -765,8 +808,8 @@ const AgentForm: React.FC<AgentFormProps> = ({
                           onChange={(e) =>
                             handlePossibleQueryChange(index, e.target.value)
                           }
-                          placeholder="Enter a sample query"
-                          className="flex-1"
+                          placeholder={DEFAULT_NEW_POSSIBLE_QUERY}
+                          className={"flex-1 placeholder:text-muted-foreground" + (isEditMode && query === DEFAULT_NEW_POSSIBLE_QUERY ? " text-muted-foreground italic" : "")}
                         />
                         {isEditMode && (
                           <TranslationTrigger
@@ -835,8 +878,8 @@ const AgentForm: React.FC<AgentFormProps> = ({
                           onChange={(e) =>
                             handleThinkingPhraseChange(index, e.target.value)
                           }
-                          placeholder="I think...|Getting the data..."
-                          className="flex-1"
+                          placeholder={DEFAULT_NEW_THINKING_PHRASE}
+                          className={"flex-1 placeholder:text-muted-foreground" + (isEditMode && phrase === DEFAULT_NEW_THINKING_PHRASE ? " text-muted-foreground italic" : "")}
                         />
                         {isEditMode && (
                           <TranslationTrigger
@@ -905,15 +948,15 @@ const AgentForm: React.FC<AgentFormProps> = ({
               </div>
 
               <div className="space-y-3">
-                <div className="flex items-center">
-                  <Toggle pressed={showAdvanced} onPressedChange={setShowAdvanced}>
+                <div className="flex items-center cursor-pointer" onClick={() => setShowAdvanced(!showAdvanced)}>
+                  <Toggle pressed={showAdvanced}>
                     {showAdvanced ? (
                       <ChevronUp className="h-3.5 w-3.5" />
                     ) : (
                       <ChevronDown className="h-3.5 w-3.5" />
                     )}
                   </Toggle>
-                  <Label className="text-sm font-medium" htmlFor="show_advanced">Advanced Configurations</Label>
+                  <Label className="text-sm font-medium cursor-pointer" htmlFor="show_advanced">Advanced Configurations</Label>
                 </div>
                 {showAdvanced && (
                   <div className="space-y-2 rounded-lg border bg-muted/30 p-4">
@@ -983,6 +1026,7 @@ export const AgentFormPage: React.FC = () => {
   const id = agentId;
   const navigate = useNavigate();
   const isEditMode = !!id;
+
   const [formData, setFormData] = useState<AgentFormData>({
     id: isEditMode ? id : undefined,
     name: "",
@@ -1027,7 +1071,8 @@ export const AgentFormPage: React.FC = () => {
 
       fetchAgentConfig();
     }
-  }, [id, isEditMode]);
+  }, [id, isEditMode, formData]);
+
   if (!agentId) {
     return (
       <div className="dashboard max-w-7xl mx-auto space-y-6 pt-8">

--- a/frontend/src/views/AIAgents/components/AgentList.tsx
+++ b/frontend/src/views/AIAgents/components/AgentList.tsx
@@ -123,6 +123,7 @@ const AgentList: React.FC<AgentListProps> = ({
         thinking_phrases: config.thinking_phrases ?? [],
         is_active: config.is_active,
         llm_analyst_id: config.llm_analyst_id ?? null,
+        has_welcome_image: config?.has_welcome_image ?? false,
         // workflow_id: config.workflow_id,
         // has_welcome_image: (config as { has_welcome_image?: boolean }).has_welcome_image,
       };

--- a/frontend/src/views/Settings/components/TranslationDialog.tsx
+++ b/frontend/src/views/Settings/components/TranslationDialog.tsx
@@ -45,28 +45,21 @@ function findDefaultLangCode(
   defaultValue: string | null | undefined,
   rows: TranslationRow[]
 ): string | null {
-  if (rows.length === 0) return null;
-  if (rows.length === 1) return rows[0].langCode;
-
-  if (defaultValue) {
-    const match = rows.find((r) => r.value === defaultValue);
-    if (match) return match.langCode;
-    const t = defaultValue.trim();
-    const matchTrim = rows.find((r) => r.value.trim() === t);
-    if (matchTrim) return matchTrim.langCode;
-  }
-  return null;
+  if (!defaultValue) return null;
+  const match = rows.find((r) => r.value === defaultValue);
+  return match?.langCode ?? null;
 }
 
 interface TranslationDialogProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
-  /** Called with the canonical default string (value of the row marked as default). */
-  onTranslationSaved?: (savedDefault?: string | null) => void;
+  onTranslationSaved: (translation: Translation) => void;
   translationToEdit?: Translation | null;
   mode?: "create" | "edit";
   initialKey?: string;
   initialDefaultValue?: string;
+  /** When provided, the dialog does not fetch languages (caller loads once). */
+  languages?: Language[];
 }
 
 export function TranslationDialog({
@@ -77,26 +70,40 @@ export function TranslationDialog({
   mode = "create",
   initialKey,
   initialDefaultValue,
+  languages: languagesFromParent,
 }: TranslationDialogProps) {
   const [dialogMode, setDialogMode] = useState<"create" | "edit">(mode);
   const [key, setKey] = useState("");
   const [defaultLangCode, setDefaultLangCode] = useState<string | null>(null);
   const [rows, setRows] = useState<TranslationRow[]>([]);
-  const [languages, setLanguages] = useState<Language[]>([]);
+  const [fetchedLanguages, setFetchedLanguages] = useState<Language[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState("");
 
+  const languages =
+    languagesFromParent !== undefined ? languagesFromParent : fetchedLanguages;
+
   useEffect(() => {
+    if (languagesFromParent !== undefined) return;
     getLanguages()
-      .then(setLanguages)
+      .then(setFetchedLanguages)
       .catch(() => toast.error("Failed to load languages."));
-  }, []);
+  }, [languagesFromParent]);
 
   const languagesRef = React.useRef(languages);
   languagesRef.current = languages;
 
   useEffect(() => {
     if (!isOpen) return;
+
+    // Caller-provided language list: wait until loaded so the default lang row
+    // matches the real catalog (parent input value seeds the correct language).
+    if (
+      languagesFromParent !== undefined &&
+      languagesFromParent.length === 0
+    ) {
+      return;
+    }
 
     let cancelled = false;
     const init = async () => {
@@ -117,19 +124,36 @@ export function TranslationDialog({
         const existing = await getTranslationByKey(initialKey);
         if (cancelled) return;
 
+        const langs = languagesRef.current;
+
         if (existing) {
           setDialogMode("edit");
           setKey(existing.key || "");
           const builtRows = translationsToRows(existing.translations);
-          setRows(builtRows);
-          setDefaultLangCode(
-            findDefaultLangCode(existing.default, builtRows)
-          );
+          let defaultLang = findDefaultLangCode(existing.default, builtRows);
+          if (defaultLang === null && builtRows.length > 0) {
+            defaultLang =
+              builtRows.find((r) => r.langCode === "en")?.langCode ??
+              builtRows[0]?.langCode ??
+              null;
+          }
+          let rowsToSet = builtRows;
+          if (initialDefaultValue !== undefined && defaultLang) {
+            rowsToSet = builtRows.map((r) =>
+              r.langCode === defaultLang
+                ? { ...r, value: initialDefaultValue }
+                : r
+            );
+          }
+          setRows(rowsToSet);
+          setDefaultLangCode(defaultLang);
         } else {
           setDialogMode("create");
           setKey(initialKey);
-          const firstLang = languagesRef.current.find((l) => l.code === "en")?.code
-            ?? languagesRef.current[0]?.code ?? "en";
+          const firstLang =
+            langs.find((l) => l.code === "en")?.code ??
+            langs[0]?.code ??
+            "en";
           setRows(
             initialDefaultValue
               ? [{ langCode: firstLang, value: initialDefaultValue }]
@@ -149,8 +173,15 @@ export function TranslationDialog({
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, translationToEdit, mode, initialKey, initialDefaultValue]);
+  }, [
+    isOpen,
+    translationToEdit,
+    mode,
+    initialKey,
+    initialDefaultValue,
+    languagesFromParent,
+    languages,
+  ]);
 
   const resetForm = () => {
     setKey("");
@@ -255,8 +286,9 @@ export function TranslationDialog({
       const defaultRow = rows.find((r) => r.langCode === defaultLangCode);
       const defaultValue = defaultRow?.value.trim() || null;
 
+      let saved: Translation;
       if (dialogMode === "create") {
-        await createTranslation({
+        saved = await createTranslation({
           key: key.trim(),
           default: defaultValue,
           translations: cleanTranslations,
@@ -269,14 +301,14 @@ export function TranslationDialog({
           return;
         }
 
-        await updateTranslation(updateKey, {
+        saved = await updateTranslation(updateKey, {
           default: defaultValue,
           translations: cleanTranslations,
         });
         toast.success("Translation updated successfully.");
       }
 
-      onTranslationSaved?.(defaultValue);
+      onTranslationSaved(saved);
       onOpenChange(false);
       resetForm();
     } catch (err) {

--- a/frontend/src/views/Settings/components/TranslationDialog.tsx
+++ b/frontend/src/views/Settings/components/TranslationDialog.tsx
@@ -45,15 +45,24 @@ function findDefaultLangCode(
   defaultValue: string | null | undefined,
   rows: TranslationRow[]
 ): string | null {
-  if (!defaultValue) return null;
-  const match = rows.find((r) => r.value === defaultValue);
-  return match?.langCode ?? null;
+  if (rows.length === 0) return null;
+  if (rows.length === 1) return rows[0].langCode;
+
+  if (defaultValue) {
+    const match = rows.find((r) => r.value === defaultValue);
+    if (match) return match.langCode;
+    const t = defaultValue.trim();
+    const matchTrim = rows.find((r) => r.value.trim() === t);
+    if (matchTrim) return matchTrim.langCode;
+  }
+  return null;
 }
 
 interface TranslationDialogProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
-  onTranslationSaved: () => void;
+  /** Called with the canonical default string (value of the row marked as default). */
+  onTranslationSaved?: (savedDefault?: string | null) => void;
   translationToEdit?: Translation | null;
   mode?: "create" | "edit";
   initialKey?: string;
@@ -267,7 +276,7 @@ export function TranslationDialog({
         toast.success("Translation updated successfully.");
       }
 
-      onTranslationSaved();
+      onTranslationSaved?.(defaultValue);
       onOpenChange(false);
       resetForm();
     } catch (err) {


### PR DESCRIPTION
## Description
- Introduced a new property `has_welcome_image` in the AgentConfig interface to manage welcome image settings.
- Updated the AgentForm component to handle default values for possible queries and thinking phrases, improving user experience.
- Implemented logic to omit unedited template rows for possible queries and thinking phrases during form submission.
- Enhanced the AgentList component to display the `has_welcome_image` property, ensuring consistent data handling across components.
- Updated AgentConfigService to use get_by_id_full for fetching agent details, ensuring complete data retrieval.
- Implemented cache invalidation for agent images upon upload and deletion to maintain data consistency.
- Modified API calls in frontend to include cache-busting parameters for welcome image requests, preventing stale image display.
- Enhanced TranslationDialog to support shared language lists, improving translation handling across components.


<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
