### PR TITLE
chore: limit node inputs to a single connection per handle - REVERT

### DIFF
--- a/frontend/src/views/AIAgents/Workflows/hooks/useSchemaValidation.ts
+++ b/frontend/src/views/AIAgents/Workflows/hooks/useSchemaValidation.ts
@@ -26,7 +26,7 @@ const findHandler = (handlers: NodeHandler[], id: string): NodeHandler | undefin
 };
 
 export const useSchemaValidation = () => {
-  const { getNode, getEdges } = useReactFlow();
+  const { getNode } = useReactFlow();
 
   const validateConnection = useCallback((connection: Connection) => {
     if (!connection.source || !connection.target || !connection.sourceHandle || !connection.targetHandle) return false;
@@ -49,23 +49,6 @@ export const useSchemaValidation = () => {
       return false;
     }
 
-    // Restrict each target (input) handle to a single incoming connection.
-    // The backend only supports one upstream input per node — except:
-    //   - aggregator nodes, which are designed to merge many branches, and
-    //   - tool-attachment handles, where many tools/MCPs feed one agent.
-    const allowsMultipleInputs =
-      targetNode.type === 'aggregatorNode' ||
-      targetHandler.compatibility === 'tools';
-
-    if (!allowsMultipleInputs) {
-      const handleAlreadyConnected = getEdges().some(
-        (edge) =>
-          edge.target === connection.target &&
-          edge.targetHandle === connection.targetHandle,
-      );
-      if (handleAlreadyConnected) return false;
-    }
-
     // If either handler doesn't have a schema, allow the connection
     if (!sourceHandler.schema || !targetHandler.schema) return true;
 
@@ -80,7 +63,7 @@ export const useSchemaValidation = () => {
     }
 
     return true;
-  }, [getNode, getEdges]);
+  }, [getNode]);
 
   return {
     validateConnection


### PR DESCRIPTION
Reverts RitechSolutions/genassist#851