### PR TITLE
feat: implement usePersistedDateRange hook for shared date range management across components

### DIFF
--- a/frontend/src/hooks/usePersistedDateRange.ts
+++ b/frontend/src/hooks/usePersistedDateRange.ts
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useState } from "react";
+import type { DateRange } from "react-day-picker";
+
+/**
+ * Globally-shared date range, persisted to localStorage so a range selected on
+ * one page (dashboard, analytics, conversations, audit logs, ...) carries over
+ * to every other page and survives a full reload.
+ *
+ * Usage is a drop-in replacement for `useState<DateRange | undefined>`:
+ *
+ *   const [dateRange, setDateRange] = usePersistedDateRange({
+ *     from: subDays(new Date(), 30),
+ *     to: new Date(),
+ *   });
+ *
+ * Pass a different `storageKey` to persist an independent range (e.g. the
+ * analytics "compare period") under its own slot, while sharing it across the
+ * pages that expose it:
+ *
+ *   const [compare, setCompare] = usePersistedDateRange(
+ *     undefined,
+ *     COMPARE_DATE_RANGE_STORAGE_KEY,
+ *   );
+ *
+ * The `defaultValue` is only used the very first time, when nothing has been
+ * persisted yet. After that, the last selected range wins everywhere.
+ */
+export const DATE_RANGE_STORAGE_KEY = "genassist_date_range";
+export const COMPARE_DATE_RANGE_STORAGE_KEY = "genassist_compare_date_range";
+
+// Same-tab sync: the `storage` event only fires in *other* tabs, so we emit a
+// custom event to keep multiple mounted consumers in this tab in sync too.
+const DATE_RANGE_CHANGE_EVENT = "genassist:date-range-change";
+
+type StoredDateRange = { from?: string; to?: string };
+
+function serialize(range: DateRange | undefined): string {
+  const payload: StoredDateRange = {
+    from: range?.from instanceof Date ? range.from.toISOString() : undefined,
+    to: range?.to instanceof Date ? range.to.toISOString() : undefined,
+  };
+  return JSON.stringify(payload);
+}
+
+function parseDate(value: string | undefined): Date | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function deserialize(raw: string | null): DateRange | undefined {
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as StoredDateRange;
+    const from = parseDate(parsed.from);
+    const to = parseDate(parsed.to);
+    if (!from && !to) return undefined;
+    return { from, to };
+  } catch {
+    return undefined;
+  }
+}
+
+function readStored(storageKey: string): DateRange | undefined {
+  try {
+    return deserialize(localStorage.getItem(storageKey));
+  } catch {
+    return undefined;
+  }
+}
+
+export function usePersistedDateRange(
+  defaultValue: DateRange | undefined,
+  storageKey: string = DATE_RANGE_STORAGE_KEY,
+): [DateRange | undefined, (value: DateRange | undefined) => void] {
+  const [value, setValue] = useState<DateRange | undefined>(() => {
+    const stored = readStored(storageKey);
+    return stored ?? defaultValue;
+  });
+
+  const setPersisted = useCallback(
+    (next: DateRange | undefined) => {
+      setValue(next);
+      try {
+        localStorage.setItem(storageKey, serialize(next));
+      } catch {
+        // Ignore write errors (e.g. storage full / unavailable).
+      }
+      // Notify other mounted consumers of this same key in this tab.
+      window.dispatchEvent(
+        new CustomEvent(DATE_RANGE_CHANGE_EVENT, { detail: { key: storageKey } }),
+      );
+    },
+    [storageKey],
+  );
+
+  // Keep this instance in sync when its range is changed elsewhere — either in
+  // another tab (`storage`) or by another consumer in this tab (custom event).
+  useEffect(() => {
+    const sync = () => setValue(readStored(storageKey) ?? undefined);
+
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === storageKey) sync();
+    };
+    const onCustom = (event: Event) => {
+      const detailKey = (event as CustomEvent<{ key?: string }>).detail?.key;
+      if (detailKey === storageKey) sync();
+    };
+
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(DATE_RANGE_CHANGE_EVENT, onCustom);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(DATE_RANGE_CHANGE_EVENT, onCustom);
+    };
+  }, [storageKey]);
+
+  return [value, setPersisted];
+}

--- a/frontend/src/views/Analytics/pages/AgentPerformancePage.tsx
+++ b/frontend/src/views/Analytics/pages/AgentPerformancePage.tsx
@@ -26,6 +26,7 @@ import {
 import { AgentPerformancePageSkeleton } from "../components/skeletons";
 import { cn } from "@/helpers/utils";
 import { useAnalyticsFilters } from "../hooks/useAnalyticsFilters";
+import { usePersistedDateRange, COMPARE_DATE_RANGE_STORAGE_KEY } from "@/hooks/usePersistedDateRange";
 import {
   fetchAgentStatsSummary,
   fetchAgentDailyStats,
@@ -68,11 +69,14 @@ interface AgentAggregated {
 }
 
 const AgentPerformancePage = () => {
-  const [dateRange, setDateRange] = useState<DateRange | undefined>({
+  const [dateRange, setDateRange] = usePersistedDateRange({
     from: subDays(new Date(), 7),
     to: new Date(),
   });
-  const [compareDateRange, setCompareDateRange] = useState<DateRange | undefined>(undefined);
+  const [compareDateRange, setCompareDateRange] = usePersistedDateRange(
+    undefined,
+    COMPARE_DATE_RANGE_STORAGE_KEY,
+  );
 
   const {
     groups,

--- a/frontend/src/views/Analytics/pages/Analytics.tsx
+++ b/frontend/src/views/Analytics/pages/Analytics.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
 import { subDays } from "date-fns";
-import type { DateRange } from "react-day-picker";
+import { usePersistedDateRange, COMPARE_DATE_RANGE_STORAGE_KEY } from "@/hooks/usePersistedDateRange";
 import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
 import { AppSidebar } from "@/layout/app-sidebar";
 import { AnalyticsMetricsSection } from "../components/AnalyticsMetricsSection";
@@ -12,11 +11,14 @@ import { useAnalyticsData } from "../hooks/useAnalyticsData";
 import { useAnalyticsFilters } from "../hooks/useAnalyticsFilters";
 
 const AnalyticsPage = () => {
-  const [dateRange, setDateRange] = useState<DateRange | undefined>({
+  const [dateRange, setDateRange] = usePersistedDateRange({
     from: subDays(new Date(), 7),
     to: new Date(),
   });
-  const [compareDateRange, setCompareDateRange] = useState<DateRange | undefined>(undefined);
+  const [compareDateRange, setCompareDateRange] = usePersistedDateRange(
+    undefined,
+    COMPARE_DATE_RANGE_STORAGE_KEY,
+  );
   const {
     groups,
     showGroupFilter,

--- a/frontend/src/views/Analytics/pages/NodeAnalyticsPage.tsx
+++ b/frontend/src/views/Analytics/pages/NodeAnalyticsPage.tsx
@@ -23,6 +23,7 @@ import { analyticsFadeUpClass } from "../constants/animations";
 import { NodeAnalyticsTableEmptyState } from "../components/AnalyticsEmptyStates";
 import { NodeAnalyticsPageSkeleton } from "../components/skeletons";
 import { useAnalyticsFilters } from "../hooks/useAnalyticsFilters";
+import { usePersistedDateRange } from "@/hooks/usePersistedDateRange";
 import { fetchNodeDailyStats } from "@/services/analyticsReports";
 import type { NodeDailyStatsItem } from "@/interfaces/analyticsReports.interface";
 import { nodeTypeLabel } from "@/helpers/nodeTypeLabel";
@@ -40,7 +41,7 @@ interface AgentNodeBreakdown {
 }
 
 const NodeAnalyticsPage = () => {
-  const [dateRange, setDateRange] = useState<DateRange | undefined>({
+  const [dateRange, setDateRange] = usePersistedDateRange({
     from: subDays(new Date(), 7),
     to: new Date(),
   });

--- a/frontend/src/views/AuditLogs/pages/AuditLogs.tsx
+++ b/frontend/src/views/AuditLogs/pages/AuditLogs.tsx
@@ -8,8 +8,8 @@ import { useIsMobile } from "@/hooks/useMobile";
 import { Button } from "@/components/button";
 import { Select, SelectItem, SelectContent, SelectTrigger } from "@/components/select";
 import { format, startOfDay, subDays, endOfDay, addDays } from "date-fns";
-import { Calendar } from "@/components/calendar";
-import { Popover, PopoverTrigger, PopoverContent } from "@/components/popover";
+import { DateRangePicker } from "@/components/date-range-picker";
+import { usePersistedDateRange } from "@/hooks/usePersistedDateRange";
 import {
   Pagination,
   PaginationContent,
@@ -38,7 +38,7 @@ export default function AuditLogs() {
   const [selectedAuditLogId, setSelectedAuditLogId] = useState<string | null>(null);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [dateRange, setDateRange] = useState(defaultRange);
+  const [dateRange, setDateRange] = usePersistedDateRange(defaultRange);
   const [selectedUser, setSelectedUser] = useState<string | null>(null);
   const [selectedAction, setSelectedAction] = useState<string | null>(null);
   const [users, setUsers] = useState<User[]>([]);
@@ -50,8 +50,8 @@ export default function AuditLogs() {
   const pageList = getPageList(currentPage, totalPages);
 
   const fetchFilteredAuditLogs = useCallback(async () => {
-    const date_from = dateRange.from ? format(dateRange.from, "yyyy-MM-dd") : "";
-    const date_to = dateRange.to ? format(dateRange.to, "yyyy-MM-dd") : "";
+    const date_from = dateRange?.from ? format(dateRange.from, "yyyy-MM-dd") : "";
+    const date_to = dateRange?.to ? format(dateRange.to, "yyyy-MM-dd") : "";
     const action = selectedAction || "";
     const user = selectedUser ?? undefined;
     const offset = (currentPage - 1) * pageSize;
@@ -75,8 +75,8 @@ export default function AuditLogs() {
 
         const logDate = new Date(log.modified_at);
         const isWithinDateRange =
-          (!dateRange.from || logDate >= dateRange.from) &&
-          (!dateRange.to || logDate <= dateRange.to);
+          (!dateRange?.from || logDate >= dateRange.from) &&
+          (!dateRange?.to || logDate <= dateRange.to);
 
         return matchesSearchQuery && matchesUser && isWithinDateRange;
       });
@@ -88,8 +88,8 @@ export default function AuditLogs() {
     }
   }, [
     currentPage,
-    dateRange.from,
-    dateRange.to,
+    dateRange?.from,
+    dateRange?.to,
     pageSize,
     searchQuery,
     selectedAction,
@@ -142,23 +142,13 @@ export default function AuditLogs() {
 
               <div className="flex flex-col lg:flex-row justify-between gap-y-4 lg:gap-y-0 gap-x-4">
                 <div className="inline-flex gap-4">
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <Button variant="outline" className="rounded-full">
-                        {dateRange.from && dateRange.to
-                          ? `${format(dateRange.from, "PPP")} - ${format(dateRange.to, "PPP")}`
-                          : "Select a date range"}
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0" align="start">
-                      <Calendar
-                        mode="range"
-                        selected={dateRange}
-                        onSelect={(range) => setDateRange({ from: range?.from, to: range?.to })}
-                        numberOfMonths={1}
-                      />
-                    </PopoverContent>
-                  </Popover>
+                  <DateRangePicker
+                    value={dateRange}
+                    onChange={setDateRange}
+                    align="start"
+                    placeholder="Select a date range"
+                    triggerClassName="rounded-full"
+                  />
 
                   <div className="w-40">
                     <Select value={selectedUser ?? ""} onValueChange={(value) => setSelectedUser(value === "" ? null : value)}>

--- a/frontend/src/views/Index.tsx
+++ b/frontend/src/views/Index.tsx
@@ -1,14 +1,13 @@
 import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
 import { AppSidebar } from "@/layout/app-sidebar";
 import { DateRangePicker } from "@/components/date-range-picker";
-import { useState } from "react";
 import { subDays, differenceInCalendarDays } from "date-fns";
-import type { DateRange } from "react-day-picker";
+import { usePersistedDateRange } from "@/hooks/usePersistedDateRange";
 import { KPISection } from "./Analytics";
 import { ActiveConversations } from "./ActiveConversations/pages/ActiveConversations";
 
 const Index = () => {
-  const [dateRange, setDateRange] = useState<DateRange | undefined>({
+  const [dateRange, setDateRange] = usePersistedDateRange({
     from: subDays(new Date(), 30),
     to: new Date(),
   });

--- a/frontend/src/views/Transcripts/pages/Transcripts.tsx
+++ b/frontend/src/views/Transcripts/pages/Transcripts.tsx
@@ -60,6 +60,7 @@ import { useAgentsList } from "@/views/Analytics/hooks/useAgentsList";
 import { DateRangePicker } from "@/components/date-range-picker";
 import type { DateRange } from "react-day-picker";
 import { format, subDays } from "date-fns";
+import { usePersistedDateRange } from "@/hooks/usePersistedDateRange";
 import { Switch } from "@/components/switch";
 import { Label } from "@/components/label";
 import { fetchCustomAttributeKeys } from "@/services/analyticsReports";
@@ -153,7 +154,7 @@ const Transcripts = () => {
     return "all";
   };
   const [statusFilter, setStatusFilter] = useState<StatusFilter>(initStatusFilter);
-  const [dateRange, setDateRange] = useState<DateRange | undefined>({
+  const [dateRange, setDateRange] = usePersistedDateRange({
     from: subDays(new Date(), 7),
     to: new Date(),
   });


### PR DESCRIPTION
## Description

implement usePersistedDateRange hook for shared date range management across components

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- implement usePersistedDateRange hook for shared date range management across components

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
