### PR TITLE
chore: limit node inputs to a single connection per handle

### DIFF
--- a/frontend/src/views/AIAgents/Workflows/hooks/useSchemaValidation.ts
+++ b/frontend/src/views/AIAgents/Workflows/hooks/useSchemaValidation.ts
@@ -26,7 +26,7 @@ const findHandler = (handlers: NodeHandler[], id: string): NodeHandler | undefin
 };
 
 export const useSchemaValidation = () => {
-  const { getNode } = useReactFlow();
+  const { getNode, getEdges } = useReactFlow();
 
   const validateConnection = useCallback((connection: Connection) => {
     if (!connection.source || !connection.target || !connection.sourceHandle || !connection.targetHandle) return false;
@@ -49,6 +49,23 @@ export const useSchemaValidation = () => {
       return false;
     }
 
+    // Restrict each target (input) handle to a single incoming connection.
+    // The backend only supports one upstream input per node — except:
+    //   - aggregator nodes, which are designed to merge many branches, and
+    //   - tool-attachment handles, where many tools/MCPs feed one agent.
+    const allowsMultipleInputs =
+      targetNode.type === 'aggregatorNode' ||
+      targetHandler.compatibility === 'tools';
+
+    if (!allowsMultipleInputs) {
+      const handleAlreadyConnected = getEdges().some(
+        (edge) =>
+          edge.target === connection.target &&
+          edge.targetHandle === connection.targetHandle,
+      );
+      if (handleAlreadyConnected) return false;
+    }
+
     // If either handler doesn't have a schema, allow the connection
     if (!sourceHandler.schema || !targetHandler.schema) return true;
 
@@ -63,7 +80,7 @@ export const useSchemaValidation = () => {
     }
 
     return true;
-  }, [getNode]);
+  }, [getNode, getEdges]);
 
   return {
     validateConnection


### PR DESCRIPTION
## Description

fix: limit node inputs to a single connection per handle

Each target (input) handle now accepts only one incoming edge, matching
the backend, which supports a single upstream input per node. Exceptions:
aggregator nodes (built to merge many branches) and tool-attachment
handles (so an agent can still wire up multiple tools/MCPs).

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release