### PR TITLE
Fix: MCP server update

### DIFF
--- a/backend/app/repositories/mcp_server.py
+++ b/backend/app/repositories/mcp_server.py
@@ -146,26 +146,36 @@ class MCPServerRepository:
 
         # Update workflows if provided
         if workflows is not None:
-            # Delete existing workflows
             existing_workflows_query = select(MCPServerWorkflowModel).where(
                 MCPServerWorkflowModel.mcp_server_id == mcp_server_id
             )
             existing_workflows_result = await self.db.execute(existing_workflows_query)
-            for wf in existing_workflows_result.scalars().all():
-                await self.db.delete(wf)
+            existing_workflows = {wf.workflow_id: wf for wf in existing_workflows_result.scalars().all()}
+            incoming_workflows = {wf_data["workflow_id"]: wf_data for wf_data in workflows}
 
-            # Ensure DELETEs are sent before INSERTs to avoid unique constraint violation
+            # Delete workflows removed from the list
+            for workflow_id, wf in existing_workflows.items():
+                if workflow_id not in incoming_workflows:
+                    await self.db.delete(wf)
+
             await self.db.flush()
 
-            # Create new workflows
-            for wf_data in workflows:
-                workflow = MCPServerWorkflowModel(
-                    mcp_server_id=mcp_server.id,
-                    workflow_id=wf_data["workflow_id"],
-                    tool_name=wf_data["tool_name"],
-                    tool_description=wf_data["tool_description"],
-                )
-                self.db.add(workflow)
+            for workflow_id, wf_data in incoming_workflows.items():
+                if workflow_id in existing_workflows:
+                    # Update changed fields
+                    existing = existing_workflows[workflow_id]
+                    if existing.tool_name != wf_data["tool_name"]:
+                        existing.tool_name = wf_data["tool_name"]
+                    if existing.tool_description != wf_data["tool_description"]:
+                        existing.tool_description = wf_data["tool_description"]
+                else:
+                    # Insert new workflow
+                    self.db.add(MCPServerWorkflowModel(
+                        mcp_server_id=mcp_server.id,
+                        workflow_id=workflow_id,
+                        tool_name=wf_data["tool_name"],
+                        tool_description=wf_data["tool_description"],
+                    ))
 
         await self.db.commit()
         await self.db.refresh(mcp_server)

--- a/backend/app/repositories/mcp_server.py
+++ b/backend/app/repositories/mcp_server.py
@@ -158,8 +158,6 @@ class MCPServerRepository:
                 if workflow_id not in incoming_workflows:
                     await self.db.delete(wf)
 
-            await self.db.flush()
-
             for workflow_id, wf_data in incoming_workflows.items():
                 if workflow_id in existing_workflows:
                     # Update changed fields

--- a/backend/app/repositories/mcp_server.py
+++ b/backend/app/repositories/mcp_server.py
@@ -1,13 +1,13 @@
-from typing import Optional, List
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, and_
-from sqlalchemy.orm import selectinload
-from uuid import UUID
-from injector import inject
 import logging
+from typing import List, Optional
+from uuid import UUID
+
+from injector import inject
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.db.models.mcp_server import MCPServerModel, MCPServerWorkflowModel
-from app.auth.utils import get_current_user_id
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +153,9 @@ class MCPServerRepository:
             existing_workflows_result = await self.db.execute(existing_workflows_query)
             for wf in existing_workflows_result.scalars().all():
                 await self.db.delete(wf)
+
+            # Ensure DELETEs are sent before INSERTs to avoid unique constraint violation
+            await self.db.flush()
 
             # Create new workflows
             for wf_data in workflows:

--- a/frontend/src/views/MCPServers/components/MCPServerDialog.tsx
+++ b/frontend/src/views/MCPServers/components/MCPServerDialog.tsx
@@ -149,34 +149,45 @@ export function MCPServerDialog({
 
     setIsSubmitting(true);
     try {
-      const payload: MCPServerCreatePayload | MCPServerUpdatePayload = {
-        name,
-        description: description || undefined,
-        is_active: isActive ? 1 : 0,
-        workflows: selectedWorkflows,
-      };
-
-      if (mode === "create") {
-        (payload as MCPServerCreatePayload).api_key = apiKey;
-        await createMCPServer(payload as MCPServerCreatePayload);
-        toast.success("MCP server created successfully.");
+      if (mode === 'create') {
+        const payload: MCPServerCreatePayload = {
+          name,
+          description: description || undefined,
+          is_active: isActive ? 1 : 0,
+          workflows: selectedWorkflows,
+          api_key: apiKey,
+        };
+        await createMCPServer(payload);
+        toast.success('MCP server created successfully.');
         // Reset API key state after saving
         setIsApiKeyGenerated(false);
         setIsApiKeyCopied(false);
         onServerSaved?.();
         onOpenChange(false);
       } else if (serverToEdit) {
-        // Only update API key if provided
-        if (apiKey.trim()) {
-          (payload as MCPServerUpdatePayload).api_key = apiKey;
-        }
-        await updateMCPServer(serverToEdit.id, payload as MCPServerUpdatePayload);
-        toast.success("MCP server updated successfully.");
+        const updatePayload: MCPServerUpdatePayload = {};
+
+        if (name !== serverToEdit.name) updatePayload.name = name;
+        if ((description || undefined) !== (serverToEdit.description || undefined))
+          updatePayload.description = description || undefined;
+        if ((isActive ? 1 : 0) !== serverToEdit.is_active) updatePayload.is_active = isActive ? 1 : 0;
+        if (apiKey.trim()) updatePayload.api_key = apiKey;
+
+        const workflowsChanged =
+          selectedWorkflows.length !== (serverToEdit.workflows || []).length ||
+          selectedWorkflows.some((sw) => {
+            const orig = (serverToEdit.workflows || []).find((w) => w.workflow_id === sw.workflow_id);
+            return !orig || orig.tool_name !== sw.tool_name || orig.tool_description !== sw.tool_description;
+          });
+        if (workflowsChanged) updatePayload.workflows = selectedWorkflows;
+
+        await updateMCPServer(serverToEdit.id, updatePayload);
+        toast.success('MCP server updated successfully.');
 
         if (onServerUpdated) {
           const updatedServer: MCPServer = {
             ...serverToEdit,
-            ...payload,
+            ...updatePayload,
             workflows: selectedWorkflows,
           };
           onServerUpdated(updatedServer);


### PR DESCRIPTION
## Description

- Implement a partial update, so backend receives only those fields that were changed.
- If list of workflows modified, backend only touches modified workflows (previously all workflows would get deleted then inserted).

## Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [X] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
