### PR TITLE
feat: add group_id field to OpenAPI schema and update GlobalChat component to use tenantId

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -29267,6 +29267,18 @@
             "type": "string",
             "format": "uuid",
             "title": "User Type Id"
+          },
+          "group_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Group Id"
           }
         },
         "type": "object",

--- a/frontend/src/components/GlobalChat.tsx
+++ b/frontend/src/components/GlobalChat.tsx
@@ -8,6 +8,7 @@ export const GlobalChat = () => {
   const [websocketUrl, setWebsocketUrl] = useState<string | undefined>(undefined);
   const [error, setError] = useState<string | null>(null);
   const genassistApiKey = import.meta.env.VITE_GENASSIST_CHAT_APIKEY;
+  const tenantId = localStorage.getItem('tenant_id') as string | undefined;
 
   useEffect(() => {
     (async () => {
@@ -35,7 +36,7 @@ export const GlobalChat = () => {
       baseUrl={baseUrl}
       websocketUrl={websocketUrl}
       apiKey={genassistApiKey}
-      tenant={undefined}
+      tenant={tenantId}
       headerTitle="Genassist Chat"
       theme={{
         primaryColor: "#173DED",


### PR DESCRIPTION
## Description
- Added a new `group_id` field to the OpenAPI schema, allowing for a string or null value.
- Updated the `GlobalChat` component to retrieve and use the `tenantId` from local storage instead of passing `undefined`.

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
