### PR TITLE
fix: add celery connection retry

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -273,6 +273,7 @@ def create_celery():
     celery_app.conf.update(
         broker_url=settings.REDIS_URL,  # Explicitly set broker URL
         result_backend=settings.REDIS_URL,  # Explicitly set result backend
+        broker_connection_retry_on_startup=True,  # Retain pre-Celery 6.0 startup retry behavior
         broker_transport_options={
             "visibility_timeout": 3600,  # 1 hour
             "fanout_prefix": True,


### PR DESCRIPTION
## Description

- add celery retry attribute to avoid no retrying failed connections with redis or other dependencies

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release