### PR TITLE
fix: Remove default for required parameters

### DIFF
--- a/backend/app/modules/workflow/agents/react_agent_lc.py
+++ b/backend/app/modules/workflow/agents/react_agent_lc.py
@@ -125,7 +125,7 @@ class ReActAgentLC(BaseToolAgent):
                 if required:
                     fields[param_name] = (
                         field_type,
-                        Field(default=param_default, description=param_description),
+                        Field(description=param_description),
                     )
                 else:
                     fields[param_name] = (


### PR DESCRIPTION
## Description

In Pydantic v2, a field with a default value cannot be required. Thus, I removed default for required parameters.

## Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
