### PR TITLE
fix: Let agent iterate if parameter validation fails

### DIFF
--- a/backend/app/modules/workflow/agents/react_agent_lc.py
+++ b/backend/app/modules/workflow/agents/react_agent_lc.py
@@ -6,6 +6,8 @@ from langchain_core.messages.base import BaseMessage
 from langchain_core.tools import StructuredTool
 from langchain_core.messages import HumanMessage, AIMessage, SystemMessage, ToolMessage
 from langchain.agents import create_agent
+from langchain.agents.middleware.types import AgentMiddleware
+from langgraph.types import Command
 from app.modules.workflow.agents.base_tool import BaseTool
 from app.modules.workflow.agents.base_tool_agent import BaseToolAgent
 from app.modules.workflow.agents.agent_utils import (
@@ -17,6 +19,16 @@ import json
 
 
 logger = logging.getLogger(__name__)
+
+
+class RetryOnToolErrorMiddleware(AgentMiddleware):
+    """Route failed tool calls back to the model so it can retry."""
+
+    async def awrap_tool_call(self, request, handler):
+        result = await handler(request)
+        if isinstance(result, ToolMessage) and result.status == "error":
+            return Command(goto="model", update={"messages": [result]})
+        return result
 
 
 class ReActAgentLC(BaseToolAgent):
@@ -151,6 +163,7 @@ class ReActAgentLC(BaseToolAgent):
             model=self.llm_model,
             tools=self.lc_tools,
             system_prompt=self.system_prompt,
+            middleware=[RetryOnToolErrorMiddleware()],
         )
 
         return agent_executor


### PR DESCRIPTION
## Description

If agent returns tool result as its own response, it must check whether the result isn't a parameter validation error. If it is, agent must iterate.

## Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
