### PR TITLE
chore: update genassist-chat-react to version 1.0.38-rc.0 and enhance npm release scripts

### DIFF
--- a/plugins/react/.gitignore
+++ b/plugins/react/.gitignore
@@ -1,4 +1,5 @@
 dist/
 node_modules/
+.npmrc
 example-app/node_modules/
 example-app/dist/

--- a/plugins/react/README.md
+++ b/plugins/react/README.md
@@ -124,10 +124,32 @@ The component interacts with the following endpoints:
 2. Update Conversation: `POST /api/conversations/in-progress/update/{conversation_id}`
 3. WebSocket:  `WS /conversations/{conversation_id}?access_token={token}&lang=en&topics=message&topics=takeover`
 
-## Run
-./
-yarn run build
+## Development
 
+From the package root:
+
+```bash
+npm run build
+```
+
+Run the example app:
+
+```bash
 cd example-app
+npm run dev
+```
 
-yarn run dev
+## Publishing (npm release scripts)
+
+These scripts bump the package version, run `build`, and publish to the npm registry. Use from a clean working tree with registry credentials configured.
+
+| Command | What it does |
+|---------|----------------|
+| `npm run release:patch` | Patch release: `npm version patch`, build, `npm publish` (latest tag). |
+| `npm run release:candidate` | `npm version prerelease --preid=rc` (next RC on the current release line), build, `npm publish --tag beta`. |
+| `npm run release:candidate:prepatch` | Prepatch RC (e.g. `1.0.0` → `1.0.1-rc.0`), build, publish with `beta` tag. |
+| `npm run release:candidate:preminor` | Preminor RC (e.g. `1.0.0` → `1.1.0-rc.0`), build, publish with `beta` tag. |
+
+RC prerelease versions use the `rc` prerelease id (`--preid=rc`). Beta-tagged publishes let consumers install with `npm install genassist-chat-react@beta`.
+
+Version-only bumps without build or publish: `npm run bump:patch`, `npm run bump:minor`, `npm run bump:major`.

--- a/plugins/react/package-lock.json
+++ b/plugins/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genassist-chat-react",
-  "version": "1.0.37",
+  "version": "1.0.38-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genassist-chat-react",
-      "version": "1.0.37",
+      "version": "1.0.38-rc.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.5",

--- a/plugins/react/package.json
+++ b/plugins/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genassist-chat-react",
-  "version": "1.0.37",
+  "version": "1.0.38-rc.0",
   "description": "React chat component for GenAssist",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -28,6 +28,10 @@
     "bump:patch": "npm version patch",
     "bump:minor": "npm version minor",
     "bump:major": "npm version major",
+    "release:patch": "npm version patch && npm run build && npm publish",
+    "release:candidate": "npm version prerelease --preid=rc && npm run build && npm publish --tag beta",
+    "release:candidate:prepatch": "npm version prepatch --preid=rc && npm run build && npm publish --tag beta",
+    "release:candidate:preminor": "npm version preminor --preid=rc && npm run build && npm publish --tag beta",
     "prepare": "npm run build"
   },
   "keywords": [


### PR DESCRIPTION
## Description

- Bumped version of genassist-chat-react to 1.0.38-rc.0 in package.json and package-lock.json.
- Added new npm scripts for managing release candidates and publishing to npm.
- Updated README.md to include development instructions and details on the new release scripts.

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release



---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
