### PR TITLE
feat: enhance agent and conversation repositories to bypass group-scope filtering for point lookups

### DIFF
--- a/backend/app/repositories/agent.py
+++ b/backend/app/repositories/agent.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Optional, Sequence, Tuple
 from uuid import UUID
 from injector import inject
 from sqlalchemy import select, func, asc, desc
@@ -15,6 +15,34 @@ class AgentRepository(DbRepository[AgentModel]):
     def __init__(self, db: AsyncSession):
         super().__init__(AgentModel, db)
 
+
+    async def get_by_id(
+        self, obj_id: UUID, *, eager: Sequence[str] | None = None
+    ) -> Optional[AgentModel]:
+        """Point lookup by primary key — bypass group-scope row filtering.
+
+        Operating on a specific known agent is gated by endpoint permissions;
+        group-scope filtering is only meant for list/analytics queries.
+        """
+        stmt = (
+            self._apply_eager_options(select(AgentModel), eager)
+            .where(AgentModel.id == obj_id)
+            .execution_options(**{GROUP_SCOPE_BYPASS_FLAG: True})
+        )
+        result = await self.db.execute(stmt)
+        return result.scalars().first()
+
+    async def get_by_operator_id(
+        self, operator_id: UUID, eager: Sequence[str] | None = None
+    ) -> Optional[AgentModel]:
+        """Point lookup by operator — bypass group-scope row filtering."""
+        stmt = (
+            self._apply_eager_options(select(AgentModel), eager)
+            .where(AgentModel.operator_id == operator_id)
+            .execution_options(**{GROUP_SCOPE_BYPASS_FLAG: True})
+        )
+        result = await self.db.execute(stmt)
+        return result.scalars().first()
 
     async def get_by_id_full(self, agent_id: UUID) -> AgentModel | None:
         """

--- a/backend/app/repositories/conversations.py
+++ b/backend/app/repositories/conversations.py
@@ -13,7 +13,7 @@ from app.core.utils.enums.conversation_status_enum import ConversationStatus
 from app.core.utils.enums.sentiment_enum import Sentiment
 from app.core.utils.enums.sort_direction_enum import SortDirection
 from app.core.utils.sql_alchemy_utils import add_dynamic_ordering, add_pagination
-from app.db.events.group_scope import get_group_scope_clause
+from app.db.events.group_scope import GROUP_SCOPE_BYPASS_FLAG, get_group_scope_clause
 from app.db.models.conversation import ConversationModel
 from starlette_context import context
 from starlette_context.errors import ContextDoesNotExistError
@@ -103,6 +103,11 @@ class ConversationRepository:
                 )
             )
 
+        # Point lookup by primary key: group-scope row filtering is meant for
+        # list/analytics queries, not for operating on a specific known
+        # conversation (already gated by conversation-scoped auth/permissions).
+        query = query.execution_options(**{GROUP_SCOPE_BYPASS_FLAG: True})
+
         result = await self.db.execute(query)
         return result.scalars().first()
 
@@ -156,6 +161,10 @@ class ConversationRepository:
                     TranscriptMessageModel.feedback
                 )
             )
+
+        # Point lookup by primary key: bypass group-scope row filtering (see
+        # fetch_conversation_by_id).
+        query = query.execution_options(**{GROUP_SCOPE_BYPASS_FLAG: True})
 
         result = await self.db.execute(query)
         return result.scalars().first()
@@ -634,6 +643,9 @@ class ConversationRepository:
                 .joinedload(OperatorModel.agent)
                 .joinedload(AgentModel.security_settings)
             )
+            # Point lookup used for auth/agent resolution: bypass group-scope row
+            # filtering so it also skips the joined AgentModel loader criteria.
+            .execution_options(**{GROUP_SCOPE_BYPASS_FLAG: True})
         )
         result = await self.db.execute(query)
         return result.unique().scalars().first()


### PR DESCRIPTION
## Description

enhance agent and conversation repositories to bypass group-scope filtering for point lookups

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- enhance agent and conversation repositories to bypass group-scope filtering for point lookups

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
