### PR TITLE
fix: return permissions check for conversation by id

### DIFF
--- a/backend/app/api/v1/routes/conversations.py
+++ b/backend/app/api/v1/routes/conversations.py
@@ -196,7 +196,7 @@ async def get_agent_chat_locales(
     response_model=ConversationRead,
     dependencies=[
         Depends(auth),
-        # Depends(permissions(P.Conversation.READ))
+        Depends(permissions(P.Conversation.READ))
     ],
 )
 async def get(


### PR DESCRIPTION
## Description

- return permissions check for conversation by id
- test socket in conversations as admin/supervisor
- test socket in plugin

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release
