### PR TITLE
feat: add credential expiry settings for API keys

### DIFF
--- a/backend/alembic/versions/00067_store_api_key_expiry_setting.py
+++ b/backend/alembic/versions/00067_store_api_key_expiry_setting.py
@@ -1,0 +1,32 @@
+"""store api key expiry setting
+
+Adds `credential_expiry_days` to persist the selected expiration option (Never/30/90/180/365).
+Rotation can then recompute `credential_expires_at` as now + stored days.
+
+Revision ID: c4b8a0d2e9f1
+Revises: b1a3ac1f5fe2
+Create Date: 2026-04-14 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c4b8a0d2e9f1"
+down_revision: Union[str, None] = "b1a3ac1f5fe2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "api_keys",
+        sa.Column("credential_expiry_days", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("api_keys", "credential_expiry_days")
+

--- a/backend/app/db/models/api_key.py
+++ b/backend/app/db/models/api_key.py
@@ -21,6 +21,8 @@ class ApiKeyModel(Base):
     credential_expires_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # Stores the selected expiration option (e.g. 30/90/180/365). Null means "Never".
+    credential_expiry_days: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     is_active: Mapped[Optional[int]] = mapped_column(Integer)
     user_id: Mapped[UUID] = mapped_column(UUID, ForeignKey("users.id"), nullable=False)
 

--- a/backend/app/repositories/api_keys.py
+++ b/backend/app/repositories/api_keys.py
@@ -1,23 +1,23 @@
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 from uuid import UUID
+
 from injector import inject
+from sqlalchemy import and_, delete, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import and_, or_, select, delete, update
 from sqlalchemy.orm import selectinload
+
 from app.auth.utils import get_current_user_id
 from app.cache.redis_cache import make_key_builder
-from app.db.models import UserModel
-from app.db.models.api_key_role import ApiKeyRoleModel
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
-
+from app.db.models import UserModel
 from app.db.models.api_key import ApiKeyModel
+from app.db.models.api_key_role import ApiKeyRoleModel
 from app.db.models.role import RoleModel
 from app.db.models.role_permission import RolePermissionModel
 from app.schemas.api_key import ApiKeyCreate, ApiKeyUpdate
 from app.schemas.filter import ApiKeysFilter
-
 
 api_key_key_builder  = make_key_builder("api_key")
 
@@ -71,6 +71,7 @@ class ApiKeysRepository:
                               key_val=encrypted_api_key,
                               hashed_value=hashed_value,
                               credential_expires_at=credential_expires_at,
+                              credential_expiry_days=api_key_create.expires_in_days,
                               )
         self.db.add(new_key)
         await self.db.flush()
@@ -134,6 +135,15 @@ class ApiKeysRepository:
             api_key.name = data.name
         if data.is_active is not None:
             api_key.is_active = data.is_active
+        if data.expires_in_days is not None:
+            if data.expires_in_days == 0:
+                api_key.credential_expiry_days = None
+                api_key.credential_expires_at = None
+            else:
+                api_key.credential_expiry_days = data.expires_in_days
+                api_key.credential_expires_at = datetime.now(timezone.utc) + timedelta(
+                    days=data.expires_in_days
+                )
 
         if data.role_ids is not None:
             await self.db.execute(
@@ -145,7 +155,7 @@ class ApiKeysRepository:
 
             for role_id in data.role_ids:
                 self.db.add(ApiKeyRoleModel(api_key_id=api_key.id, role_id=role_id))
-                
+
         api_key.updated_by = user_id
 
         self.db.add(api_key)
@@ -164,6 +174,27 @@ class ApiKeysRepository:
         api_key = await self.get_by_id(api_key_id)
         if not api_key:
             raise AppException(ErrorKey.API_KEY_NOT_FOUND, status_code=404)
+
+        # If this key has an expiry policy, restart the timer on rotation from "now".
+        if api_key.credential_expiry_days is None and api_key.credential_expires_at is not None and getattr(api_key, "created_at", None) is not None:
+            # Best-effort backfill for legacy keys created before `credential_expiry_days` existed.
+            created_at = api_key.created_at
+            exp = api_key.credential_expires_at
+            if created_at.tzinfo is None:
+                created_at = created_at.replace(tzinfo=timezone.utc)
+            if exp.tzinfo is None:
+                exp = exp.replace(tzinfo=timezone.utc)
+            lifetime_days = int(round((exp - created_at).total_seconds() / 86400))
+            if lifetime_days in (30, 90, 180, 365):
+                api_key.credential_expiry_days = lifetime_days
+
+        if api_key.credential_expiry_days is not None:
+            if api_key.credential_expiry_days > 0:
+                api_key.credential_expires_at = datetime.now(timezone.utc) + timedelta(
+                    days=api_key.credential_expiry_days
+                )
+            else:
+                api_key.credential_expires_at = None
 
         if overlap_seconds > 0:
             api_key.previous_hashed_value = api_key.hashed_value

--- a/backend/app/schemas/api_key.py
+++ b/backend/app/schemas/api_key.py
@@ -30,6 +30,12 @@ class ApiKeyUpdate(BaseModel):
     name: Optional[str] = Field(None, min_length=4, max_length=255)
     is_active: Optional[int] = None
     role_ids: Optional[list[UUID]] = None
+    expires_in_days: Optional[int] = Field(
+        None,
+        ge=0,
+        le=730,
+        description="If set: 0 clears expiry (Never); otherwise sets/overwrites credential expiry to now + this many days (UTC). Omit to leave unchanged.",
+    )
 
 
 class ApiKeyRotate(BaseModel):
@@ -62,6 +68,10 @@ class ApiKeyRead(ApiKeyBase):
     credential_expires_at: Optional[datetime] = Field(
         None,
         description="When set, this key record (current secret) is not accepted for API auth at or after this instant (UTC).",
+    )
+    credential_expiry_days: Optional[int] = Field(
+        None,
+        description="Stored expiry selection in days (30/90/180/365). Null means Never.",
     )
 
     model_config = ConfigDict(

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -20233,6 +20233,18 @@
             ],
             "title": "Credential Expires At",
             "description": "When set, this key record (current secret) is not accepted for API auth at or after this instant (UTC)."
+          },
+          "credential_expiry_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Credential Expiry Days",
+            "description": "Stored expiry selection in days (30/90/180/365). Null means Never."
           }
         },
         "type": "object",
@@ -20301,6 +20313,20 @@
               }
             ],
             "title": "Role Ids"
+          },
+          "expires_in_days": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 730.0,
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires In Days",
+            "description": "If set: 0 clears expiry (Never); otherwise sets/overwrites credential expiry to now + this many days (UTC). Omit to leave unchanged."
           }
         },
         "type": "object",

--- a/frontend/src/components/tooltip-button.tsx
+++ b/frontend/src/components/tooltip-button.tsx
@@ -1,0 +1,24 @@
+import { Tooltip, TooltipTrigger, TooltipContent } from './RadixTooltip';
+
+interface TooltipButtonProps {
+  button: React.ReactNode;
+  tooltipContent: React.ComponentProps<typeof TooltipContent>;
+  className?: string;
+  side?: 'top' | 'bottom' | 'left' | 'right';
+  align?: 'start' | 'center' | 'end';
+}
+
+export function TooltipButton({
+  button,
+  tooltipContent,
+  className,
+  side = 'top',
+  align = 'center',
+}: TooltipButtonProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent className={className} side={side} align={align} {...tooltipContent} />
+    </Tooltip>
+  );
+}

--- a/frontend/src/components/tooltip.tsx
+++ b/frontend/src/components/tooltip.tsx
@@ -8,6 +8,7 @@ interface TooltipProps {
   contentClassName?: string;
   iconClassName?: string;
   className?: string;
+  noIcon?: boolean;
 }
 
 export function Tooltip({
@@ -15,10 +16,11 @@ export function Tooltip({
   contentClassName,
   iconClassName,
   className,
+  noIcon = false,
 }: TooltipProps) {
   return (
     <div className={cn("relative group", className)}>
-      <InfoIcon className={cn("text-gray-400 cursor-help", iconClassName)} />
+      {!noIcon && <InfoIcon className={cn("text-gray-400 cursor-help", iconClassName)} />}
       <div
         className={cn(
           "absolute z-10 invisible opacity-0 group-hover:visible group-hover:opacity-100 transition-opacity bottom-full left-1/2 -translate-x-1/2 mb-2 p-2 bg-gray-800 text-white text-xs rounded shadow-lg",

--- a/frontend/src/interfaces/api-key.interface.ts
+++ b/frontend/src/interfaces/api-key.interface.ts
@@ -18,6 +18,8 @@ export interface ApiKey {
   previous_hashed_expires_at?: string | null;
   /** When set, API auth rejects this key at or after this instant (ISO UTC). */
   credential_expires_at?: string | null;
+  /** Stored expiry selection in days (30/90/180/365). Null/undefined means Never. */
+  credential_expiry_days?: number | null;
   /** Only used when creating a key (days until credential_expires_at). */
   expires_in_days?: number;
 }

--- a/frontend/src/services/apiKeys.ts
+++ b/frontend/src/services/apiKeys.ts
@@ -73,6 +73,10 @@ export const updateApiKey = async (
     requestData.agent_id = apiKeyData.agent_id;
   }
 
+  if (typeof apiKeyData.expires_in_days === "number") {
+    requestData.expires_in_days = apiKeyData.expires_in_days;
+  }
+
   const response = await apiRequest<ApiKey>(
     "PATCH",
     `api-keys/${id}/`,

--- a/frontend/src/views/ApiKeys/components/ApiKeyDialog.tsx
+++ b/frontend/src/views/ApiKeys/components/ApiKeyDialog.tsx
@@ -41,6 +41,27 @@ export function ApiKeyDialog({
   mode = "create",
   apiKeyToEdit = null,
 }: ApiKeyDialogProps) {
+  const formatExpiresIn = (credentialExpiresAt?: string | null) => {
+    if (!credentialExpiresAt) return null;
+    const expMs = new Date(credentialExpiresAt).getTime();
+    if (Number.isNaN(expMs)) return null;
+    const nowMs = Date.now();
+    const diffMs = expMs - nowMs;
+    if (diffMs <= 0) return "Expired";
+
+    const minute = 60 * 1000;
+    const hour = 60 * minute;
+    const day = 24 * hour;
+
+    const days = Math.floor(diffMs / day);
+    const hours = Math.floor((diffMs % day) / hour);
+    const minutes = Math.floor((diffMs % hour) / minute);
+
+    if (days > 0) return `${days}d ${hours}h`;
+    if (hours > 0) return `${hours}h ${minutes}m`;
+    return `${minutes}m`;
+  };
+
   const {
     name,
     setName,
@@ -68,6 +89,11 @@ export function ApiKeyDialog({
     onApiKeyUpdated,
     onOpenChange,
   });
+
+  const expiresInLabel =
+    dialogMode === "edit"
+      ? formatExpiresIn(apiKeyToEdit?.credential_expires_at ?? null)
+      : null;
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
@@ -108,6 +134,45 @@ export function ApiKeyDialog({
                 onCheckedChange={setIsActive}
               />
             </div>
+
+            {dialogMode === "edit" ? (
+              <div className="space-y-2">
+                <Label>Credential expires</Label>
+                <Select value={expiryPreset} onValueChange={setExpiryPreset}>
+                  <SelectTrigger id="credential-expiry-edit">
+                    <SelectValue placeholder="Expiry" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {API_KEY_EXPIRY_PRESET_VALUES.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                {apiKeyToEdit?.credential_expires_at ? (
+                  <div className="text-sm">
+                    {expiresInLabel ? (
+                      <span>
+                        Expires in{" "}
+                        <span className="font-medium">{expiresInLabel}</span>
+                      </span>
+                    ) : (
+                      <span>Expiration is set.</span>
+                    )}
+                  </div>
+                ) : (
+                  <p className="text-xs text-muted-foreground">
+                    This key currently never expires.
+                  </p>
+                )}
+
+                <p className="text-xs text-muted-foreground">
+                  On rotate, expiration will be recalculated from now based on this setting (unless set to Never).
+                </p>
+              </div>
+            ) : null}
 
             {dialogMode === "create" && !hasGeneratedKey ? (
               <div className="space-y-2">

--- a/frontend/src/views/ApiKeys/components/ApiKeyDialogLogic.tsx
+++ b/frontend/src/views/ApiKeys/components/ApiKeyDialogLogic.tsx
@@ -7,6 +7,27 @@ import { Role } from "@/interfaces/role.interface";
 import { ApiKey } from "@/interfaces/api-key.interface";
 import { presetToExpiresInDays } from "@/components/api-keys/apiKeyExpiryPresets";
 
+const PRESET_DAY_VALUES = new Set([30, 90, 180, 365]);
+
+function inferPresetFromApiKey(apiKey: ApiKey): string {
+  if (typeof apiKey.credential_expiry_days === "number") {
+    if (apiKey.credential_expiry_days <= 0) return "never";
+    return String(apiKey.credential_expiry_days);
+  }
+
+  // Legacy fallback: try to infer from created_at -> credential_expires_at (if present).
+  if (apiKey.created_at && apiKey.credential_expires_at) {
+    const createdMs = new Date(apiKey.created_at).getTime();
+    const expMs = new Date(apiKey.credential_expires_at).getTime();
+    if (!Number.isNaN(createdMs) && !Number.isNaN(expMs) && expMs > createdMs) {
+      const days = Math.round((expMs - createdMs) / (24 * 60 * 60 * 1000));
+      if (PRESET_DAY_VALUES.has(days)) return String(days);
+    }
+  }
+
+  return "never";
+}
+
 export function ApiKeyDialogLogic({
   isOpen,
   mode = "create",
@@ -52,6 +73,7 @@ export function ApiKeyDialogLogic({
           );
           setGeneratedKey(apiKeyToEdit.key_val);
           setHasGeneratedKey(true);
+          setExpiryPreset(inferPresetFromApiKey(apiKeyToEdit));
         } else {
           setDialogMode("create");
           setName("");
@@ -135,18 +157,17 @@ export function ApiKeyDialogLogic({
           role_ids: selectedRoles,
         };
 
-        await updateApiKey(apiKeyToEdit.id, updateData);
+        const expiresInDays = presetToExpiresInDays(expiryPreset);
+        // Persist the user's selection on the record.
+        // - undefined => "never" => backend expects 0 to clear/store Never
+        // - number => set/store that many days
+        updateData.expires_in_days = expiresInDays ?? 0;
+
+        const updatedFromApi = await updateApiKey(apiKeyToEdit.id, updateData);
         toast.success("API key updated successfully.");
 
         if (onApiKeyUpdated) {
-          const updatedKey: ApiKey = {
-            ...apiKeyToEdit,
-            ...commonFields,
-            roles: availableRoles.filter((role) =>
-              selectedRoles.includes(role.id)
-            ),
-          };
-          onApiKeyUpdated(updatedKey);
+          onApiKeyUpdated(updatedFromApi);
         }
 
         onOpenChange(false);

--- a/frontend/src/views/ApiKeys/components/ApiKeysCard.tsx
+++ b/frontend/src/views/ApiKeys/components/ApiKeysCard.tsx
@@ -1,20 +1,19 @@
-import { useEffect, useState } from "react";
-import { DataTable } from "@/components/DataTable";
-import { TableCell, TableRow } from "@/components/table";
-import { Button } from "@/components/button";
-import { Badge } from "@/components/badge";
-import { Pencil, RefreshCw } from "lucide-react";
-import { ApiKeyExpiryLines } from "@/components/api-keys/ApiKeyExpiryLines";
-import {
-  RotateApiKeyDialog,
-  type RotateApiKeyTarget,
-} from "@/components/api-keys/RotateApiKeyDialog";
-import { ApiKey } from "@/interfaces/api-key.interface";
-import { getAllApiKeys } from "@/services/apiKeys";
-import { getAllUsers } from "@/services/users";
-import { toast } from "react-hot-toast";
-import { formatDate } from "@/helpers/utils";
-import { User } from "@/interfaces/user.interface";
+import { useEffect, useState } from 'react';
+import { DataTable } from '@/components/DataTable';
+import { TableCell, TableRow } from '@/components/table';
+import { Button } from '@/components/button';
+import { Badge } from '@/components/badge';
+import { Pencil, RefreshCw } from 'lucide-react';
+import { ApiKeyExpiryLines } from '@/components/api-keys/ApiKeyExpiryLines';
+import { RotateApiKeyDialog, type RotateApiKeyTarget } from '@/components/api-keys/RotateApiKeyDialog';
+import { ApiKey } from '@/interfaces/api-key.interface';
+import { getAllApiKeys } from '@/services/apiKeys';
+import { getAllUsers } from '@/services/users';
+import { toast } from 'react-hot-toast';
+import { formatDate } from '@/helpers/utils';
+import { User } from '@/interfaces/user.interface';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/RadixTooltip';
+import { TooltipButton } from '@/components/tooltip-button';
 
 interface ApiKeysCardProps {
   searchQuery: string;
@@ -35,9 +34,7 @@ export function ApiKeysCard({
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [rotateTarget, setRotateTarget] = useState<RotateApiKeyTarget | null>(
-    null
-  );
+  const [rotateTarget, setRotateTarget] = useState<RotateApiKeyTarget | null>(null);
 
   useEffect(() => {
     fetchData();
@@ -45,37 +42,28 @@ export function ApiKeysCard({
 
   useEffect(() => {
     if (updatedApiKey) {
-      setApiKeys((prevKeys) =>
-        prevKeys.map((key) =>
-          key.id === updatedApiKey.id ? updatedApiKey : key
-        )
-      );
+      setApiKeys((prevKeys) => prevKeys.map((key) => (key.id === updatedApiKey.id ? updatedApiKey : key)));
     }
   }, [updatedApiKey]);
 
   const fetchData = async () => {
     try {
       setLoading(true);
-      const [keysData, usersData] = await Promise.all([
-        getAllApiKeys(),
-        getAllUsers(),
-      ]);
+      const [keysData, usersData] = await Promise.all([getAllApiKeys(), getAllUsers()]);
       setApiKeys(keysData);
       setUsers(usersData);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to fetch data");
-      toast.error("Failed to fetch data.");
+      setError(err instanceof Error ? err.message : 'Failed to fetch data');
+      toast.error('Failed to fetch data.');
     } finally {
       setLoading(false);
     }
   };
 
-  const filteredApiKeys = apiKeys.filter((apiKey) =>
-    apiKey.name.toLowerCase().includes(searchQuery.toLowerCase())
-  );
+  const filteredApiKeys = apiKeys.filter((apiKey) => apiKey.name.toLowerCase().includes(searchQuery.toLowerCase()));
 
-  const headers = ["Name", "Roles", "Created", "Status", "Validity", "Actions"];
+  const headers = ['Name', 'Roles', 'Created', 'Status', 'Validity', 'Actions'];
 
   const renderRow = (apiKey: ApiKey) => (
     <TableRow key={apiKey.id}>
@@ -93,34 +81,30 @@ export function ApiKeysCard({
           )}
         </div>
       </TableCell>
-      <TableCell className="truncate">
-        {apiKey.created_at ? formatDate(apiKey.created_at) : "No date"}
-      </TableCell>
+      <TableCell className="truncate">{apiKey.created_at ? formatDate(apiKey.created_at) : 'No date'}</TableCell>
       <TableCell className="overflow-hidden whitespace-nowrap text-clip">
-        <Badge variant={apiKey.is_active === 1 ? "default" : "secondary"}>
-          {apiKey.is_active === 1 ? "Active" : "Revoked"}
+        <Badge variant={apiKey.is_active === 1 ? 'default' : 'secondary'}>
+          {apiKey.is_active === 1 ? 'Active' : 'Revoked'}
         </Badge>
       </TableCell>
       <TableCell className="max-w-[220px]">
         <ApiKeyExpiryLines apiKey={apiKey} />
       </TableCell>
       <TableCell className="space-x-1">
-        <Button
-          variant="ghost"
-          size="sm"
-          title="Rotate secret"
-          onClick={() => setRotateTarget({ key: apiKey, overlap: "0" })}
-        >
-          <RefreshCw className="w-4 h-4 text-black" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => onEditApiKey(apiKey)}
-          title="Edit API Key"
-        >
-          <Pencil className="w-4 h-4 text-black" />
-        </Button>
+        <TooltipButton
+          button={
+            <Button variant="ghost" size="sm" onClick={() => setRotateTarget({ key: apiKey, overlap: '0' })}>
+              <RefreshCw className="w-4 h-4 text-black" />
+            </Button>
+          }
+          tooltipContent={{ side: 'top', align: 'center', children: <p>Rotate secret</p> }}
+        />
+        <TooltipButton
+          button={<Button variant="ghost" size="sm" onClick={() => onEditApiKey(apiKey)} title="Edit API Key">
+            <Pencil className="w-4 h-4 text-black" />
+          </Button>}
+          tooltipContent={{ side: 'top', align: 'center', children: <p>Edit API Key</p> }}
+        />
       </TableCell>
     </TableRow>
   );


### PR DESCRIPTION
## Description

- Introduced `credential_expiry_days` to the API key model to store expiration options (30/90/180/365 days or null for "Never").
- Updated the database schema to persist the new expiration setting.
- Enhanced API key creation and update processes to handle the new expiry logic.
- Modified frontend components to support displaying and selecting expiration settings for API keys.
- Implemented logic to recalculate expiration dates based on user selections during key rotation.


## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
