### PR TITLE
chore: improve dashboard speeds

### DIFF
--- a/backend/alembic/versions/00083_add_test.py
+++ b/backend/alembic/versions/00083_add_test.py
@@ -1,0 +1,80 @@
+"""add_dashboard_analytics_indexes
+
+Adds indexes supporting the dashboard analytics endpoints
+(/dashboard/summary, /dashboard/agents):
+
+- transcript_messages (conversation_id, sequence_number): supports the
+  m1->m2 self-join used to compute average response time.
+- conversations (conversation_date): supports the date-range filters in
+  get_avg_response_time / get_workflow_runs_count and the now date-bounded
+  per-operator response-time query.
+- conversations (operator_id): supports the per-operator filters/group-bys
+  in get_agents_with_stats.
+
+Indexes are created CONCURRENTLY to avoid taking a blocking lock on these
+large tables in production.
+
+Revision ID: 753019ca4eb2
+Revises: 5d4d7a65f44b
+Create Date: 2026-06-16 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '753019ca4eb2'
+down_revision: Union[str, None] = '5d4d7a65f44b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_transcript_messages_conv_seq",
+            "transcript_messages",
+            ["conversation_id", "sequence_number"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.create_index(
+            "ix_conversations_conversation_date",
+            "conversations",
+            ["conversation_date"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.create_index(
+            "ix_conversations_operator_id",
+            "conversations",
+            ["operator_id"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_conversations_operator_id",
+            table_name="conversations",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.drop_index(
+            "ix_conversations_conversation_date",
+            table_name="conversations",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.drop_index(
+            "ix_transcript_messages_conv_seq",
+            table_name="transcript_messages",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/backend/app/repositories/dashboard.py
+++ b/backend/app/repositories/dashboard.py
@@ -236,7 +236,9 @@ class DashboardRepository:
             conv_count_by_operator = {row.operator_id: row.count for row in conv_count_result.all()}
 
         # Fetch avg response times for all operators in a single query
-        avg_response_by_operator = await self._calculate_response_times_for_operators(operator_ids)
+        avg_response_by_operator = await self._calculate_response_times_for_operators(
+            operator_ids, from_date=from_date, to_date=to_date
+        )
 
         agent_stats = []
         for agent in agents:
@@ -258,7 +260,10 @@ class DashboardRepository:
         return agent_stats
 
     async def _calculate_response_times_for_operators(
-        self, operator_ids: list[UUID]
+        self,
+        operator_ids: list[UUID],
+        from_date: Optional[datetime] = None,
+        to_date: Optional[datetime] = None,
     ) -> dict[UUID, int]:
         """Calculate average response time per operator in a single SQL query."""
         if not operator_ids:
@@ -287,6 +292,11 @@ class DashboardRepository:
             )
             .group_by(ConversationModel.operator_id)
         )
+
+        if from_date:
+            query = query.where(ConversationModel.conversation_date >= from_date)
+        if to_date:
+            query = query.where(ConversationModel.conversation_date <= to_date)
 
         result = await self.db.execute(query)
         return {

--- a/backend/app/repositories/dashboard.py
+++ b/backend/app/repositories/dashboard.py
@@ -3,17 +3,16 @@ from typing import Optional
 from uuid import UUID
 
 from injector import inject
-from sqlalchemy import and_, case, func, or_
+from sqlalchemy import and_, case, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
-from sqlalchemy.orm import aliased, selectinload
+from sqlalchemy.orm import selectinload
 
 from app.db.events.group_scope import get_group_scope_clause
 from app.db.models.agent import AgentModel
 from app.db.models.agent_execution_daily_stats import AgentExecutionDailyStatsModel
 from app.db.models.app_settings import AppSettingsModel
 from app.db.models.conversation import ConversationModel
-from app.db.models.message_model import TranscriptMessageModel
 from app.db.models.operator import OperatorModel
 
 
@@ -59,34 +58,26 @@ class DashboardRepository:
         from_date: Optional[datetime] = None,
         to_date: Optional[datetime] = None
     ) -> int:
-        """Get average response time in milliseconds calculated from message timestamps.
+        """Get average response time in milliseconds from the pre-aggregated daily stats.
 
-        Calculates the actual time between customer messages and agent responses
-        by analyzing consecutive message pairs entirely in SQL.
+        Reads the twice-daily aggregated agent_execution_daily_stats table instead of
+        recomputing from raw transcript messages on every request. Days are combined as
+        an execution-count-weighted average, matching the analytics summary convention.
         """
-        m1 = aliased(TranscriptMessageModel, name="m1")
-        m2 = aliased(TranscriptMessageModel, name="m2")
-
-        query = (
-            select(func.avg((m2.start_time - m1.end_time) * 1000))
-            .select_from(m1)
-            .join(m2, and_(
-                m2.conversation_id == m1.conversation_id,
-                m2.sequence_number == m1.sequence_number + 1,
-                m2.start_time >= m1.end_time,
-            ))
-            .join(ConversationModel, ConversationModel.id == m1.conversation_id)
-            .where(
-                ConversationModel.is_deleted == 0,
-                or_(m1.speaker.ilike("%customer%"), func.lower(m1.speaker) == "speaker_00"),
-                or_(m2.speaker.ilike("%agent%"), func.lower(m2.speaker) == "speaker_01"),
-            )
+        weighted_sum = func.sum(
+            AgentExecutionDailyStatsModel.avg_response_ms
+            * AgentExecutionDailyStatsModel.execution_count
         )
+        total_executions = func.sum(AgentExecutionDailyStatsModel.execution_count)
+
+        query = select(
+            weighted_sum / func.nullif(total_executions, 0)
+        ).where(AgentExecutionDailyStatsModel.is_deleted == 0)
 
         if from_date:
-            query = query.where(ConversationModel.conversation_date >= from_date)
+            query = query.where(AgentExecutionDailyStatsModel.stat_date >= from_date)
         if to_date:
-            query = query.where(ConversationModel.conversation_date <= to_date)
+            query = query.where(AgentExecutionDailyStatsModel.stat_date <= to_date)
 
         result = await self.db.execute(query)
         avg = result.scalar()
@@ -235,9 +226,11 @@ class DashboardRepository:
             conv_count_result = await self.db.execute(conv_count_query)
             conv_count_by_operator = {row.operator_id: row.count for row in conv_count_result.all()}
 
-        # Fetch avg response times for all operators in a single query
-        avg_response_by_operator = await self._calculate_response_times_for_operators(
-            operator_ids, from_date=from_date, to_date=to_date
+        # Fetch avg response times per agent from the pre-aggregated daily stats.
+        # agent <-> operator is 1:1 (AgentModel.operator_id is unique), and the
+        # daily-stats table is keyed by agent_id, so we look up by agent.id.
+        avg_response_by_agent = await self._calculate_response_times_for_agents(
+            [a.id for a in agents], from_date=from_date, to_date=to_date
         )
 
         agent_stats = []
@@ -253,54 +246,53 @@ class DashboardRepository:
                 "is_active": agent.is_active == 1,
                 "conversations_today": conv_count_by_operator.get(agent.operator_id, 0),
                 "resolution_rate": operator_stats.avg_resolution_rate if operator_stats else 0,
-                "avg_response_time_ms": avg_response_by_operator.get(agent.operator_id, 0),
+                "avg_response_time_ms": avg_response_by_agent.get(agent.id, 0),
                 "cost": cost_by_agent.get(agent.id, 0.0),
             })
 
         return agent_stats
 
-    async def _calculate_response_times_for_operators(
+    async def _calculate_response_times_for_agents(
         self,
-        operator_ids: list[UUID],
+        agent_ids: list[UUID],
         from_date: Optional[datetime] = None,
         to_date: Optional[datetime] = None,
     ) -> dict[UUID, int]:
-        """Calculate average response time per operator in a single SQL query."""
-        if not operator_ids:
+        """Average response time per agent from the pre-aggregated daily stats.
+
+        Reads agent_execution_daily_stats (populated by the twice-daily Celery job)
+        instead of recomputing from raw transcript messages. Days are combined as an
+        execution-count-weighted average, matching the analytics summary convention.
+        """
+        if not agent_ids:
             return {}
 
-        m1 = aliased(TranscriptMessageModel, name="m1")
-        m2 = aliased(TranscriptMessageModel, name="m2")
+        weighted_sum = func.sum(
+            AgentExecutionDailyStatsModel.avg_response_ms
+            * AgentExecutionDailyStatsModel.execution_count
+        )
+        total_executions = func.sum(AgentExecutionDailyStatsModel.execution_count)
 
         query = (
             select(
-                ConversationModel.operator_id,
-                func.avg((m2.start_time - m1.end_time) * 1000).label("avg_ms"),
+                AgentExecutionDailyStatsModel.agent_id,
+                (weighted_sum / func.nullif(total_executions, 0)).label("avg_ms"),
             )
-            .select_from(m1)
-            .join(m2, and_(
-                m2.conversation_id == m1.conversation_id,
-                m2.sequence_number == m1.sequence_number + 1,
-                m2.start_time >= m1.end_time,
-            ))
-            .join(ConversationModel, ConversationModel.id == m1.conversation_id)
             .where(
-                ConversationModel.operator_id.in_(operator_ids),
-                ConversationModel.is_deleted == 0,
-                or_(m1.speaker.ilike("%customer%"), func.lower(m1.speaker) == "speaker_00"),
-                or_(m2.speaker.ilike("%agent%"), func.lower(m2.speaker) == "speaker_01"),
+                AgentExecutionDailyStatsModel.agent_id.in_(agent_ids),
+                AgentExecutionDailyStatsModel.is_deleted == 0,
             )
-            .group_by(ConversationModel.operator_id)
+            .group_by(AgentExecutionDailyStatsModel.agent_id)
         )
 
         if from_date:
-            query = query.where(ConversationModel.conversation_date >= from_date)
+            query = query.where(AgentExecutionDailyStatsModel.stat_date >= from_date)
         if to_date:
-            query = query.where(ConversationModel.conversation_date <= to_date)
+            query = query.where(AgentExecutionDailyStatsModel.stat_date <= to_date)
 
         result = await self.db.execute(query)
         return {
-            row.operator_id: int(row.avg_ms)
+            row.agent_id: int(row.avg_ms)
             for row in result.all()
             if row.avg_ms is not None
         }


### PR DESCRIPTION
## Description

- remove calculation with join on transcript messages and use agent aggregation stats for avg response time instead
- add interval dates to the avg_response time query
- add indexes to conversation table for:  ["conversation_date"], ["operator_id"] and transcript_messages for ["conversation_id", "sequence_number"] to speed up relevant queries

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release