### PR TITLE
fix: fix deselecting users group in Edit User form

### DIFF
--- a/frontend/src/views/Users/components/UserDialog.tsx
+++ b/frontend/src/views/Users/components/UserDialog.tsx
@@ -33,6 +33,9 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/RadixToolt
 import { getApiUrl } from "@/config/api";
 import { isAxiosError } from "axios";
 
+// Sentinel value for the "No group" option, since Radix SelectItem cannot use an empty string value.
+const NO_GROUP_VALUE = "__none__";
+
 interface UserDialogProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
@@ -481,11 +484,17 @@ export function UserDialog({
             {userGroups.length > 0 && (
               <div className="space-y-2">
                 <Label htmlFor="group">Group</Label>
-                <Select value={groupId} onValueChange={setGroupId}>
+                <Select
+                  value={groupId || NO_GROUP_VALUE}
+                  onValueChange={(value) =>
+                    setGroupId(value === NO_GROUP_VALUE ? "" : value)
+                  }
+                >
                   <SelectTrigger>
                     <SelectValue placeholder="Select group (optional)" />
                   </SelectTrigger>
                   <SelectContent>
+                    <SelectItem value={NO_GROUP_VALUE}>No group</SelectItem>
                     {userGroups.map((g) => (
                       <SelectItem key={g.id} value={g.id}>
                         {g.name}

--- a/frontend/src/views/Users/components/UserDialog.tsx
+++ b/frontend/src/views/Users/components/UserDialog.tsx
@@ -33,7 +33,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/RadixToolt
 import { getApiUrl } from "@/config/api";
 import { isAxiosError } from "axios";
 
-// Sentinel value for the "No group" option, since Radix SelectItem cannot use an empty string value.
+// Value for the "No group" option, since Radix SelectItem cannot use an empty string value.
 const NO_GROUP_VALUE = "__none__";
 
 interface UserDialogProps {


### PR DESCRIPTION
## Description

fix deselecting users group in Edit User form

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- fix deselecting users group in Edit User form

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
