### PR TITLE
chore: put evaluations as background task in celery instead of blocking api

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -260,6 +260,7 @@ def create_celery():
             "app.tasks.ml_model_pipeline_tasks",
             "app.tasks.kb_batch_tasks",
             "app.tasks.analytics_aggregation_tasks",
+            "app.tasks.test_suite_tasks",
         ],
     )
 

--- a/backend/app/api/v1/routes/test_suites.py
+++ b/backend/app/api/v1/routes/test_suites.py
@@ -6,6 +6,8 @@ from fastapi_injector import Injected
 
 from app.auth.dependencies import auth, permissions
 from app.core.permissions.constants import Permissions as P
+from app.core.tenant_scope import get_tenant_context
+from app.tasks.test_suite_tasks import execute_test_suite_run_task
 from app.schemas.test_suite import (
     ImportCasesFromConversationRequest,
     TestCase,
@@ -169,10 +171,17 @@ async def run_test_suite(
     service: TestSuiteService = Injected(TestSuiteService),
 ):
     """
-    Execute all test cases in the suite against the configured workflow and
-    evaluate with the requested techniques.
+    Queue a test suite run. Returns immediately with status ``queued``.
+    The actual execution is handled by a Celery background worker.
     """
-    return await service.start_run(suite_id, data)
+    run = await service.create_run(suite_id, data)
+    execute_test_suite_run_task.delay(
+        str(run.id),
+        get_tenant_context(),
+        data.input_metadata,
+        data.technique_configs,
+    )
+    return run
 
 
 @router.get(

--- a/backend/app/services/test_suite.py
+++ b/backend/app/services/test_suite.py
@@ -527,7 +527,12 @@ class TestSuiteService:
 
     # ---- Runs -------------------------------------------------------------
 
-    async def start_run(self, suite_id: UUID, data: TestRunCreate) -> TestRunInDB:
+    async def create_run(self, suite_id: UUID, data: TestRunCreate) -> TestRunInDB:
+        """
+        Validate the suite/workflow and create a TestRun with status ``queued``.
+        Does NOT execute the run — the caller is responsible for dispatching
+        the background task.
+        """
         suite = await self.suite_repo.get_by_id(suite_id)
         if not suite:
             raise AppException(status_code=404, error_key=ErrorKey.NOT_FOUND)
@@ -555,17 +560,7 @@ class TestSuiteService:
         )
 
         created = await self.run_repo.create(run)
-
-        # Fire-and-forget async execution; in the current context we execute inline
-        await self._execute_run(
-            suite,
-            workflow,
-            created,
-            run_input_metadata=data.input_metadata,
-            technique_configs=data.technique_configs,
-        )
-        refreshed = await self.run_repo.get_by_id(UUID(str(created.id)))
-        return TestRunInDB.model_validate(refreshed, from_attributes=True)  # type: ignore[arg-type]
+        return TestRunInDB.model_validate(created, from_attributes=True)
 
     async def _execute_run(
         self,

--- a/backend/app/tasks/test_suite_tasks.py
+++ b/backend/app/tasks/test_suite_tasks.py
@@ -1,0 +1,101 @@
+"""
+Celery tasks for test suite run execution.
+"""
+
+import asyncio
+import logging
+from typing import Any, Dict
+from uuid import UUID
+
+from celery import shared_task
+
+from app.core.tenant_scope import set_tenant_context, clear_tenant_context
+from app.tasks.base import create_task_wrapper
+
+logger = logging.getLogger(__name__)
+
+
+async def _execute_test_suite_run_async(
+    run_id: UUID,
+    input_metadata: Dict[str, Any] | None,
+    technique_configs: Dict[str, Dict[str, Any]] | None,
+) -> None:
+    """
+    Load the TestRun and drive execution via the injected TestSuiteService.
+    Must be called within a request scope (via create_task_wrapper) so that
+    the DI container resolves the tenant-scoped AsyncSession correctly.
+    """
+    from app.dependencies.injector import injector
+    from app.services.test_suite import TestSuiteService
+
+    service = injector.get(TestSuiteService)
+
+    run = await service.run_repo.get_by_id(run_id)
+    if not run:
+        logger.warning("TestRun %s not found — skipping", run_id)
+        return
+
+    suite = await service.suite_repo.get_by_id(run.suite_id)
+    if not suite:
+        logger.error("Suite %s not found for run %s", run.suite_id, run_id)
+        run.status = "failed"
+        run.summary_metrics = {"error": "Suite not found"}
+        await service.run_repo.update(run)
+        return
+
+    workflow = await service.workflow_service.get_by_id(UUID(str(run.workflow_id)))
+
+    await service._execute_run(
+        suite,
+        workflow,
+        run,
+        run_input_metadata=input_metadata,
+        technique_configs=technique_configs,
+    )
+
+
+@shared_task(name="execute_test_suite_run")
+def execute_test_suite_run_task(
+    run_id: str,
+    tenant_id: str,
+    input_metadata: Dict[str, Any] | None = None,
+    technique_configs: Dict[str, Dict[str, Any]] | None = None,
+) -> None:
+    """
+    Celery task that executes all test cases in a suite run asynchronously.
+
+    Args:
+        run_id: UUID string of the TestRun to execute.
+        tenant_id: Schema name of the tenant that owns this run.
+        input_metadata: Optional per-run input metadata override.
+        technique_configs: Optional per-technique evaluator configuration.
+    """
+    logger.info("Starting test suite run execution: %s (tenant: %s)", run_id, tenant_id)
+    set_tenant_context(tenant_id)
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_closed():
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        async def _run():
+            async def task(**kwargs):
+                await _execute_test_suite_run_async(
+                    UUID(kwargs["run_id"]),
+                    kwargs.get("input_metadata"),
+                    kwargs.get("technique_configs"),
+                )
+
+            wrapper = create_task_wrapper(task)
+            await wrapper(
+                run_id=run_id,
+                input_metadata=input_metadata,
+                technique_configs=technique_configs,
+            )
+
+        loop.run_until_complete(_run())
+    except Exception as exc:
+        logger.error("Error in test suite run task %s: %s", run_id, exc, exc_info=True)
+        raise
+    finally:
+        clear_tenant_context()

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -12255,7 +12255,7 @@
           "Workflow Test Suites"
         ],
         "summary": "Run Test Suite",
-        "description": "Execute all test cases in the suite against the configured workflow and\nevaluate with the requested techniques.",
+        "description": "Queue a test suite run. Returns immediately with status ``queued``.\nThe actual execution is handled by a Celery background worker.",
         "operationId": "run_test_suite_api_genagent_eval_suites__suite_id__runs_post",
         "security": [
           {

--- a/frontend/src/views/TestSuites/pages/EvaluationDetailPage.tsx
+++ b/frontend/src/views/TestSuites/pages/EvaluationDetailPage.tsx
@@ -4,7 +4,7 @@ import { PageLayout } from "@/components/PageLayout";
 import JsonViewer from "@/components/JsonViewer";
 import { Button } from "@/components/button";
 import { Badge } from "@/components/badge";
-import { ChevronLeft, Play, CheckCircle2, XCircle, ChevronDown, ChevronRight, AlertCircle } from "lucide-react";
+import { ChevronLeft, Play, CheckCircle2, XCircle, ChevronDown, ChevronRight, AlertCircle, Loader2 } from "lucide-react";
 import {
   getTestRun,
   listTestCases,
@@ -31,6 +31,16 @@ import { Progress } from "@/components/progress";
 import { cn } from "@/helpers/utils";
 
 type ResultFilter = "all" | "passed" | "failed";
+
+const RunStatusBadge: React.FC<{ status: string }> = ({ status }) => {
+  const inProgress = status === "queued" || status === "running";
+  return (
+    <Badge variant="outline" className="flex items-center gap-1">
+      {inProgress && <Loader2 className="h-3 w-3 animate-spin" />}
+      {status}
+    </Badge>
+  );
+};
 
 const EvaluationDetailPage: React.FC = () => {
   const navigate = useNavigate();
@@ -159,10 +169,26 @@ const EvaluationDetailPage: React.FC = () => {
         await appendRunToEvaluation(evaluationId, created.id);
         setRuns((prev) => [created, ...prev]);
         setSelectedRunId(created.id);
+
+        // Poll every 10 seconds until the run reaches a terminal state.
+        const pollInterval = setInterval(async () => {
+          const updated = await getTestRun(created.id);
+          if (!updated) return;
+          setRuns((prev) =>
+            prev.map((r) => (r.id === updated.id ? (updated as TestRun) : r))
+          );
+          if (updated.status === "completed" || updated.status === "failed") {
+            clearInterval(pollInterval);
+            setIsRunning(false);
+          }
+        }, 10_000);
+        // Return early — setIsRunning(false) is handled by the interval above.
+        return;
       }
-    } finally {
-      setIsRunning(false);
+    } catch {
+      // fall through to finally
     }
+    setIsRunning(false);
   };
 
   const selectedRun = runs.find((run) => run.id === selectedRunId);
@@ -323,7 +349,7 @@ const EvaluationDetailPage: React.FC = () => {
                           </div>
                         )}
                       </div>
-                      <Badge variant="outline">{run.status}</Badge>
+                      <RunStatusBadge status={run.status} />
                     </div>
                     <div className="text-xs text-gray-500 mt-1">
                       {new Date(run.created_at ?? "").toLocaleString()}
@@ -371,7 +397,7 @@ const EvaluationDetailPage: React.FC = () => {
                 <DialogTitle>
                   Run Details {selectedRun ? `#${selectedRun.id?.slice(-4)}` : ""}
                 </DialogTitle>
-                <Badge variant="outline">{selectedRun?.status}</Badge>
+                {selectedRun && <RunStatusBadge status={selectedRun.status} />}
               </div>
               {selectedRun?.created_at && (
                 <p className="text-xs text-gray-500 mt-1">


### PR DESCRIPTION
- Start celery job and poll for updates when starting an evaluation run instead of blocking ui and waiting for response
- 
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release
