### PR TITLE
feat: security G-14

### DIFF
--- a/backend/app/api/v1/routes/analytics.py
+++ b/backend/app/api/v1/routes/analytics.py
@@ -19,6 +19,7 @@ from app.schemas.analytics import (
 from app.services.analytics_export import EXTENSIONS, VALID_FORMATS, export_agent_stats, export_node_stats, get_agent_names
 from app.services.analytics_read import AnalyticsReadService
 from app.services.audio import AudioService
+from app.core.utils.cache_headers import no_store_headers
 
 logger = logging.getLogger(__name__)
 
@@ -289,7 +290,10 @@ def _build_streaming_response(content: bytes, media_type: str, filename_base: st
     return StreamingResponse(
         io.BytesIO(content),
         media_type=media_type,
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            **no_store_headers(),
+        },
     )
 
 

--- a/backend/app/api/v1/routes/llm_cost_rates.py
+++ b/backend/app/api/v1/routes/llm_cost_rates.py
@@ -10,6 +10,7 @@ from app.core.exceptions.exception_classes import AppException
 from app.core.permissions.constants import Permissions as P
 from app.schemas.llm_cost_rate import LlmCostRateImportResult, LlmCostRateRead
 from app.services.llm_cost_rates import LlmCostRateService
+from app.core.utils.cache_headers import no_store_headers
 
 router = APIRouter()
 
@@ -67,7 +68,10 @@ async def export_cost_rates_csv(
     return StreamingResponse(
         iter([csv_text]),
         media_type="text/csv; charset=utf-8",
-        headers={"Content-Disposition": 'attachment; filename="llm-cost-rates.csv"'},
+        headers={
+            "Content-Disposition": 'attachment; filename="llm-cost-rates.csv"',
+            **no_store_headers(),
+        },
     )
 
 

--- a/backend/app/api/v1/routes/ml_model_pipeline.py
+++ b/backend/app/api/v1/routes/ml_model_pipeline.py
@@ -12,6 +12,7 @@ from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.core.permissions.constants import Permissions as P
 from app.core.project_path import DATA_VOLUME
+from app.core.utils.cache_headers import no_store_headers
 from app.core.utils.file_system_utils import get_safe_file_path
 from app.schemas.ml_model_pipeline import (
     MLModelPipelineArtifactRead,
@@ -305,7 +306,8 @@ async def download_artifact(
         response = FileResponse(
             path=safe_serving_path,
             filename=artifact.artifact_name,
-            media_type=media_type
+            media_type=media_type,
+            headers=no_store_headers(),
         )
         return response
     except HTTPException:

--- a/backend/app/api/v1/routes/open_ai_fine_tuning.py
+++ b/backend/app/api/v1/routes/open_ai_fine_tuning.py
@@ -15,6 +15,7 @@ from app.schemas.open_ai_fine_tuning import (
 )
 from app.schemas.user import UserUpdate
 from app.services.open_ai_fine_tuning import OpenAIFineTuningService
+from app.core.utils.cache_headers import no_store_headers
 
 
 logger = logging.getLogger(__name__)
@@ -142,7 +143,10 @@ async def download_file(
     return Response(
         content=content.read(),
         media_type="application/octet-stream",
-        headers={"Content-Disposition": f'attachment; filename="{file_id}.jsonl"'},
+        headers={
+            "Content-Disposition": f'attachment; filename="{file_id}.jsonl"',
+            **no_store_headers(),
+        },
     )
 
 
@@ -218,7 +222,10 @@ async def generate_training_file_from_conversations(
         return Response(
             content=jsonl_bytes,
             media_type="application/jsonl",
-            headers={"Content-Disposition": 'attachment; filename="training_data.jsonl"'},
+            headers={
+                "Content-Disposition": 'attachment; filename="training_data.jsonl"',
+                **no_store_headers(),
+            },
         )
 
     filename = "training_conversations.jsonl"

--- a/backend/app/api/v1/routes/recordings.py
+++ b/backend/app/api/v1/routes/recordings.py
@@ -13,6 +13,7 @@ from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.core.permissions.constants import Permissions as P
 from app.core.utils.bi_utils import validate_upload_file_size
+from app.core.utils.cache_headers import no_store_headers
 from app.core.utils.file_system_utils import get_safe_file_path
 from app.schemas.conversation_transcript import ConversationTranscriptCreate
 from app.schemas.question import QuestionCreate
@@ -99,7 +100,7 @@ async def serve_file(rec_id: UUID, service: AudioService = Injected(AudioService
         recording_data.file_path,
         settings.RECORDINGS_DIR,
     )
-    return FileResponse(safe_serving_path)
+    return FileResponse(safe_serving_path, headers=no_store_headers())
 
 
 # @router.post("/transcribe_no_save")

--- a/backend/app/core/agent_security_utils.py
+++ b/backend/app/core/agent_security_utils.py
@@ -72,10 +72,12 @@ def apply_agent_cors_headers(
         response.headers["Access-Control-Allow-Methods"] = "*"
         response.headers["Access-Control-Allow-Headers"] = "*"
     elif "*" in allowed_origins:
-        # Allow all origins if explicitly configured
+        # Wildcard CORS is only safe for non-credentialed requests. Do not emit
+        # Access-Control-Allow-Credentials when returning "*".
         response.headers["Access-Control-Allow-Origin"] = "*"
         response.headers["Access-Control-Allow-Methods"] = "*"
         response.headers["Access-Control-Allow-Headers"] = "*"
+        response.headers.pop("Access-Control-Allow-Credentials", None)
 
     return response
 

--- a/backend/app/core/utils/cache_headers.py
+++ b/backend/app/core/utils/cache_headers.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+
+def no_store_headers(*, vary: str = "Authorization, Cookie, Origin") -> dict[str, str]:
+    """
+    Conservative cache headers for authenticated / user-specific responses.
+
+    - Prevents shared/proxy caches from storing responses.
+    - Prevents browsers from reusing content after logout/user switch.
+    """
+    return {
+        "Cache-Control": "private, no-store",
+        "Pragma": "no-cache",
+        "Expires": "0",
+        "Vary": vary,
+    }
+

--- a/backend/app/middlewares/_middleware.py
+++ b/backend/app/middlewares/_middleware.py
@@ -52,6 +52,11 @@ def get_allowed_origins() -> list[str]:
         additional_origins = [origin.strip() for origin in settings.CORS_ALLOWED_ORIGINS.split(",") if origin.strip()]
         # Add unique origins only
         for origin in additional_origins:
+            # Never allow wildcard origins here. With allow_credentials=True, "*" is unsafe and
+            # also not permitted by the CORS spec for credentialed requests.
+            if origin == "*":
+                logger.warning("Ignoring CORS_ALLOWED_ORIGINS='*' because credentials are enabled")
+                continue
             if origin not in allowed_origins:
                 allowed_origins.append(origin)
 

--- a/backend/app/services/file_manager.py
+++ b/backend/app/services/file_manager.py
@@ -23,6 +23,7 @@ from app.core.config.settings import file_storage_settings
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.schemas.app_settings import AppSettingsRead
+from app.core.utils.cache_headers import no_store_headers
 from app.core.utils.upload_streaming import async_stream_uploadfile_to_path
 
 logger = logging.getLogger(__name__)
@@ -95,13 +96,13 @@ class FileManagerService:
         # Build Content-Disposition header with both ASCII fallback and UTF-8 version
         content_disposition = f'{disposition_type};filename="{filename_encoded}";filename*=UTF-8\'\'{filename_utf8_encoded}'
 
-        headers = {
+        # NOTE: Do not set CORS headers here; they should be handled centrally by CORSMiddleware.
+        # Also, never mark these responses as publicly cacheable: file bytes can be user/tenant scoped.
+        headers: dict[str, str] = {
             "content-type": media_type,
             "content-disposition": content_disposition,
             "x-content-type-options": "nosniff",
-            "access-control-allow-origin": "*",
-            "access-control-expose-headers": "Age, Date, Content-Length, Content-Range, X-Content-Duration, X-Cache",
-            "cache-control": "public, max-age=31536000"
+            **no_store_headers(),
         }
 
         # Add Content-Length if content is provided


### PR DESCRIPTION
## Description
- Added `no_store_headers` utility to enforce conservative caching for authenticated responses across multiple routes.
- Updated file download responses in `analytics.py`, `llm_cost_rates.py`, `ml_model_pipeline.py`, `open_ai_fine_tuning.py`, `recordings.py`, and `file_manager.py` to include no-store cache headers, preventing caching of sensitive data.
- Ensured consistent application of caching policies to enhance security and user experience.

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release



---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
