### PR TITLE
feat: add agent_id and agent_name to conversation and dashboard schemas

### DIFF
--- a/backend/app/db/models/conversation.py
+++ b/backend/app/db/models/conversation.py
@@ -1,5 +1,6 @@
 from app.db.base import Base
 from typing import Optional
+from uuid import UUID
 from sqlalchemy import (
     UUID,
     BigInteger,
@@ -112,3 +113,21 @@ class ConversationModel(Base, GroupScopedMixin):
         "RecordingModel", back_populates="conversation", uselist=False
     )
     operator = relationship("OperatorModel", back_populates="conversations")
+
+    @property
+    def agent_id(self) -> Optional[UUID]:
+        """Resolved AI agent id (via operator); requires operator.agent to be loaded."""
+        operator = getattr(self, "operator", None)
+        if operator is None:
+            return None
+        agent = getattr(operator, "agent", None)
+        return agent.id if agent is not None else None
+
+    @property
+    def agent_name(self) -> Optional[str]:
+        """Resolved AI agent display name; requires operator.agent to be loaded."""
+        operator = getattr(self, "operator", None)
+        if operator is None:
+            return None
+        agent = getattr(operator, "agent", None)
+        return agent.name if agent is not None else None

--- a/backend/app/repositories/conversations.py
+++ b/backend/app/repositories/conversations.py
@@ -91,7 +91,7 @@ class ConversationRepository:
             .options(
                 joinedload(ConversationModel.analysis),
                 joinedload(ConversationModel.recording),
-                joinedload(ConversationModel.operator),
+                joinedload(ConversationModel.operator).joinedload(OperatorModel.agent),
             )
         )
 
@@ -385,7 +385,8 @@ class ConversationRepository:
         Note: include_messages=True may impact performance for large result sets.
         """
         query = select(ConversationModel).options(
-            joinedload(ConversationModel.recording)
+            joinedload(ConversationModel.recording),
+            selectinload(ConversationModel.operator).selectinload(OperatorModel.agent),
         )
 
         query = self._apply_base_filters(query, conversation_filter)

--- a/backend/app/repositories/dashboard.py
+++ b/backend/app/repositories/dashboard.py
@@ -108,7 +108,8 @@ class DashboardRepository:
             )
             .options(
                 selectinload(ConversationModel.analysis),
-                selectinload(ConversationModel.messages)
+                selectinload(ConversationModel.messages),
+                selectinload(ConversationModel.operator).selectinload(OperatorModel.agent),
             )
             .order_by(ConversationModel.created_at.desc())
             .offset(offset)

--- a/backend/app/schemas/conversation.py
+++ b/backend/app/schemas/conversation.py
@@ -83,6 +83,8 @@ class ConversationRead(ConversationBase):
     thumbs_down_count: int = 0
     thumbs_up_count: int = 0
     custom_attributes: Optional[dict[str, Any]] = None
+    agent_id: Optional[UUID] = None
+    agent_name: Optional[str] = None
 
     model_config = ConfigDict(
         from_attributes = True

--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -27,6 +27,8 @@ class ActiveConversationItem(BaseModel):
     created_at: datetime
     negative_reason: Optional[str] = None
     in_progress_hostility_score: int = 0
+    agent_id: Optional[UUID] = None
+    agent_name: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -63,6 +63,8 @@ class DashboardService:
             "duration": item.duration or 0,
             "topic": item.topic,
             "negative_reason": item.negative_reason,
+            "agent_id": str(item.agent_id) if item.agent_id else None,
+            "agent_name": item.agent_name,
         }
 
     async def get_summary_stats(
@@ -131,7 +133,9 @@ class DashboardService:
                 status=conv.status,
                 created_at=conv.created_at,
                 negative_reason=conv.negative_reason,
-                in_progress_hostility_score=conv.in_progress_hostility_score or 0
+                in_progress_hostility_score=conv.in_progress_hostility_score or 0,
+                agent_id=conv.agent_id,
+                agent_name=conv.agent_name,
             ))
 
         total = feedback_counts["total"]

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7652,7 +7652,7 @@
         ],
         "parameters": [
           {
-            "name": "x-tenant-id",
+            "name": "X-Tenant-ID",
             "in": "header",
             "required": false,
             "schema": {
@@ -20255,6 +20255,29 @@
             "type": "integer",
             "title": "In Progress Hostility Score",
             "default": 0
+          },
+          "agent_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id"
+          },
+          "agent_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
           }
         },
         "type": "object",
@@ -24015,6 +24038,29 @@
               }
             ],
             "title": "Custom Attributes"
+          },
+          "agent_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id"
+          },
+          "agent_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
           }
         },
         "type": "object",

--- a/frontend/src/context/WebSocketDashboardContext.tsx
+++ b/frontend/src/context/WebSocketDashboardContext.tsx
@@ -155,6 +155,10 @@ export function WebSocketDashboardProvider({
             negative_reason:
               (payload as { negative_reason?: string }).negative_reason ??
               existing?.negative_reason,
+            agent_id:
+              (payload as { agent_id?: string }).agent_id ?? existing?.agent_id,
+            agent_name:
+              (payload as { agent_name?: string }).agent_name ?? existing?.agent_name,
           };
           const enhanced = applyCachedTopic(merged);
           if (index !== -1) {

--- a/frontend/src/interfaces/dashboard.interface.ts
+++ b/frontend/src/interfaces/dashboard.interface.ts
@@ -15,6 +15,8 @@ export interface ActiveConversationItem {
   created_at: string;
   negative_reason: string | null;
   in_progress_hostility_score: number;
+  agent_id?: string | null;
+  agent_name?: string | null;
 }
 
 export interface ActiveConversationsResponse {

--- a/frontend/src/interfaces/liveConversation.interface.ts
+++ b/frontend/src/interfaces/liveConversation.interface.ts
@@ -13,6 +13,8 @@ export type ActiveConversation = {
     supervisor_id?: string | null;
     topic?: string;
     negative_reason?: string;
+    agent_id?: string | null;
+    agent_name?: string | null;
   };
   
   export type ActiveConversationsResponse = {

--- a/frontend/src/interfaces/transcript.interface.ts
+++ b/frontend/src/interfaces/transcript.interface.ts
@@ -40,6 +40,8 @@ export interface Analysis {
 
 export interface BackendTranscript {
   id: string;
+  agent_id?: string | null;
+  agent_name?: string | null;
   operator_id: string;
   data_source_id: string;
   recording_id: string | null;
@@ -106,6 +108,8 @@ export interface ConversationFeedbackEntry {
 
 export interface Transcript {
   id: string;
+  agent_id?: string | null;
+  agent_name?: string | null;
   audio: string;
   duration: number;
   recording_id: string | null;

--- a/frontend/src/views/ActiveConversations/components/ActiveConversationDialog.tsx
+++ b/frontend/src/views/ActiveConversations/components/ActiveConversationDialog.tsx
@@ -638,37 +638,44 @@ function TranscriptDialogContent({
   return (
     <>
       <DialogHeader>
-        <DialogTitle className="flex items-center gap-2">
-          <MessageSquare className="w-5 h-5" />
-          <span>Chat #{transcript.id.slice(-4)}</span>
-          <Badge
-            variant="default"
-            className={`ml-2 ${
-              sentiment === "positive"
-                ? "bg-green-600 text-white"
-                : sentiment === "negative"
-                ? "bg-red-600 text-white"
-                : "bg-purple-600 text-white"
-            }`}
-          >
-            {sentiment.charAt(0).toUpperCase() + sentiment.slice(1)}
-          </Badge>
-          {isConnected && (
+        <DialogTitle className="flex flex-col gap-1.5 items-start">
+          <span className="flex flex-wrap items-center gap-2">
+            <MessageSquare className="w-5 h-5 shrink-0" />
+            <span>Chat #{transcript.id.slice(-4)}</span>
             <Badge
-              variant="outline"
-              className="ml-2 bg-green-50 text-green-700 border-green-200"
+              variant="default"
+              className={
+                sentiment === "positive"
+                  ? "bg-green-600 text-white"
+                  : sentiment === "negative"
+                  ? "bg-red-600 text-white"
+                  : "bg-purple-600 text-white"
+              }
             >
-              Live
+              {sentiment.charAt(0).toUpperCase() + sentiment.slice(1)}
             </Badge>
-          )}
-          {hasTakenOver && (
-            <Badge
-              variant="outline"
-              className="ml-2 bg-blue-50 text-blue-700 border-blue-200"
-            >
-              Supervisor Mode
-            </Badge>
-          )}
+            {isConnected && (
+              <Badge
+                variant="outline"
+                className="bg-green-50 text-green-700 border-green-200"
+              >
+                Live
+              </Badge>
+            )}
+            {hasTakenOver && (
+              <Badge
+                variant="outline"
+                className="bg-blue-50 text-blue-700 border-blue-200"
+              >
+                Supervisor Mode
+              </Badge>
+            )}
+          </span>
+          {transcript.agent_name?.trim() ? (
+            <span className="flex items-center gap-1.5 text-sm font-normal text-muted-foreground">
+              {transcript.agent_name.trim()}
+            </span>
+          ) : null}
         </DialogTitle>
       </DialogHeader>
 

--- a/frontend/src/views/ActiveConversations/pages/ActiveConversations.tsx
+++ b/frontend/src/views/ActiveConversations/pages/ActiveConversations.tsx
@@ -33,6 +33,8 @@ const transformDashboardConversation = (item: ActiveConversationItem): ActiveCon
   supervisor_id: undefined,
   topic: item.topic || undefined,
   negative_reason: item.negative_reason || undefined,
+  agent_id: item.agent_id ?? undefined,
+  agent_name: item.agent_name ?? undefined,
 });
 
 export const enrichConversationItem = (item: ActiveConversation): Transcript => {
@@ -109,6 +111,8 @@ export const enrichConversationItem = (item: ActiveConversation): Transcript => 
     customer_ratio: item.customer_ratio || 0,
     word_count: item.word_count || 0,
     in_progress_hostility_score: item.in_progress_hostility_score || 0,
+    agent_id: item.agent_id ?? null,
+    agent_name: item.agent_name ?? null,
   };
 };
 
@@ -279,6 +283,10 @@ export const ActiveConversations = () => {
         transformed.metadata.topic = transformed.metadata.topic && transformed.metadata.topic !== "Unknown"
           ? transformed.metadata.topic
           : item.topic;
+      }
+      if (item.agent_name?.trim() && !transformed.agent_name?.trim()) {
+        transformed.agent_name = item.agent_name.trim();
+        if (item.agent_id) transformed.agent_id = item.agent_id;
       }
       setSelectedTranscript(transformed);
       setIsDialogOpen(true);

--- a/frontend/src/views/Transcripts/components/TranscriptDialog.tsx
+++ b/frontend/src/views/Transcripts/components/TranscriptDialog.tsx
@@ -10,7 +10,7 @@ import {
   Megaphone,
 } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/dialog';
-import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+import { useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import {
   getAudioUrl,
   submitConversationFeedback,
@@ -35,12 +35,42 @@ import { AgentResponseLogDialog } from '@/components/AgentResponseLogDialog';
 import { Switch } from '@/components/switch';
 import { DollarSign } from 'lucide-react';
 import { formatFeedbackDate } from '@/helpers/utils';
+import { useAgentsList } from '@/views/Analytics/hooks/useAgentsList';
 
 type TranscriptDialogProps = {
   transcript: Transcript | null;
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
+  /** When the list is filtered to one agent, pass its name so the header can show it without extra metadata on the row. */
+  agentName?: string;
 };
+
+function resolveAgentNameFromTranscript(
+  transcript: Transcript,
+  agentNameMap: Record<string, string>
+): string | undefined {
+  const attrs = transcript.custom_attributes;
+  if (!attrs) return undefined;
+
+  const entries = Object.entries(attrs);
+  const valueForKey = (...candidates: string[]) => {
+    for (const c of candidates) {
+      const cl = c.toLowerCase();
+      const hit = entries.find(([k]) => k.toLowerCase() === cl);
+      const v = hit?.[1];
+      if (typeof v === 'string' && v.trim()) return v.trim();
+    }
+    return undefined;
+  };
+
+  const fromNameKeys = valueForKey('agent_name', 'agentName', 'Agent Name', 'genassist_agent_name');
+  if (fromNameKeys) return fromNameKeys;
+
+  const idVal = valueForKey('agent_id', 'agentId', 'Agent ID', 'genassist_agent_id');
+  if (idVal && agentNameMap[idVal]) return agentNameMap[idVal];
+
+  return undefined;
+}
 
 const isCallTranscript = (transcript: Transcript | null) => {
   if (!transcript) return false;
@@ -141,7 +171,7 @@ function MessageFeedbackButton({
   );
 }
 
-export function TranscriptDialog({ transcript, isOpen, onOpenChange }: TranscriptDialogProps) {
+export function TranscriptDialog({ transcript, isOpen, onOpenChange, agentName: agentNameProp }: TranscriptDialogProps) {
   const [audioSrc, setAudioSrc] = useState<string>('');
   const [chatInput, setChatInput] = useState<string>('');
   const [aiMessagesByTranscript, setAiMessagesByTranscript] = useState<{
@@ -175,6 +205,21 @@ export function TranscriptDialog({ transcript, isOpen, onOpenChange }: Transcrip
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const isCall = isCallTranscript(localTranscript);
   const { toast } = useToast();
+  const { agentNameMap } = useAgentsList();
+
+  const headerAgentName = useMemo(() => {
+    if (!localTranscript) return undefined;
+    const fromApi = localTranscript.agent_name?.trim();
+    if (fromApi) return fromApi;
+    const fromProp = agentNameProp?.trim();
+    if (fromProp) return fromProp;
+    const fromAgentId =
+      localTranscript.agent_id && agentNameMap[localTranscript.agent_id]
+        ? agentNameMap[localTranscript.agent_id]
+        : undefined;
+    if (fromAgentId) return fromAgentId;
+    return resolveAgentNameFromTranscript(localTranscript, agentNameMap);
+  }, [localTranscript, agentNameProp, agentNameMap]);
 
   useEffect(() => {
     if (!localTranscript || !isCall) return;
@@ -405,9 +450,18 @@ export function TranscriptDialog({ transcript, isOpen, onOpenChange }: Transcrip
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-5xl">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            {isCall ? <PlayCircle className="w-5 h-5" /> : <MessageSquare className="w-5 h-5" />}
-            {isCall ? 'Call' : 'Chat'} #{(localTranscript?.metadata?.title ?? '----').slice(-4)}{' '}
+          <DialogTitle className="flex flex-col gap-1.5 items-start">
+            <span className="flex items-center gap-2">
+              {isCall ? <PlayCircle className="w-5 h-5 shrink-0" /> : <MessageSquare className="w-5 h-5 shrink-0" />}
+              <span>
+                {isCall ? 'Call' : 'Chat'} #{(localTranscript?.metadata?.title ?? '----').slice(-4)}
+              </span>
+            </span>
+            {headerAgentName ? (
+              <span className="flex items-center gap-1.5 text-sm font-normal text-muted-foreground pr-10">
+                {headerAgentName}
+              </span>
+            ) : null}
           </DialogTitle>
         </DialogHeader>
 

--- a/frontend/src/views/Transcripts/helpers/transformers.ts
+++ b/frontend/src/views/Transcripts/helpers/transformers.ts
@@ -139,6 +139,8 @@ export function transformTranscript(backendData: BackendTranscript): Transcript 
 
     return {
       id: backendData.id.toString(),
+      agent_id: backendData.agent_id != null ? String(backendData.agent_id) : null,
+      agent_name: backendData.agent_name ?? null,
       audio: audioUrl,
       create_time: backendData.created_at || new Date().toISOString(),
       recording_id: backendData.recording_id,

--- a/frontend/src/views/Transcripts/pages/Transcripts.tsx
+++ b/frontend/src/views/Transcripts/pages/Transcripts.tsx
@@ -1078,6 +1078,11 @@ const Transcripts = () => {
           transcript={selectedTranscript}
           isOpen={isModalOpen}
           onOpenChange={setIsModalOpen}
+          agentName={
+            selectedAgentId !== "all"
+              ? agents.find((a) => a.id === selectedAgentId)?.name
+              : undefined
+          }
         />
       )}
     </SidebarProvider>


### PR DESCRIPTION
## Description
- Enhanced ConversationModel to resolve agent_id and agent_name properties.
- Modified ConversationRepository and DashboardRepository to load agent data.
- Updated frontend components and interfaces to handle new agent fields.
- Improved TranscriptDialog and ActiveConversations to display agent information.


<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

<img width="2342" height="1612" alt="image" src="https://github.com/user-attachments/assets/be90d9bd-3e08-434a-a878-5eb2110a850d" />


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
