### PR TITLE
feat: add delete functionality for API keys

### DIFF
--- a/frontend/src/views/ApiKeys/components/ApiKeysCard.tsx
+++ b/frontend/src/views/ApiKeys/components/ApiKeysCard.tsx
@@ -3,7 +3,7 @@ import { DataTable } from '@/components/DataTable';
 import { TableCell, TableRow } from '@/components/table';
 import { Button } from '@/components/button';
 import { Badge } from '@/components/badge';
-import { Pencil, RefreshCw } from 'lucide-react';
+import { Pencil, RefreshCw, Trash } from 'lucide-react';
 import { ApiKeyExpiryLines } from '@/components/api-keys/ApiKeyExpiryLines';
 import { RotateApiKeyDialog, type RotateApiKeyTarget } from '@/components/api-keys/RotateApiKeyDialog';
 import { ApiKey } from '@/interfaces/api-key.interface';
@@ -21,6 +21,7 @@ interface ApiKeysCardProps {
   onEditApiKey: (apiKey: ApiKey) => void;
   updatedApiKey?: ApiKey | null;
   onApiKeyRotated?: (apiKey: ApiKey) => void;
+  onDeleteApiKey: (apiKey: ApiKey) => void;
 }
 
 export function ApiKeysCard({
@@ -29,6 +30,7 @@ export function ApiKeysCard({
   onEditApiKey,
   updatedApiKey = null,
   onApiKeyRotated,
+  onDeleteApiKey,
 }: ApiKeysCardProps) {
   const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
   const [users, setUsers] = useState<User[]>([]);
@@ -104,6 +106,12 @@ export function ApiKeysCard({
             <Pencil className="w-4 h-4 text-black" />
           </Button>}
           tooltipContent={{ side: 'top', align: 'center', children: <p>Edit API Key</p> }}
+        />
+        <TooltipButton
+          button={<Button variant="ghost" size="sm" onClick={() => onDeleteApiKey(apiKey)} title="Delete API Key">
+            <Trash className="w-4 h-4 text-red-500" />
+          </Button>}
+          tooltipContent={{ side: 'top', align: 'center', children: <p>Delete API Key</p> }}
         />
       </TableCell>
     </TableRow>

--- a/frontend/src/views/ApiKeys/pages/ApiKeys.tsx
+++ b/frontend/src/views/ApiKeys/pages/ApiKeys.tsx
@@ -1,9 +1,12 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { PageLayout } from "@/components/PageLayout";
 import { PageHeader } from "@/components/PageHeader";
 import { ApiKeysCard } from "@/views/ApiKeys/components/ApiKeysCard";
 import { ApiKey } from "@/interfaces/api-key.interface";
 import { ApiKeyDialog } from "../components/ApiKeyDialog";
+import { revokeApiKey } from "@/services/apiKeys";
+import { toast } from "react-hot-toast";
+import { DeleteConfirmationDialog } from "@/components/ui/delete-confirmation-dialog";
 
 export default function ApiKeys() {
   const [searchQuery, setSearchQuery] = useState("");
@@ -12,6 +15,9 @@ export default function ApiKeys() {
   const [dialogMode, setDialogMode] = useState<"create" | "edit">("create");
   const [apiKeyToEdit, setApiKeyToEdit] = useState<ApiKey | null>(null);
   const [updatedApiKey, setUpdatedApiKey] = useState<ApiKey | null>(null);
+  const [apiKeyPendingDelete, setApiKeyPendingDelete] = useState<ApiKey | null>(null);
+  const [isDeletingApiKey, setIsDeletingApiKey] = useState(false);
+  const isDeletingApiKeyRef = useRef(false);
 
   const handleApiKeySaved = () => {
     setRefreshKey((prevKey) => prevKey + 1);
@@ -33,6 +39,28 @@ export default function ApiKeys() {
     setIsDialogOpen(true);
   };
 
+  const handleDeleteApiKey = (apiKey: ApiKey) => {
+    setApiKeyPendingDelete(apiKey);
+  };
+
+  const handleConfirmDeleteApiKey = async () => {
+    if (!apiKeyPendingDelete) return;
+
+    isDeletingApiKeyRef.current = true;
+    setIsDeletingApiKey(true);
+    try {
+      await revokeApiKey(apiKeyPendingDelete.id);
+      toast.success("API key deleted successfully");
+      setApiKeyPendingDelete(null);
+      setRefreshKey((prevKey) => prevKey + 1);
+    } catch {
+      toast.error("Failed to delete API key");
+    } finally {
+      isDeletingApiKeyRef.current = false;
+      setIsDeletingApiKey(false);
+    }
+  };
+
   return (
     <PageLayout>
       <PageHeader
@@ -51,6 +79,7 @@ export default function ApiKeys() {
         onEditApiKey={handleEditApiKey}
         updatedApiKey={updatedApiKey}
         onApiKeyRotated={handleApiKeyUpdated}
+        onDeleteApiKey={handleDeleteApiKey}
       />
 
       <ApiKeyDialog
@@ -60,6 +89,21 @@ export default function ApiKeys() {
         onApiKeyUpdated={handleApiKeyUpdated}
         apiKeyToEdit={apiKeyToEdit}
         mode={dialogMode}
+      />
+
+      <DeleteConfirmationDialog
+        open={apiKeyPendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open && !isDeletingApiKeyRef.current) {
+            setApiKeyPendingDelete(null);
+          }
+        }}
+        onConfirm={handleConfirmDeleteApiKey}
+        isDeleting={isDeletingApiKey}
+        title="Delete API key?"
+        itemName={apiKeyPendingDelete?.name}
+        confirmButtonText="Delete"
+        loadingText="Deleting..."
       />
     </PageLayout>
   );


### PR DESCRIPTION
## Description
- Implemented a delete button in the ApiKeysCard component to allow users to delete API keys.
- Added confirmation dialog for delete actions in the ApiKeys page.
- Integrated API call to revoke API keys and handle success/error notifications.

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
