### PR TITLE
fix: resolve AI Insights sidebar highlighting when navigating to sibling analytics pages

### DIFF
--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -161,7 +161,7 @@ export const RoutesProvider = () => {
               ),
             },
             {
-              path: "analytics",
+              path: "analytics/ai-insights",
               element: (
                 <ProtectedRoute requiredPermissions={["read:llm_analyst"]}>
                   <Analytics />

--- a/frontend/src/layout/app-sidebar.tsx
+++ b/frontend/src/layout/app-sidebar.tsx
@@ -69,7 +69,7 @@ const menuItems: MenuItem[] = [
     children: [
       {
         title: "AI Insights",
-        url: "/analytics",
+        url: "/analytics/ai-insights",
         permissionsRequired: ["read:dashboard"],
       },
       {

--- a/frontend/src/layout/mobile-nav.tsx
+++ b/frontend/src/layout/mobile-nav.tsx
@@ -10,7 +10,7 @@ export function MobileNav() {
   const items = [
     { icon: Home, label: "Home", path: "/" },
     { icon: FileText, label: "Transcripts", path: "/transcripts" },
-    { icon: BarChart2, label: "Analytics", path: "/analytics" },
+    { icon: BarChart2, label: "Analytics", path: "/analytics/ai-insights" },
     { icon: Settings, label: "Settings", path: "/settings" }
   ];
 


### PR DESCRIPTION

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
