### PR TITLE
feat: Sentry error tracking, API errors, and user context

### DIFF
--- a/frontend/.env.template
+++ b/frontend/.env.template
@@ -62,3 +62,10 @@ VITE_ONBOARDING_PASSWORD=password
 # Enable Heartbeat polling for real-time chat updates and streaming responses
 # Set to "false" to fall back to WebSocket connections
 VITE_USE_POLL=false
+
+# -----------------------------------------------------------------------------
+# Sentry (errors, performance, logs)
+# -----------------------------------------------------------------------------
+# Client DSN from your Sentry project. When unset, Sentry is not initialized.
+# https://docs.sentry.io/platforms/javascript/guides/react/
+VITE_SENTRY_DSN=__SENTRY_DSN__

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,6 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.0",
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.4",
+        "@sentry/react": "^10.47.0",
         "@tanstack/react-query": "^5.56.2",
         "ace-builds": "^1.40.1",
         "antd": "^5.26.3",
@@ -3413,6 +3414,97 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.47.0.tgz",
+      "integrity": "sha512-bVFRAeJWMBcBCvJKIFCMJ1/yQToL4vPGqfmlnDZeypcxkqUDKQ/Y3ziLHXoDL2sx0lagcgU2vH1QhCQ67Aujjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.47.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.47.0.tgz",
+      "integrity": "sha512-pdvMmi4dQpX5S/vAAzrhHPIw3T3HjUgDNgUiCBrlp7N9/6zGO2gNPhUnNekP+CjgI/z0rvf49RLqlDenpNrMOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.47.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.47.0.tgz",
+      "integrity": "sha512-ScdovxP7hJxgMt70+7hFvwT02GIaIUAxdEM/YPsayZBeCoAukPW8WiwztJfoKtsfPyKJ5A6f0H3PIxTPcA9Row==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.47.0",
+        "@sentry/core": "10.47.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.47.0.tgz",
+      "integrity": "sha512-A5OY8friSe6g8WAK4L8IeOPiEd9D3Ps40DzRH5j2f6SUja0t90mKMvHRcRf8zq0d4BkdB+JM7tjOkwxpuv8heA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.47.0",
+        "@sentry/core": "10.47.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.47.0.tgz",
+      "integrity": "sha512-rC0agZdxKA5XWfL4VwPOr/rJMogXDqZgnVzr93YWpFn9DMZT/7LzxSJVPIJwRUjx3bFEby3PcTa3YaX7pxm1AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.47.0",
+        "@sentry-internal/feedback": "10.47.0",
+        "@sentry-internal/replay": "10.47.0",
+        "@sentry-internal/replay-canvas": "10.47.0",
+        "@sentry/core": "10.47.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.47.0.tgz",
+      "integrity": "sha512-nsYRAx3EWezDut+Zl+UwwP07thh9uY7CfSAi2whTdcJl5hu1nSp2z8bba7Vq/MGbNLnazkd3A+GITBEML924JA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.47.0.tgz",
+      "integrity": "sha512-ZtJV6xxF8jUVE9e3YQUG3Do0XapG1GjniyLyqMPgN6cNvs/HaRJODf7m60By+VGqcl5XArEjEPTvx8CdPUXDfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.47.0",
+        "@sentry/core": "10.47.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
     },
     "node_modules/@swc/core": {
       "version": "1.15.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "@radix-ui/react-toggle": "^1.1.0",
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.4",
+    "@sentry/react": "^10.47.0",
     "@tanstack/react-query": "^5.56.2",
     "ace-builds": "^1.40.1",
     "antd": "^5.26.3",

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -1,5 +1,14 @@
+import * as Sentry from "@sentry/react";
 import axios, { Method, AxiosRequestConfig, AxiosError } from "axios";
 import { setServerDown, setServerUp } from "@/config/serverStatus";
+
+function captureSentryIfApiHttpError(error: unknown): void {
+  if (!import.meta.env.VITE_SENTRY_DSN) return;
+  if (!(error instanceof AxiosError)) return;
+  const status = error.response?.status;
+  if (status === undefined || status < 400 || status >= 600) return;
+  Sentry.captureException(error, { tags: { source: "api", http_status: String(status) } });
+}
 
 const AUTH_KEYS = ["access_token", "refresh_token", "token_type", "isAuthenticated", "force_upd_pass_date", "tenant_id"] as const;
 
@@ -13,7 +22,11 @@ let failedQueue: Array<{
 
 const processQueue = (error: unknown, token: string | null = null) => {
   failedQueue.forEach(({ resolve, reject }) => {
-    error ? reject(error) : resolve(token);
+    if (error) {
+      reject(error);
+    } else {
+      resolve(token);
+    }
   });
   failedQueue = [];
 };
@@ -57,6 +70,8 @@ api.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config;
+    console.log(error, '-- error --');
+    captureSentryIfApiHttpError(error);
 
     // Handle 401 errors with token refresh
     if (error.response?.status === 401 && !originalRequest._retry) {

--- a/frontend/src/context/PermissionContext.tsx
+++ b/frontend/src/context/PermissionContext.tsx
@@ -7,6 +7,7 @@ import React, {
 } from "react";
 import { apiRequest } from "@/config/api";
 import { isServerDown } from "@/config/serverStatus";
+import { applySentryUserFromMeResponse } from "@/plugins/sentryUserSync";
 import { AuthMeResponse, isAuthenticated, persistAuthMe } from "@/services/auth";
 
 interface PermissionContextType {
@@ -45,6 +46,7 @@ export const PermissionProvider: React.FC<PermissionProviderProps> = ({
     try {
       const response = await apiRequest<AuthMeResponse>("GET", "/auth/me");
       persistAuthMe(response ?? undefined);
+      applySentryUserFromMeResponse(response ?? undefined);
       const userPermissions: string[] = response?.permissions || [];
       setPermissions(userPermissions);
     } catch (error) {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -50,8 +50,18 @@ const queryClient = new QueryClient({
   },
 })
 
-createRoot(document.getElementById("root")!).render(
-  <QueryClientProvider client={queryClient}>
-    <App />
-  </QueryClientProvider>
-);
+async function bootstrap() {
+  if (import.meta.env.VITE_SENTRY_DSN) {
+    await import("@/plugins/instrument");
+  }
+
+  const container = document.getElementById("root")!;
+  const root = createRoot(container);
+  root.render(
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  );
+}
+
+void bootstrap();

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -52,7 +52,7 @@ const queryClient = new QueryClient({
 
 async function bootstrap() {
   if (import.meta.env.VITE_SENTRY_DSN) {
-    await import("@/plugins/instrument");
+    await import("@/plugins/sentryInit.js");
   }
 
   const container = document.getElementById("root")!;

--- a/frontend/src/plugins/instrument.js
+++ b/frontend/src/plugins/instrument.js
@@ -1,0 +1,17 @@
+import * as Sentry from "@sentry/react";
+
+const dsn = import.meta.env.VITE_SENTRY_DSN;
+console.log("SENTRY_DSN", dsn, import.meta.env.MODE);
+if (dsn) {
+  Sentry.init({
+    dsn,
+    // Adds request headers and IP for users, for more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/react/configuration/options/#sendDefaultPii
+    sendDefaultPii: true,
+    environment: import.meta.env.MODE,
+    integrations: [Sentry.browserTracingIntegration(), Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] })],
+    tracesSampleRate: 1.0,
+    tracePropagationTargets: ["localhost", "app.dev.genassist.ritech.io", "app.test.genassist.ritech.io", "app.genassist.ai"],
+    enableLogs: true,
+  });
+}

--- a/frontend/src/plugins/instrument.js
+++ b/frontend/src/plugins/instrument.js
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/react";
+import { SENTRY_CLIENT_ERROR_EVENT } from "./sentryErrorEvent";
 
 const dsn = import.meta.env.VITE_SENTRY_DSN;
-console.log("SENTRY_DSN", dsn, import.meta.env.MODE);
 if (dsn) {
   Sentry.init({
     dsn,
@@ -9,9 +9,28 @@ if (dsn) {
     // https://docs.sentry.io/platforms/javascript/guides/react/configuration/options/#sendDefaultPii
     sendDefaultPii: true,
     environment: import.meta.env.MODE,
-    integrations: [Sentry.browserTracingIntegration(), Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] })],
+    integrations: [Sentry.browserTracingIntegration(), Sentry.consoleLoggingIntegration({ levels: ["warn", "error"] })],
     tracesSampleRate: 1.0,
     tracePropagationTargets: ["localhost", "app.dev.genassist.ritech.io", "app.test.genassist.ritech.io", "app.genassist.ai"],
     enableLogs: true,
+    beforeSend(event) {
+      const hasException =
+        event.exception?.values &&
+        Array.isArray(event.exception.values) &&
+        event.exception.values.length > 0;
+      if (hasException && typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent(SENTRY_CLIENT_ERROR_EVENT));
+      }
+
+      console.log(event, '-- sentry event --');
+      const user = Sentry.getIsolationScope().getUser();
+      console.log(user, '-- sentry user --');
+
+      // show report dialog if in development mode
+      if (import.meta.env.DEV) {
+        Sentry.showReportDialog({ eventId: event.event_id, user: user });
+        return null;
+      }
+    }
   });
 }

--- a/frontend/src/plugins/sentryErrorEvent.ts
+++ b/frontend/src/plugins/sentryErrorEvent.ts
@@ -1,2 +1,2 @@
-/** Dispatched from `instrument` when Sentry captures an error with an exception (see `beforeSend`). */
+/** Dispatched from `sentryInit` when Sentry captures an error with an exception (see `beforeSend`). */
 export const SENTRY_CLIENT_ERROR_EVENT = "genassist:sentry-error";

--- a/frontend/src/plugins/sentryErrorEvent.ts
+++ b/frontend/src/plugins/sentryErrorEvent.ts
@@ -1,0 +1,2 @@
+/** Dispatched from `instrument` when Sentry captures an error with an exception (see `beforeSend`). */
+export const SENTRY_CLIENT_ERROR_EVENT = "genassist:sentry-error";

--- a/frontend/src/plugins/sentryInit.js
+++ b/frontend/src/plugins/sentryInit.js
@@ -22,10 +22,8 @@ if (dsn) {
         window.dispatchEvent(new CustomEvent(SENTRY_CLIENT_ERROR_EVENT));
       }
 
-      console.log(event, '-- sentry event --');
+      // get user from isolation scope
       const user = Sentry.getIsolationScope().getUser();
-      console.log(user, '-- sentry user --');
-
       // show report dialog if in development mode
       if (import.meta.env.DEV) {
         Sentry.showReportDialog({ eventId: event.event_id, user: user });

--- a/frontend/src/plugins/sentryUserSync.ts
+++ b/frontend/src/plugins/sentryUserSync.ts
@@ -1,0 +1,33 @@
+import * as Sentry from "@sentry/react";
+import type { AuthMeResponse } from "@/services/auth";
+import {
+  getCurrentUserId,
+  getTenantId,
+} from "@/services/auth";
+
+export function hasSentry(): boolean {
+  return Boolean(import.meta.env.VITE_SENTRY_DSN);
+}
+
+/** Full user from GET /auth/me — call after a successful response. */
+export function applySentryUserFromMeResponse(
+  me: AuthMeResponse | null | undefined
+): void {
+  if (!hasSentry() || !me) return;
+
+  const id = me.id ?? getCurrentUserId() ?? undefined;
+  if (!id && !me.username) return;
+
+  Sentry.setUser({
+    id: id ?? me.username,
+    username: me.username,
+    email: me.email,
+    ...(me.username ? { name: me.username } : {}),
+  });
+
+  const tenant = getTenantId();
+  if (tenant) {
+    Sentry.setTag("tenant_id", tenant);
+  }
+}
+

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -2,6 +2,7 @@ import { jwtDecode } from "jwt-decode";
 import { apiRequest } from "@/config/api";
 import { User } from "@/interfaces/user.interface";
 import { Role } from "@/interfaces/role.interface";
+import { applySentryUserFromMeResponse, hasSentry } from "@/plugins/sentryUserSync";
 
 interface AuthTokens {
   access_token: string;
@@ -19,6 +20,9 @@ interface TokenPayload {
 }
 
 export interface AuthMeResponse {
+  id?: string;
+  username?: string;
+  email?: string;
   permissions: string[];
   roles: Role[]
 }
@@ -75,6 +79,10 @@ export const persistAuthMe = (
     JSON.stringify(response.permissions ?? [])
   );
   localStorage.setItem("user_roles", JSON.stringify(response.roles ?? []));
+
+  if (hasSentry()) {
+    applySentryUserFromMeResponse(response ?? undefined);
+  }
 };
 
 export const getUserRoleNames = (): string[] => {
@@ -157,11 +165,16 @@ export const logout = (): void => {
   localStorage.removeItem("tenant_id");
   localStorage.removeItem("auth_username");
 
+  if (hasSentry()) {
+    applySentryUserFromMeResponse(null);
+  }
+
   const token = localStorage.getItem("access_token");
   if (token) {
     try {
       apiRequest("POST", "auth/logout", {});
     } catch (error) {
+      /* ignore */
     }
   }
 };

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SENTRY_DSN?: string;
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1046,6 +1046,60 @@
   resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz"
   integrity sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==
 
+"@sentry-internal/browser-utils@10.47.0":
+  version "10.47.0"
+  resolved "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.47.0.tgz"
+  integrity sha512-bVFRAeJWMBcBCvJKIFCMJ1/yQToL4vPGqfmlnDZeypcxkqUDKQ/Y3ziLHXoDL2sx0lagcgU2vH1QhCQ67Aujjw==
+  dependencies:
+    "@sentry/core" "10.47.0"
+
+"@sentry-internal/feedback@10.47.0":
+  version "10.47.0"
+  resolved "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.47.0.tgz"
+  integrity sha512-pdvMmi4dQpX5S/vAAzrhHPIw3T3HjUgDNgUiCBrlp7N9/6zGO2gNPhUnNekP+CjgI/z0rvf49RLqlDenpNrMOg==
+  dependencies:
+    "@sentry/core" "10.47.0"
+
+"@sentry-internal/replay-canvas@10.47.0":
+  version "10.47.0"
+  resolved "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.47.0.tgz"
+  integrity sha512-A5OY8friSe6g8WAK4L8IeOPiEd9D3Ps40DzRH5j2f6SUja0t90mKMvHRcRf8zq0d4BkdB+JM7tjOkwxpuv8heA==
+  dependencies:
+    "@sentry-internal/replay" "10.47.0"
+    "@sentry/core" "10.47.0"
+
+"@sentry-internal/replay@10.47.0":
+  version "10.47.0"
+  resolved "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.47.0.tgz"
+  integrity sha512-ScdovxP7hJxgMt70+7hFvwT02GIaIUAxdEM/YPsayZBeCoAukPW8WiwztJfoKtsfPyKJ5A6f0H3PIxTPcA9Row==
+  dependencies:
+    "@sentry-internal/browser-utils" "10.47.0"
+    "@sentry/core" "10.47.0"
+
+"@sentry/browser@10.47.0":
+  version "10.47.0"
+  resolved "https://registry.npmjs.org/@sentry/browser/-/browser-10.47.0.tgz"
+  integrity sha512-rC0agZdxKA5XWfL4VwPOr/rJMogXDqZgnVzr93YWpFn9DMZT/7LzxSJVPIJwRUjx3bFEby3PcTa3YaX7pxm1AA==
+  dependencies:
+    "@sentry-internal/browser-utils" "10.47.0"
+    "@sentry-internal/feedback" "10.47.0"
+    "@sentry-internal/replay" "10.47.0"
+    "@sentry-internal/replay-canvas" "10.47.0"
+    "@sentry/core" "10.47.0"
+
+"@sentry/core@10.47.0":
+  version "10.47.0"
+  resolved "https://registry.npmjs.org/@sentry/core/-/core-10.47.0.tgz"
+  integrity sha512-nsYRAx3EWezDut+Zl+UwwP07thh9uY7CfSAi2whTdcJl5hu1nSp2z8bba7Vq/MGbNLnazkd3A+GITBEML924JA==
+
+"@sentry/react@^10.47.0":
+  version "10.47.0"
+  resolved "https://registry.npmjs.org/@sentry/react/-/react-10.47.0.tgz"
+  integrity sha512-ZtJV6xxF8jUVE9e3YQUG3Do0XapG1GjniyLyqMPgN6cNvs/HaRJODf7m60By+VGqcl5XArEjEPTvx8CdPUXDfA==
+  dependencies:
+    "@sentry/browser" "10.47.0"
+    "@sentry/core" "10.47.0"
+
 "@swc/core-darwin-arm64@1.15.11":
   version "1.15.11"
   resolved "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.11.tgz"
@@ -4065,7 +4119,7 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@*, "react@^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.3 || ^17.0 || ^18.0 || ^19.0", "react@^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc", "react@^16.8 || ^17 || ^18", "react@^16.8 || ^17.0 || ^18.0", "react@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react@^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.8.0 || ^17 || ^18 || ^19", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^18 || ^19", "react@^18 || ^19 || ^19.0.0-rc", "react@^18.0.0 || ^19.0.0 || ^19.0.0-rc", react@^18.3.1, react@>=16, react@>=16.0.0, react@>=16.11.0, react@>=16.6.0, react@>=16.8, react@>=16.8.0, react@>=16.9.0, react@>=17, react@>=18, "react@16 || 17 || 18":
+react@*, "react@^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.14.0 || 17.x || 18.x || 19.x", "react@^16.3 || ^17.0 || ^18.0 || ^19.0", "react@^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc", "react@^16.8 || ^17 || ^18", "react@^16.8 || ^17.0 || ^18.0", "react@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react@^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.8.0 || ^17 || ^18 || ^19", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^18 || ^19", "react@^18 || ^19 || ^19.0.0-rc", "react@^18.0.0 || ^19.0.0 || ^19.0.0-rc", react@^18.3.1, react@>=16, react@>=16.0.0, react@>=16.11.0, react@>=16.6.0, react@>=16.8, react@>=16.8.0, react@>=16.9.0, react@>=17, react@>=18, "react@16 || 17 || 18":
   version "18.3.1"
   resolved "https://registry.npmjs.org/react/-/react-18.3.1.tgz"
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==


### PR DESCRIPTION
## Description

- Bootstrap (main.tsx): async bootstrap() dynamically imports @/plugins/instrument only when VITE_SENTRY_DSN is defined, then mounts the app.
- Initialization (plugins/instrument.js): Sentry.init with DSN, sendDefaultPii, browser tracing, console logging integration, full trace sample rate, trace propagation targets for known app hosts, and beforeSend that dispatches a custom SENTRY_CLIENT_ERROR_EVENT for client exceptions. In development, showReportDialog is used and the event is dropped from upload (return null).
- User / tenant (plugins/sentryUserSync.ts): applySentryUserFromMeResponse sets Sentry.setUser from /auth/me (id, username, email) and tenant_id tag from existing auth helpers. Used from persistAuthMe, PermissionProvider (after successful /auth/me), and logout path.
- Auth types (auth.ts): AuthMeResponse extended with optional id, username, email for Sentry.
- API layer (config/api.ts): response interceptor calls captureSentryIfApiHttpError for Axios HTTP errors in the 400–599 range when Sentry is configured.
- Env / types: VITE_SENTRY_DSN documented in frontend/.env.template and declared in vite-env.d.ts.
- Dependencies: @sentry/react added (lockfiles updated).

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release



---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
