### PR TITLE
feat: local fine tuning UI

### DIFF
--- a/frontend/src/interfaces/localFineTune.interface.ts
+++ b/frontend/src/interfaces/localFineTune.interface.ts
@@ -119,3 +119,18 @@ export interface DeploymentStopResponse {
   status: string;
   message: string;
 }
+
+export interface DeleteJobFilesRequest {
+  delete_data_files?: boolean;
+  delete_checkpoints?: boolean;
+  delete_model?: boolean;
+}
+
+export interface DeleteJobFilesResponse {
+  job_id: string;
+  status: "success" | "partial_success" | "failed" | "no_files" | string;
+  deleted_items: string[];
+  bytes_freed: number;
+  errors: string[] | null;
+  message: string;
+}

--- a/frontend/src/interfaces/localFineTune.interface.ts
+++ b/frontend/src/interfaces/localFineTune.interface.ts
@@ -90,6 +90,7 @@ export interface CreateDeploymentRequest {
   deployment_id: string;
   job_id: string;
   gpu_id?: number | null;
+  tensor_parallel_size?: number;
   max_model_len?: number | null;
   gpu_memory_utilization?: number;
   dtype?: string;

--- a/frontend/src/interfaces/localFineTune.interface.ts
+++ b/frontend/src/interfaces/localFineTune.interface.ts
@@ -53,7 +53,8 @@ export type LocalFineTuneJobStatus =
   | "saving_model"
   | "succeeded"
   | "failed"
-  | "cancelled";
+  | "cancelled"
+  | "model_deleted";
 
 export interface LocalFineTuneJobEvent {
   job_id: string;

--- a/frontend/src/services/localFineTune.ts
+++ b/frontend/src/services/localFineTune.ts
@@ -4,6 +4,8 @@ import { getAccessToken, getTenantId } from "@/services/auth";
 import type {
   CreateDeploymentRequest,
   CreateLocalFineTuneJobRequest,
+  DeleteJobFilesRequest,
+  DeleteJobFilesResponse,
   GpuInfo,
   SystemGpusResponse,
   LocalFineTuneDeployment,
@@ -143,6 +145,20 @@ export async function createLocalFineTuneJob(
 
 export async function cancelLocalFineTuneJob(jobId: string): Promise<LocalFineTuneJob> {
   return localFineTuneRequest<LocalFineTuneJob>("POST", `api/v1/fine-tuning/jobs/${jobId}/cancel`);
+}
+
+export async function deleteLocalFineTuneJobFiles(
+  jobId: string,
+  options: DeleteJobFilesRequest = {}
+): Promise<DeleteJobFilesResponse> {
+  const { delete_data_files = true, delete_checkpoints = true, delete_model = false } = options;
+  return localFineTuneRequest<DeleteJobFilesResponse>(
+    "DELETE",
+    `api/v1/fine-tuning/jobs/${jobId}/files`,
+    {
+      params: { delete_data_files, delete_checkpoints, delete_model },
+    }
+  );
 }
 
 export async function createDeployment(

--- a/frontend/src/views/LocalFineTune/components/LocalFineTuneDeleteFilesDialog.tsx
+++ b/frontend/src/views/LocalFineTune/components/LocalFineTuneDeleteFilesDialog.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+import { Loader2, X } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/alert-dialog";
+import { Checkbox } from "@/components/checkbox";
+import { Label } from "@/components/label";
+import { deleteLocalFineTuneJobFiles } from "@/services/localFineTune";
+import { toast } from "react-hot-toast";
+
+interface LocalFineTuneDeleteFilesDialogProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  jobId: string;
+  jobDisplayName: string;
+  onDeleted?: () => void;
+}
+
+export function LocalFineTuneDeleteFilesDialog({
+  isOpen,
+  onOpenChange,
+  jobId,
+  jobDisplayName,
+  onDeleted,
+}: LocalFineTuneDeleteFilesDialogProps) {
+  const [deleteDataFiles, setDeleteDataFiles] = useState(true);
+  const [deleteCheckpoints, setDeleteCheckpoints] = useState(true);
+  const [deleteModel, setDeleteModel] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const nothingSelected = !deleteDataFiles && !deleteCheckpoints && !deleteModel;
+
+  const handleConfirm = async () => {
+    if (nothingSelected) return;
+    try {
+      setIsDeleting(true);
+      const result = await deleteLocalFineTuneJobFiles(jobId, {
+        delete_data_files: deleteDataFiles,
+        delete_checkpoints: deleteCheckpoints,
+        delete_model: deleteModel,
+      });
+      if (result.status === "failed") {
+        toast.error(result.message || "Cleanup failed");
+      } else if (result.status === "no_files") {
+        toast.success("No files found to clean up");
+      } else {
+        toast.success(result.message || "Files deleted successfully");
+      }
+      onDeleted?.();
+      onOpenChange(false);
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { error?: string } } })?.response?.data?.error ||
+        "Failed to delete files";
+      toast.error(message);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            className="absolute right-0 top-0 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete job files</AlertDialogTitle>
+            <AlertDialogDescription>
+              Select which files to delete for{" "}
+              <span className="font-medium text-foreground">{jobDisplayName}</span>.
+              This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <div className="my-4 space-y-4">
+            <div className="flex items-start gap-3">
+              <Checkbox
+                id="delete-data-files"
+                checked={deleteDataFiles}
+                onCheckedChange={(checked) => setDeleteDataFiles(Boolean(checked))}
+                className="mt-0.5"
+              />
+              <Label htmlFor="delete-data-files" className="cursor-pointer leading-none">
+                <span className="font-medium">Training / validation files</span>
+                <p className="text-xs text-muted-foreground font-normal mt-0.5">
+                  Downloaded data files used for training
+                </p>
+              </Label>
+            </div>
+            <div className="flex items-start gap-3">
+              <Checkbox
+                id="delete-checkpoints"
+                checked={deleteCheckpoints}
+                onCheckedChange={(checked) => setDeleteCheckpoints(Boolean(checked))}
+                className="mt-0.5"
+              />
+              <Label htmlFor="delete-checkpoints" className="cursor-pointer leading-none">
+                <span className="font-medium">Checkpoints</span>
+                <p className="text-xs text-muted-foreground font-normal mt-0.5">
+                  Intermediate checkpoints saved during training
+                </p>
+              </Label>
+            </div>
+            <div className="flex items-start gap-3">
+              <Checkbox
+                id="delete-model"
+                checked={deleteModel}
+                onCheckedChange={(checked) => setDeleteModel(Boolean(checked))}
+                className="mt-0.5"
+              />
+              <Label htmlFor="delete-model" className="cursor-pointer leading-none">
+                <span className="font-medium text-destructive">Fine-tuned model</span>
+                <p className="text-xs text-muted-foreground font-normal mt-0.5">
+                  The output model — cannot be recovered if deleted
+                </p>
+              </Label>
+            </div>
+          </div>
+
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirm}
+              disabled={isDeleting || nothingSelected}
+              className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+            >
+              {isDeleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Delete files
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </div>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/views/LocalFineTune/components/LocalFineTuneDeployDialog.tsx
+++ b/frontend/src/views/LocalFineTune/components/LocalFineTuneDeployDialog.tsx
@@ -7,8 +7,8 @@ import { Switch } from "@/components/switch";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/select";
 import { Loader2 } from "lucide-react";
 import { toast } from "react-hot-toast";
-import { createDeployment } from "@/services/localFineTune";
-import type { CreateDeploymentRequest } from "@/interfaces/localFineTune.interface";
+import { createDeployment, listSystemGpus } from "@/services/localFineTune";
+import type { CreateDeploymentRequest, GpuInfo } from "@/interfaces/localFineTune.interface";
 
 interface LocalFineTuneDeployDialogProps {
   isOpen: boolean;
@@ -34,8 +34,13 @@ export function LocalFineTuneDeployDialog({
   const [gpuMemUtil, setGpuMemUtil] = useState<number | "">(0.9);
   const [dtype, setDtype] = useState("auto");
   const [gpuId, setGpuId] = useState<number | "">("");
+  const [tensorParallelSize, setTensorParallelSize] = useState<number>(1);
+  const [availableGpus, setAvailableGpus] = useState<GpuInfo[]>([]);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+
+  const maxParallelism = availableGpus.length || null;
+  const parallelismExceedsGpus = maxParallelism !== null && tensorParallelSize > maxParallelism;
 
   useEffect(() => {
     if (isOpen) {
@@ -44,7 +49,10 @@ export function LocalFineTuneDeployDialog({
       setGpuMemUtil(0.9);
       setDtype("auto");
       setGpuId("");
+      setTensorParallelSize(1);
+      setAvailableGpus([]);
       setShowAdvanced(false);
+      listSystemGpus().then(setAvailableGpus).catch(() => setAvailableGpus([]));
     }
   }, [isOpen, jobId]);
 
@@ -60,6 +68,7 @@ export function LocalFineTuneDeployDialog({
       job_id: jobId,
       gpu_memory_utilization: gpuMemUtil !== "" ? Number(gpuMemUtil) : undefined,
       dtype,
+      tensor_parallel_size: tensorParallelSize,
       max_model_len: maxModelLen !== "" ? Number(maxModelLen) : null,
       gpu_id: gpuId !== "" ? Number(gpuId) : null,
     };
@@ -136,6 +145,38 @@ export function LocalFineTuneDeployDialog({
               </div>
             </div>
 
+            <div className="space-y-2">
+              <Label htmlFor="tensor-parallel-size">
+                Tensor Parallel Size
+                {maxParallelism !== null && (
+                  <span className="ml-1.5 text-xs text-muted-foreground font-normal">
+                    ({maxParallelism} GPU{maxParallelism !== 1 ? "s" : ""} available)
+                  </span>
+                )}
+              </Label>
+              <Input
+                id="tensor-parallel-size"
+                type="number"
+                min={1}
+                max={maxParallelism ?? undefined}
+                step={1}
+                value={tensorParallelSize}
+                onChange={(e) =>
+                  setTensorParallelSize(Math.max(1, Number.parseInt(e.target.value) || 1))
+                }
+                className={parallelismExceedsGpus ? "rounded-lg border-destructive" : "rounded-lg"}
+              />
+              {parallelismExceedsGpus ? (
+                <p className="text-xs text-destructive">
+                  Exceeds the {maxParallelism} GPU{maxParallelism !== 1 ? "s" : ""} available on this system.
+                </p>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Number of GPUs to use. Set to 2+ for large models (e.g. Gemma 9B across 2 GPUs).
+                </p>
+              )}
+            </div>
+
             <div className="flex items-center gap-2 border-t pt-4">
               <div className="flex-1" />
               <div className="flex items-center gap-2">
@@ -165,18 +206,30 @@ export function LocalFineTuneDeployDialog({
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="gpu-id">GPU ID</Label>
-                  <Input
-                    id="gpu-id"
-                    type="number"
-                    min={0}
-                    value={gpuId}
-                    onChange={(e) =>
-                      setGpuId(e.target.value === "" ? "" : Number(e.target.value))
-                    }
-                    placeholder="auto"
-                    className="rounded-lg"
-                  />
+                  <Label>
+                    {tensorParallelSize > 1 ? "Pin First GPU" : "GPU"}
+                  </Label>
+                  <Select
+                    value={gpuId === "" ? "auto" : String(gpuId)}
+                    onValueChange={(v) => setGpuId(v === "auto" ? "" : Number(v))}
+                  >
+                    <SelectTrigger className="rounded-lg">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="auto">Auto (by load)</SelectItem>
+                      {availableGpus.map((gpu) => (
+                        <SelectItem key={gpu.id} value={String(gpu.id)}>
+                          GPU {gpu.id} · {gpu.name} ({gpu.free_memory_gb}GB free)
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    {tensorParallelSize > 1
+                      ? `Pins the selected GPU first; ${tensorParallelSize - 1} more auto-selected by load.`
+                      : "Auto lets the service pick the GPU with the lowest load."}
+                  </p>
                 </div>
               </div>
             )}
@@ -191,7 +244,7 @@ export function LocalFineTuneDeployDialog({
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={submitting}>
+            <Button type="submit" disabled={submitting || parallelismExceedsGpus}>
               {submitting && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
               Deploy
             </Button>

--- a/frontend/src/views/LocalFineTune/components/LocalFineTuneDeploymentsCard.tsx
+++ b/frontend/src/views/LocalFineTune/components/LocalFineTuneDeploymentsCard.tsx
@@ -115,6 +115,11 @@ export function LocalFineTuneDeploymentsCard({
     );
   }, [deployments, searchQuery]);
 
+  const isRecentDeployment = (deployment: LocalFineTuneDeployment) => {
+    if (!deployment.created_at) return false;
+    return Date.now() - new Date(deployment.created_at).getTime() < 20_000;
+  };
+
   const handleHealthCheck = async (deployment: LocalFineTuneDeployment) => {
     if (healthCheckInFlight.current.has(deployment.id)) return;
     healthCheckInFlight.current.add(deployment.id);
@@ -123,6 +128,8 @@ export function LocalFineTuneDeploymentsCard({
       const result = await checkDeploymentHealth(deployment.id);
       if (result.status === "healthy") {
         toast.success(`Healthy — ${result.details}`);
+      } else if (isRecentDeployment(deployment)) {
+        toast(`Service may need a few seconds to become accessible`, { icon: "⚠️" });
       } else {
         toast.error(`Unhealthy — ${result.details}`);
       }
@@ -130,6 +137,8 @@ export function LocalFineTuneDeploymentsCard({
       const status = (err as { response?: { status?: number } })?.response?.status;
       if (status === 401) {
         toast.error("Session expired — please refresh the page");
+      } else if (isRecentDeployment(deployment)) {
+        toast(`Service may need a few seconds to become accessible`, { icon: "⚠️" });
       } else {
         toast.error("Health check failed");
       }

--- a/frontend/src/views/LocalFineTune/components/LocalFineTuneJobsCard.tsx
+++ b/frontend/src/views/LocalFineTune/components/LocalFineTuneJobsCard.tsx
@@ -13,6 +13,7 @@ import {
   getLocalFineTuneJobNameSubtitle,
 } from "@/views/LocalFineTune/utils/jobDisplayName";
 import { cancelLocalFineTuneJob } from "@/services/localFineTune";
+import { LocalFineTuneDeleteFilesDialog } from "@/views/LocalFineTune/components/LocalFineTuneDeleteFilesDialog";
 import { LocalFineTuneDeployDialog } from "@/views/LocalFineTune/components/LocalFineTuneDeployDialog";
 import {
   DropdownMenu,
@@ -107,7 +108,6 @@ export function LocalFineTuneJobsCard({
   const navigate = useNavigate();
   const [jobToDelete, setJobToDelete] = useState<LocalFineTuneJob | null>(null);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
   const [jobToCancel, setJobToCancel] = useState<LocalFineTuneJob | null>(null);
   const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
   const [isCancelling, setIsCancelling] = useState(false);
@@ -173,6 +173,7 @@ export function LocalFineTuneJobsCard({
           const hasModel = Boolean(job.fine_tuned_model);
           const isDeployable = isSucceeded && hasModel;
           const isCancellable = inProgressStatuses.has(status);
+          const isTerminal = ["succeeded", "failed", "cancelled"].includes(status);
           const disabledReason = !isSucceeded
             ? "Only Jobs with the status 'Completed' create a model that can be deployed"
             : "No model path available for this job";
@@ -226,6 +227,19 @@ export function LocalFineTuneJobsCard({
                       Cancel Job
                     </DropdownMenuItem>
                   )}
+                  {isTerminal && (
+                    <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setJobToDelete(job);
+                        setIsDeleteDialogOpen(true);
+                      }}
+                    >
+                      <Trash2 className="h-4 w-4 mr-2" />
+                      Delete Files
+                    </DropdownMenuItem>
+                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
             </TooltipProvider>
@@ -252,20 +266,6 @@ export function LocalFineTuneJobsCard({
     }
   };
 
-  const handleDeleteConfirm = async () => {
-    if (!jobToDelete) return;
-    try {
-      setIsDeleting(true);
-      setJobs((prev) => prev.filter((j) => j.id !== jobToDelete.id));
-      toast.success("Job removed from the list");
-    } catch {
-      toast.error("Failed to delete job");
-    } finally {
-      setIsDeleting(false);
-      setIsDeleteDialogOpen(false);
-      setJobToDelete(null);
-    }
-  };
 
   return (
     <>
@@ -282,18 +282,18 @@ export function LocalFineTuneJobsCard({
         onRowClick={(job) => navigate(`/local-fine-tune/${job.id}`)}
       />
 
-      <ConfirmDialog
-        isOpen={isDeleteDialogOpen}
-        onOpenChange={setIsDeleteDialogOpen}
-        onConfirm={handleDeleteConfirm}
-        isInProgress={isDeleting}
-        itemName={jobToDelete?.id}
-        title="Remove job from list?"
-        description={`This will remove job "${jobToDelete?.id}" from the list. This action is local only.`}
-        primaryButtonText="Remove"
-        secondaryButtonText="Cancel"
-        onCancel={() => setJobToDelete(null)}
-      />
+      {jobToDelete && (
+        <LocalFineTuneDeleteFilesDialog
+          isOpen={isDeleteDialogOpen}
+          onOpenChange={(open) => {
+            setIsDeleteDialogOpen(open);
+            if (!open) setJobToDelete(null);
+          }}
+          jobId={jobToDelete.id}
+          jobDisplayName={getLocalFineTuneJobDisplayName(jobToDelete)}
+          onDeleted={() => setJobToDelete(null)}
+        />
+      )}
 
       <ConfirmDialog
         isOpen={isCancelDialogOpen}

--- a/frontend/src/views/LocalFineTune/components/LocalFineTuneJobsCard.tsx
+++ b/frontend/src/views/LocalFineTune/components/LocalFineTuneJobsCard.tsx
@@ -96,6 +96,8 @@ interface LocalFineTuneJobsCardProps {
   loading: boolean;
   error: string | null;
   searchQuery: string;
+  onDeployed?: () => void;
+  onFilesDeleted?: () => void;
 }
 
 export function LocalFineTuneJobsCard({
@@ -104,6 +106,8 @@ export function LocalFineTuneJobsCard({
   loading,
   error,
   searchQuery,
+  onDeployed,
+  onFilesDeleted,
 }: LocalFineTuneJobsCardProps) {
   const navigate = useNavigate();
   const [jobToDelete, setJobToDelete] = useState<LocalFineTuneJob | null>(null);
@@ -174,9 +178,12 @@ export function LocalFineTuneJobsCard({
           const isDeployable = isSucceeded && hasModel;
           const isCancellable = inProgressStatuses.has(status);
           const isTerminal = ["succeeded", "failed", "cancelled"].includes(status);
-          const disabledReason = !isSucceeded
-            ? "Only Jobs with the status 'Completed' create a model that can be deployed"
-            : "No model path available for this job";
+          let disabledReason = "No model path available for this job";
+          if (status === "model_deleted") {
+            disabledReason = "The fine-tuned model has been deleted";
+          } else if (!isSucceeded) {
+            disabledReason = "Only jobs with the status 'Completed' create a model that can be deployed";
+          }
 
           return (
             <TooltipProvider delayDuration={200}>
@@ -291,7 +298,10 @@ export function LocalFineTuneJobsCard({
           }}
           jobId={jobToDelete.id}
           jobDisplayName={getLocalFineTuneJobDisplayName(jobToDelete)}
-          onDeleted={() => setJobToDelete(null)}
+          onDeleted={() => {
+            setJobToDelete(null);
+            onFilesDeleted?.();
+          }}
         />
       )}
 
@@ -314,7 +324,10 @@ export function LocalFineTuneJobsCard({
           onOpenChange={(open) => { if (!open) setJobToDeploy(null); }}
           jobId={jobToDeploy.id}
           jobDisplayName={getLocalFineTuneJobDisplayName(jobToDeploy)}
-          onDeployed={() => setJobToDeploy(null)}
+          onDeployed={() => {
+            setJobToDeploy(null);
+            onDeployed?.();
+          }}
         />
       )}
     </>

--- a/frontend/src/views/LocalFineTune/pages/LocalFineTune.tsx
+++ b/frontend/src/views/LocalFineTune/pages/LocalFineTune.tsx
@@ -26,6 +26,11 @@ export default function LocalFineTune() {
     setRefreshKey((k) => k + 1);
   };
 
+  const handleDeployed = () => {
+    setDeployRefreshKey((k) => k + 1);
+    setActiveTab("deployments");
+  };
+
   return (
     <PageLayout>
       <PageHeader
@@ -68,6 +73,8 @@ export default function LocalFineTune() {
             loading={loading}
             error={error}
             searchQuery={searchQuery}
+            onDeployed={handleDeployed}
+            onFilesDeleted={() => setRefreshKey((k) => k + 1)}
           />
         </>
       )}


### PR DESCRIPTION
## Description

 - Added gpu parallelism feature to allow for larger models to be deployed like Gemma 9B.
 - Added file and model deletion for each fine tuning job.
 - When deleting we have validations of active deployment which do not allow deletion.
 - When creating a deployment we automatically navigate to the deployment page and see status.
 - Usually the model needs 10 second to 1 minute to become available depending on gpus and cpu load and models size so when pressing the check health button it will show a warning for the first 30 seconds and not status: unhealthy if it cannot access it.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release