### PR TITLE
feat: add customizable chat bubble icon to GenAgentChat and ChatBubble components

### DIFF
--- a/plugins/plugin-js/example-widget/config/config.example.js
+++ b/plugins/plugin-js/example-widget/config/config.example.js
@@ -22,6 +22,7 @@ window.GENASSIST_CONFIG = {
     textColor: "#000000",
     fontFamily: "Roboto, sans-serif",
     fontSize: "16px",
-    fontWeight: 400
+    fontWeight: 400,
+    chatBubbleIcon: 'message' // 'message', 'sparkles', 'x'
   }
 };

--- a/plugins/react/src/components/ChatBubble.tsx
+++ b/plugins/react/src/components/ChatBubble.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Sparkles, X } from 'lucide-react';
+import { MessageCircle, Sparkles, X } from 'lucide-react';
 
 interface ChatBubbleProps {
   showChat: boolean;
   onClick: () => void;
   primaryColor: string;
   style?: React.CSSProperties;
+  chatBubbleIcon?: 'message' | 'sparkles' | 'x';
 }
 
 export const ChatBubble: React.FC<ChatBubbleProps> = ({
@@ -13,6 +14,7 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
   onClick,
   primaryColor,
   style,
+  chatBubbleIcon,
 }) => {
   const defaultStyle: React.CSSProperties = {
     position: 'fixed',
@@ -36,9 +38,11 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
     ...style,
   };
 
+  console.log('chatBubbleIcon', chatBubbleIcon);
+
   return (
     <div style={chatBubbleStyle} onClick={onClick}>
-      {showChat ? <X size={24} /> : <Sparkles size={24} />}
+      {showChat ? <X size={24} /> : chatBubbleIcon === 'message' ? <MessageCircle size={30} /> : chatBubbleIcon === 'sparkles' ? <Sparkles size={24} /> : <X size={24} />}
     </div>
   );
 };

--- a/plugins/react/src/components/GenAgentChat.tsx
+++ b/plugins/react/src/components/GenAgentChat.tsx
@@ -1159,6 +1159,7 @@ export const GenAgentChat: React.FC<GenAgentChatProps> = ({
             onClick={() => setIsFloatingOpen(prev => !prev)}
             primaryColor={primaryColor}
             style={getPositionStyles({ position, offsetX, offsetY })}
+            chatBubbleIcon={theme?.chatBubbleIcon}
           />
         )}
 

--- a/plugins/react/src/types/index.ts
+++ b/plugins/react/src/types/index.ts
@@ -146,6 +146,7 @@ export interface GenAgentChatProps {
     fontSize?: string;
     backgroundColor?: string;
     textColor?: string;
+    chatBubbleIcon?: React.ReactElement;
   };
   headerTitle?: string;
   description?: string;


### PR DESCRIPTION
## Description
- Introduced a new `chatBubbleIcon` prop to allow selection of different icons ('message', 'sparkles', 'x') for the chat bubble.
- Updated the ChatBubble component to render the selected icon based on the new prop.
- Modified GenAgentChat to pass the `chatBubbleIcon` from the theme configuration.

This enhancement improves the visual customization options for the chat interface.


<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

<!-- Add screenshots to help explain your changes -->
Type = message
<img width="192" height="157" alt="image" src="https://github.com/user-attachments/assets/e49d297c-8a42-4262-b7ad-8b3fb5c9005b" />

Type = sparkles
<img width="147" height="111" alt="image" src="https://github.com/user-attachments/assets/db3a8360-e73c-46ee-b915-563d629e7f82" />



---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
