### PR TITLE
refactor: remove ADMIN_TOOLS feature flag from app sidebar menu items

### DIFF
--- a/frontend/src/config/featureFlags.ts
+++ b/frontend/src/config/featureFlags.ts
@@ -29,10 +29,6 @@ export const FeatureFlags = {
       SHOW_LOCAL_FINE_TUNE: 'llmSettings.showLocalFineTune',
     },
 
-    ADMIN_TOOLS: {
-      APP_SETTINGS: 'ui.menu.app-settings',
-    },
-  
     // Workflow specific flags
     WORKFLOW: {
       CHAT_INPUT: 'workflow.chatInput',

--- a/frontend/src/layout/app-sidebar.tsx
+++ b/frontend/src/layout/app-sidebar.tsx
@@ -161,7 +161,6 @@ const menuItems: MenuItem[] = [
         title: "Configuration Vars",
         url: "/app-settings",
         permissionsRequired: ["read:app_setting"],
-        feature_flag: FeatureFlags.ADMIN_TOOLS.APP_SETTINGS,
       },
     ],
   },


### PR DESCRIPTION
## Description

remove ADMIN_TOOLS feature flag from app sidebar menu items

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- remove ADMIN_TOOLS feature flag from app sidebar menu items

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
