### PR TITLE
refactor: clean up imports and improve user_id handling in agent configuration

### DIFF
--- a/backend/app/api/v1/routes/agent_config.py
+++ b/backend/app/api/v1/routes/agent_config.py
@@ -1,7 +1,7 @@
 from typing import Dict, List
 from uuid import UUID
 
-from fastapi import APIRouter, Body, Depends, Query, Request, UploadFile, File, HTTPException
+from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, Request, UploadFile
 from fastapi.responses import Response
 from fastapi_injector import Injected
 
@@ -11,7 +11,6 @@ from app.schemas.agent import AgentCreate, AgentListItem, AgentRead, AgentUpdate
 from app.schemas.common import PaginatedResponse
 from app.schemas.filter import BaseFilterModel
 from app.services.agent_config import AgentConfigService
-
 
 router = APIRouter()
 
@@ -79,12 +78,9 @@ async def get_config_by_id(
     agent_id: UUID, config_service: AgentConfigService = Injected(AgentConfigService)
 ):
     """Get a specific agent configuration by ID"""
-    agent_model = await config_service.get_by_id_full(agent_id)
-    agent_read = AgentRead.model_validate(agent_model).model_copy(
-        update={"user_id": agent_model.operator.user.id}
-    )
-    return agent_read
-
+    # `config_service.get_by_id_full` returns an `AgentRead` (cached) with
+    # workflow + security settings and a consistently populated `user_id`.
+    return await config_service.get_by_id_full(agent_id)
 
 @router.post(
     "/configs",
@@ -103,7 +99,13 @@ async def create_config(
     result = await config_service.create(agent_create, user_id=current_user.id)
 
     return AgentRead.model_validate(result).model_copy(
-        update={"user_id": result.operator.user.id if result.operator else None}
+        update={
+            "user_id": (
+                result.operator.user.id
+                if getattr(result, "operator", None) and getattr(result.operator, "user", None)
+                else None
+            )
+        }
     )
 
 

--- a/backend/app/repositories/agent.py
+++ b/backend/app/repositories/agent.py
@@ -1,13 +1,16 @@
 from typing import Tuple
 from uuid import UUID
+
 from injector import inject
-from sqlalchemy import select, func, asc, desc
+from sqlalchemy import asc, desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
+
 from app.db.events.group_scope import GROUP_SCOPE_BYPASS_FLAG, get_group_scope_clause
 from app.db.models import AgentModel, OperatorModel
 from app.repositories.db_repository import DbRepository
 from app.schemas.filter import BaseFilterModel
+
 
 @inject
 class AgentRepository(DbRepository[AgentModel]):

--- a/backend/app/services/agent_config.py
+++ b/backend/app/services/agent_config.py
@@ -90,6 +90,17 @@ class AgentConfigService:
         null_unloaded_attributes(agent)
         agent_read = AgentRead.model_validate(agent)
 
+        # Ensure `user_id` is consistently set across all endpoints.
+        # Some routes historically injected this field manually; returning it here
+        # keeps backward compatibility and prevents downstream clients from
+        # failing after an update.
+        try:
+            if getattr(agent, "operator", None) and getattr(agent.operator, "user", None):
+                agent_read.user_id = agent.operator.user.id
+        except Exception:
+            # Best-effort: never fail the request due to missing relationship loads.
+            pass
+
         return agent_read
 
     async def get_by_id_cached(self, agent_id: UUID) -> AgentModel:
@@ -316,6 +327,7 @@ class AgentConfigService:
         # Convert to Pydantic model for caching (avoids pickling SQLAlchemy objects)
         null_unloaded_attributes(agent)
         agent_read = AgentRead.model_validate(agent)
+        agent_read.user_id = user_id
 
         return agent_read
 

--- a/backend/app/services/agent_config.py
+++ b/backend/app/services/agent_config.py
@@ -94,12 +94,9 @@ class AgentConfigService:
         # Some routes historically injected this field manually; returning it here
         # keeps backward compatibility and prevents downstream clients from
         # failing after an update.
-        try:
-            if getattr(agent, "operator", None) and getattr(agent.operator, "user", None):
-                agent_read.user_id = agent.operator.user.id
-        except Exception:
-            # Best-effort: never fail the request due to missing relationship loads.
-            pass
+        if getattr(agent, "operator", None) is not None:
+            # Use the FK column to avoid async lazy-loading `operator.user`.
+            agent_read.user_id = agent.operator.user_id
 
         return agent_read
 


### PR DESCRIPTION
## Description
- Reordered import statements for better readability.
- Simplified the retrieval of agent configuration by directly returning the result from `config_service.get_by_id_full`.
- Enhanced the `user_id` assignment logic in `AgentRead` to ensure consistent handling across endpoints, maintaining backward compatibility.


<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
