### PR TITLE
feat: implement chunked upload sessions for files and knowledge base

### DIFF
--- a/backend/alembic/versions/00069_add_kb_upload_sessions.py
+++ b/backend/alembic/versions/00069_add_kb_upload_sessions.py
@@ -1,0 +1,56 @@
+"""add files_upload_sessions for chunked uploads
+
+Revision ID: a1b2c3d4e5f7
+Revises: f7e2b1c3d4a5
+Create Date: 2026-04-16 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f7"
+down_revision: Union[str, None] = "f7e2b1c3d4a5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "files_upload_sessions",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("original_filename", sa.String(length=500), nullable=False),
+        sa.Column("content_type", sa.String(length=255), nullable=True),
+        sa.Column("temp_path", sa.String(length=2000), nullable=False),
+        sa.Column("bytes_received", sa.BigInteger(), nullable=False),
+        sa.Column("expected_bytes", sa.BigInteger(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("result_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("is_deleted", sa.Integer(), nullable=False),
+        sa.Column("created_by", sa.UUID(), nullable=True),
+        sa.Column("updated_by", sa.UUID(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "idx_files_upload_sessions_status",
+        "files_upload_sessions",
+        ["status"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_files_upload_sessions_status", table_name="files_upload_sessions")
+    op.drop_table("files_upload_sessions")

--- a/backend/app/api/v1/routes/agent_knowledge.py
+++ b/backend/app/api/v1/routes/agent_knowledge.py
@@ -1,17 +1,20 @@
-from fastapi import APIRouter, HTTPException, Depends, Body, UploadFile, File, Form, Request
-from typing import List, Dict, Optional
+import logging
 import os
-import uuid
 import shutil
+import uuid
+from typing import Dict, List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Body, Depends, File, Form, HTTPException, Request, UploadFile
 from fastapi_injector import Injected
+
 from app.auth.dependencies import auth, permissions
-from app.core.exceptions.error_messages import ErrorKey
-from app.core.exceptions.exception_classes import AppException
+from app.core.config.settings import file_storage_settings
+from app.core.config.settings import settings as project_settings
+from app.core.project_path import DATA_VOLUME
+from app.core.tenant_scope import get_tenant_context
 from app.core.utils.bi_utils import set_url_content_if_no_rag
 from app.modules.data.manager import AgentRAGServiceManager
-from app.modules.data.utils import FileExtractor, FileTextExtractor
-import logging
-from uuid import UUID
 from app.modules.data.providers.legra import (
     FaissFlatIndexer,
     HuggingFaceGenerator,
@@ -20,26 +23,30 @@ from app.modules.data.providers.legra import (
     SemanticChunker,
     SentenceTransformerEmbedder,
 )
+from app.modules.data.utils import FileExtractor, FileTextExtractor
+from app.modules.workflow.agents.rag import ThreadScopedRAG
 from app.schemas.agent_knowledge import KBBase, KBCreate, KBListItem, KBRead
 from app.schemas.common import PaginatedResponse
+from app.schemas.dynamic_form_schemas import AGENT_RAG_FORM_SCHEMAS_DICT
+from app.schemas.file import FileBase, FileUploadResponse
 from app.schemas.filter import BaseFilterModel
+from app.schemas.knowledge_upload import (
+    KbUploadSessionCreate,
+    KbUploadSessionCreateResponse,
+    KbUploadSessionStatusResponse,
+)
 from app.services.agent_knowledge import KnowledgeBaseService
 from app.services.agent_knowledge_utils import (
     populate_remote_file_metadata,
     schedule_rag_load,
 )
-from app.core.tenant_scope import get_tenant_context
-from app.tasks.kb_batch_tasks import batch_process_files_kb_async_with_scope
-from app.tasks.s3_tasks import import_s3_files_to_kb_async
-from app.core.project_path import DATA_VOLUME
-from app.modules.workflow.agents.rag import ThreadScopedRAG
-from app.schemas.dynamic_form_schemas import AGENT_RAG_FORM_SCHEMAS_DICT
+from app.services.app_settings import AppSettingsService
+
 # File manager service
 from app.services.file_manager import FileManagerService
-from app.schemas.file import FileBase, FileUploadResponse
-from app.core.config.settings import file_storage_settings
-from app.services.app_settings import AppSettingsService
-from app.db.models.file import StorageProvider
+from app.services.file_upload_session import FileUploadSessionService
+from app.tasks.kb_batch_tasks import batch_process_files_kb_async_with_scope
+from app.tasks.s3_tasks import import_s3_files_to_kb_async
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -246,11 +253,31 @@ async def upload_file(
     results = []
     logger.info(f"Starting upload of {len(files)} files.")
 
+    max_kb = project_settings.KNOWLEDGE_MAX_UPLOAD_BYTES
+    use_file_manager = file_storage_settings.FILE_MANAGER_ENABLED
+    storage_provider = None
+    app_settings_config = None
+    if use_file_manager:
+        app_settings_config = await app_settings_svc.get_by_type_and_name(
+            "FileManagerSettings", "File Manager Settings"
+        )
+        storage_provider = await file_manager_service.initialize(
+            base_url=str(request.base_url).rstrip("/"),
+            base_path=str(DATA_VOLUME),
+            app_settings=app_settings_config,
+        )
+
     for file in files:
         try:
             logger.info(
                 f"Received file upload: {file.filename}, size: {file.size}, content_type: {file.content_type}"
             )
+
+            if file.size is not None and file.size > max_kb:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"File exceeds maximum allowed size ({max_kb} bytes).",
+                )
 
             # Generate a unique filename
             file_extension = file.filename.split(".")[-1] if "." in file.filename else ""
@@ -262,17 +289,8 @@ async def upload_file(
                 "original_filename": file.filename,
             }
 
-            # check if the file manager is enabled
-            use_file_manager = file_storage_settings.FILE_MANAGER_ENABLED
-
-            if use_file_manager:
-                # subdir
-                sub_folder = f"agents_config/uploads"
-
-                # initialize the file manager service
-                app_settings_config = await app_settings_svc.get_by_type_and_name("FileManagerSettings", "File Manager Settings")
-                storage_provider = await file_manager_service.initialize(base_url=str(request.base_url).rstrip('/'), base_path=str(DATA_VOLUME), app_settings = app_settings_config)
-
+            if use_file_manager and storage_provider:
+                sub_folder = "agents_config/uploads"
                 file_base = FileBase(
                     name=unique_filename,
                     storage_path=storage_provider.get_base_path(),
@@ -281,18 +299,18 @@ async def upload_file(
                     file_extension=file_extension,
                 )
 
-                # use file manager service to upload the file
-                created_file = await file_manager_service.create_file(file, file_base=file_base)
+                created_file = await file_manager_service.create_file(
+                    file=file,
+                    file_base=file_base,
+                    max_file_size=max_kb,
+                )
                 file_id = str(created_file.id)
-
-                # await file_manager_service.download_file_to_path(file_id, file_path)
                 file_url = await file_manager_service.get_file_source_url(created_file.id)
 
                 result["file_type"] = "url"
                 result["file_url"] = file_url
                 result["file_id"] = file_id
 
-                # if the file is stored locally, add the file path to the result
                 if created_file.storage_provider == "local":
                     result["file_path"] = f"{created_file.storage_path}/{created_file.path}"
             else:
@@ -312,6 +330,8 @@ async def upload_file(
 
             logger.info(f"Upload successful: {result}")
             results.append(result)
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Error uploading file: {str(e)}")
             raise HTTPException(
@@ -319,6 +339,97 @@ async def upload_file(
 
     logger.info(f"All uploads successful: {results}")
     return results
+
+
+@router.post(
+    "/upload-session",
+    response_model=KbUploadSessionCreateResponse,
+    dependencies=[Depends(auth)],
+)
+async def create_kb_upload_session(
+    payload: KbUploadSessionCreate,
+    svc: FileUploadSessionService = Injected(FileUploadSessionService),
+):
+    """Start a chunked upload for a single large file (backward compatible with /upload)."""
+    try:
+        created = await svc.create_session(
+            payload.original_filename,
+            payload.expected_size,
+            payload.content_type,
+        )
+        return KbUploadSessionCreateResponse(
+            session_id=created.session_id,
+            max_chunk_bytes=created.max_chunk_bytes,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post(
+    "/upload-session/{session_id}/chunk",
+    dependencies=[Depends(auth)],
+)
+async def kb_upload_session_chunk(
+    session_id: UUID,
+    chunk: UploadFile = File(...),
+    chunk_index: int = Form(0),
+    svc: FileUploadSessionService = Injected(FileUploadSessionService),
+):
+    """Append one chunk to a staged upload session."""
+    try:
+        data = await chunk.read()
+        total = await svc.append_chunk(session_id, data, chunk_index)
+        return {"status": "ok", "bytes_received": total}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post(
+    "/upload-session/{session_id}/complete",
+    response_model=Dict[str, str],
+    dependencies=[Depends(auth)],
+)
+async def kb_upload_session_complete(
+    session_id: UUID,
+    request: Request,
+    svc: FileUploadSessionService = Injected(FileUploadSessionService),
+    file_manager_service: FileManagerService = Injected(FileManagerService),
+    app_settings_svc: AppSettingsService = Injected(AppSettingsService),
+):
+    """Finalize staged bytes into storage + files row (same shape as one legacy /upload item)."""
+    try:
+        return await svc.complete_session(
+            session_id,
+            request,
+            file_manager_service,
+            app_settings_svc,
+            sub_folder="agents_config/uploads",
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get(
+    "/upload-session/{session_id}",
+    response_model=KbUploadSessionStatusResponse,
+    dependencies=[Depends(auth)],
+)
+async def kb_upload_session_status(
+    session_id: UUID,
+    svc: FileUploadSessionService = Injected(FileUploadSessionService),
+):
+    try:
+        s = await svc.get_status(session_id)
+        return KbUploadSessionStatusResponse(
+            id=s.id,
+            status=s.status,
+            bytes_received=s.bytes_received,
+            expected_bytes=s.expected_bytes,
+            error_message=s.error_message,
+            result=s.result,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
 
 
 @router.post(
@@ -369,7 +480,7 @@ async def upload_file_to_chat(
         except Exception as e:
             logger.error(f"Error creating file: {str(e)}")
             raise HTTPException(
-                status_code=400, detail=f"Unsupported file type. Only PDF, DOCX, TXT, JPG, JPEG, and PNG are allowed.") from e
+                status_code=400, detail="Unsupported file type. Only PDF, DOCX, TXT, JPG, JPEG, and PNG are allowed.") from e
 
         # get file id from created file
         file_id = created_file.id

--- a/backend/app/api/v1/routes/file_manager.py
+++ b/backend/app/api/v1/routes/file_manager.py
@@ -1,5 +1,6 @@
 import base64
-from typing import List, Optional
+import uuid
+from typing import Dict, List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, Query, Request, UploadFile, status
@@ -7,7 +8,7 @@ from fastapi.responses import Response
 from fastapi_injector import Injected
 
 from app.auth.dependencies import auth, permissions
-from app.core.config.settings import file_storage_settings
+from app.core.config.settings import file_storage_settings, settings
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 
@@ -17,8 +18,14 @@ from app.core.project_path import DATA_VOLUME
 from app.core.utils.redirect_utils import validate_s3_download_redirect_url
 from app.schemas.app_settings import AppSettingsCreate
 from app.schemas.file import FileBase, FileResponse
+from app.schemas.files_upload import (
+    FilesUploadSessionCreate,
+    FilesUploadSessionCreateResponse,
+    FilesUploadSessionStatusResponse,
+)
 from app.services.app_settings import AppSettingsService
 from app.services.file_manager import FileManagerService
+from app.services.file_upload_session import FileUploadSessionService
 
 router = APIRouter()
 
@@ -230,3 +237,151 @@ async def delete_file(
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
         raise AppException(ErrorKey.FILE_NOT_FOUND,404,f"File not found: {str(e)}")
+
+
+# ==================== Upload convenience endpoints ====================
+
+
+@router.post(
+    "/upload",
+    response_model=List[Dict[str, str]],
+    dependencies=[Depends(auth), Depends(permissions(P.FileManager.CREATE))],
+)
+async def upload_files(
+    request: Request,
+    files: List[UploadFile] = File(...),
+    file_manager_service: FileManagerService = Injected(FileManagerService),
+    app_settings_svc: AppSettingsService = Injected(AppSettingsService),
+):
+    """
+    Upload multiple files and return UploadFileResponse-compatible dicts.
+
+    This endpoint mirrors the legacy `genagent/knowledge/upload` response shape,
+    but is owned by file-manager.
+    """
+    try:
+        app_settings_config = await app_settings_svc.get_by_type_and_name(
+            "FileManagerSettings", "File Manager Settings"
+        )
+        storage_provider = await file_manager_service.initialize(
+            base_url=str(request.base_url).rstrip("/"),
+            base_path=str(DATA_VOLUME),
+            app_settings=app_settings_config,
+        )
+    except Exception:
+        storage_provider = None
+
+    results: list[dict] = []
+    max_file_size = settings.MAX_CONTENT_LENGTH
+
+    for f in files:
+        if max_file_size is not None and f.size is not None and f.size > max_file_size:
+            raise AppException(
+                ErrorKey.FILE_SIZE_TOO_LARGE,
+                400,
+                f"File exceeds maximum allowed size ({max_file_size} bytes).",
+            )
+        ext = f.filename.split(".")[-1] if f.filename and "." in f.filename else ""
+        unique_name = f"{uuid.uuid4()}.{ext}" if ext else f"{uuid.uuid4()}"
+        sub_folder = "uploads"
+        file_base = FileBase(
+            name=unique_name,
+            storage_path=storage_provider.get_base_path() if storage_provider else str(DATA_VOLUME),
+            path=sub_folder,
+            storage_provider=(storage_provider.name if storage_provider else "local"),
+            file_extension=ext,
+        )
+        created = await file_manager_service.create_file(
+            file=f,
+            file_base=file_base,
+            max_file_size=max_file_size,
+        )
+        file_url = await file_manager_service.get_file_source_url(created.id)
+        result = {
+            "filename": unique_name,
+            "original_filename": f.filename or unique_name,
+            "file_type": "url",
+            "file_url": file_url,
+            "file_id": str(created.id),
+        }
+        if created.storage_provider == "local":
+            result["file_path"] = f"{created.storage_path}/{created.path}"
+        results.append(result)
+
+    return results
+
+
+@router.post(
+    "/upload-session",
+    response_model=FilesUploadSessionCreateResponse,
+    dependencies=[Depends(auth), Depends(permissions(P.FileManager.CREATE))],
+)
+async def create_files_upload_session(
+    payload: FilesUploadSessionCreate,
+    svc: FileUploadSessionService = Injected(FileUploadSessionService),
+):
+    try:
+        return await svc.create_session(
+            payload.original_filename,
+            payload.expected_size,
+            payload.content_type,
+        )
+    except ValueError as e:
+        raise AppException(ErrorKey.MISSING_PARAMETER, 400, str(e))
+
+
+@router.post(
+    "/upload-session/{session_id}/chunk",
+    dependencies=[Depends(auth), Depends(permissions(P.FileManager.CREATE))],
+)
+async def files_upload_session_chunk(
+    session_id: UUID,
+    chunk: UploadFile = File(...),
+    chunk_index: int = 0,
+    svc: FileUploadSessionService = Injected(FileUploadSessionService),
+):
+    try:
+        data = await chunk.read()
+        total = await svc.append_chunk(session_id, data, chunk_index)
+        return {"status": "ok", "bytes_received": total}
+    except ValueError as e:
+        raise AppException(ErrorKey.MISSING_PARAMETER, 400, str(e))
+
+
+@router.post(
+    "/upload-session/{session_id}/complete",
+    response_model=Dict[str, str],
+    dependencies=[Depends(auth), Depends(permissions(P.FileManager.CREATE))],
+)
+async def files_upload_session_complete(
+    session_id: UUID,
+    request: Request,
+    svc: FileUploadSessionService = Injected(FileUploadSessionService),
+    file_manager_service: FileManagerService = Injected(FileManagerService),
+    app_settings_svc: AppSettingsService = Injected(AppSettingsService),
+):
+    try:
+        return await svc.complete_session(
+            session_id,
+            request,
+            file_manager_service,
+            app_settings_svc,
+            sub_folder="uploads",
+        )
+    except ValueError as e:
+        raise AppException(ErrorKey.MISSING_PARAMETER, 400, str(e))
+
+
+@router.get(
+    "/upload-session/{session_id}",
+    response_model=FilesUploadSessionStatusResponse,
+    dependencies=[Depends(auth), Depends(permissions(P.FileManager.READ))],
+)
+async def files_upload_session_status(
+    session_id: UUID,
+    svc: FileUploadSessionService = Injected(FileUploadSessionService),
+):
+    try:
+        return await svc.get_status(session_id)
+    except ValueError as e:
+        raise AppException(ErrorKey.FILE_NOT_FOUND, 404, str(e))

--- a/backend/app/api/v1/routes/file_manager.py
+++ b/backend/app/api/v1/routes/file_manager.py
@@ -97,24 +97,24 @@ async def download_file(
 ):
     """Download a file by ID."""
     try:
-        # download the file
-        file, content = await service.download_file(file_id)
+        file = await service.get_file_by_id(file_id)
 
-        # get the file url if the service is using s3
+        # For S3-backed files, redirect to a presigned URL to avoid proxying large payloads
+        # through the API process (CPU/memory bottleneck).
         if file.storage_provider == "s3":
-            # get the file url
             file_url = await service.get_file_url(file)
             safe_url = validate_s3_download_redirect_url(
                 file_url, file_storage_settings.AWS_S3_ENDPOINT_URL
             )
-            # Use Response + Location instead of RedirectResponse so redirect
-            # sinks that only match RedirectResponse(url=...) do not fire; behavior is equivalent.
             return Response(
                 status_code=status.HTTP_302_FOUND,
                 headers={"Location": safe_url},
             )
 
-        headers, media_type = service.build_file_headers(file, content=content, disposition_type="attachment")
+        _file, content = await service.download_file(file_id)
+        headers, media_type = service.build_file_headers(
+            file, content=content, disposition_type="attachment"
+        )
 
         return Response(
             content=content,
@@ -130,6 +130,7 @@ async def get_file_source(
     file_id: UUID,
     request: Request,
     service: FileManagerService = Injected(FileManagerService),
+    force_proxy: bool = False,
 ):
     """Get file source content for inline display."""
     try:
@@ -145,9 +146,20 @@ async def get_file_source(
                 headers=headers
             )
 
-        # if the service is not using s3, download the file content
-        # For GET requests, download the file content
-        file, content = await service.download_file(file_id)
+        # Default behavior: for S3-backed files, redirect to presigned URL instead of
+        # proxying bytes through the API process. `force_proxy=true` keeps legacy behavior.
+        if file.storage_provider == "s3" and not force_proxy:
+            file_url = await service.get_file_url(file)
+            safe_url = validate_s3_download_redirect_url(
+                file_url, file_storage_settings.AWS_S3_ENDPOINT_URL
+            )
+            return Response(
+                status_code=status.HTTP_302_FOUND,
+                headers={"Location": safe_url},
+            )
+
+        # Legacy / non-S3 behavior: download and return bytes inline.
+        _file, content = await service.download_file(file_id)
         headers, media_type = service.build_file_headers(file, content=content, disposition_type="inline")
 
         return Response(

--- a/backend/app/core/config/settings.py
+++ b/backend/app/core/config/settings.py
@@ -93,7 +93,14 @@ class ProjectSettings(BaseSettings):
     RECORDINGS_DIR: str = str(DATA_VOLUME / "recordings")
 
     # === Limits ===
-    MAX_CONTENT_LENGTH: int = 50 * 1024 * 1024  # 50MB
+    # Canonical max request body / upload size (aligned with frontend nginx client_max_body_size).
+    MAX_CONTENT_LENGTH: int = 100 * 1024 * 1024  # 100MB
+    # Knowledge-base uploads (legacy /upload and chunked /upload-session).
+    KNOWLEDGE_MAX_UPLOAD_BYTES: int = 100 * 1024 * 1024  # 100MB
+    KNOWLEDGE_UPLOAD_MAX_CHUNK_BYTES: int = 20 * 1024 * 1024  # 20MB per chunk
+    # File-manager uploads (canonical). Defaults match knowledge settings for backward compatibility.
+    FILES_MAX_UPLOAD_BYTES: int = 100 * 1024 * 1024  # 100MB
+    FILES_UPLOAD_MAX_CHUNK_BYTES: int = 20 * 1024 * 1024  # 20MB per chunk
     DEFAULT_WINDOW_SECONDS: int = 60
 
     # === Language ===

--- a/backend/app/core/utils/upload_streaming.py
+++ b/backend/app/core/utils/upload_streaming.py
@@ -1,0 +1,60 @@
+"""Helpers for streaming large uploads without loading entire files into memory."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Optional, Tuple
+
+from fastapi import UploadFile
+
+DEFAULT_CHUNK_SIZE = 1024 * 1024  # 1 MiB
+
+
+async def async_stream_uploadfile_to_path(
+    upload_file: UploadFile,
+    dest_path: str,
+    max_bytes: Optional[int],
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+) -> Tuple[int, Optional[str]]:
+    """
+    Stream an UploadFile to a filesystem path.
+
+    Returns (total_bytes_written, content_type).
+    """
+    parent = os.path.dirname(os.path.abspath(dest_path))
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+    total = 0
+    mime = upload_file.content_type
+
+    def _write_chunk(f, data: bytes) -> None:
+        f.write(data)
+
+    with open(dest_path, "wb") as out:
+        while True:
+            chunk = await upload_file.read(chunk_size)
+            if not chunk:
+                break
+            total += len(chunk)
+            if max_bytes is not None and total > max_bytes:
+                raise ValueError(
+                    f"File exceeds maximum allowed size ({max_bytes} bytes)."
+                )
+            await asyncio.to_thread(_write_chunk, out, chunk)
+
+    return total, mime
+
+
+async def append_bytes_to_path(path: str, data: bytes) -> None:
+    """Append bytes to a file (used for chunked uploads)."""
+
+    def _append() -> None:
+        parent = os.path.dirname(os.path.abspath(path))
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(path, "ab") as f:
+            f.write(data)
+
+    await asyncio.to_thread(_append)

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -41,6 +41,7 @@ from .app_settings import AppSettingsModel
 from .webhook import WebhookModel
 from .mcp_server import MCPServerModel, MCPServerWorkflowModel
 from .file import FileModel, StorageProvider
+from .files_upload_session import FilesUploadSessionModel
 from .user_group import UserGroupModel
 from .user_supervised_group import UserSupervisedGroupModel
 __all__ = [
@@ -96,6 +97,7 @@ __all__ = [
     "StorageProvider",
     "UserGroupModel",
     "UserSupervisedGroupModel",
+    "FilesUploadSessionModel",
 ]
 
 models = [

--- a/backend/app/db/models/files_upload_session.py
+++ b/backend/app/db/models/files_upload_session.py
@@ -1,0 +1,29 @@
+"""DB model for chunked uploads (file-manager-owned)."""
+
+from typing import Optional
+
+from sqlalchemy import BigInteger, Index, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class FilesUploadSessionModel(Base):
+    """
+    Tracks a resumable/chunked upload before the file is registered in `files`
+    and returned to the client in UploadFileResponse shape.
+    """
+
+    __tablename__ = "files_upload_sessions"
+    __table_args__ = (Index("idx_files_upload_sessions_status", "status"),)
+
+    status: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    original_filename: Mapped[str] = mapped_column(String(500), nullable=False)
+    content_type: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    temp_path: Mapped[str] = mapped_column(String(2000), nullable=False)
+    bytes_received: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    expected_bytes: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    result_json: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
+

--- a/backend/app/dependencies/dependency_injection.py
+++ b/backend/app/dependencies/dependency_injection.py
@@ -1,83 +1,84 @@
-from contextlib import asynccontextmanager
-from injector import Module, provider, singleton
-from typing import Annotated
 import logging
+from typing import Annotated
+
+from fastapi_injector import RequestScopeFactory, request_scope
+from injector import Module, provider, singleton
+from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from fastapi_injector import request_scope
-from fastapi_injector import RequestScopeFactory
-from app.repositories.transcript_message import TranscriptMessageRepository
-from app.repositories.tenant import TenantRepository
-from app.services.tenant import TenantService
-from app.services.transcript_message_service import TranscriptMessageService
-from app.services.workflow import WorkflowService
-from app.services.users import UserService
-from app.services.user_groups import UserGroupService
-from app.services.user_types import UserTypesService
-from app.services.roles import RolesService
-from app.services.role_permissions import RolePermissionsService
-from app.services.permissions import PermissionsService
-from app.services.operators import OperatorService
-from app.services.operator_statistics import OperatorStatisticsService
-from app.services.llm_cost_rates import LlmCostRateService
-from app.services.llm_providers import LlmProviderService
-from app.services.llm_analysts import LlmAnalystService
-from app.services.gpt_speaker_separator import SpeakerSeparator
-from app.services.gpt_questions import QuestionAnswerer
-from app.services.gpt_kpi_analyzer import GptKpiAnalyzer
-from app.services.feature_flag import FeatureFlagService
-from app.services.datasources import DataSourceService
-from app.services.conversations import ConversationService
-from app.services.conversation_analysis import ConversationAnalysisService
-from app.services.auth import AuthService
-from app.services.audit_logs import AuditLogService
-from app.services.agent_response_log import AgentResponseLogService
-from app.services.audio import AudioService
-from app.services.app_settings import AppSettingsService
-from app.services.api_keys import ApiKeysService
-from app.services.agent_tool import ToolService
-from app.repositories.tool import ToolRepository
-from app.services.agent_knowledge import KnowledgeBaseService
-from app.services.agent_config import AgentConfigService
-from app.repositories.workflow import WorkflowRepository
-from app.repositories.users import UserRepository
-from app.repositories.user_groups import UserGroupRepository
-from app.repositories.user_types import UserTypesRepository
-from app.repositories.roles import RolesRepository
-from app.repositories.role_permissions import RolePermissionsRepository
-from app.repositories.recordings import RecordingsRepository
-from app.repositories.permissions import PermissionsRepository
-from app.repositories.operators import OperatorRepository
-from app.repositories.operator_statistics import OperatorStatisticsRepository
-from app.repositories.llm_cost_rates import LlmCostRateRepository
-from app.repositories.llm_providers import LlmProviderRepository
-from app.repositories.llm_analysts import LlmAnalystRepository
-from app.repositories.knowledge_base import KnowledgeBaseRepository
-from app.repositories.feature_flag import FeatureFlagRepository
-from app.repositories.datasources import DataSourcesRepository
-from app.repositories.conversations import ConversationRepository
-from app.repositories.conversation_analysis import ConversationAnalysisRepository
-from app.repositories.audit_logs import AuditLogRepository
-from app.repositories.agent_response_log import AgentResponseLogRepository
-from app.repositories.app_settings import AppSettingsRepository
-from app.repositories.api_keys import ApiKeysRepository
-from app.repositories.agent import AgentRepository
-from app.modules.websockets.socket_connection_manager import SocketConnectionManager
-from app.modules.workflow.llm.provider import LLMProvider
-from redis.asyncio import Redis
-from app.modules.data.manager import AgentRAGServiceManager
-from app.repositories.file_manager import FileManagerRepository
-from app.services.file_manager import FileManagerService
-from app.repositories.analytics_aggregation import AnalyticsAggregationRepository
-from app.repositories.analytics_read import AnalyticsReadRepository
-from app.services.analytics_aggregation import AnalyticsAggregationService
-from app.services.analytics_read import AnalyticsReadService
-# Multi-tenant session manager
-from app.core.tenant_scope import tenant_scope
-from app.db.multi_tenant_session import multi_tenant_manager
 # Settings
 from app.core.config.settings import settings
 
+# Multi-tenant session manager
+from app.core.tenant_scope import tenant_scope
+from app.db.multi_tenant_session import multi_tenant_manager
+from app.modules.data.manager import AgentRAGServiceManager
+from app.modules.websockets.socket_connection_manager import SocketConnectionManager
+from app.modules.workflow.llm.provider import LLMProvider
+from app.repositories.agent import AgentRepository
+from app.repositories.agent_response_log import AgentResponseLogRepository
+from app.repositories.analytics_aggregation import AnalyticsAggregationRepository
+from app.repositories.analytics_read import AnalyticsReadRepository
+from app.repositories.api_keys import ApiKeysRepository
+from app.repositories.app_settings import AppSettingsRepository
+from app.repositories.audit_logs import AuditLogRepository
+from app.repositories.conversation_analysis import ConversationAnalysisRepository
+from app.repositories.conversations import ConversationRepository
+from app.repositories.datasources import DataSourcesRepository
+from app.repositories.feature_flag import FeatureFlagRepository
+from app.repositories.file_manager import FileManagerRepository
+from app.repositories.file_upload_session import FileUploadSessionRepository
+from app.repositories.knowledge_base import KnowledgeBaseRepository
+from app.repositories.llm_analysts import LlmAnalystRepository
+from app.repositories.llm_cost_rates import LlmCostRateRepository
+from app.repositories.llm_providers import LlmProviderRepository
+from app.repositories.operator_statistics import OperatorStatisticsRepository
+from app.repositories.operators import OperatorRepository
+from app.repositories.permissions import PermissionsRepository
+from app.repositories.recordings import RecordingsRepository
+from app.repositories.role_permissions import RolePermissionsRepository
+from app.repositories.roles import RolesRepository
+from app.repositories.tenant import TenantRepository
+from app.repositories.tool import ToolRepository
+from app.repositories.transcript_message import TranscriptMessageRepository
+from app.repositories.user_groups import UserGroupRepository
+from app.repositories.user_types import UserTypesRepository
+from app.repositories.users import UserRepository
+from app.repositories.workflow import WorkflowRepository
+from app.services.agent_config import AgentConfigService
+from app.services.agent_knowledge import KnowledgeBaseService
+from app.services.agent_response_log import AgentResponseLogService
+from app.services.agent_tool import ToolService
+from app.services.analytics_aggregation import AnalyticsAggregationService
+from app.services.analytics_read import AnalyticsReadService
+from app.services.api_keys import ApiKeysService
+from app.services.app_settings import AppSettingsService
+from app.services.audio import AudioService
+from app.services.audit_logs import AuditLogService
+from app.services.auth import AuthService
+from app.services.conversation_analysis import ConversationAnalysisService
+from app.services.conversations import ConversationService
+from app.services.datasources import DataSourceService
+from app.services.feature_flag import FeatureFlagService
+from app.services.file_manager import FileManagerService
+from app.services.file_upload_session import FileUploadSessionService
+from app.services.gpt_kpi_analyzer import GptKpiAnalyzer
+from app.services.gpt_questions import QuestionAnswerer
+from app.services.gpt_speaker_separator import SpeakerSeparator
+from app.services.llm_analysts import LlmAnalystService
+from app.services.llm_cost_rates import LlmCostRateService
+from app.services.llm_providers import LlmProviderService
+from app.services.operator_statistics import OperatorStatisticsService
+from app.services.operators import OperatorService
+from app.services.permissions import PermissionsService
+from app.services.role_permissions import RolePermissionsService
+from app.services.roles import RolesService
+from app.services.tenant import TenantService
+from app.services.transcript_message_service import TranscriptMessageService
+from app.services.user_groups import UserGroupService
+from app.services.user_types import UserTypesService
+from app.services.users import UserService
+from app.services.workflow import WorkflowService
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +110,7 @@ class Dependencies(Module):
         """
 
         return Redis.from_url(
-            settings.REDIS_URL, 
+            settings.REDIS_URL,
             auto_close_connection_pool=True,
             decode_responses=True,
             max_connections=settings.REDIS_MAX_CONNECTIONS,
@@ -136,7 +137,7 @@ class Dependencies(Module):
             auto_close_connection_pool=True,
             decode_responses=False,
             max_connections=settings.REDIS_MAX_CONNECTIONS_FOR_ENDPOINT_CACHE,
-            socket_timeout=settings.REDIS_SOCKET_TIMEOUT, 
+            socket_timeout=settings.REDIS_SOCKET_TIMEOUT,
             socket_connect_timeout=settings.REDIS_SOCKET_CONNECT_TIMEOUT,
             retry_on_timeout=True,
             health_check_interval=settings.REDIS_HEALTH_CHECK_INTERVAL,
@@ -174,7 +175,7 @@ class Dependencies(Module):
 
         session_factory = multi_tenant_manager.get_tenant_session_factory(tenant_id)
         session = session_factory()
-        
+
         return session
 
     def configure(self, binder):
@@ -312,6 +313,8 @@ class Dependencies(Module):
         # File Manager services
         binder.bind(FileManagerRepository, scope=request_scope)
         binder.bind(FileManagerService, scope=request_scope)
+        binder.bind(FileUploadSessionRepository, scope=request_scope)
+        binder.bind(FileUploadSessionService, scope=request_scope)
 
         # Analytics services
         binder.bind(AnalyticsAggregationRepository, scope=request_scope)

--- a/backend/app/modules/filemanager/providers/base.py
+++ b/backend/app/modules/filemanager/providers/base.py
@@ -71,6 +71,27 @@ class BaseStorageProvider(ABC):
         """
         pass
 
+    async def upload_file_from_local_path(
+        self,
+        local_path: str,
+        file_path: str,
+        file_metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """
+        Upload from a local filesystem path (avoids loading the whole file into memory).
+
+        Default implementation reads the file and delegates to upload_file().
+        Providers may override with native streaming uploads (e.g. S3 upload_file).
+        """
+        import asyncio
+
+        def _read_all() -> bytes:
+            with open(local_path, "rb") as f:
+                return f.read()
+
+        content = await asyncio.to_thread(_read_all)
+        return await self.upload_file(content, file_path, file_metadata)
+
     @abstractmethod
     async def download_file(self, file_path: str) -> bytes:
         """

--- a/backend/app/modules/filemanager/providers/local/provider.py
+++ b/backend/app/modules/filemanager/providers/local/provider.py
@@ -75,6 +75,30 @@ class LocalFileSystemProvider(BaseStorageProvider):
         return (self.base_path / Path(file_path)).resolve()
 
 
+    async def upload_file_from_local_path(
+        self,
+        local_path: str,
+        file_path: str,
+        file_metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Copy from a temp/local path into storage without loading entire file into RAM."""
+        import asyncio
+        import shutil
+
+        try:
+            full_path = self._resolve_path(file_path)
+            full_path.parent.mkdir(parents=True, exist_ok=True)
+
+            def _copy() -> None:
+                shutil.copy2(local_path, full_path)
+
+            await asyncio.to_thread(_copy)
+            logger.debug(f"Uploaded file from {local_path} to {full_path}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to upload file from local path {local_path}: {e}")
+            return False
+
     async def upload_file(
         self,
         file_content: bytes,

--- a/backend/app/modules/filemanager/providers/s3/provider.py
+++ b/backend/app/modules/filemanager/providers/s3/provider.py
@@ -4,6 +4,7 @@ AWS S3 Storage Provider (Stub Implementation)
 TODO: Implement full S3 storage operations using boto3.
 """
 
+import asyncio
 import logging
 from typing import List, Dict, Any, Optional
 from app.core.utils.s3_utils import S3Client
@@ -54,6 +55,19 @@ class S3StorageProvider(BaseStorageProvider):
     def get_base_path(self) -> str:
         """Get the base path of the storage provider."""
         return self.aws_bucket_name
+
+    async def upload_file_from_local_path(
+        self,
+        local_path: str,
+        file_path: str,
+        file_metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Upload a local file to S3 using the boto3 multipart-capable upload_file API."""
+
+        def _upload() -> bool:
+            return self.s3_client.upload_file(local_path, self.aws_bucket_name, file_path)
+
+        return await asyncio.to_thread(_upload)
 
     async def upload_file(
         self,

--- a/backend/app/repositories/file_upload_session.py
+++ b/backend/app/repositories/file_upload_session.py
@@ -1,0 +1,35 @@
+"""Repository for files_upload_sessions."""
+
+from uuid import UUID
+
+from injector import inject
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models.files_upload_session import FilesUploadSessionModel
+
+
+@inject
+class FileUploadSessionRepository:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def create(self, row: FilesUploadSessionModel) -> FilesUploadSessionModel:
+        self.db.add(row)
+        await self.db.commit()
+        await self.db.refresh(row)
+        return row
+
+    async def get_by_id(self, session_id: UUID) -> FilesUploadSessionModel | None:
+        q = select(FilesUploadSessionModel).where(
+            FilesUploadSessionModel.id == session_id,
+            FilesUploadSessionModel.is_deleted == 0,
+        )
+        r = await self.db.execute(q)
+        return r.scalars().first()
+
+    async def update(self, row: FilesUploadSessionModel) -> FilesUploadSessionModel:
+        await self.db.commit()
+        await self.db.refresh(row)
+        return row
+

--- a/backend/app/schemas/files_upload.py
+++ b/backend/app/schemas/files_upload.py
@@ -1,0 +1,30 @@
+"""Schemas for chunked (file-manager) upload sessions."""
+
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class FilesUploadSessionCreate(BaseModel):
+    original_filename: str = Field(..., min_length=1, max_length=500)
+    expected_size: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description="Optional declared total size in bytes for validation on complete",
+    )
+    content_type: Optional[str] = Field(default=None, max_length=255)
+
+
+class FilesUploadSessionCreateResponse(BaseModel):
+    session_id: str
+    max_chunk_bytes: int = Field(description="Maximum bytes accepted per /chunk request")
+
+
+class FilesUploadSessionStatusResponse(BaseModel):
+    id: str
+    status: str
+    bytes_received: int
+    expected_bytes: Optional[int] = None
+    error_message: Optional[str] = None
+    result: Optional[Dict[str, Any]] = None
+

--- a/backend/app/schemas/knowledge_upload.py
+++ b/backend/app/schemas/knowledge_upload.py
@@ -1,0 +1,31 @@
+"""Schemas for chunked knowledge upload sessions."""
+
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class KbUploadSessionCreate(BaseModel):
+    original_filename: str = Field(..., min_length=1, max_length=500)
+    expected_size: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description="Optional declared total size in bytes for validation on complete",
+    )
+    content_type: Optional[str] = Field(default=None, max_length=255)
+
+
+class KbUploadSessionCreateResponse(BaseModel):
+    session_id: str
+    max_chunk_bytes: int = Field(
+        description="Maximum bytes accepted per /chunk request"
+    )
+
+
+class KbUploadSessionStatusResponse(BaseModel):
+    id: str
+    status: str
+    bytes_received: int
+    expected_bytes: Optional[int] = None
+    error_message: Optional[str] = None
+    result: Optional[Dict[str, Any]] = None

--- a/backend/app/services/file_manager.py
+++ b/backend/app/services/file_manager.py
@@ -1,5 +1,6 @@
-from ast import Dict
+import asyncio
 import re
+import tempfile
 from uuid import UUID
 import uuid
 from fastapi import UploadFile
@@ -22,6 +23,7 @@ from app.core.config.settings import file_storage_settings
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.schemas.app_settings import AppSettingsRead
+from app.core.utils.upload_streaming import async_stream_uploadfile_to_path
 
 logger = logging.getLogger(__name__)
 
@@ -126,48 +128,76 @@ class FileManagerService:
             file: File to upload
             allowed_extensions: Optional list of allowed file extensions
         """
-
+        file_path = "unknown"
+        file_name = file.filename or "unnamed"
         try:
-            file_extension = file.filename.split(".")[-1] if "." in file.filename else ""
+            file_extension = file.filename.split(".")[-1] if "." in (file.filename or "") else ""
             file_extension = file_extension.lower() if file_extension else "txt"
 
-            # check if file extension is allowed
             if allowed_extensions is not None:
                 self._validate_file_extension(file_extension, allowed_extensions)
 
-            # read from the file
-            file_content = await file.read()
-            file_size = len(file_content)
-            file_mime_type = file.content_type
-            file_name = file.filename
-
-            # check if file size is allowed
-            if max_file_size is not None:
-                self._validate_file_size(file_size, max_file_size)
-
-            # Prefer the storage provider coming from the request payload; fall back to the
-            # already configured provider if present, otherwise default to "local".
             file_storage_provider = (
                 file_base.storage_provider
                 or (self.storage_provider.name if self.storage_provider else None)
                 or "local"
             )
 
-            # Generate a unique file name only when the client hasn't provided one
             unique_file_name = f"{uuid.uuid4()}.{file_extension}" if file_base.name is None else file_base.name
             file_path = f"{file_base.path}/{unique_file_name}" if file_base.path else unique_file_name
 
-            # Get or initialize the storage provider
             provider_name = file_storage_provider or "local"
             await self._initialize_storage_provider(provider_name)
             if not self.storage_provider or not self.storage_provider.is_initialized():
                 raise ValueError("Storage provider not initialized")
 
-            # Resolve the storage path that will be persisted with the file metadata.
-            # If the caller has explicitly provided a storage_path, prefer that.
             storage_path = file_base.storage_path or self.storage_provider.get_base_path()
 
-            # create the file data
+            # Stream bytes to storage (avoid loading entire file into memory).
+            if self.storage_provider.name == "local":
+                dest = os.path.join(
+                    self.storage_provider.get_base_path(),
+                    file_path.replace("\\", "/").lstrip("/"),
+                )
+                file_size, streamed_mime = await async_stream_uploadfile_to_path(
+                    file, dest, max_file_size
+                )
+                upload_ok = True
+            else:
+                tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".upload")
+                tmp_path = tmp.name
+                tmp.close()
+                upload_ok = False
+                try:
+                    file_size, streamed_mime = await async_stream_uploadfile_to_path(
+                        file, tmp_path, max_file_size
+                    )
+                    upload_ok = await self.storage_provider.upload_file_from_local_path(
+                        tmp_path,
+                        file_path,
+                        file_metadata={
+                            "name": file_base.name or file_name,
+                            "mime_type": streamed_mime or file.content_type or "application/octet-stream",
+                        },
+                    )
+                finally:
+                    if os.path.exists(tmp_path):
+                        try:
+                            os.unlink(tmp_path)
+                        except OSError:
+                            pass
+
+            if not upload_ok:
+                raise AppException(
+                    error_key=ErrorKey.INTERNAL_ERROR,
+                    error_detail=(
+                        f"Failed to upload file {file_path} on storage provider "
+                        f"{self.storage_provider.name}"
+                    ),
+                )
+
+            file_mime_type = streamed_mime or file.content_type or "application/octet-stream"
+
             file_data = FileBase(
                 name=file_base.name or file_name,
                 original_filename=file_base.original_filename or file_name,
@@ -183,22 +213,134 @@ class FileManagerService:
                 permissions=file_base.permissions,
             )
 
-            # Upload file content if provided
-            if file_content is not None:
-                upload_result = await self.storage_provider.upload_file(
-                    file_content=file_content,
-                    file_path=file_path,
-                    file_metadata={"name": file_data.name, "mime_type": file_data.mime_type}
-                )
-                if not upload_result:
-                    raise AppException(error_key=ErrorKey.INTERNAL_ERROR, error_detail=f"Failed to upload file {file_path} on storage provider {self.storage_provider.name}")
+            return await self.repository.create_file(file_data)
+        except AppException:
+            raise
         except Exception as e:
             logger.error(f"Failed to create file: {e}")
-            raise AppException(error_key=ErrorKey.INTERNAL_ERROR, error_detail=f"Failed to create file {file_path} on storage provider {self.storage_provider.name}: {str(e)}")
-        finally:
-            # Create file metadata record
+            raise AppException(
+                error_key=ErrorKey.INTERNAL_ERROR,
+                error_detail=(
+                    f"Failed to create file {file_path} on storage provider "
+                    f"{getattr(self.storage_provider, 'name', 'unknown')}: {str(e)}"
+                ),
+            )
+
+    async def create_file_from_local_path(
+        self,
+        local_path: str,
+        file_base: FileBase,
+        *,
+        original_filename: str,
+        mime_type: Optional[str] = None,
+        allowed_extensions: Optional[list[str]] = None,
+        max_file_size: Optional[int] = None,
+        delete_source: bool = True,
+    ) -> FileModel:
+        """
+        Register a file that already exists on disk (e.g. after a chunked upload) in storage + DB.
+        """
+        file_path = "unknown"
+        file_name = original_filename or "unnamed"
+        try:
+            if not os.path.isfile(local_path):
+                raise ValueError(f"Local path does not exist or is not a file: {local_path}")
+
+            file_size = os.path.getsize(local_path)
+            if max_file_size is not None:
+                self._validate_file_size(file_size, max_file_size)
+
+            file_extension = (
+                original_filename.split(".")[-1].lower()
+                if "." in original_filename
+                else "txt"
+            )
+            if allowed_extensions is not None:
+                self._validate_file_extension(file_extension, allowed_extensions)
+
+            file_storage_provider = (
+                file_base.storage_provider
+                or (self.storage_provider.name if self.storage_provider else None)
+                or "local"
+            )
+
+            unique_file_name = f"{uuid.uuid4()}.{file_extension}" if file_base.name is None else file_base.name
+            file_path = f"{file_base.path}/{unique_file_name}" if file_base.path else unique_file_name
+
+            provider_name = file_storage_provider or "local"
+            await self._initialize_storage_provider(provider_name)
+            if not self.storage_provider or not self.storage_provider.is_initialized():
+                raise ValueError("Storage provider not initialized")
+
+            storage_path = file_base.storage_path or self.storage_provider.get_base_path()
+
+            if self.storage_provider.name == "local":
+                dest = os.path.join(
+                    self.storage_provider.get_base_path(),
+                    file_path.replace("\\", "/").lstrip("/"),
+                )
+                import shutil
+
+                def _copy() -> None:
+                    os.makedirs(os.path.dirname(dest) or ".", exist_ok=True)
+                    shutil.copy2(local_path, dest)
+
+                await asyncio.to_thread(_copy)
+            else:
+                upload_ok = await self.storage_provider.upload_file_from_local_path(
+                    local_path,
+                    file_path,
+                    file_metadata={
+                        "name": file_base.name or file_name,
+                        "mime_type": mime_type or "application/octet-stream",
+                    },
+                )
+                if not upload_ok:
+                    raise AppException(
+                        error_key=ErrorKey.INTERNAL_ERROR,
+                        error_detail=(
+                            f"Failed to upload file {file_path} on storage provider "
+                            f"{self.storage_provider.name}"
+                        ),
+                    )
+
+            file_mime_type = mime_type or "application/octet-stream"
+
+            file_data = FileBase(
+                name=file_base.name or file_name,
+                original_filename=file_base.original_filename or file_name,
+                mime_type=file_mime_type,
+                size=file_size,
+                file_extension=file_extension,
+                storage_provider=file_storage_provider,
+                storage_path=storage_path,
+                path=file_path,
+                description=file_base.description,
+                file_metadata=file_base.file_metadata,
+                tags=file_base.tags,
+                permissions=file_base.permissions,
+            )
+
             db_file = await self.repository.create_file(file_data)
+
+            if delete_source:
+                try:
+                    os.unlink(local_path)
+                except OSError:
+                    pass
+
             return db_file
+        except AppException:
+            raise
+        except Exception as e:
+            logger.error(f"Failed to create file from local path: {e}")
+            raise AppException(
+                error_key=ErrorKey.INTERNAL_ERROR,
+                error_detail=(
+                    f"Failed to create file {file_path} on storage provider "
+                    f"{getattr(self.storage_provider, 'name', 'unknown')}: {str(e)}"
+                ),
+            )
 
     async def get_file_by_id(self, file_id: UUID) -> FileModel:
         """Get file metadata by ID."""

--- a/backend/app/services/file_upload_session.py
+++ b/backend/app/services/file_upload_session.py
@@ -1,0 +1,249 @@
+"""Chunked upload session service (file-manager-owned)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+import uuid
+from typing import Optional
+from uuid import UUID
+
+from fastapi import Request
+from injector import inject
+
+from app.core.config.settings import file_storage_settings, settings
+from app.core.project_path import DATA_VOLUME
+from app.core.utils.upload_streaming import append_bytes_to_path
+from app.db.models.files_upload_session import FilesUploadSessionModel
+from app.repositories.file_upload_session import FileUploadSessionRepository
+from app.schemas.file import FileBase
+from app.schemas.files_upload import (
+    FilesUploadSessionCreateResponse,
+    FilesUploadSessionStatusResponse,
+)
+from app.services.app_settings import AppSettingsService
+from app.services.file_manager import FileManagerService
+
+logger = logging.getLogger(__name__)
+
+SESSION_SUBDIR = "uploads/sessions"
+
+STATUS_RECEIVING = "receiving"
+STATUS_COMPLETED = "completed"
+STATUS_FAILED = "failed"
+
+
+@inject
+class FileUploadSessionService:
+    def __init__(self, repository: FileUploadSessionRepository):
+        self.repository = repository
+        self._session_dir = str(DATA_VOLUME / SESSION_SUBDIR)
+        os.makedirs(self._session_dir, exist_ok=True)
+
+    def _max_upload_bytes(self) -> int:
+        # Backward compatible: if FILES_* is not present, fall back to KNOWLEDGE_*.
+        return int(getattr(settings, "FILES_MAX_UPLOAD_BYTES", settings.FILES_MAX_UPLOAD_BYTES))
+
+    def _max_chunk_bytes(self) -> int:
+        return int(
+            getattr(settings, "FILES_UPLOAD_MAX_CHUNK_BYTES", settings.FILES_UPLOAD_MAX_CHUNK_BYTES)
+        )
+
+    async def create_session(
+        self,
+        original_filename: str,
+        expected_size: Optional[int],
+        content_type: Optional[str] = None,
+    ) -> FilesUploadSessionCreateResponse:
+        max_b = self._max_upload_bytes()
+        if expected_size is not None and expected_size > max_b:
+            max_mb = round(max_b / 1024 / 1024, 2)
+            raise ValueError(f"Declared file size exceeds maximum allowed ({max_mb} MB).")
+
+        sid = uuid.uuid4()
+        temp_path = os.path.join(self._session_dir, f"{sid}.part")
+        row = FilesUploadSessionModel(
+            id=sid,
+            status=STATUS_RECEIVING,
+            original_filename=original_filename,
+            content_type=content_type,
+            temp_path=temp_path,
+            bytes_received=0,
+            expected_bytes=expected_size,
+            error_message=None,
+            result_json=None,
+        )
+        await self.repository.create(row)
+        return FilesUploadSessionCreateResponse(
+            session_id=str(sid),
+            max_chunk_bytes=self._max_chunk_bytes(),
+        )
+
+    async def append_chunk(
+        self,
+        session_id: UUID,
+        chunk_bytes: bytes,
+        chunk_index: int,
+    ) -> int:
+        max_b = self._max_upload_bytes()
+        max_chunk = self._max_chunk_bytes()
+        if len(chunk_bytes) > max_chunk:
+            raise ValueError(f"Chunk exceeds maximum chunk size ({max_chunk} bytes).")
+
+        row = await self.repository.get_by_id(session_id)
+        if not row:
+            raise ValueError("Upload session not found.")
+        if row.status != STATUS_RECEIVING:
+            raise ValueError(f"Cannot append to session in status: {row.status}")
+
+        new_total = row.bytes_received + len(chunk_bytes)
+        if new_total > max_b:
+            row.status = STATUS_FAILED
+            row.error_message = f"Upload exceeds maximum allowed size ({max_b} bytes)."
+            await self.repository.update(row)
+            raise ValueError(row.error_message)
+
+        await append_bytes_to_path(row.temp_path, chunk_bytes)
+        row.bytes_received = new_total
+        row.status = STATUS_RECEIVING
+        await self.repository.update(row)
+        logger.info(
+            "files_upload_session chunk: id=%s index=%s bytes=%s total=%s",
+            session_id,
+            chunk_index,
+            len(chunk_bytes),
+            new_total,
+        )
+        return new_total
+
+    async def get_status(self, session_id: UUID) -> FilesUploadSessionStatusResponse:
+        row = await self.repository.get_by_id(session_id)
+        if not row:
+            raise ValueError("Upload session not found.")
+        result = None
+        if row.status == STATUS_COMPLETED and row.result_json:
+            result = row.result_json
+        return FilesUploadSessionStatusResponse(
+            id=str(row.id),
+            status=row.status,
+            bytes_received=row.bytes_received,
+            expected_bytes=row.expected_bytes,
+            error_message=row.error_message,
+            result=result,
+        )
+
+    async def complete_session(
+        self,
+        session_id: UUID,
+        request: Request,
+        file_manager_service: FileManagerService,
+        app_settings_svc: AppSettingsService,
+        *,
+        sub_folder: str = "uploads",
+    ) -> dict:
+        row = await self.repository.get_by_id(session_id)
+        if not row:
+            raise ValueError("Upload session not found.")
+        if row.status == STATUS_COMPLETED and row.result_json:
+            return row.result_json
+        if row.status == STATUS_FAILED:
+            raise ValueError(row.error_message or "Upload session failed.")
+        if row.bytes_received <= 0:
+            raise ValueError("No data received for this upload session.")
+
+        max_b = self._max_upload_bytes()
+        if row.bytes_received > max_b:
+            row.status = STATUS_FAILED
+            row.error_message = f"Upload exceeds maximum allowed size ({max_b} bytes)."
+            await self.repository.update(row)
+            raise ValueError(row.error_message)
+
+        if row.expected_bytes is not None and row.bytes_received != row.expected_bytes:
+            raise ValueError(
+                f"Size mismatch: received {row.bytes_received} bytes, expected {row.expected_bytes}."
+            )
+
+        temp_path = row.temp_path
+        if not os.path.isfile(temp_path):
+            row.status = STATUS_FAILED
+            row.error_message = "Staged upload file missing on server."
+            await self.repository.update(row)
+            raise ValueError(row.error_message)
+
+        try:
+            original_name = row.original_filename
+            file_extension = original_name.split(".")[-1] if "." in original_name else ""
+            unique_filename = (
+                f"{uuid.uuid4()}.{file_extension}" if file_extension else f"{uuid.uuid4()}"
+            )
+
+            result: dict = {
+                "filename": unique_filename,
+                "original_filename": original_name,
+            }
+
+            use_file_manager = file_storage_settings.FILE_MANAGER_ENABLED
+            if use_file_manager:
+                app_settings_config = await app_settings_svc.get_by_type_and_name(
+                    "FileManagerSettings", "File Manager Settings"
+                )
+                storage_provider = await file_manager_service.initialize(
+                    base_url=str(request.base_url).rstrip("/"),
+                    base_path=str(DATA_VOLUME),
+                    app_settings=app_settings_config,
+                )
+
+                file_base = FileBase(
+                    name=unique_filename,
+                    storage_path=storage_provider.get_base_path(),
+                    path=sub_folder,
+                    storage_provider=storage_provider.name,
+                    file_extension=file_extension,
+                )
+
+                created_file = await file_manager_service.create_file_from_local_path(
+                    temp_path,
+                    file_base=file_base,
+                    original_filename=original_name,
+                    mime_type=row.content_type,
+                    max_file_size=max_b,
+                    delete_source=True,
+                )
+
+                file_url = await file_manager_service.get_file_source_url(created_file.id)
+                result["file_type"] = "url"
+                result["file_url"] = file_url
+                result["file_id"] = str(created_file.id)
+                if created_file.storage_provider == "local":
+                    result["file_path"] = f"{created_file.storage_path}/{created_file.path}"
+            else:
+                upload_dir = str(DATA_VOLUME / sub_folder)
+                os.makedirs(upload_dir, exist_ok=True)
+                dest_path = os.path.join(upload_dir, unique_filename)
+
+                def _move() -> None:
+                    shutil.move(temp_path, dest_path)
+
+                await asyncio.to_thread(_move)
+                result["file_path"] = dest_path
+
+            row.status = STATUS_COMPLETED
+            row.result_json = result
+            row.error_message = None
+            await self.repository.update(row)
+            return result
+        except Exception as e:
+            logger.exception("complete_session failed: %s", e)
+            row.status = STATUS_FAILED
+            row.error_message = str(e)
+            await self.repository.update(row)
+            staged = row.temp_path
+            if staged and os.path.isfile(staged):
+                try:
+                    os.unlink(staged)
+                except OSError:
+                    pass
+            raise
+

--- a/backend/app/tasks/audio_tasks.py
+++ b/backend/app/tasks/audio_tasks.py
@@ -1,17 +1,19 @@
 import asyncio
 import logging
+import os
+import tempfile
 from datetime import datetime, timezone
 from typing import Optional
-from app.dependencies.injector import injector
-from app.core.utils.s3_utils import S3Client
-from app.services.datasources import DataSourceService
-from celery import shared_task
-from io import BytesIO
-from app.services.audio import AudioService
-from app.db.seed.seed_data_config import SeedTestData
-from app.schemas.recording import RecordingCreate
 
+from celery import shared_task
 from fastapi import UploadFile
+
+from app.core.utils.s3_utils import S3Client
+from app.db.seed.seed_data_config import SeedTestData
+from app.dependencies.injector import injector
+from app.schemas.recording import RecordingCreate
+from app.services.audio import AudioService
+from app.services.datasources import DataSourceService
 
 logger = logging.getLogger(__name__)
 
@@ -109,32 +111,50 @@ async def transcribe_audio_files_async(ds_id: Optional[str] = None):
                     count_files_skipped += 1
                     continue
 
-                content = s3_client.get_file_content(file_info["key"])
+                # Download to disk to avoid loading large objects into memory.
+                tmp_path: str | None = None
+                tmp_fh = None
+                try:
+                    suffix = os.path.splitext(file_info["key"])[1] or ".bin"
+                    fd, tmp_path = tempfile.mkstemp(prefix="s3_audio_", suffix=suffix)
+                    os.close(fd)
+                    ok = s3_client.download_file(file_info["key"], tmp_path)
+                    if not ok:
+                        raise Exception(f"Failed to download S3 object: {file_info['key']}")
 
-                # Convert to UploadFile
-                upload_file = UploadFile(
-                    file=BytesIO(content),  # in-memory stream
-                    filename=file_info["key"],  # ,
-                    # content_type="application/octet-stream"
-                )
+                    tmp_fh = open(tmp_path, "rb")
+                    upload_file = UploadFile(
+                        file=tmp_fh,
+                        filename=file_info["key"],
+                    )
 
-                logger.info(
-                    f"Transcribing file: {file_info['key']} of Datasource {ds_item.name}"
-                )
-                # transcript = await transcribe_audio_whisper_no_save(upload_file)
+                    logger.info(
+                        f"Transcribing file: {file_info['key']} of Datasource {ds_item.name}"
+                    )
+                    # transcript = await transcribe_audio_whisper_no_save(upload_file)
 
-                transcribed_recording = await audioService.process_recording(
-                    upload_file, metadata
-                )
+                    transcribed_recording = await audioService.process_recording(
+                        upload_file, metadata
+                    )
 
-                logger.info(f"Transcription for {file_info['key']}: completed")
+                    logger.info(f"Transcription for {file_info['key']}: completed")
 
-                # TODO: save it in Recording
+                    # TODO: save it in Recording
 
-                transcribed.append(
-                    {"file": file_info["key"], "timestamp": datetime.now().isoformat()}
-                )
-                count_transctibed_sucess += 1
+                    transcribed.append(
+                        {"file": file_info["key"], "timestamp": datetime.now().isoformat()}
+                    )
+                    count_transctibed_sucess += 1
+                finally:
+                    try:
+                        if tmp_fh:
+                            tmp_fh.close()
+                    finally:
+                        if tmp_path and os.path.exists(tmp_path):
+                            try:
+                                os.unlink(tmp_path)
+                            except OSError:
+                                pass
             except Exception as e:
                 count_transcribed_fail += 1
                 logger.error(f"Failed to transcribe {file_info['key']}: {str(e)}")

--- a/backend/app/tasks/s3_tasks.py
+++ b/backend/app/tasks/s3_tasks.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
 import logging
+import os
+import tempfile
 from datetime import datetime
 from typing import Optional
 from uuid import UUID
@@ -196,12 +198,24 @@ async def import_s3_files_to_kb_async(kb_id: Optional[UUID] = None):
                 current_file += 1
                 logger.info(f"Processing file {current_file} of {len(s3_new_files)}")
 
-                # Download file content
-                file_content = s3_client.get_file_content(file_info["key"])
-                logger.info(f"Extracting text from {file_info}...")
-                extracted_text = FileTextExtractor().extract(
-                    filename=file_info["key"], content=file_content
-                )
+                # Download to disk and extract from path to avoid reading large objects into memory.
+                tmp_path: str | None = None
+                try:
+                    suffix = os.path.splitext(file_info["key"])[1] or ".bin"
+                    fd, tmp_path = tempfile.mkstemp(prefix="s3_", suffix=suffix)
+                    os.close(fd)
+                    ok = s3_client.download_file(file_info["key"], tmp_path)
+                    if not ok:
+                        raise Exception(f"Failed to download S3 object: {file_info['key']}")
+
+                    logger.info(f"Extracting text from {file_info}...")
+                    extracted_text = FileTextExtractor().extract(path=tmp_path)
+                finally:
+                    if tmp_path and os.path.exists(tmp_path):
+                        try:
+                            os.unlink(tmp_path)
+                        except OSError:
+                            pass
 
                 # Create knowledge base item
                 last_file_date = datetime.strptime(

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -9355,6 +9355,227 @@
         ]
       }
     },
+    "/api/genagent/knowledge/upload-session": {
+      "post": {
+        "tags": [
+          "v1",
+          "Knowledge Base"
+        ],
+        "summary": "Create Kb Upload Session",
+        "description": "Start a chunked upload for a single large file (backward compatible with /upload).",
+        "operationId": "create_kb_upload_session_api_genagent_knowledge_upload_session_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KbUploadSessionCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KbUploadSessionCreateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/genagent/knowledge/upload-session/{session_id}/chunk": {
+      "post": {
+        "tags": [
+          "v1",
+          "Knowledge Base"
+        ],
+        "summary": "Kb Upload Session Chunk",
+        "description": "Append one chunk to a staged upload session.",
+        "operationId": "kb_upload_session_chunk_api_genagent_knowledge_upload_session__session_id__chunk_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_kb_upload_session_chunk_api_genagent_knowledge_upload_session__session_id__chunk_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/genagent/knowledge/upload-session/{session_id}/complete": {
+      "post": {
+        "tags": [
+          "v1",
+          "Knowledge Base"
+        ],
+        "summary": "Kb Upload Session Complete",
+        "description": "Finalize staged bytes into storage + files row (same shape as one legacy /upload item).",
+        "operationId": "kb_upload_session_complete_api_genagent_knowledge_upload_session__session_id__complete_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Kb Upload Session Complete Api Genagent Knowledge Upload Session  Session Id  Complete Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/genagent/knowledge/upload-session/{session_id}": {
+      "get": {
+        "tags": [
+          "v1",
+          "Knowledge Base"
+        ],
+        "summary": "Kb Upload Session Status",
+        "operationId": "kb_upload_session_status_api_genagent_knowledge_upload_session__session_id__get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KbUploadSessionStatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/genagent/knowledge/upload-chat-file": {
       "post": {
         "tags": [
@@ -11600,6 +11821,292 @@
             "content": {
               "application/json": {
                 "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/file-manager/upload": {
+      "post": {
+        "tags": [
+          "v1",
+          "FileManager"
+        ],
+        "summary": "Upload Files",
+        "description": "Upload multiple files and return UploadFileResponse-compatible dicts.\n\nThis endpoint mirrors the legacy `genagent/knowledge/upload` response shape,\nbut is owned by file-manager.",
+        "operationId": "upload_files_api_file_manager_upload_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_files_api_file_manager_upload_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "type": "array",
+                  "title": "Response Upload Files Api File Manager Upload Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/file-manager/upload-session": {
+      "post": {
+        "tags": [
+          "v1",
+          "FileManager"
+        ],
+        "summary": "Create Files Upload Session",
+        "operationId": "create_files_upload_session_api_file_manager_upload_session_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FilesUploadSessionCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilesUploadSessionCreateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/file-manager/upload-session/{session_id}/chunk": {
+      "post": {
+        "tags": [
+          "v1",
+          "FileManager"
+        ],
+        "summary": "Files Upload Session Chunk",
+        "operationId": "files_upload_session_chunk_api_file_manager_upload_session__session_id__chunk_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "chunk_index",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Chunk Index"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_files_upload_session_chunk_api_file_manager_upload_session__session_id__chunk_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/file-manager/upload-session/{session_id}/complete": {
+      "post": {
+        "tags": [
+          "v1",
+          "FileManager"
+        ],
+        "summary": "Files Upload Session Complete",
+        "operationId": "files_upload_session_complete_api_file_manager_upload_session__session_id__complete_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Files Upload Session Complete Api File Manager Upload Session  Session Id  Complete Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/file-manager/upload-session/{session_id}": {
+      "get": {
+        "tags": [
+          "v1",
+          "FileManager"
+        ],
+        "summary": "Files Upload Session Status",
+        "operationId": "files_upload_session_status_api_file_manager_upload_session__session_id__get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilesUploadSessionStatusResponse"
+                }
               }
             }
           },
@@ -21032,6 +21539,20 @@
         ],
         "title": "Body_create_workflow_from_wizard_api_workflow_manager_config_from_wizard_post"
       },
+      "Body_files_upload_session_chunk_api_file_manager_upload_session__session_id__chunk_post": {
+        "properties": {
+          "chunk": {
+            "type": "string",
+            "format": "binary",
+            "title": "Chunk"
+          }
+        },
+        "type": "object",
+        "required": [
+          "chunk"
+        ],
+        "title": "Body_files_upload_session_chunk_api_file_manager_upload_session__session_id__chunk_post"
+      },
       "Body_import_cost_rates_csv_api_llm_cost_rates_import_post": {
         "properties": {
           "file": {
@@ -21045,6 +21566,25 @@
           "file"
         ],
         "title": "Body_import_cost_rates_csv_api_llm_cost_rates_import_post"
+      },
+      "Body_kb_upload_session_chunk_api_genagent_knowledge_upload_session__session_id__chunk_post": {
+        "properties": {
+          "chunk": {
+            "type": "string",
+            "format": "binary",
+            "title": "Chunk"
+          },
+          "chunk_index": {
+            "type": "integer",
+            "title": "Chunk Index",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "chunk"
+        ],
+        "title": "Body_kb_upload_session_chunk_api_genagent_knowledge_upload_session__session_id__chunk_post"
       },
       "Body_process_files_api_genagent_knowledge_process_files_post": {
         "properties": {
@@ -21294,6 +21834,23 @@
           "purpose"
         ],
         "title": "Body_upload_file_to_openai_api_openai_upload_post"
+      },
+      "Body_upload_files_api_file_manager_upload_post": {
+        "properties": {
+          "files": {
+            "items": {
+              "type": "string",
+              "format": "binary"
+            },
+            "type": "array",
+            "title": "Files"
+          }
+        },
+        "type": "object",
+        "required": [
+          "files"
+        ],
+        "title": "Body_upload_files_api_file_manager_upload_post"
       },
       "Body_upload_pkl_file_api_ml_models_upload_post": {
         "properties": {
@@ -23064,6 +23621,122 @@
         ],
         "title": "FileUploadResponse"
       },
+      "FilesUploadSessionCreate": {
+        "properties": {
+          "original_filename": {
+            "type": "string",
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Original Filename"
+          },
+          "expected_size": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Size",
+            "description": "Optional declared total size in bytes for validation on complete"
+          },
+          "content_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "original_filename"
+        ],
+        "title": "FilesUploadSessionCreate"
+      },
+      "FilesUploadSessionCreateResponse": {
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          },
+          "max_chunk_bytes": {
+            "type": "integer",
+            "title": "Max Chunk Bytes",
+            "description": "Maximum bytes accepted per /chunk request"
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_id",
+          "max_chunk_bytes"
+        ],
+        "title": "FilesUploadSessionCreateResponse"
+      },
+      "FilesUploadSessionStatusResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "bytes_received": {
+            "type": "integer",
+            "title": "Bytes Received"
+          },
+          "expected_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Bytes"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "result": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Result"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "status",
+          "bytes_received"
+        ],
+        "title": "FilesUploadSessionStatusResponse"
+      },
       "FolderRequest": {
         "properties": {
           "smb_host": {
@@ -24421,6 +25094,122 @@
         ],
         "title": "KBRead",
         "description": "Response model"
+      },
+      "KbUploadSessionCreate": {
+        "properties": {
+          "original_filename": {
+            "type": "string",
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Original Filename"
+          },
+          "expected_size": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Size",
+            "description": "Optional declared total size in bytes for validation on complete"
+          },
+          "content_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "original_filename"
+        ],
+        "title": "KbUploadSessionCreate"
+      },
+      "KbUploadSessionCreateResponse": {
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          },
+          "max_chunk_bytes": {
+            "type": "integer",
+            "title": "Max Chunk Bytes",
+            "description": "Maximum bytes accepted per /chunk request"
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_id",
+          "max_chunk_bytes"
+        ],
+        "title": "KbUploadSessionCreateResponse"
+      },
+      "KbUploadSessionStatusResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "bytes_received": {
+            "type": "integer",
+            "title": "Bytes Received"
+          },
+          "expected_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Bytes"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "result": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Result"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "status",
+          "bytes_received"
+        ],
+        "title": "KbUploadSessionStatusResponse"
       },
       "LanguageCreate": {
         "properties": {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -11760,6 +11760,16 @@
               "format": "uuid",
               "title": "File Id"
             }
+          },
+          {
+            "name": "force_proxy",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Force Proxy"
+            }
           }
         ],
         "responses": {

--- a/frontend/.env.template
+++ b/frontend/.env.template
@@ -68,6 +68,9 @@ VITE_ONBOARDING_PASSWORD=password
 # Set to "false" to fall back to WebSocket connections
 VITE_USE_POLL=false
 
+# Bytes threshold for switching file uploads to chunked session API (default 15MB if unset)
+# VITE_FILES_UPLOAD_SESSION_THRESHOLD_BYTES=15728640
+
 # -----------------------------------------------------------------------------
 # Sentry (errors, performance, logs)
 # -----------------------------------------------------------------------------

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -35,7 +35,7 @@ RUN npm install
 RUN npm run build
 
 # Use a lightweight web server to serve the built files
-FROM nginx:1.29.4-alpine3.23-slim AS production
+FROM nginx:alpine3.23-slim AS production
 
 # Set working directory to nginx asset directory
 WORKDIR /usr/share/nginx/html

--- a/frontend/container/nginx/nginx.conf
+++ b/frontend/container/nginx/nginx.conf
@@ -3,7 +3,8 @@ server {
       listen [::]:8080;
       server_name localhost;
 
-      client_max_body_size 100M;  # Increase the size limit to 100MB
+      # Align with backend MAX_CONTENT_LENGTH / KNOWLEDGE_MAX_UPLOAD_BYTES (default 100MB)
+      client_max_body_size 100M;
       client_body_buffer_size 128k;  # Increase the buffer size for larger requests
 
 
@@ -15,7 +16,7 @@ server {
       location / {
             root /usr/share/nginx/html;
             index index.html;
-            
+
             # Allow all methods for static content
             if ($request_method = 'OPTIONS') {
                 add_header 'Access-Control-Allow-Origin' '*';

--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button } from '@/components/button';
 import { Label } from '@/components/label';
 import { FileText, Upload, X, Download } from 'lucide-react';
@@ -7,6 +7,7 @@ import { UploadFileResponse } from '@/interfaces/file-manager.interface';
 import { downloadFile, getFileDownloadUrl } from '@/helpers/utils';
 import { getApiUrlString } from '@/config/api';
 import toast from "react-hot-toast";
+import { Progress } from "@/components/progress";
 
 export interface FileUploaderProps {
   label: string;
@@ -14,6 +15,7 @@ export interface FileUploaderProps {
   initialOriginalFileName?: string;
   initialServerFilePath?: string;
   initialServerFileUrl?: string;
+  onUploadingChange?: (isUploading: boolean) => void;
   onUploadComplete?: (result: UploadFileResponse) => void;
   onRemove?: () => void;
   placeholder?: string;
@@ -25,6 +27,7 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
   initialOriginalFileName = '',
   initialServerFilePath,
   initialServerFileUrl,
+  onUploadingChange,
   onUploadComplete,
   onRemove,
   placeholder = 'Select a file to upload',
@@ -34,6 +37,11 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
   const [serverFilePath, setServerFilePath] = useState<string | undefined>(initialServerFilePath);
   const [serverFileUrl, setServerFileUrl] = useState<string | undefined>(initialServerFileUrl);
   const [isUploading, setIsUploading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState(0);
+
+  useEffect(() => {
+    onUploadingChange?.(isUploading);
+  }, [isUploading, onUploadingChange]);
 
   const handleDownload = (e: React.MouseEvent, isFileUrl: boolean = false) => {
     e.stopPropagation();
@@ -111,9 +119,12 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
     if (!targetFile) return null;
 
     setIsUploading(true);
+    setUploadProgress(0);
 
     try {
-      const result = await uploadFiles([targetFile]);
+      const result = await uploadFiles([targetFile], {
+        onProgress: (p) => setUploadProgress(p),
+      });
       if (result.length > 0) {
         const fileResponse = result[0];
         // based on the file response and file manager service, set the server file path and url
@@ -238,7 +249,16 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
           </div>
         )}
 
-        {isUploading && <div className="p-2 text-sm text-muted-foreground">Uploading file... Please wait.</div>}
+        {isUploading && (
+          <div className="p-2 space-y-2">
+            <div className="text-sm text-muted-foreground">
+              {uploadProgress >= 95
+                ? "Processing on server... (almost done)"
+                : `Uploading file... ${uploadProgress > 0 ? `${uploadProgress}%` : "Please wait."}`}
+            </div>
+            <Progress value={uploadProgress} className="h-2" />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -34,12 +34,17 @@ const processQueue = (error: unknown, token: string | null = null) => {
 const ensureTrailingSlash = (url: string): string =>
   url.endsWith("/") ? url : `${url}/`;
 
+/** Default HTTP client timeout for JSON/API calls (not used for large file uploads — see uploadConstants). */
+export const API_DEFAULT_TIMEOUT_MS = 120000;
+
 const api = axios.create({
   headers: {
     "Content-Type": "application/json",
   },
-  timeout: 120000, // Increased to 2 minutes for SQL operations
+  timeout: API_DEFAULT_TIMEOUT_MS,
 });
+
+export { API_UPLOAD_TIMEOUT_MS } from "@/config/uploadConstants";
 
 // Interceptor: Request
 api.interceptors.request.use(
@@ -236,6 +241,39 @@ export const apiRequest = async <T>(
 export { api };
 
 // Simple connectivity probe used by Retry buttons
+/** User-facing message for failed uploads (timeout vs HTTP vs network). */
+export function formatUploadOrNetworkError(err: unknown): string {
+  if (!(err instanceof AxiosError)) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  const code = err.code;
+  const status = err.response?.status;
+  const detail = (err.response?.data as { detail?: unknown } | undefined)?.detail;
+  const detailStr =
+    typeof detail === "string"
+      ? detail
+      : Array.isArray(detail)
+        ? detail.map((d) => (typeof d === "object" && d && "msg" in d ? String((d as { msg: string }).msg) : String(d))).join("; ")
+        : undefined;
+
+  if (code === "ECONNABORTED") {
+    return "Upload timed out or was cancelled. Try again, or use a smaller file / faster connection.";
+  }
+  if (!err.response && (code === "ERR_NETWORK" || code === "ECONNRESET")) {
+    return "Network error during upload. Check your connection and try again.";
+  }
+  if (status === 413) {
+    return "File is too large for the server. Reduce file size or ask an admin to raise upload limits.";
+  }
+  if (status === 400 && detailStr) {
+    return detailStr;
+  }
+  if (status && detailStr) {
+    return detailStr;
+  }
+  return err.message || "Upload failed.";
+}
+
 export const probeApiHealth = async (): Promise<boolean> => {
   const baseURL = await getApiUrl();
   const candidates = [

--- a/frontend/src/config/uploadConstants.ts
+++ b/frontend/src/config/uploadConstants.ts
@@ -1,0 +1,16 @@
+/** Axios: 0 = no client-side timeout (large uploads can exceed any fixed window). */
+export const API_UPLOAD_TIMEOUT_MS = 0;
+
+/** Use chunked session upload when a single file exceeds this size (bytes). */
+export const FILES_UPLOAD_SESSION_THRESHOLD_BYTES =
+  Number(import.meta.env.VITE_FILES_UPLOAD_SESSION_THRESHOLD_BYTES) > 0
+    ? Number(import.meta.env.VITE_FILES_UPLOAD_SESSION_THRESHOLD_BYTES)
+    : 15 * 1024 * 1024;
+
+/** Must stay <= backend FILES_UPLOAD_MAX_CHUNK_BYTES (default 20 MiB). */
+export const FILES_UPLOAD_CHUNK_SIZE = 8 * 1024 * 1024;
+
+// Backward-compatible exports
+export const KNOWLEDGE_UPLOAD_SESSION_THRESHOLD_BYTES =
+  FILES_UPLOAD_SESSION_THRESHOLD_BYTES;
+export const KNOWLEDGE_UPLOAD_CHUNK_SIZE = FILES_UPLOAD_CHUNK_SIZE;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,16 @@
-import { apiRequest, getApiUrl, api } from "@/config/api";
+import {
+  apiRequest,
+  getApiUrl,
+  api,
+  formatUploadOrNetworkError,
+  API_UPLOAD_TIMEOUT_MS,
+  API_DEFAULT_TIMEOUT_MS,
+} from "@/config/api";
+import {
+  FILES_UPLOAD_CHUNK_SIZE,
+  FILES_UPLOAD_SESSION_THRESHOLD_BYTES,
+} from "@/config/uploadConstants";
+import type { AxiosRequestConfig } from "axios";
 import { DynamicFormSchema } from "@/interfaces/dynamicFormSchemas.interface";
 import {
   AgentConfig,
@@ -51,7 +63,7 @@ async function apiRequestWithFormData<T>(
   method: "GET" | "POST" | "PUT" | "DELETE",
   endpoint: string,
   formData?: FormData,
-  config: Record<string, unknown> = {}
+  config: AxiosRequestConfig = {}
 ): Promise<T> {
   const baseURL = await getApiUrl();
   const fullUrl = `${baseURL}genagent/${endpoint.replace(/^\//, "")}`;
@@ -61,19 +73,12 @@ async function apiRequestWithFormData<T>(
       method,
       url: fullUrl,
       data: formData,
-      headers: {
-        "Content-Type": "multipart/form-data",
-      },
+      timeout: config.timeout ?? API_UPLOAD_TIMEOUT_MS,
       ...config,
     });
     return response.data;
   } catch (error: unknown) {
-    const axiosError = error as AxiosError;
-    const errorData = (axiosError.response?.data as { detail?: string }) || {};
-    throw new Error(
-      errorData.detail ||
-        `API error: ${axiosError.response?.status || axiosError.message}`
-    );
+    throw new Error(formatUploadOrNetworkError(error));
   }
 }
 
@@ -163,7 +168,8 @@ export async function uploadWelcomeImage(
   return apiRequestWithFormData<{ status: string; message: string }>(
     "POST",
     `agents/configs/${agentId}/welcome-image`,
-    formData
+    formData,
+    { timeout: API_DEFAULT_TIMEOUT_MS }
   );
 }
 
@@ -253,13 +259,126 @@ export async function finalizeKnowledgeItem(id: string) {
   return apiRequest("POST", `genagent/knowledge/finalize/${id}`);
 }
 
-export const uploadFiles = async (files: File[]): Promise<UploadFileResponse[]> => {
-  const formData = new FormData();
-  files.forEach((file) => {
-    formData.append("files", file);
-  });
+export type UploadKnowledgeFilesOptions = {
+  onProgress?: (percent: number) => void;
+};
 
-  return apiRequestWithFormData<UploadFileResponse[]>("POST", "knowledge/upload", formData);
+/** Never show 100% until the server response completes. */
+const capClientProgress = (pct: number): number => Math.min(95, Math.max(0, pct));
+
+async function uploadFilesMultipartViaFileManager(
+  files: File[],
+  options?: UploadKnowledgeFilesOptions
+): Promise<UploadFileResponse[]> {
+  const baseURL = await getApiUrl();
+  const url = `${baseURL}file-manager/upload`;
+  const formData = new FormData();
+  files.forEach((file) => formData.append("files", file));
+  try {
+    const response = await api.post<UploadFileResponse[]>(url, formData, {
+      timeout: API_UPLOAD_TIMEOUT_MS,
+      onUploadProgress: (ev) => {
+        if (!ev.total || !options?.onProgress) return;
+        options.onProgress(
+          capClientProgress(Math.round((ev.loaded * 100) / ev.total))
+        );
+      },
+    });
+    options?.onProgress?.(100);
+    return response.data;
+  } catch (error: unknown) {
+    throw new Error(formatUploadOrNetworkError(error));
+  }
+}
+
+interface KbUploadSessionCreateResponse {
+  session_id: string;
+  max_chunk_bytes: number;
+}
+
+async function uploadKnowledgeFileViaSession(
+  file: File,
+  options?: UploadKnowledgeFilesOptions
+): Promise<UploadFileResponse[]> {
+  const baseURL = await getApiUrl();
+  const createUrl = `${baseURL}file-manager/upload-session`;
+  const { data: session } = await api.post<KbUploadSessionCreateResponse>(
+    createUrl,
+    {
+      original_filename: file.name,
+      expected_size: file.size,
+      content_type: file.type || undefined,
+    },
+    { timeout: API_UPLOAD_TIMEOUT_MS }
+  );
+  const sessionId = session.session_id;
+  const chunkSize = Math.min(FILES_UPLOAD_CHUNK_SIZE, session.max_chunk_bytes);
+
+  let offset = 0;
+  let chunkIndex = 0;
+  while (offset < file.size) {
+    const end = Math.min(offset + chunkSize, file.size);
+    const blob = file.slice(offset, end);
+    const fd = new FormData();
+    fd.append("chunk", blob, "chunk.bin");
+    fd.append("chunk_index", String(chunkIndex));
+    fd.append("is_last", end >= file.size ? "true" : "false");
+    const chunkUrl = `${baseURL}file-manager/upload-session/${sessionId}/chunk`;
+    await api.post(chunkUrl, fd, {
+      timeout: API_UPLOAD_TIMEOUT_MS,
+      onUploadProgress: (ev) => {
+        if (!options?.onProgress) return;
+        const loaded = offset + (ev.loaded ?? 0);
+        const pct = Math.min(100, Math.round((loaded * 100) / Math.max(file.size, 1)));
+        options.onProgress(capClientProgress(pct));
+      },
+    });
+    offset = end;
+    chunkIndex += 1;
+  }
+
+  // Upload is fully sent; the server may still need time to assemble/commit.
+  options?.onProgress?.(95);
+  const completeUrl = `${baseURL}file-manager/upload-session/${sessionId}/complete`;
+  const { data: one } = await api.post<UploadFileResponse>(completeUrl, {}, {
+    timeout: API_UPLOAD_TIMEOUT_MS,
+  });
+  options?.onProgress?.(100);
+  return [one];
+}
+
+/**
+ * Upload knowledge files. Uses chunked session upload for files larger than
+ * FILES_UPLOAD_SESSION_THRESHOLD_BYTES; otherwise one multipart request.
+ */
+export const uploadFiles = async (
+  files: File[],
+  options?: UploadKnowledgeFilesOptions
+): Promise<UploadFileResponse[]> => {
+  if (files.length === 0) return [];
+  const allSmall = files.every(
+    (f) => f.size <= FILES_UPLOAD_SESSION_THRESHOLD_BYTES
+  );
+  if (allSmall) {
+    return uploadFilesMultipartViaFileManager(files, options);
+  }
+  const results: UploadFileResponse[] = [];
+  for (let i = 0; i < files.length; i++) {
+    const f = files[i];
+    const wrapProgress = (p: number) => {
+      if (!options?.onProgress) return;
+      const totalPct = ((i + p / 100) / files.length) * 100;
+      options.onProgress(Math.min(100, Math.round(totalPct)));
+    };
+    if (f.size > FILES_UPLOAD_SESSION_THRESHOLD_BYTES) {
+      const part = await uploadKnowledgeFileViaSession(f, { onProgress: wrapProgress });
+      results.push(...part);
+    } else {
+      const part = await uploadFilesMultipartViaFileManager([f], { onProgress: wrapProgress });
+      results.push(...part);
+    }
+  }
+  return results;
 };
 
 // Endpoint to trigger KB synchronization execution MANUALLY

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -274,13 +274,16 @@ async function uploadFilesMultipartViaFileManager(
   const url = `${baseURL}file-manager/upload`;
   const formData = new FormData();
   files.forEach((file) => formData.append("files", file));
+  const fallbackTotalBytes = files.reduce((acc, f) => acc + (f.size ?? 0), 0);
   try {
     const response = await api.post<UploadFileResponse[]>(url, formData, {
       timeout: API_UPLOAD_TIMEOUT_MS,
       onUploadProgress: (ev) => {
-        if (!ev.total || !options?.onProgress) return;
+        if (!options?.onProgress) return;
+        const total = ev.total ?? fallbackTotalBytes;
+        if (!total) return;
         options.onProgress(
-          capClientProgress(Math.round((ev.loaded * 100) / ev.total))
+          capClientProgress(Math.round((ev.loaded * 100) / total))
         );
       },
     });

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/training/TrainDataSourceDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/training/TrainDataSourceDialog.tsx
@@ -51,6 +51,7 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
   const [csvFilePath, setCsvFilePath] = useState(data.csvFilePath ?? null);
   const [csvFileId, setCsvFileId] = useState(data.csvFileId ?? null);
   const [csvFileUrl, setCsvFileUrl] = useState(data.csvFileUrl ?? null);
+  const [isCsvUploading, setIsCsvUploading] = useState(false);
   const [availableDataSources, setAvailableDataSources] = useState<
     DataSource[]
   >([]);
@@ -171,8 +172,11 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
           <Button variant="outline" onClick={onClose}>
             Cancel
           </Button>
-          <Button onClick={handleSave}>
-            <Save className="h-4 w-4 mr-2" />
+          <Button
+            onClick={handleSave}
+            loading={isCsvUploading}
+            icon={<Save className="h-4 w-4" />}
+          >
             Save Changes
           </Button>
         </>
@@ -248,6 +252,7 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
             initialServerFilePath={csvFilePath ?? ""}
             initialServerFileUrl={csvFileUrl ?? ""}
             initialOriginalFileName={csvFileName ?? ""}
+            onUploadingChange={setIsCsvUploading}
             onUploadComplete={(result) => {
               setCsvFileName(result.original_filename);
               setCsvFilePath(result.file_path);

--- a/frontend/src/views/KnowledgeBase/pages/KnowledgeBaseForm.tsx
+++ b/frontend/src/views/KnowledgeBase/pages/KnowledgeBaseForm.tsx
@@ -47,6 +47,7 @@ import { KnowledgeItem, UrlHeaderRow, UploadResult, FileItem } from '../types/kn
 import { SidebarProvider, SidebarTrigger } from '@/components/sidebar';
 import { AppSidebar } from '@/layout/app-sidebar';
 import { useIsMobile } from '@/hooks/useMobile';
+import { Progress } from '@/components/progress';
 
 const DEFAULT_FORM_DATA: KnowledgeItem = {
   id: uuidv4(),
@@ -128,6 +129,7 @@ const KnowledgeBaseForm: React.FC = () => {
   const [dynamicRagConfig, setDynamicRagConfig] = useState<RagConfigValues>({});
   const [loading, setLoading] = useState<boolean>(isEditMode);
   const [isUploading, setIsUploading] = useState<boolean>(false);
+  const [uploadProgress, setUploadProgress] = useState<number>(0);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [urls, setUrls] = useState<string[]>(['']);
   const [urlHeaders, setUrlHeaders] = useState<UrlHeaderRow[]>([]);
@@ -319,14 +321,18 @@ const KnowledgeBaseForm: React.FC = () => {
   const uploadFiles = async (): Promise<UploadResult[] | null> => {
     if (selectedFiles.length === 0) return null;
     setIsUploading(true);
+    setUploadProgress(0);
     try {
-      const result = await apiUploadFiles(selectedFiles);
+      const result = await apiUploadFiles(selectedFiles, {
+        onProgress: (pct) => setUploadProgress(pct),
+      });
       return result as unknown as UploadResult[];
     } catch (err) {
       setError(`Failed to upload files: ${err instanceof Error ? err.message : String(err)}`);
       return null;
     } finally {
       setIsUploading(false);
+      setUploadProgress(0);
     }
   };
 
@@ -959,8 +965,11 @@ const KnowledgeBaseForm: React.FC = () => {
                                   </div>
                                 )}
                                 {isUploading && (
-                                  <div className="p-2 text-sm text-muted-foreground">
-                                    Uploading files... Please wait.
+                                  <div className="p-2 space-y-2">
+                                    <div className="text-sm text-muted-foreground">
+                                      Uploading files... {uploadProgress > 0 ? `${uploadProgress}%` : 'Please wait.'}
+                                    </div>
+                                    <Progress value={uploadProgress} className="h-2" />
                                   </div>
                                 )}
                               </div>


### PR DESCRIPTION
## Description
- Added new endpoints for creating, managing, and completing chunked upload sessions for files and knowledge base items.
- Introduced a new database model for tracking upload sessions and their statuses.
- Enhanced file manager service to support streaming uploads without loading entire files into memory.
- Updated OpenAPI schema to reflect new upload session functionalities and responses.
- Increased maximum upload size limits for both knowledge base and file manager uploads.

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Required to be added on the Pipelines:

```
# 1GB
KNOWLEDGE_MAX_UPLOAD_BYTES=1073741824

# 20MB
KNOWLEDGE_UPLOAD_MAX_CHUNK_BYTES=20000000

# 1GB
FILES_MAX_UPLOAD_BYTES=1073741824

# 20MB
FILES_UPLOAD_MAX_CHUNK_BYTES=20000000
```
---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
