### PR TITLE
feat: add custom attributes to conversations for filtering and analytics

### DIFF
--- a/backend/alembic/versions/00061_add_custom_attributes_to_conversations.py
+++ b/backend/alembic/versions/00061_add_custom_attributes_to_conversations.py
@@ -1,0 +1,39 @@
+"""add custom_attributes JSONB column to conversations
+
+Stores workflow dynamic parameters (e.g. region, tier) as queryable
+JSONB on each conversation so they can be filtered and used in analytics.
+
+Revision ID: f1a2b3c4d5e6
+Revises: e8f9a0b1c2d3
+Create Date: 2026-04-03 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "f1a2b3c4d5e6"
+down_revision: Union[str, None] = "e8f9a0b1c2d3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversations",
+        sa.Column("custom_attributes", JSONB, nullable=True),
+    )
+    op.create_index(
+        "ix_conversations_custom_attributes_gin",
+        "conversations",
+        ["custom_attributes"],
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_conversations_custom_attributes_gin", table_name="conversations")
+    op.drop_column("conversations", "custom_attributes")

--- a/backend/alembic/versions/00062_add_custom_attributes_to_conversations.py
+++ b/backend/alembic/versions/00062_add_custom_attributes_to_conversations.py
@@ -3,9 +3,9 @@
 Stores workflow dynamic parameters (e.g. region, tier) as queryable
 JSONB on each conversation so they can be filtered and used in analytics.
 
-Revision ID: f1a2b3c4d5e6
-Revises: e8f9a0b1c2d3
-Create Date: 2026-04-03 10:00:00.000000
+Revision ID: a2b3c4d5e6f7
+Revises: f1c2d3e4a5b6
+Create Date: 2026-04-08 10:00:00.000000
 
 """
 
@@ -15,8 +15,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects.postgresql import JSONB
 
-revision: str = "f1a2b3c4d5e6"
-down_revision: Union[str, None] = "e8f9a0b1c2d3"
+revision: str = "a2b3c4d5e6f7"
+down_revision: Union[str, None] = "f1c2d3e4a5b6"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -404,6 +404,15 @@ def create_celery():
             "options": {"expires": 7200},  # Task expires after 2 hours
         }
 
+    # One-time backfill of custom attributes from agent response logs
+    # Runs once at startup via beat; skips conversations already populated
+    if settings.CELERY_ENABLE_BACKFILL_CUSTOM_ATTRIBUTES_TASK:
+        beat_schedule["backfill-custom-attributes"] = {
+            "task": "app.tasks.backfill_custom_attributes.backfill_custom_attributes",
+            "schedule": crontab(minute="0", hour="3"),
+            "options": {"expires": 7200},
+        }
+
     celery_app.conf.beat_schedule = beat_schedule
 
     return celery_app

--- a/backend/app/api/v1/routes/analytics.py
+++ b/backend/app/api/v1/routes/analytics.py
@@ -248,6 +248,42 @@ async def get_metrics_daily(
         return {"items": []}
 
 
+
+@router.get(
+    "/custom-attributes/keys",
+    dependencies=[
+        Depends(auth),
+        Depends(permissions(P.Dashboard.READ)),
+    ],
+    summary="Get available custom attribute keys",
+)
+async def get_custom_attribute_keys(
+    agent_id: UUID | None = Query(default=None),
+    service: AnalyticsReadService = Injected(AnalyticsReadService),
+) -> list[str]:
+    return await service.get_custom_attribute_keys(agent_id=agent_id)
+
+
+@router.get(
+    "/custom-attributes/breakdown",
+    dependencies=[
+        Depends(auth),
+        Depends(permissions(P.Dashboard.READ)),
+    ],
+    summary="Get conversation breakdown by custom attribute value",
+)
+async def get_custom_attribute_breakdown(
+    key: str = Query(..., description="Custom attribute key to group by"),
+    agent_id: UUID | None = Query(default=None),
+    from_date: datetime | None = Query(default=None),
+    to_date: datetime | None = Query(default=None),
+    service: AnalyticsReadService = Injected(AnalyticsReadService),
+) -> list[dict]:
+    return await service.get_custom_attribute_breakdown(
+        key=key, agent_id=agent_id, from_date=from_date, to_date=to_date
+    )
+
+
 def _build_streaming_response(content: bytes, media_type: str, filename_base: str, fmt: str) -> StreamingResponse:
     filename = f"{filename_base}.{EXTENSIONS[fmt]}"
     return StreamingResponse(

--- a/backend/app/core/config/settings.py
+++ b/backend/app/core/config/settings.py
@@ -52,6 +52,7 @@ class ProjectSettings(BaseSettings):
     CELERY_ENABLE_CHECK_SCHEDULED_PIPELINE_RUNS_TASK: bool = True
     CELERY_ENABLE_SUMMARIZE_FILES_FROM_AZURE_TASK: bool = True
     CELERY_ENABLE_AGGREGATE_AGENT_ANALYTICS_TASK: bool = True
+    CELERY_ENABLE_BACKFILL_CUSTOM_ATTRIBUTES_TASK: bool = True
 
     # Worker pool: "solo" avoids SIGSEGV with PyTorch/transformers/sentence-transformers (app tasks load these).
     # Use "prefork" only if you run workers that do not import ML libs; set CELERY_WORKER_POOL=prefork.

--- a/backend/app/core/utils/custom_attributes.py
+++ b/backend/app/core/utils/custom_attributes.py
@@ -1,0 +1,63 @@
+"""
+Shared utilities for extracting custom workflow attributes from agent responses.
+
+Used by both the real-time capture (chat_as_client_use_case) and the
+backfill Celery task to ensure consistent extraction logic.
+"""
+
+# Keys from chatInputNode output or SetStateNode that are internal, not business attributes
+INTERNAL_KEYS = frozenset({
+    "message", "conversation_history", "node_outputs",
+    "session.message", "session.thread_id", "thread_id",
+    "error",
+})
+
+
+def is_valid_attr_value(v) -> bool:
+    """Return True if the value is a non-empty scalar suitable for a custom attribute."""
+    if not isinstance(v, (str, int, float, bool)):
+        return False
+    if isinstance(v, str) and v.strip().lower() in ("", "null", "none", "undefined"):
+        return False
+    return True
+
+
+def extract_custom_attributes_from_state(node_statuses: dict) -> dict:
+    """Extract custom attributes from nodeExecutionStatus dict.
+
+    Reads chatInputNode output (validated inputSchema keys only),
+    then merges SetStateNode updates (latest wins).
+    Filters out internal keys and non-scalar values.
+    """
+    if not isinstance(node_statuses, dict):
+        return {}
+
+    attrs: dict = {}
+
+    # Get custom attributes from chatInputNode output
+    for node_info in node_statuses.values():
+        if node_info.get("type") == "chatInputNode":
+            output = node_info.get("output", {})
+            if isinstance(output, dict):
+                for k, v in output.items():
+                    if k not in INTERNAL_KEYS and v is not None and is_valid_attr_value(v):
+                        attrs[k] = v
+            break  # Only one chatInputNode per workflow
+
+    # Merge SetStateNode updates (latest wins)
+    for node_info in node_statuses.values():
+        if node_info.get("type") == "setStateNode":
+            updated = node_info.get("output", {}).get("updated", {})
+            if isinstance(updated, dict):
+                for k, v in updated.items():
+                    if k not in INTERNAL_KEYS and v is not None and is_valid_attr_value(v):
+                        attrs[k] = v
+
+    return attrs
+
+
+def extract_custom_attributes(agent_response: dict) -> dict:
+    """Extract custom attributes from a full agent response dict."""
+    raw_state = agent_response.get("row_agent_response", {}).get("state", {})
+    node_statuses = raw_state.get("nodeExecutionStatus", {})
+    return extract_custom_attributes_from_state(node_statuses)

--- a/backend/app/db/models/conversation.py
+++ b/backend/app/db/models/conversation.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     Text,
     text,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 import datetime
@@ -88,6 +89,7 @@ class ConversationModel(Base):
     thumbs_down_count: Mapped[int] = mapped_column(Integer, server_default=text("0"))
     thumbs_up_count: Mapped[int] = mapped_column(Integer, server_default=text("0"))
     finalize_llm_analyst_id: Mapped[Optional[UUID]] = mapped_column(PGUUID(as_uuid=True), nullable=True)
+    custom_attributes: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
 
     # NEW: Add relationship to messages
     messages: Mapped[list["TranscriptMessageModel"]] = relationship(

--- a/backend/app/repositories/analytics_read.py
+++ b/backend/app/repositories/analytics_read.py
@@ -1,15 +1,18 @@
 import logging
-from datetime import date
+from datetime import date, datetime
 
 from app.core.utils.date_time_utils import previous_period
 from uuid import UUID
 
 from injector import inject
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.db.models.agent import AgentModel
 from app.db.models.agent_execution_daily_stats import AgentExecutionDailyStatsModel
+from app.db.models.conversation import ConversationAnalysisModel, ConversationModel
 from app.db.models.node_execution_daily_stats import NodeExecutionDailyStatsModel
+from app.db.models.operator import OperatorModel
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +148,77 @@ class AnalyticsReadRepository:
         stmt = stmt.group_by(NodeExecutionDailyStatsModel.node_type).order_by(
             func.sum(NodeExecutionDailyStatsModel.execution_count).desc()
         )
+
+        result = await self.db.execute(stmt)
+        rows = result.mappings().all()
+        return [dict(r) for r in rows]
+
+    async def get_custom_attribute_keys(
+        self,
+        agent_id: UUID | None = None,
+    ) -> list[str]:
+        """Return distinct custom attribute keys for an agent's conversations."""
+        if agent_id is not None:
+            raw = text(
+                "SELECT DISTINCT k "
+                "FROM conversations c "
+                "JOIN operators o ON c.operator_id = o.id "
+                "JOIN agents a ON a.operator_id = o.id AND a.id = :agent_id "
+                ", jsonb_object_keys(c.custom_attributes) AS k "
+                "WHERE c.custom_attributes IS NOT NULL "
+                "AND jsonb_typeof(c.custom_attributes) = 'object' "
+                "ORDER BY k"
+            )
+            result = await self.db.execute(raw, {"agent_id": agent_id})
+        else:
+            raw = text(
+                "SELECT DISTINCT k "
+                "FROM conversations c "
+                ", jsonb_object_keys(c.custom_attributes) AS k "
+                "WHERE c.custom_attributes IS NOT NULL "
+                "AND jsonb_typeof(c.custom_attributes) = 'object' "
+                "ORDER BY k"
+            )
+            result = await self.db.execute(raw)
+        return [row[0] for row in result.all()]
+
+    async def get_custom_attribute_breakdown(
+        self,
+        key: str,
+        agent_id: UUID | None = None,
+        from_date: date | datetime | None = None,
+        to_date: date | datetime | None = None,
+    ) -> list[dict]:
+        """Group conversations by a custom attribute value with avg analysis scores."""
+        attr_value = ConversationModel.custom_attributes[key].astext.label("value")
+
+        stmt = (
+            select(
+                attr_value,
+                func.count(ConversationModel.id).label("conversation_count"),
+                func.avg(ConversationAnalysisModel.customer_satisfaction).label("avg_satisfaction"),
+                func.avg(ConversationAnalysisModel.resolution_rate).label("avg_resolution_rate"),
+                func.avg(ConversationAnalysisModel.efficiency).label("avg_efficiency"),
+                func.avg(ConversationAnalysisModel.quality_of_service).label("avg_quality"),
+            )
+            .outerjoin(ConversationAnalysisModel, ConversationAnalysisModel.conversation_id == ConversationModel.id)
+            .join(OperatorModel, ConversationModel.operator_id == OperatorModel.id)
+            .join(AgentModel, AgentModel.operator_id == OperatorModel.id)
+            .where(ConversationModel.custom_attributes[key].astext.isnot(None))
+        )
+
+        if agent_id is not None:
+            stmt = stmt.where(AgentModel.id == agent_id)
+        if from_date is not None:
+            stmt = stmt.where(
+                func.coalesce(ConversationModel.conversation_date, ConversationModel.created_at) >= from_date
+            )
+        if to_date is not None:
+            stmt = stmt.where(
+                func.coalesce(ConversationModel.conversation_date, ConversationModel.created_at) <= to_date
+            )
+
+        stmt = stmt.group_by(attr_value).order_by(func.count(ConversationModel.id).desc())
 
         result = await self.db.execute(stmt)
         rows = result.mappings().all()

--- a/backend/app/repositories/conversations.py
+++ b/backend/app/repositories/conversations.py
@@ -2,7 +2,8 @@ import datetime
 from typing import List, Optional, Sequence, Tuple
 from uuid import UUID
 from injector import inject
-from sqlalchemy import asc, cast, desc, func, and_, or_, nulls_last, String
+from sqlalchemy import asc, cast, desc, func, and_, or_, nulls_last, String, update
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import contains_eager, joinedload, selectinload
@@ -197,6 +198,18 @@ class ConversationRepository:
         await self.db.refresh(conversation)
         return conversation
 
+    async def update_custom_attributes(
+        self, conversation_id: UUID, custom_attributes: dict
+    ) -> None:
+        """Update only the custom_attributes column without touching ORM relationships."""
+        stmt = (
+            update(ConversationModel)
+            .where(ConversationModel.id == conversation_id)
+            .values(custom_attributes=custom_attributes)
+        )
+        await self.db.execute(stmt)
+        await self.db.commit()
+
     def _apply_base_filters(self, query, conversation_filter: ConversationFilter):
         """Apply all shared WHERE clauses so fetch and count stay in sync."""
         if conversation_filter.minimum_hostility_score:
@@ -242,6 +255,15 @@ class ConversationRepository:
         if conversation_filter.id_suffix:
             query = query.where(
                 cast(ConversationModel.id, String).like(f"%{conversation_filter.id_suffix.lower()}")
+            )
+
+        custom_attrs = conversation_filter.custom_attributes_dict
+        if custom_attrs:
+            # Use @> (contains) operator to leverage the GIN index
+            query = query.where(
+                ConversationModel.custom_attributes.op("@>")(
+                    cast(custom_attrs, JSONB)
+                )
             )
 
         # Conditional topic filtering

--- a/backend/app/schemas/conversation.py
+++ b/backend/app/schemas/conversation.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 from pydantic import BaseModel, ConfigDict
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 from app.schemas.conversation_analysis import ConversationAnalysisRead
 from app.schemas.recording import RecordingRead
@@ -66,6 +66,7 @@ class ConversationBase(BaseModel):
 
 class ConversationCreate(ConversationBase):
     id: Optional[UUID] = None
+    custom_attributes: Optional[dict[str, Any]] = None
 
 class ConversationRead(ConversationBase):
     id: UUID
@@ -81,8 +82,7 @@ class ConversationRead(ConversationBase):
     messages: Optional[list[TranscriptMessageRead]] = None
     thumbs_down_count: int = 0
     thumbs_up_count: int = 0
-
-
+    custom_attributes: Optional[dict[str, Any]] = None
 
     model_config = ConfigDict(
         from_attributes = True

--- a/backend/app/schemas/filter.py
+++ b/backend/app/schemas/filter.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date, datetime
 from typing import Optional
 from uuid import UUID
@@ -67,6 +68,20 @@ class ConversationFilter(BaseFilterModel):
     to_create_datetime_messages: Optional[datetime] = Field(None, description="End datetime message was created")
     workflow_id: Optional[UUID] = Field(None, description="Filter conversations by the workflow used by the agent")
     id_suffix: Optional[str] = Field(None, description="Filter conversations by the last N characters of the UUID")
+    custom_attributes: Optional[str] = Field(
+        None,
+        description='JSON-encoded custom attribute filters, e.g. {"region": "Germany"}',
+    )
+
+    @property
+    def custom_attributes_dict(self) -> dict[str, str] | None:
+        if not self.custom_attributes:
+            return None
+        try:
+            parsed = json.loads(self.custom_attributes)
+            return parsed if isinstance(parsed, dict) else None
+        except (json.JSONDecodeError, TypeError):
+            return None
 
 
 class ApiKeysFilter(BaseFilterModel):

--- a/backend/app/services/analytics_read.py
+++ b/backend/app/services/analytics_read.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import date
+from datetime import date, datetime
 from uuid import UUID
 
 from injector import inject
@@ -131,4 +131,21 @@ class AnalyticsReadService:
             from_date=from_date,
             to_date=to_date,
             items=items,
+        )
+
+    async def get_custom_attribute_keys(
+        self,
+        agent_id: UUID | None = None,
+    ) -> list[str]:
+        return await self.repo.get_custom_attribute_keys(agent_id=agent_id)
+
+    async def get_custom_attribute_breakdown(
+        self,
+        key: str,
+        agent_id: UUID | None = None,
+        from_date: date | datetime | None = None,
+        to_date: date | datetime | None = None,
+    ) -> list[dict]:
+        return await self.repo.get_custom_attribute_breakdown(
+            key=key, agent_id=agent_id, from_date=from_date, to_date=to_date
         )

--- a/backend/app/services/conversations.py
+++ b/backend/app/services/conversations.py
@@ -85,6 +85,8 @@ class ConversationService:
     async def update_conversation(self, conversation: ConversationModel):
         return await self.conversation_repo.update_conversation(conversation)
 
+    async def update_custom_attributes(self, conversation_id: UUID, custom_attributes: dict):
+        return await self.conversation_repo.update_custom_attributes(conversation_id, custom_attributes)
 
     async def get_conversation_by_id(self, conversation_id: UUID, raise_not_found: bool = True,
             include_messages: bool = False, ):

--- a/backend/app/tasks/backfill_custom_attributes.py
+++ b/backend/app/tasks/backfill_custom_attributes.py
@@ -1,0 +1,136 @@
+import asyncio
+import json
+import logging
+
+from celery import shared_task
+
+from app.core.utils.custom_attributes import extract_custom_attributes_from_state
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 500
+
+
+@shared_task
+def backfill_custom_attributes(force: bool = False):
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(backfill_custom_attributes_async_with_scope(force=force))
+
+
+async def backfill_custom_attributes_async_with_scope(force: bool = False):
+    from app.tasks.base import run_task_with_tenant_support
+
+    return await run_task_with_tenant_support(
+        backfill_custom_attributes_async,
+        "backfill custom attributes",
+        force=force,
+    )
+
+
+async def backfill_custom_attributes_async(force: bool = False):
+    """Backfill custom_attributes on conversations from agent_response_logs.
+
+    Args:
+        force: If True, re-process all conversations (even those with existing attributes).
+               If False (default), only process conversations where custom_attributes IS NULL.
+    """
+    from sqlalchemy import select, update, func
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from app.db.models.agent_response_log import AgentResponseLogModel
+    from app.db.models.conversation import ConversationModel
+    from app.dependencies.injector import injector
+
+    db: AsyncSession = injector.get(AsyncSession)
+
+    total_updated = 0
+    offset = 0
+    mode = "force (re-process all)" if force else "incremental (NULL only)"
+    logger.info(f"Backfill mode: {mode}")
+
+    while True:
+        stmt = (
+            select(ConversationModel.id)
+            .order_by(ConversationModel.id)
+            .offset(offset)
+            .limit(BATCH_SIZE)
+        )
+        if not force:
+            stmt = stmt.where(ConversationModel.custom_attributes.is_(None))
+        result = await db.execute(stmt)
+        conversation_ids = [row[0] for row in result.all()]
+
+        if not conversation_ids:
+            break
+
+        # Batch-fetch the latest log per conversation (avoids N+1)
+        latest_log_subq = (
+            select(
+                AgentResponseLogModel.conversation_id,
+                func.max(AgentResponseLogModel.logged_at).label("max_logged_at"),
+            )
+            .where(AgentResponseLogModel.conversation_id.in_(conversation_ids))
+            .group_by(AgentResponseLogModel.conversation_id)
+            .subquery()
+        )
+        logs_stmt = (
+            select(AgentResponseLogModel.conversation_id, AgentResponseLogModel.raw_response)
+            .join(
+                latest_log_subq,
+                (AgentResponseLogModel.conversation_id == latest_log_subq.c.conversation_id)
+                & (AgentResponseLogModel.logged_at == latest_log_subq.c.max_logged_at),
+            )
+        )
+        logs_result = await db.execute(logs_stmt)
+        logs_by_conv = {row[0]: row[1] for row in logs_result.all()}
+
+        batch_updated = 0
+
+        for conv_id in conversation_ids:
+            log_row = logs_by_conv.get(conv_id)
+            if not log_row:
+                if force:
+                    await db.execute(
+                        update(ConversationModel)
+                        .where(ConversationModel.id == conv_id)
+                        .values(custom_attributes=None)
+                    )
+                continue
+
+            try:
+                payload = json.loads(log_row) if isinstance(log_row, str) else log_row
+                node_statuses = (
+                    payload.get("row_agent_response", {})
+                    .get("state", {})
+                    .get("nodeExecutionStatus", {})
+                )
+                attrs = extract_custom_attributes_from_state(node_statuses)
+
+                if attrs:
+                    await db.execute(
+                        update(ConversationModel)
+                        .where(ConversationModel.id == conv_id)
+                        .values(custom_attributes=attrs)
+                    )
+                    batch_updated += 1
+                elif force:
+                    await db.execute(
+                        update(ConversationModel)
+                        .where(ConversationModel.id == conv_id)
+                        .values(custom_attributes=None)
+                    )
+
+            except (json.JSONDecodeError, AttributeError, KeyError) as e:
+                logger.debug(f"Skipping conversation {conv_id}: {e}")
+                continue
+
+        await db.commit()
+        total_updated += batch_updated
+        offset += BATCH_SIZE
+        logger.info(
+            f"Backfill progress: processed {offset} conversations, "
+            f"updated {total_updated} so far"
+        )
+
+    logger.info(f"Backfill complete: updated {total_updated} conversations")
+    return {"status": "completed", "updated": total_updated}

--- a/backend/app/use_cases/chat_as_client_use_case.py
+++ b/backend/app/use_cases/chat_as_client_use_case.py
@@ -22,6 +22,7 @@ from app.services.agent_config import AgentConfigService
 from app.services.agent_response_log import AgentResponseLogService
 from app.services.analytics_realtime import update_stats_incrementally
 from app.services.conversations import ConversationService
+from app.core.utils.custom_attributes import extract_custom_attributes
 from app.services.file_manager import FileManagerService
 
 logger = logging.getLogger(__name__)
@@ -202,6 +203,18 @@ async def process_conversation_update_with_agent(
             tenant_id=tenant_id,
         )
     )
+
+    # Persist custom workflow attributes via direct UPDATE to avoid expiring ORM relationships
+    if conversation.status == ConversationStatus.IN_PROGRESS.value:
+        try:
+            new_attrs = extract_custom_attributes(agent_response)
+            if new_attrs:
+                existing = updated_conversation.custom_attributes or {}
+                existing.update(new_attrs)
+                await service.update_custom_attributes(updated_conversation.id, existing)
+                updated_conversation.custom_attributes = existing
+        except Exception as e:
+            logger.warning(f"Failed to persist custom_attributes: {e}")
 
     # return the updated conversation
     return updated_conversation

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4965,6 +4965,22 @@
               ],
               "title": "Id Suffix"
             }
+          },
+          {
+            "name": "custom_attributes",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Custom Attributes"
+            }
           }
         ],
         "responses": {
@@ -5838,6 +5854,22 @@
               ],
               "title": "Id Suffix"
             }
+          },
+          {
+            "name": "custom_attributes",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Custom Attributes"
+            }
           }
         ],
         "responses": {
@@ -6373,6 +6405,22 @@
                 }
               ],
               "title": "Id Suffix"
+            }
+          },
+          {
+            "name": "custom_attributes",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Custom Attributes"
             }
           }
         ],
@@ -11707,6 +11755,230 @@
             "content": {
               "application/json": {
                 "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/analytics/custom-attributes/backfill": {
+      "post": {
+        "tags": [
+          "v1",
+          "Analytics"
+        ],
+        "summary": "Trigger backfill of custom attributes from agent response logs",
+        "operationId": "trigger_custom_attributes_backfill_api_analytics_custom_attributes_backfill_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Re-process all conversations, not just those without attributes",
+              "default": false,
+              "title": "Force"
+            },
+            "description": "Re-process all conversations, not just those without attributes"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/analytics/custom-attributes/keys": {
+      "get": {
+        "tags": [
+          "v1",
+          "Analytics"
+        ],
+        "summary": "Get available custom attribute keys",
+        "operationId": "get_custom_attribute_keys_api_analytics_custom_attributes_keys_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "title": "Response Get Custom Attribute Keys Api Analytics Custom Attributes Keys Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/analytics/custom-attributes/breakdown": {
+      "get": {
+        "tags": [
+          "v1",
+          "Analytics"
+        ],
+        "summary": "Get conversation breakdown by custom attribute value",
+        "operationId": "get_custom_attribute_breakdown_api_analytics_custom_attributes_breakdown_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Custom attribute key to group by",
+              "title": "Key"
+            },
+            "description": "Custom attribute key to group by"
+          },
+          {
+            "name": "agent_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "from_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "From Date"
+            }
+          },
+          {
+            "name": "to_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "To Date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "title": "Response Get Custom Attribute Breakdown Api Analytics Custom Attributes Breakdown Get"
+                }
               }
             }
           },
@@ -20645,6 +20917,18 @@
             "type": "integer",
             "title": "Thumbs Up Count",
             "default": 0
+          },
+          "custom_attributes": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Custom Attributes"
           }
         },
         "type": "object",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -11799,58 +11799,6 @@
         }
       }
     },
-    "/api/analytics/custom-attributes/backfill": {
-      "post": {
-        "tags": [
-          "v1",
-          "Analytics"
-        ],
-        "summary": "Trigger backfill of custom attributes from agent response logs",
-        "operationId": "trigger_custom_attributes_backfill_api_analytics_custom_attributes_backfill_post",
-        "security": [
-          {
-            "APIKeyHeader": []
-          },
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "force",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "Re-process all conversations, not just those without attributes",
-              "default": false,
-              "title": "Force"
-            },
-            "description": "Re-process all conversations, not just those without attributes"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/analytics/custom-attributes/keys": {
       "get": {
         "tags": [

--- a/frontend/src/interfaces/transcript.interface.ts
+++ b/frontend/src/interfaces/transcript.interface.ts
@@ -69,6 +69,7 @@ export interface BackendTranscript {
   feedback?: string | ConversationFeedbackEntry[] | null;
   thumbs_up_count?: number;
   thumbs_down_count?: number;
+  custom_attributes?: Record<string, string> | null;
 }
 
 export interface TranscriptMetrics {
@@ -125,4 +126,5 @@ export interface Transcript {
   transcript?: TranscriptEntry[] | string | null;
   thumbs_up_count?: number;
   thumbs_down_count?: number;
+  custom_attributes?: Record<string, string> | null;
 }

--- a/frontend/src/services/analyticsReports.ts
+++ b/frontend/src/services/analyticsReports.ts
@@ -99,3 +99,45 @@ export const fetchAgentNodeBreakdown = async (
     return null;
   }
 };
+
+export interface CustomAttributeBreakdownItem {
+  value: string;
+  conversation_count: number;
+  avg_satisfaction: number | null;
+  avg_resolution_rate: number | null;
+  avg_efficiency: number | null;
+  avg_quality: number | null;
+}
+
+export const fetchCustomAttributeKeys = async (
+  agentId?: string
+): Promise<string[]> => {
+  try {
+    const qs = buildQueryString({ agent_id: agentId });
+    return (await apiRequest<string[]>("get", `/analytics/custom-attributes/keys${qs}`)) ?? [];
+  } catch (error) {
+    console.error("Error fetching custom attribute keys:", error);
+    return [];
+  }
+};
+
+export const fetchCustomAttributeBreakdown = async (
+  key: string,
+  params?: Pick<AnalyticsFilterParams, "agent_id" | "from_date" | "to_date">
+): Promise<CustomAttributeBreakdownItem[]> => {
+  try {
+    const qs = buildQueryString({
+      key,
+      agent_id: params?.agent_id,
+      from_date: params?.from_date,
+      to_date: params?.to_date,
+    });
+    return (await apiRequest<CustomAttributeBreakdownItem[]>(
+      "get",
+      `/analytics/custom-attributes/breakdown${qs}`
+    )) ?? [];
+  } catch (error) {
+    console.error("Error fetching custom attribute breakdown:", error);
+    return [];
+  }
+};

--- a/frontend/src/services/transcripts.ts
+++ b/frontend/src/services/transcripts.ts
@@ -51,6 +51,7 @@ export interface FetchTranscriptsParams {
   efficiency_min?: number;
   efficiency_max?: number;
   id_suffix?: string;
+  custom_attributes?: Record<string, string>;
 }
 
 export const fetchTranscripts = async (
@@ -66,6 +67,7 @@ export const fetchTranscripts = async (
       limit, skip, sentiment, hostility_neutral_max, hostility_positive_max,
       include_feedback, conversation_status, order_by, sort_direction,
       agent_id, workflow_id, scoreFilters, from_date, to_date, exclude_empty, id_suffix,
+      custom_attributes,
     } = params;
 
     let url = "conversations/";
@@ -103,6 +105,9 @@ export const fetchTranscripts = async (
       Object.entries(scoreFilters).forEach(([key, val]) => {
         if (val !== undefined) queryParams.append(key, String(val));
       });
+    }
+    if (custom_attributes && Object.keys(custom_attributes).length > 0) {
+      queryParams.append("custom_attributes", JSON.stringify(custom_attributes));
     }
 
     if (queryParams.toString()) {

--- a/frontend/src/views/Analytics/components/reports/AttributeBreakdownChart.tsx
+++ b/frontend/src/views/Analytics/components/reports/AttributeBreakdownChart.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as RechartsTooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/card";
+import { Skeleton } from "@/components/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/select";
+import {
+  fetchCustomAttributeKeys,
+  fetchCustomAttributeBreakdown,
+  type CustomAttributeBreakdownItem,
+} from "@/services/analyticsReports";
+import type { DateRange } from "react-day-picker";
+import { format } from "date-fns";
+
+const ROW_HEIGHT = 44;
+const CHART_MIN_HEIGHT = 180;
+const CHART_PADDING = 40;
+
+const formatScore = (v: number | null): string =>
+  v != null ? `${Math.round(v * 10)}%` : "—";
+
+interface AttributeBreakdownChartProps {
+  agentId?: string;
+  dateRange?: DateRange;
+}
+
+export const AttributeBreakdownChart = ({
+  agentId,
+  dateRange,
+}: AttributeBreakdownChartProps) => {
+  const [keys, setKeys] = useState<string[]>([]);
+  const [selectedKey, setSelectedKey] = useState<string>("");
+  const [data, setData] = useState<CustomAttributeBreakdownItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const id = agentId !== "all" ? agentId : undefined;
+    fetchCustomAttributeKeys(id).then((k) => {
+      setKeys(k);
+      if (k.length > 0 && !k.includes(selectedKey)) {
+        setSelectedKey(k[0]);
+      }
+    });
+  }, [agentId]);
+
+  const fromDateStr = useMemo(
+    () => (dateRange?.from ? format(dateRange.from, "yyyy-MM-dd") : undefined),
+    [dateRange?.from?.getTime()]
+  );
+  const toDateStr = useMemo(
+    () => (dateRange?.to ? format(dateRange.to, "yyyy-MM-dd") + " 23:59:59" : undefined),
+    [dateRange?.to?.getTime()]
+  );
+
+  useEffect(() => {
+    if (!selectedKey) {
+      setData([]);
+      return;
+    }
+    setLoading(true);
+    fetchCustomAttributeBreakdown(selectedKey, {
+      agent_id: agentId !== "all" ? agentId : undefined,
+      from_date: fromDateStr,
+      to_date: toDateStr,
+    })
+      .then(setData)
+      .finally(() => setLoading(false));
+  }, [selectedKey, agentId, fromDateStr, toDateStr]);
+
+  if (keys.length === 0) return null;
+
+  const totalConversations = data.reduce((sum, d) => sum + d.conversation_count, 0);
+  const chartHeight = Math.max(CHART_MIN_HEIGHT, data.length * ROW_HEIGHT + CHART_PADDING);
+
+  return (
+    <Card className="mt-6">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+        <div>
+          <CardTitle className="text-base font-semibold">
+            Conversations by Attribute
+          </CardTitle>
+          {!loading && data.length > 0 && (
+            <p className="text-xs text-muted-foreground mt-1">
+              {totalConversations} conversation{totalConversations !== 1 ? "s" : ""} across {data.length} value{data.length !== 1 ? "s" : ""}
+            </p>
+          )}
+        </div>
+        <Select value={selectedKey} onValueChange={setSelectedKey}>
+          <SelectTrigger className="w-44">
+            <SelectValue placeholder="Select attribute" />
+          </SelectTrigger>
+          <SelectContent>
+            {keys.map((k) => (
+              <SelectItem key={k} value={k}>
+                {k}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="space-y-4 py-4">
+            {[1, 0.75, 0.5].map((w, i) => (
+              <div key={i} className="flex items-center gap-3">
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-8 rounded" style={{ width: `${w * 100}%` }} />
+              </div>
+            ))}
+          </div>
+        ) : data.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-12">
+            No data for this attribute yet.
+          </p>
+        ) : (
+          <>
+            <ResponsiveContainer width="100%" height={chartHeight}>
+              <BarChart
+                data={data}
+                layout="vertical"
+                margin={{ top: 4, right: 24, left: 4, bottom: 4 }}
+                barCategoryGap="20%"
+              >
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  horizontal={false}
+                  stroke="#f0f0f0"
+                />
+                <XAxis
+                  type="number"
+                  allowDecimals={false}
+                  tick={{ fontSize: 11, fill: "#9ca3af" }}
+                  axisLine={{ stroke: "#e5e7eb" }}
+                  tickLine={false}
+                />
+                <YAxis
+                  type="category"
+                  dataKey="value"
+                  width={140}
+                  tick={{ fontSize: 12, fill: "#374151", fontWeight: 500 }}
+                  axisLine={false}
+                  tickLine={false}
+                />
+                <RechartsTooltip
+                  cursor={{ fill: "rgba(0,0,0,0.04)" }}
+                  contentStyle={{
+                    borderRadius: 8,
+                    border: "1px solid #e5e7eb",
+                    boxShadow: "0 4px 6px -1px rgba(0,0,0,0.07)",
+                    fontSize: 12,
+                    padding: "8px 12px",
+                  }}
+                  formatter={(val: number) => [val, "Conversations"]}
+                  labelStyle={{ fontWeight: 600, marginBottom: 2 }}
+                />
+                <Bar
+                  dataKey="conversation_count"
+                  fill="#3b82f6"
+                  radius={[0, 6, 6, 0]}
+                  name="Conversations"
+                  maxBarSize={32}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+
+            {/* Metrics table */}
+            <div className="mt-6 rounded-lg border border-gray-100 overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-gray-50/80">
+                    <th className="text-left py-2.5 px-4 font-medium text-muted-foreground capitalize">
+                      {selectedKey}
+                    </th>
+                    <th className="text-right py-2.5 px-4 font-medium text-muted-foreground">
+                      Conversations
+                    </th>
+                    <th className="text-right py-2.5 px-4 font-medium text-muted-foreground">
+                      Satisfaction
+                    </th>
+                    <th className="text-right py-2.5 px-4 font-medium text-muted-foreground">
+                      Resolution
+                    </th>
+                    <th className="text-right py-2.5 px-4 font-medium text-muted-foreground">
+                      Efficiency
+                    </th>
+                    <th className="text-right py-2.5 px-4 font-medium text-muted-foreground">
+                      Quality
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.map((row) => {
+                    const pct = totalConversations > 0
+                      ? Math.round((row.conversation_count / totalConversations) * 100)
+                      : 0;
+                    return (
+                      <tr
+                        key={row.value}
+                        className="border-t border-gray-100 hover:bg-gray-50/50"
+                      >
+                        <td className="py-2.5 px-4 font-medium">{row.value}</td>
+                        <td className="text-right py-2.5 px-4 tabular-nums">
+                          {row.conversation_count}
+                          <span className="text-muted-foreground text-xs ml-1">({pct}%)</span>
+                        </td>
+                        <td className="text-right py-2.5 px-4 tabular-nums">{formatScore(row.avg_satisfaction)}</td>
+                        <td className="text-right py-2.5 px-4 tabular-nums">{formatScore(row.avg_resolution_rate)}</td>
+                        <td className="text-right py-2.5 px-4 tabular-nums">{formatScore(row.avg_efficiency)}</td>
+                        <td className="text-right py-2.5 px-4 tabular-nums">{formatScore(row.avg_quality)}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/frontend/src/views/Analytics/pages/Analytics.tsx
+++ b/frontend/src/views/Analytics/pages/Analytics.tsx
@@ -6,6 +6,7 @@ import { AppSidebar } from "@/layout/app-sidebar";
 import { useIsMobile } from "@/hooks/useMobile";
 import { AnalyticsMetricsSection } from "../components/AnalyticsMetricsSection";
 import { AnalyticsFilters } from "../components/AnalyticsFilters";
+import { AttributeBreakdownChart } from "../components/reports/AttributeBreakdownChart";
 import { useAnalyticsData } from "../hooks/useAnalyticsData";
 import { useAgentsList } from "../hooks/useAgentsList";
 
@@ -53,6 +54,11 @@ const AnalyticsPage = () => {
                 refreshing={refreshing}
                 error={error}
                 compareDateRange={compareDateRange}
+              />
+
+              <AttributeBreakdownChart
+                agentId={agentFilter}
+                dateRange={dateRange}
               />
             </div>
           </div>

--- a/frontend/src/views/Transcripts/helpers/transformers.ts
+++ b/frontend/src/views/Transcripts/helpers/transformers.ts
@@ -174,6 +174,7 @@ export function transformTranscript(backendData: BackendTranscript): Transcript 
       feedback: feedbackArray,
       thumbs_up_count: backendData.thumbs_up_count ?? 0,
       thumbs_down_count: backendData.thumbs_down_count ?? 0,
+      custom_attributes: backendData.custom_attributes ?? null,
     };
   } catch (error) {
     return {

--- a/frontend/src/views/Transcripts/hooks/useTranscriptData.ts
+++ b/frontend/src/views/Transcripts/hooks/useTranscriptData.ts
@@ -27,12 +27,14 @@ interface UseTranscriptDataOptions {
   from_date?: string;
   to_date?: string;
   exclude_empty?: boolean;
+  custom_attributes?: Record<string, string>;
 }
 
 export const useTranscriptData = (options: UseTranscriptDataOptions = {}) => {
-  const { id, limit, skip, sentiment, hostility_neutral_max, hostility_positive_max, include_feedback, sortNewestFirst = true, conversation_status, order_by, sort_direction, agent_id, scoreFilters, from_date, to_date, exclude_empty } = options;
+  const { id, limit, skip, sentiment, hostility_neutral_max, hostility_positive_max, include_feedback, sortNewestFirst = true, conversation_status, order_by, sort_direction, agent_id, scoreFilters, from_date, to_date, exclude_empty, custom_attributes } = options;
   // Stabilize score filters for dependency tracking
   const scoreFiltersKey = scoreFilters ? JSON.stringify(scoreFilters) : "";
+  const customAttrsKey = custom_attributes ? JSON.stringify(custom_attributes) : "";
   // Stabilize array reference for useCallback dependency
   const statusKey = conversation_status?.join(",") ?? "";
 
@@ -75,7 +77,7 @@ export const useTranscriptData = (options: UseTranscriptDataOptions = {}) => {
         const params = {
           limit, skip, sentiment, hostility_neutral_max, hostility_positive_max,
           include_feedback, conversation_status, order_by, sort_direction,
-          agent_id, scoreFilters, from_date, to_date, exclude_empty,
+          agent_id, scoreFilters, from_date, to_date, exclude_empty, custom_attributes,
         };
 
         const { items: backendData, total: backendTotal } = await fetchTranscripts(params);
@@ -132,7 +134,7 @@ export const useTranscriptData = (options: UseTranscriptDataOptions = {}) => {
       }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id, limit, skip, sentiment, hostility_neutral_max, hostility_positive_max, include_feedback, sortNewestFirst, statusKey, order_by, sort_direction, agent_id, scoreFiltersKey, from_date, to_date, exclude_empty]);
+  }, [id, limit, skip, sentiment, hostility_neutral_max, hostility_positive_max, include_feedback, sortNewestFirst, statusKey, order_by, sort_direction, agent_id, scoreFiltersKey, from_date, to_date, exclude_empty, customAttrsKey]);
 
   const permissions = usePermissions();
 

--- a/frontend/src/views/Transcripts/pages/Transcripts.tsx
+++ b/frontend/src/views/Transcripts/pages/Transcripts.tsx
@@ -16,6 +16,7 @@ import {
   Award,
   Zap,
   SlidersHorizontal,
+  Tag,
 } from "lucide-react";
 import { Card } from "@/components/card";
 import { Button } from "@/components/button";
@@ -37,7 +38,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/dropdown-menu";
-import { type CSSProperties, useState, useEffect, useMemo, type ReactNode } from "react";
+import { type CSSProperties, useState, useEffect, useMemo, useCallback, type ReactNode } from "react";
 import { Transcript } from "@/interfaces/transcript.interface";
 import { TranscriptDialog } from "../components/TranscriptDialog";
 import { ActiveConversationDialog } from "@/views/ActiveConversations/components/ActiveConversationDialog";
@@ -61,6 +62,7 @@ import type { DateRange } from "react-day-picker";
 import { format, subDays } from "date-fns";
 import { Switch } from "@/components/switch";
 import { Label } from "@/components/label";
+import { fetchCustomAttributeKeys } from "@/services/analyticsReports";
 
 const ITEMS_PER_PAGE = 10;
 
@@ -136,6 +138,10 @@ const Transcripts = () => {
     efficiency: "all",
   });
 
+  // Custom attribute filters
+  const [customAttrFilters, setCustomAttrFilters] = useState<Record<string, string>>({});
+  const [availableAttrKeys, setAvailableAttrKeys] = useState<string[]>([]);
+
   // Derive initial status filter from URL
   const initStatusFilter = (): StatusFilter => {
     const statuses = searchParams.getAll("status");
@@ -183,6 +189,14 @@ const Transcripts = () => {
     [qualityFilters]
   );
 
+  const activeCustomAttrCount = Object.keys(customAttrFilters).length;
+
+  // Fetch available custom attribute keys when agent changes
+  useEffect(() => {
+    const agentId = selectedAgentId !== "all" ? selectedAgentId : undefined;
+    fetchCustomAttributeKeys(agentId).then(setAvailableAttrKeys);
+  }, [selectedAgentId]);
+
   const {
     conversations: wsConversations,
     resyncHint,
@@ -202,6 +216,7 @@ const Transcripts = () => {
     from_date: dateRange?.from ? format(dateRange.from, "yyyy-MM-dd") : undefined,
     to_date: dateRange?.to ? format(dateRange.to, "yyyy-MM-dd 23:59:59") : undefined,
     exclude_empty: hideEmpty || undefined,
+    custom_attributes: activeCustomAttrCount > 0 ? customAttrFilters : undefined,
   });
 
   const isMobile = useIsMobile();
@@ -372,6 +387,19 @@ const Transcripts = () => {
     updateUrlParams({ page: 1 });
   };
 
+  const handleCustomAttrFilter = useCallback((key: string, value: string) => {
+    setCustomAttrFilters((prev) => {
+      if (value === "") {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      }
+      return { ...prev, [key]: value };
+    });
+    setCurrentPage(1);
+    updateUrlParams({ page: 1 });
+  }, [updateUrlParams]);
+
   const getSortLabel = (): { label: string; icon: ReactNode } | null => {
     if (!orderBy) return null;
     const dirLabel = sortDirection === "desc" ? "High\u2192Low" : "Low\u2192High";
@@ -417,10 +445,8 @@ const Transcripts = () => {
     ITEMS_PER_PAGE,
     currentPage
   );
-  const paginatedTranscripts = filteredTranscripts.slice(
-    pagination.startIndex,
-    pagination.endIndex
-  );
+  // API already returns the correct page via skip/limit — no client-side slicing needed
+  const paginatedTranscripts = filteredTranscripts;
   const pageItemCount = paginatedTranscripts.length;
 
   const handleTakeOver = async (transcriptId: string): Promise<boolean> => {
@@ -640,6 +666,77 @@ const Transcripts = () => {
                       ))}
                     </DropdownMenuContent>
                   </DropdownMenu>
+
+                  {/* Custom attributes filter */}
+                  {availableAttrKeys.length > 0 && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <button
+                          type="button"
+                          className={`flex h-8 shrink-0 items-center gap-1.5 rounded-full border px-2.5 text-xs ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 transition-colors ${
+                            activeCustomAttrCount > 0
+                              ? "border-primary/30 bg-primary/5 text-foreground"
+                              : "border-input bg-white text-muted-foreground hover:bg-gray-50"
+                          }`}
+                        >
+                          <Tag className="h-3.5 w-3.5 shrink-0" />
+                          <span>Attributes</span>
+                          {activeCustomAttrCount > 0 && (
+                            <span className="flex h-4 min-w-[16px] items-center justify-center rounded-full bg-primary px-1 text-[10px] font-medium text-primary-foreground">
+                              {activeCustomAttrCount}
+                            </span>
+                          )}
+                          <ChevronDown className="h-3 w-3 shrink-0 opacity-50" />
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end" className="min-w-[12rem]">
+                        {activeCustomAttrCount > 0 && (
+                          <DropdownMenuItem
+                            onClick={() => {
+                              setCustomAttrFilters({});
+                              setCurrentPage(1);
+                              updateUrlParams({ page: 1 });
+                            }}
+                            className="text-muted-foreground"
+                          >
+                            Clear attribute filters
+                          </DropdownMenuItem>
+                        )}
+                        {availableAttrKeys.map((attrKey) => (
+                          <DropdownMenuSub key={attrKey}>
+                            <DropdownMenuSubTrigger className="flex items-center gap-2">
+                              <Tag className="h-3.5 w-3.5 text-gray-400" />
+                              {attrKey}
+                              {customAttrFilters[attrKey] && (
+                                <Badge variant="outline" className="ml-auto text-[10px] px-1 py-0">
+                                  {customAttrFilters[attrKey]}
+                                </Badge>
+                              )}
+                            </DropdownMenuSubTrigger>
+                            <DropdownMenuSubContent>
+                              <DropdownMenuItem onClick={() => handleCustomAttrFilter(attrKey, "")}>
+                                All {!customAttrFilters[attrKey] && "\u2713"}
+                              </DropdownMenuItem>
+                              {/* Values are entered as text - user types the value they want to filter by */}
+                              <div className="px-2 py-1.5">
+                                <input
+                                  type="text"
+                                  placeholder={`Filter by ${attrKey}...`}
+                                  defaultValue={customAttrFilters[attrKey] || ""}
+                                  className="w-full rounded border border-input px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+                                  onKeyDown={(e) => {
+                                    if (e.key === "Enter") {
+                                      handleCustomAttrFilter(attrKey, (e.target as HTMLInputElement).value);
+                                    }
+                                  }}
+                                />
+                              </div>
+                            </DropdownMenuSubContent>
+                          </DropdownMenuSub>
+                        ))}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
 
                   {/* Sort dropdown */}
                   <DropdownMenu>
@@ -875,6 +972,20 @@ const Transcripts = () => {
                                     {s.label}: {formatScorePercentage(s.value)}
                                   </TooltipContent>
                                 </Tooltip>
+                              ))}
+                            </div>
+                          )}
+                          {/* Custom attribute badges */}
+                          {transcript.custom_attributes && Object.keys(transcript.custom_attributes).length > 0 && (
+                            <div className="flex items-center gap-1.5 mt-1.5 flex-wrap">
+                              {Object.entries(transcript.custom_attributes).map(([key, value]) => (
+                                <span
+                                  key={key}
+                                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full border border-gray-200 bg-gray-50 text-[11px] font-medium text-gray-600"
+                                >
+                                  <Tag className="h-3 w-3 text-gray-400" />
+                                  {key}: {String(value)}
+                                </span>
                               ))}
                             </div>
                           )}


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

Store workflow dynamic parameters (e.g. region, tier) as queryable JSONB on each conversation, enabling filtering in the conversation list and segmentation in analytics.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

<img width="1363" height="1255" alt="Screenshot 2026-04-08 at 12 49 12 PM" src="https://github.com/user-attachments/assets/ab29219d-bb88-4fc4-80c7-edfbc227e0d4" />
<img width="1486" height="504" alt="Screenshot 2026-04-08 at 12 49 28 PM" src="https://github.com/user-attachments/assets/32bd41f0-4e90-4450-98e4-80d43b954afa" />
<img width="1467" height="1293" alt="Screenshot 2026-04-08 at 12 49 58 PM" src="https://github.com/user-attachments/assets/b060cdd1-9bd1-4727-8d9a-e2da08e5d58d" />
---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.

