### PR TITLE
feat: add CSV export functionality for LLM cost rates and backfill updated_at field

### DIFF
--- a/backend/alembic/versions/00061_backfill_llm_cost_rates_updated_at.py
+++ b/backend/alembic/versions/00061_backfill_llm_cost_rates_updated_at.py
@@ -1,0 +1,97 @@
+"""backfill llm_cost_rates.updated_at + enforce unique provider/model (active)
+
+Fixes legacy rows that may have NULL updated_at due to a model/schema mismatch.
+Also ensures (provider_key, model_key) is unique among non-deleted rows by:
+- normalizing keys to lowercase+trim
+- soft-deleting duplicates (keeping the most recent row)
+- creating a partial unique index for active rows
+
+Revision ID: f1c2d3e4a5b6
+Revises: e8f9a0b1c2d3
+Create Date: 2026-04-07 12:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f1c2d3e4a5b6"
+down_revision: Union[str, None] = "e8f9a0b1c2d3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+            UPDATE llm_cost_rates
+            SET updated_at = COALESCE(created_at, CURRENT_TIMESTAMP)
+            WHERE updated_at IS NULL
+            """
+        )
+    )
+
+    # Normalize keys to match importer behavior (trim + lowercase) to prevent
+    # case/whitespace duplicates from surviving.
+    conn.execute(
+        sa.text(
+            """
+            UPDATE llm_cost_rates
+            SET
+              provider_key = LOWER(TRIM(provider_key)),
+              model_key = LOWER(TRIM(model_key))
+            WHERE
+              provider_key IS NOT NULL
+              AND model_key IS NOT NULL
+            """
+        )
+    )
+
+    # Soft-delete duplicates (keep the most recent row per provider/model).
+    # Uses a window function; marks all but rn=1 as deleted.
+    conn.execute(
+        sa.text(
+            """
+            WITH ranked AS (
+              SELECT
+                id,
+                ROW_NUMBER() OVER (
+                  PARTITION BY provider_key, model_key
+                  ORDER BY COALESCE(updated_at, created_at) DESC, id DESC
+                ) AS rn
+              FROM llm_cost_rates
+              WHERE is_deleted = 0
+            )
+            UPDATE llm_cost_rates
+            SET is_deleted = 1
+            WHERE id IN (SELECT id FROM ranked WHERE rn > 1)
+            """
+        )
+    )
+
+    # Enforce uniqueness among active rows only.
+    op.create_index(
+        "uq_llm_cost_rates_provider_model_active",
+        "llm_cost_rates",
+        ["provider_key", "model_key"],
+        unique=True,
+        postgresql_where=sa.text("is_deleted = 0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_llm_cost_rates_provider_model_active",
+        table_name="llm_cost_rates",
+        postgresql_where=sa.text("is_deleted = 0"),
+    )
+
+    # Non-destructive: we don't revert timestamps or resurrect duplicates.
+    return
+

--- a/backend/app/api/v1/routes/llm_cost_rates.py
+++ b/backend/app/api/v1/routes/llm_cost_rates.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from fastapi.responses import StreamingResponse
 from fastapi_injector import Injected
 
 from app.auth.dependencies import auth, permissions
@@ -20,6 +21,10 @@ router = APIRouter()
 )
 async def list_cost_rates(service: LlmCostRateService = Injected(LlmCostRateService)):
     rows = await service.list_active()
+    # Defensive: older rows might have NULL updated_at; avoid breaking response validation.
+    for r in rows:
+        if getattr(r, "updated_at", None) is None:
+            r.updated_at = getattr(r, "created_at", None)
     return [
         LlmCostRateRead.model_validate(r, from_attributes=True)
         for r in rows
@@ -49,6 +54,21 @@ async def import_cost_rates_csv(
             error_detail="File must be UTF-8 encoded"
         ) from e
     return await service.import_csv(text)
+
+
+@router.get(
+    "/export",
+    dependencies=[Depends(auth), Depends(permissions(P.LlmProvider.READ))],
+)
+async def export_cost_rates_csv(
+    service: LlmCostRateService = Injected(LlmCostRateService),
+):
+    csv_text = await service.export_csv()
+    return StreamingResponse(
+        iter([csv_text]),
+        media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": 'attachment; filename="llm-cost-rates.csv"'},
+    )
 
 
 @router.delete(

--- a/backend/app/db/models/llm_cost_rate.py
+++ b/backend/app/db/models/llm_cost_rate.py
@@ -1,6 +1,4 @@
-from datetime import datetime
-
-from sqlalchemy import DateTime, Index, Numeric, PrimaryKeyConstraint, String
+from sqlalchemy import Index, Numeric, PrimaryKeyConstraint, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -19,4 +17,3 @@ class LlmCostRateModel(Base):
     model_key: Mapped[str] = mapped_column(String(512), nullable=False)
     input_per_1k: Mapped[float] = mapped_column(Numeric(18, 10), nullable=False)
     output_per_1k: Mapped[float] = mapped_column(Numeric(18, 10), nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/backend/app/repositories/llm_cost_rates.py
+++ b/backend/app/repositories/llm_cost_rates.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 
 from injector import inject
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models.llm_cost_rate import LlmCostRateModel
@@ -25,10 +25,12 @@ class LlmCostRateRepository:
     async def get_active_by_provider_model(
         self, provider_key: str, model_key: str
     ) -> LlmCostRateModel | None:
+        provider_key = (provider_key or "").strip().lower()
+        model_key = (model_key or "").strip().lower()
         result = await self.db.execute(
             select(LlmCostRateModel).where(
-                LlmCostRateModel.provider_key == provider_key,
-                LlmCostRateModel.model_key == model_key,
+                func.lower(func.trim(LlmCostRateModel.provider_key)) == provider_key,
+                func.lower(func.trim(LlmCostRateModel.model_key)) == model_key,
                 LlmCostRateModel.is_deleted == 0,
             )
         )

--- a/backend/app/services/llm_cost_rates.py
+++ b/backend/app/services/llm_cost_rates.py
@@ -1,6 +1,7 @@
 import csv
 import io
 import logging
+from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from uuid import UUID
 
@@ -24,6 +25,25 @@ class LlmCostRateService:
 
     async def list_active(self) -> list[LlmCostRateModel]:
         return await self.repo.list_active()
+
+    async def export_csv(self) -> str:
+        """
+        Export the current rates in the same 4-column format the importer accepts.
+        """
+        rows = await self.repo.list_active()
+        out = io.StringIO()
+        writer = csv.writer(out, lineterminator="\n")
+        writer.writerow(["provider", "model", "input_per_1k", "output_per_1k"])
+        for r in rows:
+            writer.writerow(
+                [
+                    (r.provider_key or "").strip(),
+                    (r.model_key or "").strip(),
+                    f"{float(r.input_per_1k):.10g}",
+                    f"{float(r.output_per_1k):.10g}",
+                ]
+            )
+        return out.getvalue()
 
     async def delete_by_id(self, rate_id: UUID) -> bool:
         tenant = get_tenant_context()
@@ -59,8 +79,8 @@ class LlmCostRateService:
             return ""
 
         for i, row in enumerate(reader, start=2):
-            prov = col(row, "provider").lower()
-            mod = col(row, "model").lower()
+            prov = col(row, "provider").strip().lower()
+            mod = col(row, "model").strip().lower()
             if not prov or not mod:
                 errors.append(f"Row {i}: provider and model are required")
                 continue
@@ -77,6 +97,8 @@ class LlmCostRateService:
             if existing:
                 existing.input_per_1k = inp
                 existing.output_per_1k = out
+                # Defensive: older schema/model mismatch could leave this NULL.
+                existing.updated_at = datetime.now(timezone.utc)
                 self.repo.db.add(existing)
                 updated += 1
             else:
@@ -86,6 +108,7 @@ class LlmCostRateService:
                         model_key=mod,
                         input_per_1k=inp,
                         output_per_1k=out,
+                        updated_at=datetime.now(timezone.utc),
                     )
                 )
                 inserted += 1

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7161,6 +7161,34 @@
         ]
       }
     },
+    "/api/llm-cost-rates/export": {
+      "get": {
+        "tags": [
+          "v1",
+          "LlmCostRates"
+        ],
+        "summary": "Export Cost Rates Csv",
+        "operationId": "export_cost_rates_csv_api_llm_cost_rates_export_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
     "/api/llm-cost-rates/{rate_id}": {
       "delete": {
         "tags": [

--- a/frontend/src/services/llmCostRates.ts
+++ b/frontend/src/services/llmCostRates.ts
@@ -49,3 +49,29 @@ export async function importLlmCostRatesCsv(
 export async function deleteLlmCostRate(id: string): Promise<void> {
   await apiRequest("DELETE", `llm-cost-rates/${id}`);
 }
+
+export async function exportLlmCostRatesCsv(): Promise<Blob> {
+  const baseURL = (await getApiUrl()).replace(/\/$/, "");
+  const fullUrl = `${baseURL}/llm-cost-rates/export`;
+
+  const token = localStorage.getItem("access_token");
+  const tokenType = localStorage.getItem("token_type") || "Bearer";
+  const tenantId = localStorage.getItem("tenant_id");
+
+  const headers: Record<string, string> = {};
+  if (token) {
+    headers.Authorization = `${tokenType} ${token}`;
+  }
+  if (tenantId) {
+    headers["x-tenant-id"] = tenantId;
+  }
+
+  const response = await fetch(fullUrl, { method: "GET", headers });
+  if (!response.ok) {
+    const errBody = (await response.json().catch(() => ({}))) as {
+      detail?: string;
+    };
+    throw new Error(errBody.detail || `Export failed (${response.status})`);
+  }
+  return await response.blob();
+}

--- a/frontend/src/views/LlmProviders/components/LlmCostRatesDialog.tsx
+++ b/frontend/src/views/LlmProviders/components/LlmCostRatesDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -20,6 +20,7 @@ import {
   getLlmCostRates,
   importLlmCostRatesCsv,
   deleteLlmCostRate,
+  exportLlmCostRatesCsv,
 } from "@/services/llmCostRates";
 import type { LlmCostRate } from "@/interfaces/llmCostRate.interface";
 import toast from "react-hot-toast";
@@ -59,6 +60,8 @@ export function LlmCostRatesDialog({
   const [rowToDelete, setRowToDelete] = useState<LlmCostRate | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(25);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -78,6 +81,25 @@ export function LlmCostRatesDialog({
       void load();
     }
   }, [open, load]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [open]);
+
+  const totalRows = rows.length;
+  const totalPages = Math.max(1, Math.ceil(totalRows / pageSize));
+
+  useEffect(() => {
+    if (page > totalPages) setPage(totalPages);
+  }, [page, totalPages]);
+
+  const pagedRows = useMemo(() => {
+    const start = (page - 1) * pageSize;
+    return rows.slice(start, start + pageSize);
+  }, [rows, page, pageSize]);
+
+  const fromRow = totalRows === 0 ? 0 : (page - 1) * pageSize + 1;
+  const toRow = totalRows === 0 ? 0 : Math.min(totalRows, page * pageSize);
 
   const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -148,6 +170,21 @@ export function LlmCostRatesDialog({
     toast.success("Template downloaded.");
   };
 
+  const downloadCurrentRatesCsv = async () => {
+    try {
+      const blob = await exportLlmCostRatesCsv();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "llm-cost-rates.csv";
+      a.click();
+      URL.revokeObjectURL(url);
+      toast.success("Current rates downloaded.");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Export failed.");
+    }
+  };
+
   return (
     <>
     <Dialog
@@ -179,6 +216,15 @@ export function LlmCostRatesDialog({
           >
             <FileText className="w-4 h-4 mr-2" />
             CSV template
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void downloadCurrentRatesCsv()}
+          >
+            <Download className="w-4 h-4 mr-2" />
+            Download current CSV
           </Button>
           <Button
             type="button"
@@ -239,7 +285,7 @@ export function LlmCostRatesDialog({
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {rows.map((r) => (
+                {pagedRows.map((r) => (
                   <TableRow key={r.id}>
                     <TableCell className="font-mono text-xs">
                       {r.provider_key}
@@ -276,6 +322,57 @@ export function LlmCostRatesDialog({
             </Table>
           )}
         </div>
+
+        {!loading && rows.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+            <span className="tabular-nums">
+              {fromRow}–{toRow} of {totalRows}
+            </span>
+
+            <div className="flex items-center gap-2 ml-auto">
+              <label className="flex items-center gap-2">
+                <span className="text-xs">Rows</span>
+                <select
+                  className="h-8 rounded-md border bg-background px-2 text-sm text-foreground"
+                  value={pageSize}
+                  onChange={(e) => {
+                    const next = Number(e.target.value);
+                    setPageSize(next);
+                    setPage(1);
+                  }}
+                >
+                  {[10, 25, 50, 100].map((n) => (
+                    <option key={n} value={n}>
+                      {n}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+              >
+                Prev
+              </Button>
+              <span className="tabular-nums">
+                Page {page} / {totalPages}
+              </span>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages}
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
 


### PR DESCRIPTION
## Description
- Introduced a new endpoint to export LLM cost rates as a CSV file.
- Implemented a backfill migration to update NULL values in the updated_at field and enforce uniqueness on provider/model keys.
- Enhanced the LLM cost rates service to support CSV export and adjusted the repository to handle key normalization.
- Updated frontend components to include a download button for the exported CSV.

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release



---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
