### PR TITLE
feat: implement notification read per user

### DIFF
--- a/backend/alembic/versions/00082_add_notifications_read.py
+++ b/backend/alembic/versions/00082_add_notifications_read.py
@@ -1,0 +1,73 @@
+"""add user_notification_reads
+
+Revision ID: 0684bdb56872
+Revises: k1l2m3n4o5p6
+Create Date: 2026-05-21 11:58:19.175589
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0684bdb56872"
+down_revision: Union[str, None] = "k1l2m3n4o5p6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_notification_reads",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("notification_id", sa.String(length=255), nullable=False),
+        sa.Column("read_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_by", sa.UUID(), nullable=True),
+        sa.Column("updated_by", sa.UUID(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=True,
+        ),
+        sa.Column("is_deleted", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id",
+            "notification_id",
+            name="uq_user_notification_reads_user_notification",
+        ),
+    )
+    op.create_index(
+        op.f("ix_user_notification_reads_notification_id"),
+        "user_notification_reads",
+        ["notification_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_user_notification_reads_user_id"),
+        "user_notification_reads",
+        ["user_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_user_notification_reads_user_id"),
+        table_name="user_notification_reads",
+    )
+    op.drop_index(
+        op.f("ix_user_notification_reads_notification_id"),
+        table_name="user_notification_reads",
+    )
+    op.drop_table("user_notification_reads")

--- a/backend/app/api/v1/routes/conversations.py
+++ b/backend/app/api/v1/routes/conversations.py
@@ -991,7 +991,9 @@ async def websocket_dashboard_endpoint(
     websocket: WebSocket,
     principal: SocketPrincipal = socket_auth([P.Conversation.READ_IN_PROGRESS]),
     lang: Optional[str] = Query(default="en"),
-    topics: list[str] = Query(default=["message", "update", "finalize", "hostile", "statistics"]),
+    topics: list[str] = Query(
+        default=["message", "update", "finalize", "hostile", "statistics", "notification"],
+    ),
     socket_connection_manager: SocketConnectionManager = Injected(SocketConnectionManager),
     dashboard_service: DashboardService = Injected(DashboardService),
 ):

--- a/backend/app/api/v1/routes/dashboard.py
+++ b/backend/app/api/v1/routes/dashboard.py
@@ -16,7 +16,7 @@ from app.schemas.dashboard import (
     DashboardSummaryStats,
     IntegrationsResponse,
 )
-from app.schemas.notification import NotificationFeedResponse
+from app.schemas.notification import NotificationBellResponse, NotificationFeedResponse
 from app.services.dashboard import DashboardService
 from app.services.notification_feed import NotificationFeedService
 
@@ -210,6 +210,10 @@ async def get_notifications(
         default=True,
         description="When false, omits workflow failed notifications.",
     ),
+    unread_only: bool = Query(
+        default=False,
+        description="When true, returns only unread notifications (paginated after filtering).",
+    ),
     notification_feed_service: NotificationFeedService = Injected(NotificationFeedService),
 ) -> NotificationFeedResponse:
     if not hasattr(request.state, "user") or not request.state.user:
@@ -228,5 +232,41 @@ async def get_notifications(
         include_conversation_finalized_hostility=include_conversation_finalized_hostility,
         include_workflow_failed=include_workflow_failed,
         notification_type=notification_type,
+        unread_only=unread_only,
     )
     return NotificationFeedResponse(items=items, has_more=has_more)
+
+
+@router.get(
+    "/notifications/bell",
+    response_model=NotificationBellResponse,
+    dependencies=[
+        Depends(auth),
+        Depends(permissions(P.Dashboard.READ)),
+    ],
+    summary="Get bell notification preview",
+    description="Returns the 10 most recent notifications and an unread count for the bell badge.",
+)
+async def get_notification_bell_preview(
+    request: Request,
+    include_conversation_started: bool = Query(default=True),
+    include_conversation_hostility: bool = Query(default=True),
+    include_conversation_finalized_hostility: bool = Query(default=True),
+    include_workflow_failed: bool = Query(default=True),
+    notification_feed_service: NotificationFeedService = Injected(NotificationFeedService),
+) -> NotificationBellResponse:
+    if not hasattr(request.state, "user") or not request.state.user:
+        raise AppException(status_code=401, error_key=ErrorKey.NOT_AUTHENTICATED)
+    user = request.state.user
+    gid = getattr(user, "group_id", None)
+    supervised = list(getattr(user, "supervised_group_ids", None) or [])
+    items, unread_count = await notification_feed_service.get_bell_preview(
+        user_id=user.id,
+        user_group_id=gid,
+        supervised_group_ids=supervised,
+        include_conversation_started=include_conversation_started,
+        include_conversation_hostility=include_conversation_hostility,
+        include_conversation_finalized_hostility=include_conversation_finalized_hostility,
+        include_workflow_failed=include_workflow_failed,
+    )
+    return NotificationBellResponse(items=items, unread_count=unread_count)

--- a/backend/app/api/v1/routes/notification.py
+++ b/backend/app/api/v1/routes/notification.py
@@ -8,6 +8,8 @@ from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.schemas.notification import (
     NotificationAdminTargetingRead,
+    NotificationMarkReadRequest,
+    NotificationMarkReadResponse,
     NotificationTypeTargetingRead,
     NotificationTypeTargetingUpdate,
     NotificationUserSettingsRead,
@@ -43,6 +45,29 @@ async def get_notification_user_settings(
         request.state.user.id,
         user_group_id=gid,
         supervised_group_ids=supervised,
+    )
+
+
+@router.post(
+    "/reads",
+    response_model=NotificationMarkReadResponse,
+    dependencies=[Depends(auth)],
+    summary="Mark notification instances as read",
+    description=(
+        "Persists read state per synthetic notification id for the current user. "
+        "Does not affect future notifications of the same type."
+    ),
+)
+async def mark_notifications_read(
+    dto: NotificationMarkReadRequest,
+    request: Request,
+    service: NotificationService = Injected(NotificationService),
+) -> NotificationMarkReadResponse:
+    if not hasattr(request.state, "user") or not request.state.user:
+        raise AppException(status_code=401, error_key=ErrorKey.NOT_AUTHENTICATED)
+    return await service.mark_notifications_read(
+        request.state.user.id,
+        dto.notification_ids,
     )
 
 

--- a/backend/app/core/utils/notification_ids.py
+++ b/backend/app/core/utils/notification_ids.py
@@ -1,0 +1,32 @@
+"""Validation for synthetic notification ids used by the dashboard feed."""
+
+from __future__ import annotations
+
+
+NOTIFICATION_ID_PREFIXES: tuple[str, ...] = (
+    "conversation_started:",
+    "conversation_hostility:",
+    "conversation_finalized_hostility:",
+    "workflow_failed:",
+)
+
+
+def is_valid_notification_id(notification_id: str) -> bool:
+    if not notification_id or len(notification_id) > 255:
+        return False
+    return any(notification_id.startswith(prefix) for prefix in NOTIFICATION_ID_PREFIXES)
+
+
+def normalize_notification_ids(notification_ids: list[str]) -> list[str]:
+    """Deduplicate while preserving order; drop empty/invalid ids."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in notification_ids:
+        nid = (raw or "").strip()
+        if not nid or nid in seen or not is_valid_notification_id(nid):
+            continue
+        seen.add(nid)
+        out.append(nid)
+        if len(out) >= 500:
+            break
+    return out

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -22,6 +22,7 @@ from app.db.models.role_permission import RolePermissionModel
 from app.db.models.translation import LanguageModel, TranslationKeyModel, TranslationValueModel
 from app.db.models.user import UserModel
 from app.db.models.user_notification_setting import UserNotificationSettingModel
+from app.db.models.user_notification_read import UserNotificationReadModel
 from app.db.models.user_role import UserRoleModel
 from app.db.models.notification_type import NotificationTypeModel
 from app.db.models.notification_type_recipient_group import NotificationTypeRecipientGroupModel
@@ -65,6 +66,7 @@ __all__ = [
     "UserRoleModel",
     "UserModel",
     "UserNotificationSettingModel",
+    "UserNotificationReadModel",
     "NotificationTypeModel",
     "LlmAnalystModel",
     "LlmProvidersModel",
@@ -122,6 +124,7 @@ models = [
     NodeExecutionDailyStatsModel,
     UserModel,
     UserNotificationSettingModel,
+    UserNotificationReadModel,
     NotificationTypeModel,
     RoleModel,
     PermissionModel,

--- a/backend/app/db/models/user_notification_read.py
+++ b/backend/app/db/models/user_notification_read.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class UserNotificationReadModel(Base):
+    """Per-user read receipt for a single notification instance (synthetic feed id)."""
+
+    __tablename__ = "user_notification_reads"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "notification_id",
+            name="uq_user_notification_reads_user_notification",
+        ),
+    )
+
+    user_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    notification_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    read_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/backend/app/repositories/notification.py
+++ b/backend/app/repositories/notification.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from datetime import datetime, timezone
 from uuid import UUID
 
 from injector import inject
@@ -8,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db.models.notification_type import NotificationTypeModel
 from app.db.models.notification_type_recipient_group import NotificationTypeRecipientGroupModel
 from app.db.models.notification_type_recipient_user import NotificationTypeRecipientUserModel
+from app.db.models.user_notification_read import UserNotificationReadModel
 from app.db.models.user_notification_setting import UserNotificationSettingModel
 
 NOTIFICATION_TYPE_DEFINITIONS: dict[str, dict[str, bool]] = {
@@ -269,3 +271,46 @@ class NotificationRepository:
         users_map = await self._recipient_users_by_type_id([nt.id])
         groups_map = await self._recipient_groups_by_type_id([nt.id])
         return nt, users_map.get(nt.id, set()), groups_map.get(nt.id, set())
+
+    async def get_read_notification_ids(
+        self,
+        user_id: UUID,
+        notification_ids: list[str] | None = None,
+    ) -> set[str]:
+        stmt = select(UserNotificationReadModel.notification_id).where(
+            UserNotificationReadModel.user_id == user_id,
+            UserNotificationReadModel.is_deleted == 0,
+        )
+        if notification_ids is not None:
+            if not notification_ids:
+                return set()
+            stmt = stmt.where(
+                UserNotificationReadModel.notification_id.in_(notification_ids)
+            )
+        result = await self.db.execute(stmt)
+        return set(result.scalars().all())
+
+    async def mark_notifications_read(
+        self, user_id: UUID, notification_ids: list[str]
+    ) -> int:
+        if not notification_ids:
+            return 0
+
+        existing = await self.get_read_notification_ids(user_id, notification_ids)
+        now = datetime.now(timezone.utc)
+        added = 0
+        for notification_id in notification_ids:
+            if notification_id in existing:
+                continue
+            self.db.add(
+                UserNotificationReadModel(
+                    user_id=user_id,
+                    notification_id=notification_id,
+                    read_at=now,
+                )
+            )
+            added += 1
+
+        if added:
+            await self.db.commit()
+        return added

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -12,11 +12,32 @@ class NotificationItem(BaseModel):
     type: str
     action_url: str
     group_id: str | None = None
+    read: bool = False
+
+
+class NotificationMarkReadRequest(BaseModel):
+    notification_ids: list[str] = Field(
+        ...,
+        min_length=1,
+        max_length=500,
+        description="Synthetic notification ids to mark as read for the current user.",
+    )
+
+
+class NotificationMarkReadResponse(BaseModel):
+    marked_count: int
 
 
 class NotificationFeedResponse(BaseModel):
     items: list[NotificationItem]
     has_more: bool = False
+
+
+class NotificationBellResponse(BaseModel):
+    """Latest notifications for the header bell popover."""
+
+    items: list[NotificationItem]
+    unread_count: int = 0
 
 
 class NotificationUserSettingsRead(BaseModel):

--- a/backend/app/services/notification.py
+++ b/backend/app/services/notification.py
@@ -6,9 +6,11 @@ from app.auth.utils import current_user_is_admin
 from app.db.models.notification_type import NotificationTypeModel
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
+from app.core.utils.notification_ids import normalize_notification_ids
 from app.repositories.notification import NotificationRepository
 from app.schemas.notification import (
     NotificationAdminTargetingRead,
+    NotificationMarkReadResponse,
     NotificationTypeTargetingRead,
     NotificationTypeTargetingUpdate,
     NotificationUserSettingsRead,
@@ -182,3 +184,16 @@ class NotificationService:
             user_ids=sorted(user_ids_out, key=str),
             group_ids=sorted(group_ids_out, key=str),
         )
+
+    async def mark_notifications_read(
+        self, user_id: UUID, notification_ids: list[str]
+    ) -> NotificationMarkReadResponse:
+        normalized = normalize_notification_ids(notification_ids)
+        if not normalized:
+            raise AppException(
+                status_code=400,
+                error_key=ErrorKey.MISSING_PARAMETER,
+                error_detail="No valid notification ids were provided.",
+            )
+        await self.repo.mark_notifications_read(user_id, normalized)
+        return NotificationMarkReadResponse(marked_count=len(normalized))

--- a/backend/app/services/notification_feed.py
+++ b/backend/app/services/notification_feed.py
@@ -22,7 +22,6 @@ NotificationTypeFilter = Literal[
     "conversation_finalized_hostility",
 ]
 
-
 @inject
 class NotificationFeedService:
     def __init__(
@@ -46,7 +45,65 @@ class NotificationFeedService:
         include_conversation_finalized_hostility: bool = True,
         include_workflow_failed: bool = True,
         notification_type: NotificationTypeFilter = "all",
+        unread_only: bool = False,
     ) -> tuple[list[NotificationItem], bool]:
+        all_items = await self._collect_merged_items(
+            user_id=user_id,
+            user_group_id=user_group_id,
+            supervised_group_ids=supervised_group_ids,
+            include_conversation_started=include_conversation_started,
+            include_conversation_hostility=include_conversation_hostility,
+            include_conversation_finalized_hostility=include_conversation_finalized_hostility,
+            include_workflow_failed=include_workflow_failed,
+            notification_type=notification_type,
+            merge_cap=500 if unread_only else min(max(skip + limit, limit), 500),
+        )
+        all_items = await self._apply_read_state(user_id=user_id, items=all_items)
+        if unread_only:
+            all_items = [item for item in all_items if not item.read]
+        page = all_items[skip : skip + limit]
+        has_more = len(all_items) > skip + limit
+        return page, has_more
+
+    async def get_bell_preview(
+        self,
+        *,
+        user_id: UUID,
+        user_group_id: UUID | None,
+        supervised_group_ids: list[UUID],
+        include_conversation_started: bool = True,
+        include_conversation_hostility: bool = True,
+        include_conversation_finalized_hostility: bool = True,
+        include_workflow_failed: bool = True,
+    ) -> tuple[list[NotificationItem], int]:
+        all_items = await self._collect_merged_items(
+            user_id=user_id,
+            user_group_id=user_group_id,
+            supervised_group_ids=supervised_group_ids,
+            include_conversation_started=include_conversation_started,
+            include_conversation_hostility=include_conversation_hostility,
+            include_conversation_finalized_hostility=include_conversation_finalized_hostility,
+            include_workflow_failed=include_workflow_failed,
+            notification_type="all",
+            merge_cap=500,
+        )
+        all_items = await self._apply_read_state(user_id=user_id, items=all_items)
+        unread_count = sum(1 for item in all_items if not item.read)
+        return all_items[:10], unread_count
+
+    async def _collect_merged_items(
+        self,
+        *,
+        user_id: UUID,
+        user_group_id: UUID | None,
+        supervised_group_ids: list[UUID],
+        include_conversation_started: bool,
+        include_conversation_hostility: bool,
+        include_conversation_finalized_hostility: bool,
+        include_workflow_failed: bool,
+        notification_type: NotificationTypeFilter,
+        merge_cap: int,
+    ) -> list[NotificationItem]:
         audience = await self._notification_repo.build_audience_flags_for_user(
             user_id=user_id,
             user_group_id=user_group_id,
@@ -54,7 +111,6 @@ class NotificationFeedService:
             bypass_audience_restrictions=current_user_is_admin(),
         )
 
-        fetch_cap = min(max(skip + limit, limit), 500)
         include_started = (
             include_conversation_started
             and notification_type in ("all", "conversation_started")
@@ -77,31 +133,42 @@ class NotificationFeedService:
         )
 
         started = (
-            await self._conversation_started_notifications(limit=fetch_cap)
+            await self._conversation_started_notifications(limit=merge_cap)
             if include_started
             else []
         )
         hostility = (
-            await self._hostility_notifications(limit=fetch_cap)
+            await self._hostility_notifications(limit=merge_cap)
             if include_hostility
             else []
         )
         finalized_hostile = (
-            await self._finalized_high_hostility_notifications(limit=fetch_cap)
+            await self._finalized_high_hostility_notifications(limit=merge_cap)
             if include_finalized_hostility
             else []
         )
         workflow_failed = (
-            await self._workflow_failed_notifications(limit=fetch_cap)
+            await self._workflow_failed_notifications(limit=merge_cap)
             if include_failed
             else []
         )
 
         all_items = [*started, *hostility, *finalized_hostile, *workflow_failed]
         all_items.sort(key=lambda item: item.timestamp, reverse=True)
-        page = all_items[skip : skip + limit]
-        has_more = len(all_items) > skip + limit
-        return page, has_more
+        return all_items
+
+    async def _apply_read_state(
+        self, *, user_id: UUID, items: list[NotificationItem]
+    ) -> list[NotificationItem]:
+        if not items:
+            return items
+        read_ids = await self._notification_repo.get_read_notification_ids(
+            user_id,
+            [item.id for item in items],
+        )
+        return [
+            item.model_copy(update={"read": item.id in read_ids}) for item in items
+        ]
 
     async def _conversation_started_notifications(self, limit: int) -> list[NotificationItem]:
         stmt = (

--- a/backend/tests/unit/test_notification_ids.py
+++ b/backend/tests/unit/test_notification_ids.py
@@ -1,0 +1,26 @@
+from app.core.utils.notification_ids import (
+    is_valid_notification_id,
+    normalize_notification_ids,
+)
+
+
+def test_is_valid_notification_id_accepts_known_prefixes():
+    assert is_valid_notification_id("conversation_started:550e8400-e29b-41d4-a716-446655440000")
+    assert is_valid_notification_id("workflow_failed:pipeline:550e8400-e29b-41d4-a716-446655440000")
+
+
+def test_is_valid_notification_id_rejects_unknown_prefix():
+    assert not is_valid_notification_id("unknown:abc")
+    assert not is_valid_notification_id("")
+
+
+def test_normalize_notification_ids_dedupes_and_filters():
+    raw = [
+        "conversation_started:550e8400-e29b-41d4-a716-446655440000",
+        "conversation_started:550e8400-e29b-41d4-a716-446655440000",
+        "bad-id",
+        "",
+    ]
+    assert normalize_notification_ids(raw) == [
+        "conversation_started:550e8400-e29b-41d4-a716-446655440000"
+    ]

--- a/frontend/src/components/NotificationBellPopover.tsx
+++ b/frontend/src/components/NotificationBellPopover.tsx
@@ -5,12 +5,11 @@ import { Button } from "@/components/button"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/popover"
 import { ScrollArea } from "@/components/scroll-area"
 import { formatTimeAgo } from "@/helpers/formatters"
-import { useNotifications } from "@/hooks/useNotifications"
+import { useNotificationBell } from "@/hooks/useNotifications"
 import { Notification } from "@/interfaces/notification.interface"
 import { cn } from "@/helpers/utils"
 
 type NotificationBellPopoverProps = {
-  maxItems?: number
   className?: string
   /** Smaller trigger (e.g. sidebar beside avatar) */
   compact?: boolean
@@ -66,14 +65,10 @@ function formatNotificationDescription(
 }
 
 export function NotificationBellPopover({
-  maxItems = 10,
   className,
   compact = false,
 }: NotificationBellPopoverProps) {
-  const { notifications, markAsRead } = useNotifications()
-
-  const unreadCount = notifications.filter((notification) => !notification.read).length
-  const previewItems = notifications.slice(0, maxItems)
+  const { notifications, unreadCount, markAsRead } = useNotificationBell()
 
   return (
     <Popover>
@@ -115,12 +110,12 @@ export function NotificationBellPopover({
 
         <ScrollArea className="h-[320px] max-w-full">
           <div className="min-w-0 max-w-full px-2 pt-1 pb-1">
-            {previewItems.length === 0 ? (
+            {notifications.length === 0 ? (
               <p className="px-2 py-4 text-center text-sm text-zinc-500">
                 No notifications yet.
               </p>
             ) : (
-              previewItems.map((notification) => {
+              notifications.map((notification) => {
                 const typeMeta = notificationTypeStyle[notification.type]
                 const TypeIcon = typeMeta.icon
                 const conversationShortId = getConversationShortId(notification)

--- a/frontend/src/constants/notificationQueryKeys.ts
+++ b/frontend/src/constants/notificationQueryKeys.ts
@@ -1,0 +1,19 @@
+import type { NotificationTypeFilter } from "@/services/dashboard"
+
+export const NOTIFICATION_BELL_QUERY_KEY = ["notifications-bell"] as const
+export const NOTIFICATIONS_INFINITE_QUERY_KEY = [
+  "notifications-feed-infinite",
+] as const
+
+export function notificationsInfiniteQueryKey(
+  conversationStarted: boolean,
+  notificationType: NotificationTypeFilter = "all",
+  unreadOnly = false
+): readonly [string, boolean, NotificationTypeFilter, boolean] {
+  return [
+    NOTIFICATIONS_INFINITE_QUERY_KEY[0],
+    conversationStarted,
+    notificationType,
+    unreadOnly,
+  ]
+}

--- a/frontend/src/context/WebSocketDashboardContext.tsx
+++ b/frontend/src/context/WebSocketDashboardContext.tsx
@@ -6,7 +6,13 @@ import {
   useRef,
   useState,
 } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useWebSocket } from "@/hooks/useWebSocket";
+import {
+  handleDashboardNotificationMessage,
+  type NotificationFeedIncludes,
+} from "@/hooks/notificationSocketSync";
+import { useNotificationUserSettings } from "@/hooks/useNotificationUserSettings";
 import { ActiveConversation } from "@/interfaces/liveConversation.interface";
 import {
   ConversationDataPayload,
@@ -26,9 +32,8 @@ const DEFAULT_TOPICS = [
   "update",
   "notification",
 ] as const;
-const EFFECTIVE_TOPICS: string[] = Array.from(
-  new Set([...DEFAULT_TOPICS, "message", "hostile", "update"])
-);
+/** Must include `notification` — bell real-time updates use the dashboard socket, not per-conversation sockets. */
+const EFFECTIVE_TOPICS: string[] = Array.from(new Set(DEFAULT_TOPICS));
 
 export type DashboardMessageListener = (
   data: Record<string, unknown>
@@ -91,6 +96,19 @@ export function WebSocketDashboardProvider({
   const [finalizedIds, setFinalizedIds] = useState<string[]>([]);
   const [resyncHint, setResyncHint] = useState<number>(0);
   const messageListenersRef = useRef(new Set<DashboardMessageListener>());
+  const queryClient = useQueryClient();
+  const { settings: notificationSettings } = useNotificationUserSettings();
+
+  const notificationIncludes = useMemo<NotificationFeedIncludes>(
+    () => ({
+      conversationStarted: notificationSettings.conversationStarted,
+      conversationHostility: notificationSettings.conversationHostility,
+      conversationFinalizedHostility:
+        notificationSettings.conversationFinalizedHostility,
+      workflowFailed: notificationSettings.workflowFailed,
+    }),
+    [notificationSettings]
+  );
 
   const subscribe = useCallback((listener: DashboardMessageListener) => {
     messageListenersRef.current.add(listener);
@@ -99,17 +117,23 @@ export function WebSocketDashboardProvider({
     };
   }, []);
 
-  const handleMessage = useCallback((data: Record<string, unknown>) => {
-    const topic = (data.topic || data.type) as string;
+  const handleMessage = useCallback(
+    (data: Record<string, unknown>) => {
+      const topic = (data.topic || data.type) as string;
 
-    if (topic === "notification") {
-      for (const listener of messageListenersRef.current) {
-        listener(data);
+      if (topic === "notification") {
+        handleDashboardNotificationMessage(
+          queryClient,
+          data,
+          notificationIncludes
+        );
+        for (const listener of messageListenersRef.current) {
+          listener(data);
+        }
+        return;
       }
-      return;
-    }
 
-    switch (topic) {
+      switch (topic) {
       case "conversation_list": {
         const payload = data.payload as ConversationListPayload;
         if (Array.isArray(payload.conversations)) {
@@ -276,7 +300,9 @@ export function WebSocketDashboardProvider({
       default:
         break;
     }
-  }, []);
+    },
+    [queryClient, notificationIncludes]
+  );
 
   const { isConnected, error, refetch } = useWebSocket({
     roomType: "dashboard",

--- a/frontend/src/hooks/notificationSocketSync.ts
+++ b/frontend/src/hooks/notificationSocketSync.ts
@@ -1,0 +1,186 @@
+import type { QueryClient, InfiniteData } from "@tanstack/react-query"
+
+import { Notification } from "@/interfaces/notification.interface"
+import type { NotificationTypeFilter } from "@/services/dashboard"
+import {
+  isConversationFinalizedHostilityNotification,
+  isConversationHostilityNotification,
+  isConversationStartedNotification,
+  isWorkflowFailedNotification,
+} from "@/hooks/useNotificationUserSettings"
+import {
+  NOTIFICATION_BELL_QUERY_KEY,
+  NOTIFICATIONS_INFINITE_QUERY_KEY,
+} from "@/constants/notificationQueryKeys"
+
+export type NotificationFeedIncludes = {
+  conversationStarted: boolean
+  conversationHostility: boolean
+  conversationFinalizedHostility: boolean
+  workflowFailed: boolean
+}
+
+type NotificationFeedPage = {
+  items: Notification[]
+  hasMore: boolean
+}
+
+export function mapSocketPayloadToNotification(
+  payload: Record<string, unknown>
+): Notification | null {
+  const id = String(payload.id ?? "")
+  if (!id) return null
+  const level = String(payload.type ?? "info")
+  const type: Notification["type"] =
+    level === "success" ||
+    level === "warning" ||
+    level === "error" ||
+    level === "info"
+      ? level
+      : "info"
+  return {
+    id,
+    title: String(payload.title ?? "Notification"),
+    description: String(payload.description ?? ""),
+    timestamp: String(payload.timestamp ?? new Date().toISOString()),
+    type,
+    actionUrl: payload.action_url ? String(payload.action_url) : undefined,
+    read: false,
+  }
+}
+
+export function notificationAllowedByUserSettings(
+  notificationId: string,
+  includes: NotificationFeedIncludes
+): boolean {
+  if (
+    isConversationStartedNotification(notificationId) &&
+    !includes.conversationStarted
+  ) {
+    return false
+  }
+  if (
+    isConversationHostilityNotification(notificationId) &&
+    !includes.conversationHostility
+  ) {
+    return false
+  }
+  if (
+    isConversationFinalizedHostilityNotification(notificationId) &&
+    !includes.conversationFinalizedHostility
+  ) {
+    return false
+  }
+  if (isWorkflowFailedNotification(notificationId) && !includes.workflowFailed) {
+    return false
+  }
+  return true
+}
+
+function notificationMatchesTypeFilter(
+  notificationId: string,
+  typeFilter: NotificationTypeFilter
+): boolean {
+  if (typeFilter === "all") return true
+  if (typeFilter === "conversation_started") {
+    return isConversationStartedNotification(notificationId)
+  }
+  if (typeFilter === "conversation_hostility") {
+    return isConversationHostilityNotification(notificationId)
+  }
+  if (typeFilter === "conversation_finalized_hostility") {
+    return isConversationFinalizedHostilityNotification(notificationId)
+  }
+  return false
+}
+
+function upsertNotificationList(
+  items: Notification[],
+  incoming: Notification
+): Notification[] {
+  const withoutDup = items.filter((item) => item.id !== incoming.id)
+  return [incoming, ...withoutDup]
+}
+
+export function applyIncomingNotificationToCaches(
+  queryClient: QueryClient,
+  incoming: Notification,
+  includes: NotificationFeedIncludes
+): void {
+  if (!notificationAllowedByUserSettings(incoming.id, includes)) return
+
+  queryClient.setQueriesData<{
+    items: Notification[]
+    unreadCount: number
+  }>(
+    { queryKey: NOTIFICATION_BELL_QUERY_KEY },
+    (prev) => {
+      if (!prev) return prev
+      const existing = prev.items.find((n) => n.id === incoming.id)
+      const items = upsertNotificationList(prev.items, incoming).slice(
+        0,
+        10
+      )
+      let unreadCount = prev.unreadCount
+      if (!existing && !incoming.read) {
+        unreadCount += 1
+      } else if (existing?.read && !incoming.read) {
+        unreadCount += 1
+      } else if (existing && !existing.read && incoming.read) {
+        unreadCount = Math.max(0, unreadCount - 1)
+      }
+      return {
+        items,
+        unreadCount,
+      }
+    }
+  )
+
+  queryClient.setQueriesData<InfiniteData<NotificationFeedPage>>(
+    { queryKey: NOTIFICATIONS_INFINITE_QUERY_KEY },
+    (old, { queryKey }) => {
+      if (!old?.pages?.length) return old
+
+      const key = queryKey as readonly unknown[]
+      const typeFilter = (key[2] as NotificationTypeFilter) ?? "all"
+      const unreadOnly = Boolean(key[3])
+
+      if (!notificationMatchesTypeFilter(incoming.id, typeFilter)) {
+        return old
+      }
+      if (unreadOnly && incoming.read) {
+        return old
+      }
+
+      const pages = [...old.pages]
+      const first = pages[0]
+      const mergedItems = upsertNotificationList(first.items, incoming)
+      pages[0] = { ...first, items: mergedItems }
+      return { ...old, pages }
+    }
+  )
+}
+
+export function invalidateNotificationFeeds(queryClient: QueryClient): void {
+  void queryClient.invalidateQueries({ queryKey: NOTIFICATION_BELL_QUERY_KEY })
+  void queryClient.invalidateQueries({
+    queryKey: NOTIFICATIONS_INFINITE_QUERY_KEY,
+  })
+}
+
+export function handleDashboardNotificationMessage(
+  queryClient: QueryClient,
+  data: Record<string, unknown>,
+  includes: NotificationFeedIncludes
+): boolean {
+  const topic = String(data.type ?? data.topic ?? "")
+  if (topic !== "notification") return false
+
+  const payload = (data.payload ?? {}) as Record<string, unknown>
+  const incoming = mapSocketPayloadToNotification(payload)
+  if (!incoming) return false
+
+  applyIncomingNotificationToCaches(queryClient, incoming, includes)
+  invalidateNotificationFeeds(queryClient)
+  return true
+}

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,51 +1,46 @@
-import { useCallback, useEffect, useMemo } from "react"
+import { useCallback, useEffect, useMemo, useRef } from "react"
 import {
   useQuery,
   useQueryClient,
   useInfiniteQuery,
+  useMutation,
   type InfiniteData,
 } from "@tanstack/react-query"
 import { toast } from "react-hot-toast"
 
-import { isPollEnabled } from "@/config/api"
+import { isPollEnabled, isWsEnabled } from "@/config/api"
 import { Notification } from "@/interfaces/notification.interface"
 import {
-  fetchDashboardNotifications,
   fetchDashboardNotificationsPage,
+  fetchNotificationBellPreview,
+  NOTIFICATIONS_PAGE_SIZE,
   type NotificationTypeFilter,
 } from "@/services/dashboard"
-import { useWebSocketDashboardContext } from "@/context/WebSocketDashboardContext"
+import { markNotificationsRead } from "@/services/notificationReads"
 import {
-  isConversationFinalizedHostilityNotification,
-  isConversationHostilityNotification,
-  isConversationStartedNotification,
-  isWorkflowFailedNotification,
-  useNotificationUserSettings,
-} from "@/hooks/useNotificationUserSettings"
+  NOTIFICATION_BELL_QUERY_KEY,
+  NOTIFICATIONS_INFINITE_QUERY_KEY,
+  notificationsInfiniteQueryKey,
+} from "@/constants/notificationQueryKeys"
+import { useNotificationUserSettings } from "@/hooks/useNotificationUserSettings"
 
-export const NOTIFICATIONS_QUERY_KEY = ["notifications-feed"] as const
-export const NOTIFICATIONS_INFINITE_QUERY_KEY = [
-  "notifications-feed-infinite",
-] as const
+export {
+  NOTIFICATION_BELL_QUERY_KEY,
+  NOTIFICATIONS_INFINITE_QUERY_KEY,
+  notificationsInfiniteQueryKey,
+} from "@/constants/notificationQueryKeys"
 
-export function notificationsInfiniteQueryKey(
-  conversationStarted: boolean,
-  notificationType: NotificationTypeFilter = "all"
-): readonly [string, boolean, NotificationTypeFilter] {
-  return [NOTIFICATIONS_INFINITE_QUERY_KEY[0], conversationStarted, notificationType]
-}
-
-const NOTIFICATION_READ_MAP_KEY = "notifications_read_map"
-const NOTIFICATIONS_PAGE_SIZE = 20
+const LEGACY_READ_MAP_KEY = "notifications_read_map"
+const LEGACY_READ_MAP_MIGRATED_KEY = "notifications_read_map_migrated_v1"
 
 type NotificationFeedPage = {
   items: Notification[]
   hasMore: boolean
 }
 
-function loadReadMap(): Record<string, boolean> {
+function loadLegacyReadMap(): Record<string, boolean> {
   try {
-    const raw = localStorage.getItem(NOTIFICATION_READ_MAP_KEY)
+    const raw = localStorage.getItem(LEGACY_READ_MAP_KEY)
     if (!raw) return {}
     return JSON.parse(raw) as Record<string, boolean>
   } catch {
@@ -53,209 +48,178 @@ function loadReadMap(): Record<string, boolean> {
   }
 }
 
-function saveReadMap(readMap: Record<string, boolean>): void {
-  localStorage.setItem(NOTIFICATION_READ_MAP_KEY, JSON.stringify(readMap))
+async function migrateLegacyReadMapOnce(): Promise<void> {
+  if (localStorage.getItem(LEGACY_READ_MAP_MIGRATED_KEY)) return
+  const readMap = loadLegacyReadMap()
+  const ids = Object.keys(readMap).filter((id) => readMap[id])
+  if (ids.length > 0) {
+    await markNotificationsRead(ids)
+  }
+  localStorage.removeItem(LEGACY_READ_MAP_KEY)
+  localStorage.setItem(LEGACY_READ_MAP_MIGRATED_KEY, "1")
 }
 
-function applyReadMap(items: Notification[]): Notification[] {
-  const readMap = loadReadMap()
-  return items.map((item) => ({ ...item, read: Boolean(readMap[item.id]) }))
-}
-
-export const useNotifications = () => {
-  const queryClient = useQueryClient()
-  const { subscribe } = useWebSocketDashboardContext()
+function useNotificationFeedIncludes() {
   const { settings } = useNotificationUserSettings()
-  const {
-    conversationStarted,
-    conversationHostility,
-    conversationFinalizedHostility,
-    workflowFailed,
-  } = settings
+  return useMemo(
+    () => ({
+      conversationStarted: settings.conversationStarted,
+      conversationHostility: settings.conversationHostility,
+      conversationFinalizedHostility: settings.conversationFinalizedHostility,
+      workflowFailed: settings.workflowFailed,
+    }),
+    [settings]
+  )
+}
 
-  const { data: notifications = [], refetch } = useQuery<Notification[]>({
-    queryKey: [
-      ...NOTIFICATIONS_QUERY_KEY,
-      conversationStarted,
-      conversationHostility,
-      conversationFinalizedHostility,
-      workflowFailed,
-    ],
+export function useInvalidateNotificationQueries() {
+  const queryClient = useQueryClient()
+  return useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: NOTIFICATION_BELL_QUERY_KEY })
+    void queryClient.invalidateQueries({
+      queryKey: NOTIFICATIONS_INFINITE_QUERY_KEY,
+    })
+  }, [queryClient])
+}
+
+function useMarkNotificationsReadMutation() {
+  const invalidateFeeds = useInvalidateNotificationQueries()
+
+  return useMutation({
+    mutationFn: (notificationIds: string[]) => markNotificationsRead(notificationIds),
+    onSuccess: invalidateFeeds,
+    onError: invalidateFeeds,
+  })
+}
+
+/** Bell popover: latest 10 notifications from dedicated endpoint. */
+export const useNotificationBell = () => {
+  const markReadMutation = useMarkNotificationsReadMutation()
+  const legacyMigrationStarted = useRef(false)
+  const includes = useNotificationFeedIncludes()
+
+  const feedIncludes = useMemo(
+    () => ({
+      includeConversationStarted: includes.conversationStarted,
+      includeConversationHostility: includes.conversationHostility,
+      includeConversationFinalizedHostility: includes.conversationFinalizedHostility,
+      includeWorkflowFailed: includes.workflowFailed,
+    }),
+    [includes]
+  )
+
+  const bellQueryKey = [...NOTIFICATION_BELL_QUERY_KEY, feedIncludes] as const
+
+  const { data, refetch } = useQuery({
+    queryKey: bellQueryKey,
     queryFn: async () => {
-      const items = await fetchDashboardNotifications(80, {
-        includeConversationStarted: conversationStarted,
-        includeConversationHostility: conversationHostility,
-        includeConversationFinalizedHostility: conversationFinalizedHostility,
-        includeWorkflowFailed: workflowFailed,
-      })
-      return applyReadMap(items ?? [])
+      const preview = await fetchNotificationBellPreview(feedIncludes)
+      return preview ?? { items: [], unreadCount: 0 }
     },
-    refetchInterval: isPollEnabled ? 15000 : false,
+    // Poll as fallback when WS is enabled (isPollEnabled is false then) so the bell still updates if the dashboard socket misses an event.
+    refetchInterval: isPollEnabled ? 15000 : isWsEnabled ? 30000 : false,
   })
 
-  const updateCachedNotifications = useCallback(
-    (updater: (prev: Notification[]) => Notification[]) => {
-      queryClient.setQueryData<Notification[]>(
-        [
-          ...NOTIFICATIONS_QUERY_KEY,
-          conversationStarted,
-          conversationHostility,
-          conversationFinalizedHostility,
-          workflowFailed,
-        ],
-        (prev) => updater(prev ?? [])
-      )
-    },
-    [
-      queryClient,
-      conversationStarted,
-      conversationHostility,
-      conversationFinalizedHostility,
-      workflowFailed,
-    ]
-  )
-
-  const markAllAsRead = () => {
-    const readMap = loadReadMap()
-    notifications.forEach((notification) => {
-      readMap[notification.id] = true
+  useEffect(() => {
+    if (legacyMigrationStarted.current) return
+    legacyMigrationStarted.current = true
+    void migrateLegacyReadMapOnce().then(() => {
+      void refetch()
     })
-    saveReadMap(readMap)
-    updateCachedNotifications((prev) =>
-      prev.map((notification) => ({ ...notification, read: true }))
-    )
-    toast.success("All notifications are marked as read.")
-  }
-
-  const markAsRead = (id: string) => {
-    const readMap = loadReadMap()
-    readMap[id] = true
-    saveReadMap(readMap)
-    updateCachedNotifications((prev) =>
-      prev.map((notification) =>
-        notification.id === id ? { ...notification, read: true } : notification
-      )
-    )
-  }
-
-  const handleSocketMessage = useCallback(
-    (data: Record<string, unknown>) => {
-      const topic = String(data.type ?? data.topic ?? "")
-      if (topic !== "notification") return
-      const payload = (data.payload ?? {}) as Record<string, unknown>
-      const incoming: Notification = {
-        id: String(payload.id ?? ""),
-        title: String(payload.title ?? "Notification"),
-        description: String(payload.description ?? ""),
-        timestamp: String(payload.timestamp ?? new Date().toISOString()),
-        type: (payload.type as Notification["type"]) ?? "info",
-        actionUrl: payload.action_url ? String(payload.action_url) : undefined,
-        read: Boolean(loadReadMap()[String(payload.id ?? "")]),
-      }
-
-      if (!incoming.id) return
-      if (!conversationStarted && isConversationStartedNotification(incoming.id)) {
-        return
-      }
-      if (!conversationHostility && isConversationHostilityNotification(incoming.id)) {
-        return
-      }
-      if (
-        !conversationFinalizedHostility &&
-        isConversationFinalizedHostilityNotification(incoming.id)
-      ) {
-        return
-      }
-      if (!workflowFailed && isWorkflowFailedNotification(incoming.id)) {
-        return
-      }
-
-      updateCachedNotifications((prev) => {
-        const exists = prev.some((item) => item.id === incoming.id)
-        if (exists) {
-          return prev.map((item) =>
-            item.id === incoming.id ? { ...item, ...incoming } : item
-          )
-        }
-        return [incoming, ...prev]
-      })
-
-      void queryClient.invalidateQueries({
-        queryKey: NOTIFICATIONS_INFINITE_QUERY_KEY,
-      })
-    },
-    [
-      conversationStarted,
-      conversationHostility,
-      conversationFinalizedHostility,
-      workflowFailed,
-      updateCachedNotifications,
-      queryClient,
-    ]
-  )
-
-  useEffect(() => subscribe(handleSocketMessage), [subscribe, handleSocketMessage])
+  }, [refetch])
 
   useEffect(() => {
     void refetch()
-  }, [
-    conversationStarted,
-    conversationHostility,
-    conversationFinalizedHostility,
-    workflowFailed,
-    refetch,
-  ])
+  }, [feedIncludes, refetch])
 
-  const unreadCount = useMemo(
-    () => notifications.filter((notification) => !notification.read).length,
-    [notifications]
+  const queryClient = useQueryClient()
+
+  const markAsRead = useCallback(
+    (id: string) => {
+      queryClient.setQueryData<{
+        items: Notification[]
+        unreadCount: number
+      }>(bellQueryKey, (prev) => {
+        if (!prev) return prev
+        const wasUnread = prev.items.some((n) => n.id === id && !n.read)
+        return {
+          items: prev.items.map((n) =>
+            n.id === id ? { ...n, read: true } : n
+          ),
+          unreadCount: wasUnread
+            ? Math.max(0, prev.unreadCount - 1)
+            : prev.unreadCount,
+        }
+      })
+      markReadMutation.mutate([id])
+    },
+    [queryClient, bellQueryKey, markReadMutation]
   )
 
   return {
-    notifications,
-    unreadCount,
-    markAllAsRead,
+    notifications: data?.items ?? [],
+    unreadCount: data?.unreadCount ?? 0,
     markAsRead,
     refetch,
   }
 }
 
+/** Notifications page: infinite scroll */
 export const useNotificationsInfinite = ({
   typeFilter = "all",
+  unreadOnly = false,
 }: {
   typeFilter?: NotificationTypeFilter
+  unreadOnly?: boolean
 } = {}) => {
   const queryClient = useQueryClient()
-  const { settings } = useNotificationUserSettings()
-  const {
-    conversationStarted,
-    conversationHostility,
-    conversationFinalizedHostility,
-    workflowFailed,
-  } = settings
+  const markReadMutation = useMarkNotificationsReadMutation()
+  const legacyMigrationStarted = useRef(false)
+  const includes = useNotificationFeedIncludes()
+
+  const feedIncludes = useMemo(
+    () => ({
+      includeConversationStarted: includes.conversationStarted,
+      includeConversationHostility: includes.conversationHostility,
+      includeConversationFinalizedHostility: includes.conversationFinalizedHostility,
+      includeWorkflowFailed: includes.workflowFailed,
+    }),
+    [includes]
+  )
+
   const infiniteKey = [
-    ...notificationsInfiniteQueryKey(conversationStarted, typeFilter),
-    conversationHostility,
-    conversationFinalizedHostility,
-    workflowFailed,
+    ...notificationsInfiniteQueryKey(
+      includes.conversationStarted,
+      typeFilter,
+      unreadOnly
+    ),
+    includes.conversationHostility,
+    includes.conversationFinalizedHostility,
+    includes.workflowFailed,
   ] as const
 
-  const infinite = useInfiniteQuery({
+  const {
+    data,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+    isPending,
+    isError,
+    refetch: refetchInfinite,
+  } = useInfiniteQuery({
     queryKey: infiniteKey,
     queryFn: async ({ pageParam }): Promise<NotificationFeedPage> => {
       const skip = pageParam as number
       const page = await fetchDashboardNotificationsPage(
         NOTIFICATIONS_PAGE_SIZE,
         skip,
-        conversationStarted,
-        conversationHostility,
-        conversationFinalizedHostility,
-        workflowFailed,
-        typeFilter
+        feedIncludes,
+        typeFilter,
+        unreadOnly
       )
       if (!page) return { items: [], hasMore: false }
       return {
-        items: applyReadMap(page.items),
+        items: page.items,
         hasMore: page.hasMore,
       }
     },
@@ -264,9 +228,17 @@ export const useNotificationsInfinite = ({
       lastPage.hasMore ? (lastSkip as number) + lastPage.items.length : undefined,
   })
 
+  useEffect(() => {
+    if (legacyMigrationStarted.current) return
+    legacyMigrationStarted.current = true
+    void migrateLegacyReadMapOnce().then(() => {
+      void refetchInfinite()
+    })
+  }, [refetchInfinite])
+
   const flatNotifications = useMemo(
-    () => infinite.data?.pages.flatMap((p) => p.items) ?? [],
-    [infinite.data]
+    () => data?.pages.flatMap((p) => p.items) ?? [],
+    [data]
   )
 
   const setInfinitePagesRead = useCallback(
@@ -287,83 +259,79 @@ export const useNotificationsInfinite = ({
         }
       )
     },
-    [
-      queryClient,
-      conversationStarted,
-      conversationHostility,
-      conversationFinalizedHostility,
-      workflowFailed,
-      typeFilter,
-      infiniteKey,
-    ]
+    [queryClient, infiniteKey]
+  )
+
+  const persistMarkRead = useCallback(
+    (ids: string[]) => {
+      if (ids.length === 0) return
+      markReadMutation.mutate(ids)
+    },
+    [markReadMutation]
   )
 
   const markAsRead = useCallback(
     (id: string) => {
-      const readMap = loadReadMap()
-      readMap[id] = true
-      saveReadMap(readMap)
-      setInfinitePagesRead((n) => n.id === id)
-      void queryClient.invalidateQueries({
-        queryKey: [
-          ...NOTIFICATIONS_QUERY_KEY,
-          conversationStarted,
-          conversationHostility,
-          conversationFinalizedHostility,
-          workflowFailed,
-        ],
-      })
+      if (unreadOnly) {
+        queryClient.setQueryData<InfiniteData<NotificationFeedPage>>(
+          infiniteKey,
+          (old) => {
+            if (!old) return old
+            return {
+              ...old,
+              pages: old.pages.map((page) => ({
+                ...page,
+                items: page.items.filter((n) => n.id !== id),
+              })),
+            }
+          }
+        )
+      } else {
+        setInfinitePagesRead((n) => n.id === id)
+      }
+      persistMarkRead([id])
     },
-    [
-      queryClient,
-      conversationStarted,
-      conversationHostility,
-      conversationFinalizedHostility,
-      workflowFailed,
-      setInfinitePagesRead,
-    ]
+    [unreadOnly, queryClient, infiniteKey, setInfinitePagesRead, persistMarkRead]
   )
 
   const markAllAsRead = useCallback(() => {
-    const key = infiniteKey
-    const pages = queryClient.getQueryData<InfiniteData<NotificationFeedPage>>(
-      key
-    )
-    const ids = pages?.pages.flatMap((p) => p.items.map((i) => i.id)) ?? []
-    const readMap = loadReadMap()
-    ids.forEach((id) => {
-      readMap[id] = true
-    })
-    saveReadMap(readMap)
-    setInfinitePagesRead(() => true)
-    void queryClient.invalidateQueries({
-      queryKey: [
-        ...NOTIFICATIONS_QUERY_KEY,
-        conversationStarted,
-        conversationHostility,
-        conversationFinalizedHostility,
-        workflowFailed,
-      ],
-    })
+    const unreadIds = flatNotifications
+      .filter((n) => !n.read)
+      .map((n) => n.id)
+    if (unreadIds.length === 0) return
+    if (unreadOnly) {
+      queryClient.setQueryData<InfiniteData<NotificationFeedPage>>(
+        infiniteKey,
+        (old) => {
+          if (!old) return old
+          return {
+            ...old,
+            pages: old.pages.map(() => ({ items: [], hasMore: false })),
+          }
+        }
+      )
+    } else {
+      setInfinitePagesRead(() => true)
+    }
+    persistMarkRead(unreadIds)
     toast.success("All loaded notifications are marked as read.")
   }, [
+    flatNotifications,
+    unreadOnly,
     queryClient,
-    conversationStarted,
-    conversationHostility,
-    conversationFinalizedHostility,
-    workflowFailed,
-    setInfinitePagesRead,
     infiniteKey,
+    setInfinitePagesRead,
+    persistMarkRead,
   ])
 
   return {
     notifications: flatNotifications,
-    hasNextPage: infinite.hasNextPage,
-    fetchNextPage: infinite.fetchNextPage,
-    isFetchingNextPage: infinite.isFetchingNextPage,
-    isLoading: infinite.isPending,
-    isError: infinite.isError,
-    refetch: infinite.refetch,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+    isLoading: isPending,
+    isError,
+    refetch: refetchInfinite,
     markAsRead,
     markAllAsRead,
   }

--- a/frontend/src/services/dashboard.ts
+++ b/frontend/src/services/dashboard.ts
@@ -95,7 +95,7 @@ export const fetchDashboardIntegrations = async (): Promise<IntegrationsResponse
   }
 };
 
-type NotificationFeedItemRaw = Omit<Notification, "read" | "actionUrl"> & {
+type NotificationFeedItemRaw = Omit<Notification, "actionUrl"> & {
   action_url: string;
 };
 
@@ -108,7 +108,7 @@ function mapNotificationFeedItems(
     description: item.description,
     timestamp: item.timestamp,
     type: item.type,
-    read: false,
+    read: Boolean(item.read),
     actionUrl: item.action_url,
   }));
 }
@@ -118,34 +118,60 @@ export type NotificationFeedPageResult = {
   hasMore: boolean;
 };
 
+export type NotificationBellPreview = {
+  items: Notification[];
+  unreadCount: number;
+};
+
+export const NOTIFICATIONS_PAGE_SIZE = 20;
+
 export type NotificationTypeFilter =
   | "all"
   | "conversation_started"
   | "conversation_hostility"
   | "conversation_finalized_hostility";
 
+type NotificationFeedIncludeOptions = {
+  includeConversationStarted: boolean;
+  includeConversationHostility: boolean;
+  includeConversationFinalizedHostility: boolean;
+  includeWorkflowFailed: boolean;
+};
+
+function appendNotificationFeedIncludes(
+  params: URLSearchParams,
+  includes: NotificationFeedIncludeOptions
+): void {
+  params.set(
+    "include_conversation_started",
+    String(includes.includeConversationStarted)
+  );
+  params.set(
+    "include_conversation_hostility",
+    String(includes.includeConversationHostility)
+  );
+  params.set(
+    "include_conversation_finalized_hostility",
+    String(includes.includeConversationFinalizedHostility)
+  );
+  params.set("include_workflow_failed", String(includes.includeWorkflowFailed));
+}
+
 /** Paginated notification feed (merged, sorted server-side). */
 export const fetchDashboardNotificationsPage = async (
   limit: number,
   skip: number,
-  includeConversationStarted: boolean,
-  includeConversationHostility: boolean,
-  includeConversationFinalizedHostility: boolean,
-  includeWorkflowFailed: boolean,
-  notificationType: NotificationTypeFilter = "all"
+  includes: NotificationFeedIncludeOptions,
+  notificationType: NotificationTypeFilter = "all",
+  unreadOnly = false
 ): Promise<NotificationFeedPageResult | null> => {
   try {
     const params = new URLSearchParams();
     params.set("limit", String(limit));
     params.set("skip", String(skip));
     params.set("notification_type", notificationType);
-    params.set("include_conversation_started", String(includeConversationStarted));
-    params.set("include_conversation_hostility", String(includeConversationHostility));
-    params.set(
-      "include_conversation_finalized_hostility",
-      String(includeConversationFinalizedHostility)
-    );
-    params.set("include_workflow_failed", String(includeWorkflowFailed));
+    params.set("unread_only", String(unreadOnly));
+    appendNotificationFeedIncludes(params, includes);
     const response = await apiRequest<{
       items: NotificationFeedItemRaw[];
       has_more: boolean;
@@ -161,30 +187,26 @@ export const fetchDashboardNotificationsPage = async (
   }
 };
 
-export type FetchDashboardNotificationsOptions = {
-  skip?: number;
-  includeConversationStarted?: boolean;
-  includeConversationHostility?: boolean;
-  includeConversationFinalizedHostility?: boolean;
-  includeWorkflowFailed?: boolean;
-  notificationType?: NotificationTypeFilter;
-};
-
-/** First page (or window) of notifications for sidebar / bell cache. */
-export const fetchDashboardNotifications = async (
-  limit: number = 50,
-  options?: FetchDashboardNotificationsOptions
-): Promise<Notification[] | null> => {
-  const page = await fetchDashboardNotificationsPage(
-    limit,
-    options?.skip ?? 0,
-    options?.includeConversationStarted ?? true,
-    options?.includeConversationHostility ?? true,
-    options?.includeConversationFinalizedHostility ?? true,
-    options?.includeWorkflowFailed ?? true,
-    options?.notificationType ?? "all"
-  );
-  return page?.items ?? null;
+/** Latest notifications for the header bell (max 10) plus unread badge count. */
+export const fetchNotificationBellPreview = async (
+  includes: NotificationFeedIncludeOptions
+): Promise<NotificationBellPreview | null> => {
+  try {
+    const params = new URLSearchParams();
+    appendNotificationFeedIncludes(params, includes);
+    const response = await apiRequest<{
+      items: NotificationFeedItemRaw[];
+      unread_count: number;
+    }>("get", `/dashboard/notifications/bell?${params.toString()}`);
+    if (!response) return null;
+    return {
+      items: mapNotificationFeedItems(response.items),
+      unreadCount: response.unread_count ?? 0,
+    };
+  } catch (error) {
+    console.error("Error fetching notification bell preview:", error);
+    return null;
+  }
 };
 
 /**

--- a/frontend/src/services/notificationReads.ts
+++ b/frontend/src/services/notificationReads.ts
@@ -1,0 +1,23 @@
+import { apiRequest } from "@/config/api"
+
+type MarkNotificationsReadResponse = {
+  marked_count: number
+}
+
+export async function markNotificationsRead(
+  notificationIds: string[]
+): Promise<number | null> {
+  const unique = [...new Set(notificationIds.filter(Boolean))]
+  if (unique.length === 0) return 0
+  try {
+    const response = await apiRequest<MarkNotificationsReadResponse>(
+      "post",
+      "/notifications/reads",
+      { notification_ids: unique }
+    )
+    return response?.marked_count ?? null
+  } catch (error) {
+    console.error("Error marking notifications as read:", error)
+    return null
+  }
+}

--- a/frontend/src/views/Notifications/hooks/useNotifications.ts
+++ b/frontend/src/views/Notifications/hooks/useNotifications.ts
@@ -1,1 +1,4 @@
-export { useNotifications } from "@/hooks/useNotifications"
+export {
+  useNotificationBell,
+  useNotificationsInfinite,
+} from "@/hooks/useNotifications"

--- a/frontend/src/views/Notifications/index.tsx
+++ b/frontend/src/views/Notifications/index.tsx
@@ -1,10 +1,14 @@
 import NotificationsPage from './pages/NotificationsPage'
 import { NotificationCard } from './components/NotificationCard'
-import { useNotifications } from './hooks/useNotifications'
+import {
+  useNotificationBell,
+  useNotificationsInfinite,
+} from './hooks/useNotifications'
 
 export {
   NotificationCard,
-  useNotifications
+  useNotificationBell,
+  useNotificationsInfinite,
 }
 
 export default NotificationsPage 

--- a/frontend/src/views/Notifications/pages/NotificationsPage.tsx
+++ b/frontend/src/views/Notifications/pages/NotificationsPage.tsx
@@ -98,6 +98,8 @@ const NotificationsPage = () => {
     if (!allowed) setTypeFilter("all")
   }, [typeFilter, allowedTypeFilterOptions])
 
+  const unreadOnly = activeTab === "unread"
+
   const {
     notifications,
     markAllAsRead,
@@ -106,14 +108,7 @@ const NotificationsPage = () => {
     fetchNextPage,
     isFetchingNextPage,
     isLoading,
-  } = useNotificationsInfinite({ typeFilter })
-
-  const filteredNotifications = notifications
-
-  const unreadNotifications = useMemo(
-    () => filteredNotifications.filter((n) => !n.read),
-    [filteredNotifications]
-  )
+  } = useNotificationsInfinite({ typeFilter, unreadOnly })
 
   useEffect(() => {
     const sentinel =
@@ -130,7 +125,7 @@ const NotificationsPage = () => {
           void fetchNextPage()
         }
       },
-      { root: null, rootMargin: "200px", threshold: 0 }
+      { root: null, rootMargin: "100px", threshold: 0.1 }
     )
 
     observer.observe(sentinel)
@@ -140,8 +135,8 @@ const NotificationsPage = () => {
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
-    filteredNotifications.length,
-    unreadNotifications.length,
+    notifications.length,
+    unreadOnly,
   ])
 
   return (
@@ -195,7 +190,7 @@ const NotificationsPage = () => {
               </TabsList>
               <TabsContent value="all">
                 <Card className="overflow-hidden">
-                  {isLoading && filteredNotifications.length === 0 ? (
+                  {isLoading && notifications.length === 0 ? (
                     <div className="flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground">
                       <Loader2
                         className="h-8 w-8 animate-spin"
@@ -203,7 +198,7 @@ const NotificationsPage = () => {
                       />
                       <p className="text-sm">Loading notifications…</p>
                     </div>
-                  ) : filteredNotifications.length === 0 && !hasNextPage ? (
+                  ) : notifications.length === 0 && !hasNextPage ? (
                     <EmptyNotificationsState
                       title="No notifications yet"
                       description="When there is activity you follow—such as new conversations, high hostility alerts, or workflow issues—it will show up here. You can choose which types you receive in Settings."
@@ -214,7 +209,7 @@ const NotificationsPage = () => {
                     />
                   ) : (
                     <div className="p-2">
-                      {filteredNotifications.map((notification) => (
+                      {notifications.map((notification) => (
                         <NotificationCard
                           key={notification.id}
                           notification={notification}
@@ -227,11 +222,14 @@ const NotificationsPage = () => {
                         aria-hidden
                       />
                       {isFetchingNextPage ? (
-                        <div className="flex justify-center py-3">
+                        <div className="flex items-center justify-center py-4 border-t">
                           <Loader2
                             className="h-5 w-5 animate-spin text-muted-foreground"
                             aria-label="Loading more"
                           />
+                          <span className="ml-2 text-sm text-muted-foreground">
+                            Loading more...
+                          </span>
                         </div>
                       ) : null}
                     </div>
@@ -240,7 +238,7 @@ const NotificationsPage = () => {
               </TabsContent>
               <TabsContent value="unread">
                 <Card className="overflow-hidden">
-                  {isLoading && filteredNotifications.length === 0 ? (
+                  {isLoading && notifications.length === 0 ? (
                     <div className="flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground">
                       <Loader2
                         className="h-8 w-8 animate-spin"
@@ -248,14 +246,14 @@ const NotificationsPage = () => {
                       />
                       <p className="text-sm">Loading notifications…</p>
                     </div>
-                  ) : unreadNotifications.length === 0 && !hasNextPage ? (
+                  ) : notifications.length === 0 && !hasNextPage ? (
                     <EmptyNotificationsState
                       title="No unread notifications"
                       description="You are up to date. New unread items will appear in this tab when they arrive."
                     />
                   ) : (
                     <div className="p-2">
-                      {unreadNotifications.map((notification) => (
+                      {notifications.map((notification) => (
                         <NotificationCard
                           key={notification.id}
                           notification={notification}
@@ -268,11 +266,14 @@ const NotificationsPage = () => {
                         aria-hidden
                       />
                       {isFetchingNextPage ? (
-                        <div className="flex justify-center py-3">
+                        <div className="flex justify-center py-4 border-t">
                           <Loader2
                             className="h-5 w-5 animate-spin text-muted-foreground"
                             aria-label="Loading more"
                           />
+                          <span className="ml-2 text-sm text-muted-foreground">
+                            Loading more...
+                          </span>
                         </div>
                       ) : null}
                     </div>

--- a/websocket/src/routes/dashboard.py
+++ b/websocket/src/routes/dashboard.py
@@ -18,7 +18,16 @@ async def ws_dashboard(
     auth_user: AuthenticatedUser = require_authenticated_user(
         required_permissions=["*", "read:in_progress_conversation"]
     ),
-    topics: list[str] = Query(default=["message"]),
+    topics: list[str] = Query(
+        default=[
+            "message",
+            "update",
+            "finalize",
+            "hostile",
+            "statistics",
+            "notification",
+        ],
+    ),
 ):
     manager = websocket.app.state.manager
 


### PR DESCRIPTION
## Description

implement notification read per user

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- Implemented notification read tracking with a new user_notification_reads table and associated logic.
- Created utility functions for validating and normalizing notification IDs.
- Updated notification fetching logic to support unread notifications and improved caching.
- Refactored notification-related hooks and components for better performance and maintainability.
- Added tests for notification ID validation and normalization functions.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
