### PR TITLE
refactor: Update AgentForm component to improve image loading

### DIFF
--- a/frontend/src/views/AIAgents/components/AgentForm.tsx
+++ b/frontend/src/views/AIAgents/components/AgentForm.tsx
@@ -243,7 +243,9 @@ const AgentForm: React.FC<AgentFormProps> = ({
     let cancelled = false;
 
     const loadExistingImage = async () => {
-      if (!(isEditMode && id && data?.has_welcome_image)) return;
+      // In many edit-entry points we don't have an accurate has_welcome_image flag.
+      // Attempt to load and simply no-op if the server says "not found".
+      if (!(isEditMode && id)) return;
       try {
         const imageBlob = await getWelcomeImage(id);
         if (cancelled) return;
@@ -265,18 +267,20 @@ const AgentForm: React.FC<AgentFormProps> = ({
 
     void loadExistingImage();
 
-    // load advanced settings
-    if (isEditMode && !!formData.llm_analyst_id) {
-      setShowAdvanced(true);
-    }
-
     return () => {
       cancelled = true;
       if (objectUrl) {
         URL.revokeObjectURL(objectUrl);
       }
     };
-  }, [isEditMode, id, data?.has_welcome_image]);
+  }, [isEditMode, id]);
+
+  // Auto-expand advanced section when editing agents that already use an analyst.
+  useEffect(() => {
+    if (isEditMode && !!formData.llm_analyst_id) {
+      setShowAdvanced(true);
+    }
+  }, [isEditMode, formData.llm_analyst_id]);
 
   const handleInputChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -1110,7 +1114,7 @@ export const AgentFormPage: React.FC = () => {
 
       fetchAgentConfig();
     }
-  }, [id, isEditMode, formData]);
+  }, [id, isEditMode]);
 
   if (!agentId) {
     return (


### PR DESCRIPTION
## Description

- Adjusted image loading logic to handle cases where the has_welcome_image flag may not be accurate during edits.
- Introduced a new useEffect to automatically expand the advanced settings section when editing agents that already have an analyst assigned.
- Cleaned up dependencies in useEffect hooks for better performance and clarity.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release



---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
