### PR TITLE
refactor: enhance ML model inference and training nodes to support new model response structure

### DIFF
--- a/backend/app/modules/workflow/engine/nodes/ml/ml_model_inference_node.py
+++ b/backend/app/modules/workflow/engine/nodes/ml/ml_model_inference_node.py
@@ -183,9 +183,24 @@ class MLModelInferenceNode(BaseNode):
                     # Wrap single value in list to treat as batch of 1
                     normalized_inputs[key] = [value]
 
-            model = model_response.get("model", {})
-            metadata = model_response.get("metadata", {})
-            feature_names = metadata.get("feature_columns", [])
+            # normalized model response
+            # {
+            #     "model": {
+            #         "model": model,
+            #         "metadata": metadata
+            #     }
+            # }
+            # legacy model response
+            # model response is the raw model object
+            # check if model_response has a "version" key or is a dictionary with a "version" key
+            if "version" in model_response and model_response["version"] == "v2.0":
+                model = model_response.get("model", {})
+                metadata = model_response.get("metadata", {})
+                feature_names = metadata.get("feature_columns", [])
+            else:
+                # legacy model response is the raw model object
+                model = model_response.get("model", {})
+                feature_names = model.feature_names_in_ if hasattr(model, "feature_names_in_") else []
 
             # Prepare DataFrame for prediction (always batch format)
             try:

--- a/backend/app/modules/workflow/engine/nodes/ml/train_model_node.py
+++ b/backend/app/modules/workflow/engine/nodes/ml/train_model_node.py
@@ -4,21 +4,20 @@ Train Model node implementation using the BaseNode class.
 This node trains ML models on CSV data and saves them as .pkl files.
 """
 
-from typing import Dict, Any, Optional
 import logging
 import pickle
-import uuid
-from pathlib import Path
+from typing import Any, Dict, Optional
+
 import pandas as pd
-from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.linear_model import LinearRegression, LogisticRegression
+from sklearn.model_selection import train_test_split
 from sklearn.neural_network import MLPClassifier, MLPRegressor
 
-from app.modules.workflow.engine.base_node import BaseNode
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.core.project_path import DATA_VOLUME
+from app.modules.workflow.engine.base_node import BaseNode
 from app.modules.workflow.engine.nodes.ml import ml_utils
 
 logger = logging.getLogger(__name__)
@@ -51,7 +50,7 @@ class TrainModelNode(BaseNode):
         Args:
             config: The resolved configuration for the node containing:
                 - name: Model name (required)
-                - modelType: Type of model - "xgboost", "random_forest", "linear_regression", 
+                - modelType: Type of model - "xgboost", "random_forest", "linear_regression",
                             "logistic_regression", "neural_network" (required)
                 - fileUrl: Path to CSV file with training data (required)
                 - targetColumn: Name of the target column (required)
@@ -123,14 +122,14 @@ class TrainModelNode(BaseNode):
             # Validate columns exist
             all_columns = list(df.columns)
             missing_columns = []
-            
+
             if target_column not in all_columns:
                 missing_columns.append(target_column)
-            
+
             for col in feature_columns:
                 if col not in all_columns:
                     missing_columns.append(col)
-            
+
             if missing_columns:
                 logger.error(f"Columns not found in data: {missing_columns}. Available columns: {all_columns}")
                 return {
@@ -204,15 +203,28 @@ class TrainModelNode(BaseNode):
                 metrics = self._evaluate_model(model, X_val, y_val, is_classification)
                 logger.info(f"Validation metrics: {metrics}")
 
-            # Save model to .pkl file
-            pkl_file_path = await self._save_model(model, name, self.state.thread_id)
+            # Save model to .pkl file (model + metadata payload)
+            model_artifact = await self._save_model(
+                model=model,
+                name=name,
+                thread_id=self.state.thread_id,
+                metadata={
+                    # Marker used to distinguish "new payload PKL" vs legacy "raw model PKL"
+                    "metadata_schema_version": 1,
+                    # Three core fields inference can rely on:
+                    "feature_columns": feature_columns,
+                    "target_column": target_column,
+                    "model_type": model_type,
+                },
+            )
 
             # Prepare response
             result = {
                 "success": True,
                 "model_name": name,
                 "model_type": model_type,
-                "model_file_path": pkl_file_path,
+                "model_file_path": model_artifact["model_file_path"],
+                "model_version": model_artifact["model_version"],
                 "target_column": target_column,
                 "feature_columns": feature_columns,
                 "training_samples": len(X_train),
@@ -220,7 +232,7 @@ class TrainModelNode(BaseNode):
                 "metrics": metrics,
             }
 
-            logger.info(f"Model training completed successfully: {pkl_file_path}")
+            logger.info(f"Model training completed successfully: {model_artifact['model_file_path']}")
             return result
 
         except AppException:
@@ -429,8 +441,13 @@ class TrainModelNode(BaseNode):
             Dictionary with evaluation metrics
         """
         from sklearn.metrics import (
-            accuracy_score, precision_score, recall_score, f1_score,
-            mean_squared_error, mean_absolute_error, r2_score
+            accuracy_score,
+            f1_score,
+            mean_absolute_error,
+            mean_squared_error,
+            precision_score,
+            r2_score,
+            recall_score,
         )
 
         y_pred = model.predict(X_val)
@@ -451,7 +468,9 @@ class TrainModelNode(BaseNode):
 
         return metrics
 
-    async def _save_model(self, model: Any, name: str, thread_id: str) -> str:
+    async def _save_model(
+        self, model: Any, name: str, thread_id: str, metadata: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """
         Save trained model to a .pkl file.
 
@@ -461,25 +480,28 @@ class TrainModelNode(BaseNode):
             thread_id: Thread ID for directory organization
 
         Returns:
-            Path to saved .pkl file
+            Dictionary with:
+                - model_file_path: Path to saved .pkl file
+                - model_version: Generated version identifier for this artifact
         """
         try:
             # Create models directory within the project's data volume
             models_dir = DATA_VOLUME / "ml_models" / thread_id
             models_dir.mkdir(parents=True, exist_ok=True)
+            model_version = "v2.0"
 
             # Generate unique filename
-            unique_id = str(uuid.uuid4())
-            safe_name = "".join(c if c.isalnum() or c in ('-', '_') else '_' for c in name)
-            filename = f"{safe_name}_{unique_id}.pkl"
+            safe_name = "".join(c if c.isalnum() or c in ("-", "_") else "_" for c in name)
+            filename = f"{safe_name}_{model_version}.pkl"
             file_path = models_dir / filename
 
-            # Save model using pickle
+            # Save model + metadata using pickle
+            payload = {"model": model, "metadata": metadata, "version": model_version}
             with open(file_path, "wb") as f:
-                pickle.dump(model, f)
+                pickle.dump(payload, f)
 
             logger.info(f"Saved model to: {file_path}")
-            return str(file_path)
+            return {"model_file_path": str(file_path), "model_version": model_version}
 
         except Exception as e:
             logger.error(f"Error saving model: {str(e)}", exc_info=True)

--- a/backend/app/services/ml_model_manager.py
+++ b/backend/app/services/ml_model_manager.py
@@ -139,7 +139,11 @@ class MLModelManager:
             updated_at: Last update timestamp from database
 
         Returns:
-            Loaded model object
+            Normalized model payload:
+                {
+                    "model": <loaded model>,
+                    "metadata": <dict>
+                }
         """
         model_id_str = str(model_id)
 
@@ -178,15 +182,38 @@ class MLModelManager:
 
             # Load the model
             logger.info(f"Loading ML model {model_id_str} from {pkl_file} and pkl_file_id: {pkl_file_id}")
-            model = await self._load_model_from_file(pkl_file)
+            loaded = await self._load_model_from_file(pkl_file)
+            model_payload = self._normalize_loaded_model(loaded)
 
             # Cache the model
             self._cached_models[model_id_str] = CachedMLModel(
-                model=model, model_id=model_id, updated_at=updated_at, pkl_file=pkl_file, pkl_file_id=pkl_file_id
+                model=model_payload,
+                model_id=model_id,
+                updated_at=updated_at,
+                pkl_file=pkl_file,
+                pkl_file_id=pkl_file_id,
             )
 
             logger.info(f"Cached ML model {model_id_str}")
-            return model
+            return model_payload
+
+    @staticmethod
+    def _normalize_loaded_model(loaded: Any) -> Dict[str, Any]:
+        """
+        Normalize different PKL formats into a single shape:
+            {"model": <model>, "metadata": <dict>}
+
+        Supported:
+        - Legacy: raw model object
+        - v1: raw model object without "model" and "metadata" keys
+        - v2: {"model": <model>, "metadata": {...}, "version": "v2.0"}
+        """
+        # v1: raw model object without "model" and "metadata" keys
+        if isinstance(loaded, dict):
+            return {"model": loaded.get("model", {}), "metadata": loaded.get("metadata", {}), "version": loaded.get("version", "v2.0")}
+
+        # Legacy: raw model pickled directly
+        return {"model": loaded }
 
     async def _validate_model_safe(self, pkl_file: str) -> None:
         """


### PR DESCRIPTION
## Description
- Updated MLModelInferenceNode to handle both legacy and new model response formats, ensuring compatibility with versioned model responses.
- Modified TrainModelNode to save models with associated metadata, improving model management and retrieval.
- Introduced normalization for loaded models in MLModelManager to standardize model payloads across different formats.
<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
