### PR TITLE
chore: change timeout for sandbox call from 30 to 120 seconds

### DIFF
--- a/backend/app/modules/workflow/utils.py
+++ b/backend/app/modules/workflow/utils.py
@@ -17,7 +17,7 @@ from app.modules.workflow.sandbox import (
 logger = logging.getLogger(__name__)
 
 # Maximum wall-clock seconds for user-supplied Python code execution.
-_EXEC_TIMEOUT_SECONDS = 30
+_EXEC_TIMEOUT_SECONDS = 120
 
 
 def add_executable_function(code: str) -> str:


### PR DESCRIPTION
## Description

- change timeout for sandbox call from 30 to 120 seconds

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release
