### PR TITLE
fix: remove agent fetching in the same sql alchemy session as the update

### DIFF
--- a/backend/app/api/v1/routes/agent_config.py
+++ b/backend/app/api/v1/routes/agent_config.py
@@ -124,10 +124,7 @@ async def update_config(
     if agent.is_system and not current_user_is_admin():
         raise HTTPException(status_code=403, detail="Only admins can modify system agents")
 
-    await agent_config_service.update(agent_id, agent_update)
-    # Fetch the updated agent with all relationships to ensure security_settings is included
-    agent_read = await agent_config_service.get_by_id_full(agent_id)
-    return agent_read
+    return await agent_config_service.update(agent_id, agent_update)
 
 
 @router.delete(


### PR DESCRIPTION
## Description

- removed agent fetching in same sql alchemy session as update because during update the relationships were expired in db.refresh(obj) and set to null by null_unloaded_attributes(), thus sql alchemy didn't not re-fetch them and stored partial agent in redis

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release
