### PR TITLE
feat: add prepareSubmitData prop to AgentForm for disclaimer url data transformation when there is no translation

### DIFF
--- a/frontend/src/helpers/disclaimerHtml.ts
+++ b/frontend/src/helpers/disclaimerHtml.ts
@@ -1,0 +1,30 @@
+/**
+ * Normalize disclaimer HTML for storage and plugin rendering.
+ *
+ * ContentEditable entity-escapes angle brackets when users type or paste markup
+ * like `<a href="...">`. Translation textarea values stay unescaped. This decodes
+ * escaped tags and parses markup into proper DOM HTML (same shape as translations).
+ */
+export function normalizeDisclaimerHtml(html: string): string {
+  if (!html) return "";
+
+  const decodeEscapedMarkup = (source: string): string => {
+    if (!/&lt;\s*\/?\s*[a-z]/i.test(source)) return source;
+    const decoder = document.createElement("textarea");
+    decoder.innerHTML = source;
+    return decoder.value;
+  };
+
+  const container = document.createElement("div");
+  container.innerHTML = decodeEscapedMarkup(html.trim());
+
+  const serialized = container.innerHTML;
+  if (
+    serialized === "<br>" ||
+    serialized.replace(/<[^>]*>/g, "").trim() === ""
+  ) {
+    return "";
+  }
+
+  return serialized;
+}

--- a/frontend/src/views/AIAgents/components/AgentForm.tsx
+++ b/frontend/src/views/AIAgents/components/AgentForm.tsx
@@ -38,6 +38,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { TranslationDialog } from "@/views/Settings/components/TranslationDialog";
 import { DisclaimerEditor } from "@/components/DisclaimerEditor";
+import { normalizeDisclaimerHtml } from "@/helpers/disclaimerHtml";
 import { getTranslationByKey, getLanguages } from "@/services/translations";
 import { Language, Translation } from "@/interfaces/translation.interface";
 import { getTranslationCount } from "../utils";
@@ -75,6 +76,10 @@ interface AgentFormProps {
   hideButtons?: boolean;
   // Form ID for external button association
   formId?: string;
+  /** Optional hook to transform payload immediately before create/update (e.g. sheet footer submit). */
+  prepareSubmitData?: (
+    data: Omit<AgentFormData, "id">,
+  ) => Omit<AgentFormData, "id">;
 }
 
 interface TranslationTriggerProps {
@@ -178,6 +183,7 @@ const AgentForm: React.FC<AgentFormProps> = ({
   onSaved,
   hideButtons = false,
   formId,
+  prepareSubmitData,
 }: AgentFormProps) => {
   const id = data?.id;
   const navigate = useNavigate();
@@ -462,19 +468,21 @@ const AgentForm: React.FC<AgentFormProps> = ({
           }
         }
         const { id: _, ...rest } = formData;
+        const prepared = prepareSubmitData?.(rest) ?? rest;
         const dataToSubmit = {
-          ...rest,
-          possible_queries: omitEmptyStrings(rest.possible_queries),
-          thinking_phrases: omitEmptyStrings(rest.thinking_phrases),
+          ...prepared,
+          possible_queries: omitEmptyStrings(prepared.possible_queries),
+          thinking_phrases: omitEmptyStrings(prepared.thinking_phrases),
         };
         await updateAgentConfig(id, dataToSubmit);
         agentId = id;
       } else {
         const { id: _, has_welcome_image, ...rest } = formData;
+        const prepared = prepareSubmitData?.(rest) ?? rest;
         const dataToSubmit = {
-          ...rest,
-          possible_queries: omitEmptyStrings(rest.possible_queries),
-          thinking_phrases: omitEmptyStrings(rest.thinking_phrases),
+          ...prepared,
+          possible_queries: omitEmptyStrings(prepared.possible_queries),
+          thinking_phrases: omitEmptyStrings(prepared.thinking_phrases),
         };
         const agentConfig = await createAgentConfig({
           ...dataToSubmit,
@@ -1163,6 +1171,13 @@ interface AgentDialogProps {
   onSaved?: () => void;
 }
 
+const prepareAgentSheetSubmitData = (
+  data: Omit<AgentFormData, "id">,
+): Omit<AgentFormData, "id"> => ({
+  ...data,
+  input_disclaimer_html: normalizeDisclaimerHtml(data.input_disclaimer_html ?? ""),
+});
+
 export const AgentFormDialog = ({
   isOpen,
   onClose,
@@ -1215,6 +1230,7 @@ export const AgentFormDialog = ({
             onSaved={onSaved}
             hideButtons={true}
             formId={formId}
+            prepareSubmitData={prepareAgentSheetSubmitData}
           />
         </div>
         {/* Sticky Footer with Action Buttons */}


### PR DESCRIPTION
## Description

add prepareSubmitData prop to AgentForm for disclaimer url data transformation when there is no translation

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- add prepareSubmitData prop to AgentForm for disclaimer url data transformation when there is no translation

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
