### PR TITLE
fix: Retain context after HITL node resumes

### DIFF
--- a/backend/app/modules/workflow/engine/nodes/human_in_the_loop_node.py
+++ b/backend/app/modules/workflow/engine/nodes/human_in_the_loop_node.py
@@ -1,7 +1,7 @@
 """Human In The Loop node that collects user data via a dynamic form."""
 
-from typing import Any, Dict
 import logging
+from typing import Any, Dict
 
 from app.modules.workflow.engine.base_node import BaseNode
 from app.modules.workflow.engine.workflow_state import WorkflowPausedException
@@ -63,6 +63,19 @@ class HumanInTheLoopNode(BaseNode):
             if paused_outputs:
                 self.get_state().node_outputs.update(paused_outputs)
 
+            # Fill in context captured before the pause (session, conversation_history,
+            # stateful values) that the chat input node computed and that never re-runs on
+            # resume. The resume request itself carries the real turn — the form-submission
+            # message and current metadata — so it wins; the snapshot only backfills what
+            # the resume request lacks. The invisible start-form trigger flag must not leak
+            # into this real turn.
+            paused_context = await self.get_memory().get_metadata("paused_request_context")
+            if paused_context:
+                self.get_state().restore_resume_context(
+                    paused_context,
+                    drop_keys={"start_form_trigger", "message"},
+                )
+
             cancelled = self.state.initial_values.get("human_in_the_loop_cancelled", False)
             output_data = {**human_in_the_loop_from_form, "_cancelled": True} if cancelled else human_in_the_loop_from_form
             # Cache for ask_once
@@ -77,9 +90,16 @@ class HumanInTheLoopNode(BaseNode):
             logger.info(f"HumanInTheLoopNode {self.node_id}: using provided input values")
             return provided_values
 
-        # 4. Pause workflow — save state and raise exception to propagate through all layers
+        # 4. Pause workflow — save state and raise exception to propagate through all layers.
+        # Snapshot both the node outputs produced so far and the request context (message,
+        # session, conversation_history, stateful values, metadata) so the resume — which
+        # starts a fresh state at this node and skips the upstream chat input — continues as
+        # the same logical execution rather than with blank inputs.
         await self.get_memory().set_metadata(
             "paused_node_outputs", self.get_state().node_outputs
+        )
+        await self.get_memory().set_metadata(
+            "paused_request_context", self.get_state().capture_resume_context()
         )
 
         form_schema = {

--- a/backend/app/modules/workflow/engine/workflow_state.py
+++ b/backend/app/modules/workflow/engine/workflow_state.py
@@ -2,6 +2,7 @@
 Enhanced workflow state management for execution tracking and performance metrics.
 """
 
+import copy
 import logging
 import time
 import uuid
@@ -452,6 +453,61 @@ class WorkflowState:
     def get_memory(self) -> BaseConversationMemory:
         """Get the conversation memory for this workflow execution"""
         return self.memory
+
+    def capture_resume_context(self) -> dict:
+        """Snapshot the request context a paused execution needs to resume as the same
+        logical run.
+
+        A node that pauses (e.g. HumanInTheLoop) stores this; on resume the engine starts
+        a fresh WorkflowState at the paused node, so without rehydration the original
+        request inputs and session (the message, conversation_history, stateful values and
+        any metadata the pre-pause nodes saw) would be lost. node_outputs is captured
+        separately by the pausing node.
+        """
+        # Deep copy so a later resume (which restores this) can't alias and mutate the
+        # values this execution is still using; also matches the JSON round-trip the Redis
+        # memory backend performs, keeping behaviour identical across backends.
+        return copy.deepcopy({
+            "initial_values": self.initial_values,
+            "session": self.get_session(),
+        })
+
+    def restore_resume_context(
+        self, snapshot: dict, drop_keys: set[str] | None = None
+    ) -> None:
+        """Rehydrate request context captured by capture_resume_context() into this state.
+
+        The CURRENT (resume) request defines the turn — its message, metadata and submitted
+        form data always win. The snapshot only fills in context the resume request lacks
+        (e.g. stateful/session values the pre-pause chat input computed), so downstream
+        nodes keep that context without losing the user's actual submission. Keys in
+        drop_keys are never imported from the snapshot — turn-specific flags (e.g. the
+        invisible start-form trigger) must not leak into the resumed turn.
+        """
+        if not snapshot:
+            return
+        drop_keys = drop_keys or set()
+
+        saved_initial = {
+            k: v
+            for k, v in (snapshot.get("initial_values") or {}).items()
+            if k not in drop_keys
+        }
+        if saved_initial:
+            # Current request wins; the snapshot only fills keys the resume request lacks.
+            merged = {**saved_initial, **self.initial_values}
+            self.initial_values = merged
+            self.session = merged
+            self._apply_initial_values(merged)
+
+        saved_session = snapshot.get("session")
+        if saved_session:
+            current_session = self.get_session()
+            filled = {
+                **{k: v for k, v in saved_session.items() if k not in drop_keys},
+                **current_session,
+            }
+            self.set_value("session", filled)
 
     def record_workflow_output(self, output: Any) -> None:
         """Record the final output of the workflow execution"""


### PR DESCRIPTION
## Description

Snapshot the context and prior node outputs at the Human In The Loop (HITL) node and backfill them on resume, so nodes after it keep everything that ran before.

## Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
