### PR TITLE
fix: remove compile from deny list _ATTR_DENYLIST

### DIFF
--- a/backend/app/modules/workflow/sandbox.py
+++ b/backend/app/modules/workflow/sandbox.py
@@ -53,7 +53,7 @@ _DUNDER_DENYLIST: frozenset[str] = frozenset({
 })
 
 _ATTR_DENYLIST: frozenset[str] = frozenset({
-    "environ", "system", "popen", "exec", "eval", "compile",
+    "environ", "system", "popen", "exec", "eval",
     "subprocess", "execvp", "execvpe", "spawnl",
 })
 


### PR DESCRIPTION
## Description

- remove compile from deny list _ATTR_DENYLIST as it blocks code that contains re.compile, or Pattern.compile, etc

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release


**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
