### PR TITLE
fix: conversation update when executing with tenant

### DIFF
--- a/backend/app/auth/dependencies_conversations.py
+++ b/backend/app/auth/dependencies_conversations.py
@@ -260,8 +260,6 @@ def socket_auth_conversation(required_permissions: list[str]):
         access_token: str | None = Query(default=None),
         api_key: str | None = Query(default=None),
         auth_service=Injected(AuthService),
-        conversation_service: ConversationService = Injected(ConversationService),
-        agent_config_service: AgentConfigService = Injected(AgentConfigService),
     ) -> SocketPrincipal:
         try:
             resolved_tenant_id = None
@@ -300,6 +298,10 @@ def socket_auth_conversation(required_permissions: list[str]):
             set_tenant_context(resolved_tenant_id)
             logger.debug(f"WebSocket tenant context set: {resolved_tenant_id}")
 
+            from app.dependencies.injector import injector
+            conversation_service = injector.get(ConversationService)
+            agent_config_service = injector.get(AgentConfigService)
+
             if access_token:
                 guest_handled = False
                 try:
@@ -312,7 +314,6 @@ def socket_auth_conversation(required_permissions: list[str]):
                     guest_user_id = guest_data.get("user_id")
                     if not guest_user_id:
                         raise WebSocketException(code=4401, reason="Invalid guest token")
-                    from app.dependencies.injector import injector
                     from app.services.users import UserService
 
                     user_service = injector.get(UserService)


### PR DESCRIPTION
## Description

Root cause: Injected(ConversationService) and Injected(AgentConfigService) in the WebSocket auth dependency were resolved by FastAPI's DI system before the function body ran — before set_tenant_context() was called. Their AsyncSession was bound to core_db (master) instead of the tenant DB.

Fix: Removed those two from the function parameters and resolved them via injector.get() after set_tenant_context() at line 301-303. This matches the existing pattern used for UserService at line 319.

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
