### PR TITLE
fix:remove header with del instead of pop for agent headers

### DIFF
--- a/backend/app/core/agent_security_utils.py
+++ b/backend/app/core/agent_security_utils.py
@@ -77,7 +77,8 @@ def apply_agent_cors_headers(
         response.headers["Access-Control-Allow-Origin"] = "*"
         response.headers["Access-Control-Allow-Methods"] = "*"
         response.headers["Access-Control-Allow-Headers"] = "*"
-        response.headers.pop("Access-Control-Allow-Credentials", None)
+        if "access-control-allow-credentials" in response.headers:
+            del response.headers["access-control-allow-credentials"]
 
     return response
 


### PR DESCRIPTION
## Description

- fix access-control-allow-credentials deletion in agent headers
## Type of Change


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release
