### PR TITLE
feat: enforce unique email on users

### DIFF
--- a/backend/alembic/versions/00060_users_email_unique_active.py
+++ b/backend/alembic/versions/00060_users_email_unique_active.py
@@ -1,4 +1,7 @@
-"""unique email among non-deleted users
+"""unique email on users (all rows, including soft-deleted)
+
+Enforces a single unique index on email across all rows, including soft-deleted,
+so the same address cannot exist on both an active and a deleted user.
 
 Revision ID: e8f9a0b1c2d3
 Revises: d7e3f1a2b8c5
@@ -9,7 +12,6 @@ Create Date: 2026-03-31 12:00:00.000000
 from typing import Sequence, Union
 
 from alembic import op
-import sqlalchemy as sa
 
 revision: str = "e8f9a0b1c2d3"
 down_revision: Union[str, None] = "d7e3f1a2b8c5"
@@ -19,13 +21,12 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     op.create_index(
-        "users_email_active_key",
+        "uq_users_email",
         "users",
         ["email"],
         unique=True,
-        postgresql_where=sa.text("is_deleted = 0"),
     )
 
 
 def downgrade() -> None:
-    op.drop_index("users_email_active_key", table_name="users")
+    op.drop_index("uq_users_email", table_name="users")

--- a/backend/alembic/versions/00060_users_email_unique_active.py
+++ b/backend/alembic/versions/00060_users_email_unique_active.py
@@ -9,8 +9,10 @@ Create Date: 2026-03-31 12:00:00.000000
 
 """
 
+import re
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 revision: str = "e8f9a0b1c2d3"
@@ -18,8 +20,67 @@ down_revision: Union[str, None] = "d7e3f1a2b8c5"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
+_EMAIL_RE = re.compile(r"^(.+)@(.+)$")
+
+
+def _split_email(email: str) -> tuple[str, str] | None:
+    m = _EMAIL_RE.match(email.strip())
+    if not m:
+        return None
+    return m.group(1), m.group(2)
+
+
+def _dedupe_user_emails(connection) -> None:
+    """
+    Before creating a unique index on users.email, rename duplicate rows so each
+    address is unique: first row per email unchanged, others get local+1@domain,
+    local+2@domain, ... skipping any address already taken.
+    """
+    dup_rows = connection.execute(
+        sa.text("""
+            SELECT email
+            FROM users
+            WHERE email IS NOT NULL AND TRIM(email) <> ''
+            GROUP BY email
+            HAVING COUNT(*) > 1
+        """)
+    ).fetchall()
+
+    for (email,) in dup_rows:
+        parts = _split_email(email)
+        if parts is None:
+            local, domain = "user", "invalid.local"
+        else:
+            local, domain = parts
+
+        user_rows = connection.execute(
+            sa.text("SELECT id FROM users WHERE email = :email ORDER BY id"),
+            {"email": email},
+        ).fetchall()
+
+        for i, row in enumerate(user_rows[1:], start=1):
+            suffix = i
+            while True:
+                new_email = f"{local}+{suffix}@{domain}"
+                taken = connection.execute(
+                    sa.text("SELECT 1 FROM users WHERE email = :e LIMIT 1"),
+                    {"e": new_email},
+                ).fetchone()
+                if not taken:
+                    break
+                suffix += 1
+            connection.execute(
+                sa.text("UPDATE users SET email = :new WHERE id = :id"),
+                {"new": new_email, "id": row.id},
+            )
+
 
 def upgrade() -> None:
+    # Rename duplicate emails so each address is unique: first row per email unchanged, others get local+1@domain,
+    # local+2@domain, ... skipping any address already taken.
+    connection = op.get_bind()
+    _dedupe_user_emails(connection)
+
     op.create_index(
         "uq_users_email",
         "users",

--- a/backend/alembic/versions/00060_users_email_unique_active.py
+++ b/backend/alembic/versions/00060_users_email_unique_active.py
@@ -1,0 +1,31 @@
+"""unique email among non-deleted users
+
+Revision ID: e8f9a0b1c2d3
+Revises: d7e3f1a2b8c5
+Create Date: 2026-03-31 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "e8f9a0b1c2d3"
+down_revision: Union[str, None] = "d7e3f1a2b8c5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "users_email_active_key",
+        "users",
+        ["email"],
+        unique=True,
+        postgresql_where=sa.text("is_deleted = 0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("users_email_active_key", table_name="users")

--- a/backend/alembic/versions/00060_users_email_unique_active.py
+++ b/backend/alembic/versions/00060_users_email_unique_active.py
@@ -82,7 +82,7 @@ def upgrade() -> None:
     _dedupe_user_emails(connection)
 
     op.create_index(
-        "uq_users_email",
+        "users_email_unique",
         "users",
         ["email"],
         unique=True,
@@ -90,4 +90,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index("uq_users_email", table_name="users")
+    op.drop_index("users_email_unique", table_name="users")

--- a/backend/app/db/models/user.py
+++ b/backend/app/db/models/user.py
@@ -7,7 +7,6 @@ from sqlalchemy import (
     PrimaryKeyConstraint,
     String,
     UniqueConstraint,
-    text,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
@@ -24,12 +23,7 @@ class UserModel(Base):
     __table_args__ = (
         PrimaryKeyConstraint('id', name='users_pkey'),
         UniqueConstraint('username', name='users_username_key'),
-        Index(
-            'users_email_active_key',
-            'email',
-            unique=True,
-            postgresql_where=text('is_deleted = 0'),
-        ),
+        Index('uq_users_email', 'email', unique=True),
     )
     username: Mapped[str] = mapped_column(String(255))
     email: Mapped[str] = mapped_column(String(255))

--- a/backend/app/db/models/user.py
+++ b/backend/app/db/models/user.py
@@ -1,5 +1,14 @@
 from typing import Optional
-from sqlalchemy import DateTime, Integer, PrimaryKeyConstraint, String, UniqueConstraint, ForeignKey, text
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    PrimaryKeyConstraint,
+    String,
+    UniqueConstraint,
+    text,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 from uuid import UUID
@@ -14,7 +23,13 @@ class UserModel(Base):
     __tablename__ = 'users'
     __table_args__ = (
         PrimaryKeyConstraint('id', name='users_pkey'),
-        UniqueConstraint('username', name='users_username_key')
+        UniqueConstraint('username', name='users_username_key'),
+        Index(
+            'users_email_active_key',
+            'email',
+            unique=True,
+            postgresql_where=text('is_deleted = 0'),
+        ),
     )
     username: Mapped[str] = mapped_column(String(255))
     email: Mapped[str] = mapped_column(String(255))

--- a/backend/app/repositories/users.py
+++ b/backend/app/repositories/users.py
@@ -103,9 +103,16 @@ class UserRepository:
         return result.scalars().first()
 
 
-    async def get_by_email(self, email: str) -> UserModel | None:
+    async def get_by_email(
+        self, email: str, *, include_deleted: bool = False
+    ) -> UserModel | None:
         query = select(UserModel).where(UserModel.email == email)
-        result = await self.db.execute(query)
+        exec_query = (
+            query.execution_options(**{SOFT_DELETE_FLAG: True})
+            if include_deleted
+            else query
+        )
+        result = await self.db.execute(exec_query)
         return result.scalars().first()
 
     async def get_all(self, filter: BaseFilterModel):

--- a/backend/app/repositories/users.py
+++ b/backend/app/repositories/users.py
@@ -103,7 +103,7 @@ class UserRepository:
         return result.scalars().first()
 
 
-    async def get_by_email(self, email: str) -> UserModel:
+    async def get_by_email(self, email: str) -> UserModel | None:
         query = select(UserModel).where(UserModel.email == email)
         result = await self.db.execute(query)
         return result.scalars().first()

--- a/backend/app/repositories/users.py
+++ b/backend/app/repositories/users.py
@@ -1,28 +1,30 @@
+import logging
 from datetime import datetime
+from operator import or_
 from uuid import UUID
+
+from fastapi_cache import FastAPICache
 from injector import inject
+from redis.exceptions import ResponseError
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload, selectinload
+
 from app.auth.utils import get_password_hash
 from app.cache.redis_cache import make_key_builder
+from app.core.exceptions.error_messages import ErrorKey
+from app.core.exceptions.exception_classes import AppException
 from app.core.utils.sql_alchemy_utils import add_dynamic_ordering, add_pagination
+from app.db.events.soft_delete import SOFT_DELETE_FLAG
 from app.db.models import UserRoleModel
 from app.db.models.api_key import ApiKeyModel
 from app.db.models.api_key_role import ApiKeyRoleModel
 from app.db.models.role import RoleModel
 from app.db.models.role_permission import RolePermissionModel
+from app.db.models.user import UserModel
 from app.db.models.user_type import UserTypeModel
-from app.core.exceptions.error_messages import ErrorKey
-from app.core.exceptions.exception_classes import AppException
-from sqlalchemy.orm import selectinload, joinedload
-from sqlalchemy import delete, select, update
-
-from app.db.events.soft_delete import SOFT_DELETE_FLAG
 from app.schemas.filter import BaseFilterModel
 from app.schemas.user import UserCreate, UserUpdate
-from app.db.models.user import UserModel
-import logging
-from fastapi_cache import FastAPICache
-from redis.exceptions import ResponseError
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +36,7 @@ class UserRepository:
 
     def __init__(self, db: AsyncSession):
         self.db = db
-        
+
     async def create(self, user: UserCreate):
         # Validate user type
         user_type = await self.db.get(UserTypeModel, user.user_type_id)
@@ -100,6 +102,17 @@ class UserRepository:
         """Retrieve a user by username."""
         query = select(UserModel).where(UserModel.username == username).options(joinedload(UserModel.user_type))
         result = await self.db.execute(query)
+        return result.scalars().first()
+
+    async def get_by_username_or_email(self, username_or_email: str, *, include_deleted: bool = False) -> UserModel | None:
+        """Retrieve a user by username or email."""
+        query = select(UserModel).where(or_(UserModel.username == username_or_email, UserModel.email == username_or_email)).options(joinedload(UserModel.user_type))
+        exec_query = (
+            query.execution_options(**{SOFT_DELETE_FLAG: True})
+            if include_deleted
+            else query
+        )
+        result = await self.db.execute(exec_query)
         return result.scalars().first()
 
 

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -2,9 +2,11 @@ import logging
 import os
 from datetime import datetime, timedelta, timezone
 from typing import Optional
-from injector import inject
+
 import jwt
+from injector import inject
 from jwt.exceptions import ExpiredSignatureError, InvalidTokenError
+
 from app.auth.utils import verify_password
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
@@ -12,7 +14,6 @@ from app.schemas.api_key import ApiKeyInternal
 from app.schemas.user import UserReadAuth
 from app.services.api_keys import ApiKeysService
 from app.services.users import UserService
-
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +57,6 @@ class AuthService:
 
     async def decode_jwt(self, token: str) -> UserReadAuth:
         try:
-            from app.core.tenant_scope import get_tenant_context
 
             payload = jwt.decode(token, self.secret_key, algorithms=[self.algorithm])
             username = payload.get("sub")
@@ -122,15 +122,10 @@ class AuthService:
         from app.dependencies.injector import injector
 
         user_service = injector.get(UserService)
-        user = await user_service.get_by_username(
+        user = await user_service.get_by_username_or_email(
             username_or_email, throw_not_found=False
         )
         # Check by email if not found by username
-        if not user:
-            user = await user_service.get_user_by_email(
-                username_or_email, throw_not_found=False
-            )
-
         if not user:
             raise AppException(
                 error_key=ErrorKey.INVALID_USERNAME_OR_PASSWORD,

--- a/backend/app/services/operators.py
+++ b/backend/app/services/operators.py
@@ -35,7 +35,9 @@ class OperatorService:
     # ----------  helpers  ------------------------------------------------
 
     async def create(self, operator_create: OperatorCreate, generated_password):
-        if await self.user_repository.get_by_email(operator_create.user.email):
+        if await self.user_repository.get_by_email(
+            operator_create.user.email, include_deleted=True
+        ):
             raise AppException(error_key=ErrorKey.EMAIL_ALREADY_EXISTS)
 
         # --- 1) build UserModel -----------------------------------------
@@ -87,7 +89,7 @@ class OperatorService:
         last_name   = ""
         """
         # ---------- uniqueness checks ----------------------------------
-        if await self.user_repository.get_by_email(email):
+        if await self.user_repository.get_by_email(email, include_deleted=True):
             raise AppException(error_key=ErrorKey.EMAIL_ALREADY_EXISTS)
 
         # ---------- UserModel -----------------------------------------

--- a/backend/app/services/users.py
+++ b/backend/app/services/users.py
@@ -35,7 +35,9 @@ class UserService:
         if existing_user:
             raise AppException(error_key=ErrorKey.USERNAME_ALREADY_EXISTS)
 
-        existing_email = await self.repository.get_by_email(user.email)
+        existing_email = await self.repository.get_by_email(
+            user.email, include_deleted=True
+        )
         if existing_email:
             raise AppException(error_key=ErrorKey.EMAIL_ALREADY_EXISTS)
 
@@ -122,7 +124,9 @@ class UserService:
 
     async def update(self, user_id: UUID, user_data: UserUpdate):
         if user_data.email is not None:
-            existing = await self.repository.get_by_email(user_data.email)
+            existing = await self.repository.get_by_email(
+                user_data.email, include_deleted=True
+            )
             if existing is not None and existing.id != user_id:
                 raise AppException(error_key=ErrorKey.EMAIL_ALREADY_EXISTS)
 

--- a/backend/app/services/users.py
+++ b/backend/app/services/users.py
@@ -35,6 +35,10 @@ class UserService:
         if existing_user:
             raise AppException(error_key=ErrorKey.USERNAME_ALREADY_EXISTS)
 
+        existing_email = await self.repository.get_by_email(user.email)
+        if existing_email:
+            raise AppException(error_key=ErrorKey.EMAIL_ALREADY_EXISTS)
+
         user.password = get_password_hash(user.password)
         new_user = await self.repository.create(user)
         model = await self.repository.get_full(new_user.id)
@@ -117,6 +121,11 @@ class UserService:
         return full
 
     async def update(self, user_id: UUID, user_data: UserUpdate):
+        if user_data.email is not None:
+            existing = await self.repository.get_by_email(user_data.email)
+            if existing is not None and existing.id != user_id:
+                raise AppException(error_key=ErrorKey.EMAIL_ALREADY_EXISTS)
+
         updated_user = await self.repository.update(user_id, user_data)
         await invalidate_user_cache(user_id)
         user_with_full_data = await self.get_by_id(updated_user.id)

--- a/backend/app/services/users.py
+++ b/backend/app/services/users.py
@@ -77,18 +77,27 @@ class UserService:
         #     raise AppException(error_key=ErrorKey.LOGIN_ERROR_CONSOLE_USER)
         return user_auth
 
-    async def get_by_username(self, username: str, throw_not_found: bool = True):
+    async def get_by_username(self, username: str, *, include_deleted: bool = False, throw_not_found: bool = True):
         """Fetch a user by their username."""
-        user = await self.repository.get_by_username(username)
+        user = await self.repository.get_by_username(username, include_deleted=include_deleted)
         if not user:
             if throw_not_found:
                 raise AppException(error_key=ErrorKey.USER_NOT_FOUND, status_code=404)
             return None
         return user
 
-    async def get_user_by_email(self, email: str, throw_not_found: bool = True):
+    async def get_by_email(self, email: str, *, include_deleted: bool = False, throw_not_found: bool = True):
+        """Fetch a user by their email."""
+        user = await self.repository.get_by_email(email, include_deleted=include_deleted)
+        if not user:
+            if throw_not_found:
+                raise AppException(error_key=ErrorKey.USER_NOT_FOUND, status_code=404)
+            return None
+        return user
+
+    async def get_by_username_or_email(self, username_or_email: str, *, include_deleted: bool = False, throw_not_found: bool = True):
         """Fetch a user by their username."""
-        user = await self.repository.get_by_email(email)
+        user = await self.repository.get_by_username_or_email(username_or_email, include_deleted=include_deleted)
         if not user:
             if throw_not_found:
                 raise AppException(error_key=ErrorKey.USER_NOT_FOUND, status_code=404)

--- a/backend/tests/unit/test_user_service.py
+++ b/backend/tests/unit/test_user_service.py
@@ -57,7 +57,9 @@ async def test_create_user_success(user_service, mock_repository, sample_user_da
 
     # Assert
     mock_repository.get_by_username.assert_called_once_with(user_create.username)
-    mock_repository.get_by_email.assert_called_once_with(user_create.email)
+    mock_repository.get_by_email.assert_called_once_with(
+        user_create.email, include_deleted=True
+    )
     mock_repository.create.assert_called_once()
     mock_repository.get_full.assert_called_once()
     assert result.username == sample_user_data["username"]
@@ -89,7 +91,9 @@ async def test_create_user_duplicate_email(user_service, mock_repository, sample
 
     assert exc_info.value.error_key == ErrorKey.EMAIL_ALREADY_EXISTS
     mock_repository.get_by_username.assert_called_once_with(user_create.username)
-    mock_repository.get_by_email.assert_called_once_with(user_create.email)
+    mock_repository.get_by_email.assert_called_once_with(
+        user_create.email, include_deleted=True
+    )
     mock_repository.create.assert_not_called()
 
 @pytest.mark.asyncio
@@ -199,7 +203,9 @@ async def test_update_user_success(user_service, mock_repository):
     result = await user_service.update(user_id, update_data)
 
     # Assert
-    mock_repository.get_by_email.assert_called_once_with(update_data.email)
+    mock_repository.get_by_email.assert_called_once_with(
+        update_data.email, include_deleted=True
+    )
     mock_repository.update.assert_called_once_with(user_id, update_data)
     mock_repository.get_full.assert_called_once_with(mock_updated_user.id)
     assert result == mock_updated_user
@@ -215,7 +221,9 @@ async def test_update_user_duplicate_email(user_service, mock_repository):
         await user_service.update(user_id, update_data)
 
     assert exc_info.value.error_key == ErrorKey.EMAIL_ALREADY_EXISTS
-    mock_repository.get_by_email.assert_called_once_with(update_data.email)
+    mock_repository.get_by_email.assert_called_once_with(
+        update_data.email, include_deleted=True
+    )
     mock_repository.update.assert_not_called()
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_user_service.py
+++ b/backend/tests/unit/test_user_service.py
@@ -43,6 +43,7 @@ async def test_create_user_success(user_service, mock_repository, sample_user_da
     # Setup
     user_create = UserCreate(**sample_user_data)
     mock_repository.get_by_username.return_value = None
+    mock_repository.get_by_email.return_value = None
     mock_repository.create.return_value = MagicMock(id=uuid4())
     mock_repository.get_full.return_value = MagicMock(
         id=uuid4(),
@@ -56,6 +57,7 @@ async def test_create_user_success(user_service, mock_repository, sample_user_da
 
     # Assert
     mock_repository.get_by_username.assert_called_once_with(user_create.username)
+    mock_repository.get_by_email.assert_called_once_with(user_create.email)
     mock_repository.create.assert_called_once()
     mock_repository.get_full.assert_called_once()
     assert result.username == sample_user_data["username"]
@@ -73,6 +75,21 @@ async def test_create_user_duplicate_username(user_service, mock_repository, sam
     
     assert exc_info.value.error_key == ErrorKey.USERNAME_ALREADY_EXISTS
     mock_repository.get_by_username.assert_called_once_with(user_create.username)
+    mock_repository.get_by_email.assert_not_called()
+    mock_repository.create.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_create_user_duplicate_email(user_service, mock_repository, sample_user_data):
+    user_create = UserCreate(**sample_user_data)
+    mock_repository.get_by_username.return_value = None
+    mock_repository.get_by_email.return_value = MagicMock()
+
+    with pytest.raises(AppException) as exc_info:
+        await user_service.create(user_create)
+
+    assert exc_info.value.error_key == ErrorKey.EMAIL_ALREADY_EXISTS
+    mock_repository.get_by_username.assert_called_once_with(user_create.username)
+    mock_repository.get_by_email.assert_called_once_with(user_create.email)
     mock_repository.create.assert_not_called()
 
 @pytest.mark.asyncio
@@ -161,20 +178,20 @@ async def test_update_user_success(user_service, mock_repository):
     # Setup
     user_id = uuid4()
     update_data = UserUpdate(
-        username="test",
         email="updated@example.com",
         is_active=0,
-        user_type=UserTypeRead(id=UUID('00000196-edb1-2b80-a681-167fc2a697dd'), name="interactive", created_at=datetime.now(), updated_at=datetime.now())
+        user_type_id=UUID('00000196-edb1-2b80-a681-167fc2a697dd'),
     )
     mock_updated_user = UserRead(
             id=user_id,
-            username="test",
+            username="testuser",
             email="updated@example.com",
             is_active=0,
             roles=[],
             user_type=UserTypeRead(id=UUID("00000196-edb1-2b80-a681-167fc2a697dd"), name="interactive", created_at=datetime.now(), updated_at=datetime.now()),
             api_keys=[]
             )
+    mock_repository.get_by_email.return_value = None
     mock_repository.update.return_value = mock_updated_user
     mock_repository.get_full.return_value = mock_updated_user
 
@@ -182,9 +199,24 @@ async def test_update_user_success(user_service, mock_repository):
     result = await user_service.update(user_id, update_data)
 
     # Assert
+    mock_repository.get_by_email.assert_called_once_with(update_data.email)
     mock_repository.update.assert_called_once_with(user_id, update_data)
     mock_repository.get_full.assert_called_once_with(mock_updated_user.id)
     assert result == mock_updated_user
+
+@pytest.mark.asyncio
+async def test_update_user_duplicate_email(user_service, mock_repository):
+    user_id = uuid4()
+    other_id = uuid4()
+    update_data = UserUpdate(email="taken@example.com")
+    mock_repository.get_by_email.return_value = MagicMock(id=other_id)
+
+    with pytest.raises(AppException) as exc_info:
+        await user_service.update(user_id, update_data)
+
+    assert exc_info.value.error_key == ErrorKey.EMAIL_ALREADY_EXISTS
+    mock_repository.get_by_email.assert_called_once_with(update_data.email)
+    mock_repository.update.assert_not_called()
 
 @pytest.mark.asyncio
 async def test_get_all_users(user_service, mock_repository):

--- a/frontend/src/views/Users/components/UserDialog.tsx
+++ b/frontend/src/views/Users/components/UserDialog.tsx
@@ -187,7 +187,11 @@ export function UserDialog({
       let errorMessage = "";
 
       if (error.status === 400) {
-        errorMessage = "A user with this username already exists.";
+        if (data?.error_key === 'EMAIL_ALREADY_EXISTS') {
+          errorMessage = "A user with this email already exists.";
+        } else {
+          errorMessage = "A user with this username already exists.";
+        }
       } else if (data.error) {
         errorMessage = data.error;
       } else if (data.detail) {


### PR DESCRIPTION
## Description
- Added a new Alembic migration to create a unique index on the email field for non-deleted users in the users table.
- Updated UserModel to include the new index definition.
- Enhanced UserService to check for existing emails during user creation and updates, raising an exception if a duplicate is found.
- Added unit tests to verify the new email uniqueness validation during user creation and updates.

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
