### PR TITLE
chore: add celery heartbeat interval

### DIFF
--- a/backend/run_celery.py
+++ b/backend/run_celery.py
@@ -1,4 +1,7 @@
 import logging
+import os
+import threading
+import time
 from celery.signals import worker_process_init
 from app import create_app
 from app.core.config.settings import settings
@@ -6,6 +9,48 @@ from app.core.config.settings import settings
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
+
+
+# Path the liveness probe checks; interval the heartbeat thread refreshes it.
+HEARTBEAT_FILE = os.environ.get("CELERY_HEARTBEAT_FILE", "/tmp/celery_heartbeat")
+HEARTBEAT_INTERVAL_SECONDS = int(os.environ.get("CELERY_HEARTBEAT_INTERVAL", "15"))
+
+
+def _start_heartbeat_thread() -> None:
+    """
+    Liveness heartbeat for the solo-pool worker.
+
+    The solo pool runs tasks inline in the worker's main thread, so Celery's
+    own control channel (``celery inspect ping``) cannot answer while a task is
+    running — a healthy long task would look dead to an ``inspect ping`` probe.
+
+    Instead we run a separate daemon thread that writes the current time to
+    ``HEARTBEAT_FILE`` every ``HEARTBEAT_INTERVAL_SECONDS``. A k8s liveness
+    probe checks that file's age (see deployment manifest). Because the task's
+    async I/O releases the GIL while awaiting, this thread keeps ticking during
+    a healthy long task, but stops if the process dies or hard-freezes — which
+    is exactly what we want the probe to restart. (A task merely hung on the
+    network is handled separately by the per-task asyncio.wait_for timeout.)
+    """
+    def _beat() -> None:
+        while True:
+            try:
+                # Write+rename so the probe never reads a half-written file.
+                tmp = f"{HEARTBEAT_FILE}.tmp"
+                with open(tmp, "w") as fh:
+                    fh.write(str(int(time.time())))
+                os.replace(tmp, HEARTBEAT_FILE)
+            except Exception as exc:  # never let the heartbeat thread die
+                logger.warning("Celery heartbeat write failed: %s", exc)
+            time.sleep(HEARTBEAT_INTERVAL_SECONDS)
+
+    thread = threading.Thread(target=_beat, name="celery-heartbeat", daemon=True)
+    thread.start()
+    logger.info(
+        "Celery heartbeat thread started (file=%s, interval=%ss)",
+        HEARTBEAT_FILE,
+        HEARTBEAT_INTERVAL_SECONDS,
+    )
 
 
 @worker_process_init.connect
@@ -33,6 +78,12 @@ if __name__ == "__main__":
     # The command will be passed as arguments when running the script
     import sys
     from celery.__main__ import main as celery_main
+
+    # Only the worker needs a liveness heartbeat (beat/flower are separate
+    # processes with their own concerns). The solo pool runs the worker in this
+    # main process, so a daemon thread here reflects worker liveness directly.
+    if "worker" in sys.argv:
+        _start_heartbeat_thread()
 
     # Pass all command line arguments to Celery
     sys.argv[0] = 'celery'  # Replace script name with 'celery'


### PR DESCRIPTION
## Description

-  add heartbeat time file write in celery every 15 seconds for usage with eks probe, 
- example: 
  livenessProbe:
    exec:
      command: ["sh", "-c", "test $(( $(date +%s) - $(stat -c %Y /tmp/celery_heartbeat) )) -lt 120"]                                                                                                                                                                                             
    initialDelaySeconds: 60
    periodSeconds: 30
    failureThreshold: 3

  Restarts the pod if the heartbeat is older than 120s.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release
