### PR TITLE
feat: add llm fallback strategies

### DIFF
--- a/backend/alembic/versions/00088_add_fallback_chains_table.py
+++ b/backend/alembic/versions/00088_add_fallback_chains_table.py
@@ -15,7 +15,7 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 
-revision: str = "c4d5e6f7a8b9"
+revision: str = "66c71887a6da"
 down_revision: Union[str, None] = "9f1df080dab5"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/alembic/versions/00088_add_fallback_chains_table.py
+++ b/backend/alembic/versions/00088_add_fallback_chains_table.py
@@ -1,0 +1,43 @@
+"""Add fallback_chains table
+
+Reusable, named ordered lists of LLM providers (with a retry policy) that workflow
+LLM/Agent nodes can reference for automatic provider failover.
+
+Revision ID: c4d5e6f7a8b9
+Revises: 9f1df080dab5
+Create Date: 2026-06-30 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "c4d5e6f7a8b9"
+down_revision: Union[str, None] = "9f1df080dab5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "fallback_chains",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=True),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("provider_ids", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("retry_policy", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("is_active", sa.Integer(), nullable=True, server_default="1"),
+        sa.Column("is_deleted", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_by", sa.UUID(), nullable=True),
+        sa.Column("updated_by", sa.UUID(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("fallback_chains")

--- a/backend/alembic/versions/00090_add_fallback_chains_table.py
+++ b/backend/alembic/versions/00090_add_fallback_chains_table.py
@@ -3,8 +3,8 @@
 Reusable, named ordered lists of LLM providers (with a retry policy) that workflow
 LLM/Agent nodes can reference for automatic provider failover.
 
-Revision ID: c4d5e6f7a8b9
-Revises: 9f1df080dab5
+Revision ID: 66c71887a6da
+Revises: b2c3d4e5f6a7
 Create Date: 2026-06-30 00:00:00.000000
 
 """
@@ -16,7 +16,7 @@ from sqlalchemy.dialects import postgresql
 
 
 revision: str = "66c71887a6da"
-down_revision: Union[str, None] = "9f1df080dab5"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/api/v1/routes/__init__.py
+++ b/backend/app/api/v1/routes/__init__.py
@@ -16,6 +16,7 @@ from app.api.v1.routes import (
     customers,
     dashboard,
     datasources,
+    fallback_chains,
     feature_flags,
     file_manager,
     gmail,
@@ -102,6 +103,7 @@ router.include_router(voice_live.router, prefix="/voice", tags=["Voice"])
 # router.include_router(conversation_analysis.router, prefix="/conversation-analysis", tags=["ConversationAnalysisRead"])
 
 router.include_router(llm_providers.router, prefix="/llm-providers", tags=["LlmProviders"])
+router.include_router(fallback_chains.router, prefix="/fallback-chains", tags=["FallbackChains"])
 router.include_router(audio_providers.router, prefix="/audio-providers", tags=["AudioProviders"])
 router.include_router(llm_cost_rates.router, prefix="/llm-cost-rates", tags=["LlmCostRates"])
 router.include_router(llm_analysts.router, prefix="/llm-analyst", tags=["LlmAnalyst"])

--- a/backend/app/api/v1/routes/fallback_chains.py
+++ b/backend/app/api/v1/routes/fallback_chains.py
@@ -1,0 +1,86 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from fastapi_injector import Injected
+
+from app.auth.dependencies import auth, permissions
+from app.cache.redis_cache import invalidate_fallback_chain_cache
+from app.core.permissions.constants import Permissions as P
+from app.schemas.fallback_chain import (
+    FallbackChainCreate,
+    FallbackChainMinimal,
+    FallbackChainRead,
+    FallbackChainUpdate,
+)
+from app.services.fallback_chains import FallbackChainService
+
+router = APIRouter()
+
+
+@router.get(
+    "",
+    response_model=list[FallbackChainRead],
+    dependencies=[Depends(auth), Depends(permissions(P.LlmProvider.READ))],
+)
+async def get_all(service: FallbackChainService = Injected(FallbackChainService)):
+    return await service.get_all()
+
+
+@router.get(
+    "/minimal",
+    response_model=list[FallbackChainMinimal],
+    dependencies=[Depends(auth), Depends(permissions(P.LlmProvider.READ))],
+)
+async def get_all_minimal(service: FallbackChainService = Injected(FallbackChainService)):
+    return await service.get_all_minimal()
+
+
+@router.get(
+    "/{chain_id}",
+    response_model=FallbackChainRead,
+    dependencies=[Depends(auth), Depends(permissions(P.LlmProvider.READ))],
+)
+async def get(chain_id: UUID, service: FallbackChainService = Injected(FallbackChainService)):
+    return await service.get_by_id(chain_id)
+
+
+@router.post(
+    "",
+    response_model=FallbackChainRead,
+    dependencies=[Depends(auth), Depends(permissions(P.LlmProvider.CREATE))],
+)
+async def create(
+    data: FallbackChainCreate,
+    service: FallbackChainService = Injected(FallbackChainService),
+):
+    res = await service.create(data)
+    await invalidate_fallback_chain_cache(chain_id=None)
+    return res
+
+
+@router.patch(
+    "/{chain_id}",
+    response_model=FallbackChainRead,
+    dependencies=[Depends(auth), Depends(permissions(P.LlmProvider.UPDATE))],
+)
+async def update(
+    chain_id: UUID,
+    data: FallbackChainUpdate,
+    service: FallbackChainService = Injected(FallbackChainService),
+):
+    res = await service.update(chain_id, data)
+    await invalidate_fallback_chain_cache(chain_id=chain_id)
+    return res
+
+
+@router.delete(
+    "/{chain_id}",
+    dependencies=[Depends(auth), Depends(permissions(P.LlmProvider.DELETE))],
+)
+async def delete(
+    chain_id: UUID,
+    service: FallbackChainService = Injected(FallbackChainService),
+):
+    res = await service.delete(chain_id)
+    await invalidate_fallback_chain_cache(chain_id=chain_id)
+    return res

--- a/backend/app/api/v1/routes/llm_providers.py
+++ b/backend/app/api/v1/routes/llm_providers.py
@@ -8,9 +8,12 @@ from app.auth.dependencies import auth, permissions
 from app.auth.utils import oauth2
 from app.cache.redis_cache import invalidate_llm_provider_cache
 from app.core.config.settings import settings
+from app.core.exceptions.error_messages import ErrorKey
+from app.core.exceptions.exception_classes import AppException
 from app.core.permissions.constants import Permissions as P
 from app.modules.workflow.llm.provider import LLMProvider
 from app.schemas.llm import LlmProviderBase, LlmProviderCreate, LlmProviderMinimal, LlmProviderRead, LlmProviderUpdate
+from app.services.fallback_chains import FallbackChainService
 from app.services.llm_providers import LlmProviderService
 
 router = APIRouter()
@@ -96,7 +99,18 @@ async def update(
 async def delete(
     llm_provider_id: UUID,
     service: LlmProviderService = Injected(LlmProviderService),
+    chain_service: FallbackChainService = Injected(FallbackChainService),
 ):
+    # Block deletion if any fallback chain still references this provider, so we
+    # don't leave dangling references behind (mirrors the LLM-analyst FK guard).
+    referencing_chains = await chain_service.chains_referencing_provider(llm_provider_id)
+    if referencing_chains:
+        raise AppException(
+            error_key=ErrorKey.LLM_PROVIDER_IN_USE_BY_CHAIN,
+            status_code=409,
+            error_detail=", ".join(referencing_chains),
+        )
+
     res = await service.delete(llm_provider_id)
     await invalidate_llm_provider_cache(provider_id=llm_provider_id)
     return res

--- a/backend/app/cache/redis_cache.py
+++ b/backend/app/cache/redis_cache.py
@@ -214,5 +214,11 @@ async def invalidate_audio_provider_cache(provider_id: UUID | None = None):
     await invalidate_cache("audio_providers:get_all", None)
 
 
+async def invalidate_fallback_chain_cache(chain_id: UUID | None = None):
+    if chain_id:
+        await invalidate_cache("fallback_chains:get_by_id", str(chain_id))
+    await invalidate_cache("fallback_chains:get_all", None)
+
+
 async def invalidate_user_cache(user_id: UUID):
     await invalidate_cache("users:get_by_id_for_auth", user_id)

--- a/backend/app/core/exceptions/error_messages.py
+++ b/backend/app/core/exceptions/error_messages.py
@@ -69,6 +69,7 @@ class ErrorKey(Enum):
     LLM_ANALYST_NOT_FOUND = "LLM_ANALYST_NOT_FOUND"
     FALLBACK_CHAIN_NOT_FOUND = "FALLBACK_CHAIN_NOT_FOUND"
     FALLBACK_CHAIN_INVALID_PROVIDER = "FALLBACK_CHAIN_INVALID_PROVIDER"
+    LLM_PROVIDER_IN_USE_BY_CHAIN = "LLM_PROVIDER_IN_USE_BY_CHAIN"
     NOT_AUTHORIZED_TO_TAKE_OVER = "NOT_AUTHORIZED_TO_TAKE_OVER"
     TOOL_NOT_FOUND = "TOOL_NOT_FOUND"
     TOOL_CREATION_FAILED = "TOOL_CREATION_FAILED"
@@ -221,6 +222,7 @@ ERROR_MESSAGES = {
         ErrorKey.LLM_ANALYST_NOT_FOUND: "LLM Analyst not found.",
         ErrorKey.FALLBACK_CHAIN_NOT_FOUND: "Fallback chain not found.",
         ErrorKey.FALLBACK_CHAIN_INVALID_PROVIDER: "Fallback chain references an LLM provider that does not exist.",
+        ErrorKey.LLM_PROVIDER_IN_USE_BY_CHAIN: "This LLM provider is used by one or more fallback chains. Remove it from those chains before deleting.",
         ErrorKey.NOT_AUTHORIZED_TO_TAKE_OVER: "You are not authorized to take over conversations.",
         ErrorKey.TOOL_NOT_FOUND: "Tool not found.",
         ErrorKey.TOOL_CREATION_FAILED: "Tool creation failed.",

--- a/backend/app/core/exceptions/error_messages.py
+++ b/backend/app/core/exceptions/error_messages.py
@@ -67,6 +67,8 @@ class ErrorKey(Enum):
     WEBHOOK_NOT_FOUND = "WEBHOOK_NOT_FOUND"
     LLM_PROVIDER_NOT_FOUND = "LLM_PROVIDER_NOT_FOUND"
     LLM_ANALYST_NOT_FOUND = "LLM_ANALYST_NOT_FOUND"
+    FALLBACK_CHAIN_NOT_FOUND = "FALLBACK_CHAIN_NOT_FOUND"
+    FALLBACK_CHAIN_INVALID_PROVIDER = "FALLBACK_CHAIN_INVALID_PROVIDER"
     NOT_AUTHORIZED_TO_TAKE_OVER = "NOT_AUTHORIZED_TO_TAKE_OVER"
     TOOL_NOT_FOUND = "TOOL_NOT_FOUND"
     TOOL_CREATION_FAILED = "TOOL_CREATION_FAILED"
@@ -217,6 +219,8 @@ ERROR_MESSAGES = {
         ErrorKey.DATASOURCE_NOT_FOUND: "Datasource not found.",
         ErrorKey.LLM_PROVIDER_NOT_FOUND: "LLM Provider not found.",
         ErrorKey.LLM_ANALYST_NOT_FOUND: "LLM Analyst not found.",
+        ErrorKey.FALLBACK_CHAIN_NOT_FOUND: "Fallback chain not found.",
+        ErrorKey.FALLBACK_CHAIN_INVALID_PROVIDER: "Fallback chain references an LLM provider that does not exist.",
         ErrorKey.NOT_AUTHORIZED_TO_TAKE_OVER: "You are not authorized to take over conversations.",
         ErrorKey.TOOL_NOT_FOUND: "Tool not found.",
         ErrorKey.TOOL_CREATION_FAILED: "Tool creation failed.",

--- a/backend/app/core/utils/llm_usage_utils.py
+++ b/backend/app/core/utils/llm_usage_utils.py
@@ -95,4 +95,15 @@ def extract_usage_from_aimessage(message: Any) -> Optional[Dict[str, int]]:
     if not metadata:
         return None
 
-    return extract_usage_from_response_metadata(metadata)
+    usage = extract_usage_from_response_metadata(metadata)
+
+    # If this response came from a FallbackChatModel, record which provider actually
+    # answered so usage can be attributed correctly (the primary may have failed over).
+    if usage is not None and isinstance(metadata, dict):
+        from app.modules.workflow.llm.fallback_exceptions import FALLBACK_PROVIDER_ID_KEY
+
+        responding_provider_id = metadata.get(FALLBACK_PROVIDER_ID_KEY)
+        if responding_provider_id:
+            usage["provider_id"] = responding_provider_id
+
+    return usage

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -9,6 +9,7 @@ from app.db.models.audit_log import AuditLogModel
 from app.db.models.conversation import ConversationAnalysisModel, ConversationModel
 from app.db.models.customer import CustomerModel
 from app.db.models.datasource import DataSourceModel
+from app.db.models.fallback_chain import FallbackChainModel
 from app.db.models.job import JobModel
 from app.db.models.job_logs import JobLogsModel
 from app.db.models.llm import LlmAnalystModel, LlmProvidersModel
@@ -124,6 +125,7 @@ __all__ = [
     "PromptConfigModel",
     "FilesUploadSessionModel",
     "AudioProvidersModel",
+    "FallbackChainModel",
     "MessageIssueModel",
     "SupportTicketModel",
     "SupportTicketCommentModel",
@@ -181,6 +183,7 @@ models = [
     PromptVersionModel,
     PromptConfigModel,
     AudioProvidersModel,
+    FallbackChainModel,
     MessageIssueModel,
     SupportTicketModel,
     SupportTicketCommentModel,

--- a/backend/app/db/models/fallback_chain.py
+++ b/backend/app/db/models/fallback_chain.py
@@ -1,0 +1,28 @@
+from typing import Optional
+
+from sqlalchemy import Integer, PrimaryKeyConstraint, String
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class FallbackChainModel(Base):
+    """A reusable, named ordered list of LLM providers tried in priority order.
+
+    `provider_ids` is an ordered list of `llm_providers.id` strings (index 0 =
+    highest priority). `retry_policy` holds `{ "retry_count": int,
+    "backoff_seconds": float }`. No secrets are stored here — only references to
+    existing LLM providers.
+    """
+
+    __tablename__ = "fallback_chains"
+    __table_args__ = (
+        PrimaryKeyConstraint("id", name="fallback_chains_pk"),
+    )
+
+    name: Mapped[Optional[str]] = mapped_column(String(255))
+    description: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    provider_ids: Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
+    retry_policy: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
+    is_active: Mapped[Optional[int]] = mapped_column(Integer)

--- a/backend/app/dependencies/dependency_injection.py
+++ b/backend/app/dependencies/dependency_injection.py
@@ -40,6 +40,7 @@ from app.repositories.knowledge_base import KnowledgeBaseRepository
 from app.repositories.llm_analysts import LlmAnalystRepository
 from app.repositories.llm_cost_rates import LlmCostRateRepository
 from app.repositories.audio_providers import AudioProviderRepository
+from app.repositories.fallback_chains import FallbackChainRepository
 from app.repositories.llm_providers import LlmProviderRepository
 from app.repositories.operator_statistics import OperatorStatisticsRepository
 from app.repositories.operators import OperatorRepository
@@ -80,6 +81,7 @@ from app.services.gpt_speaker_separator import SpeakerSeparator
 from app.services.llm_analysts import LlmAnalystService
 from app.services.llm_cost_rates import LlmCostRateService
 from app.services.audio_providers import AudioProviderService
+from app.services.fallback_chains import FallbackChainService
 from app.services.llm_providers import LlmProviderService
 from app.services.local_fine_tuning import LocalFineTuningService
 from app.services.operator_statistics import OperatorStatisticsService
@@ -264,6 +266,9 @@ class Dependencies(Module):
 
         binder.bind(LlmProviderService, scope=request_scope)
         binder.bind(LlmProviderRepository, scope=request_scope)
+
+        binder.bind(FallbackChainService, scope=request_scope)
+        binder.bind(FallbackChainRepository, scope=request_scope)
 
         binder.bind(AudioProviderService, scope=request_scope)
         binder.bind(AudioProviderRepository, scope=request_scope)

--- a/backend/app/modules/workflow/engine/llm_usage_tracking.py
+++ b/backend/app/modules/workflow/engine/llm_usage_tracking.py
@@ -37,11 +37,21 @@ async def merge_llm_usage_from_result(
     from app.dependencies.injector import injector
 
     llm_service = injector.get(LlmProviderService)
-    provider_info = await llm_service.get_by_id(provider_id)
-    provider = (provider_info.llm_model_provider or "").lower()
-    model = provider_info.llm_model or ""
+
+    # Resolve provider/model lazily and cache per id. A usage entry may carry its own
+    # provider_id (stamped by FallbackChatModel when a fallback served the request);
+    # otherwise fall back to the node's primary provider_id.
+    resolved: dict[str, tuple[str, str]] = {}
+
+    async def _provider_model(pid: str) -> tuple[str, str]:
+        if pid not in resolved:
+            info = await llm_service.get_by_id(pid)
+            resolved[pid] = ((info.llm_model_provider or "").lower(), info.llm_model or "")
+        return resolved[pid]
 
     for u in llm_usage_list:
+        pid = u.get("provider_id") or provider_id
+        provider, model = await _provider_model(pid)
         state.add_llm_usage(
             input_tokens=u.get("input_tokens", 0),
             output_tokens=u.get("output_tokens", 0),

--- a/backend/app/modules/workflow/engine/nodes/agent_node.py
+++ b/backend/app/modules/workflow/engine/nodes/agent_node.py
@@ -196,6 +196,7 @@ class AgentNode(PIIAnonymizerMixin, BaseNode):
         """
         # Get configuration values (already resolved by BaseNode)
         provider_id: str | None = config.get("providerId", None)
+        fallback_chain_id: str | None = config.get("fallbackChainId", None)
         # ToolSelector, ReActAgent
         agent_type: str = config.get("type", "ToolSelector")
         max_iterations = config.get("maxIterations", 7)
@@ -230,7 +231,7 @@ class AgentNode(PIIAnonymizerMixin, BaseNode):
         try:
             from app.dependencies.injector import injector
             llm_provider = injector.get(LLMProvider)
-            llm_model = await llm_provider.get_model(provider_id)
+            llm_model = await llm_provider.get_model_for_node(provider_id, fallback_chain_id)
             logger.info("Agent type selected: %s, LLM model: %s",
                         agent_type, llm_model)
 

--- a/backend/app/modules/workflow/engine/nodes/llm_model_node.py
+++ b/backend/app/modules/workflow/engine/nodes/llm_model_node.py
@@ -184,6 +184,7 @@ class LLMModelNode(PIIAnonymizerMixin, BaseNode):
         """
         # Get configuration values (already resolved by BaseNode)
         provider_id = config.get("providerId")
+        fallback_chain_id = config.get("fallbackChainId")
         system_prompt = config.get("systemPrompt", "You are a helpful assistant.")
         prompt = config.get("userPrompt", "Hello, how can you help me?")
         _type = config.get("type", "base")
@@ -199,7 +200,7 @@ class LLMModelNode(PIIAnonymizerMixin, BaseNode):
             from app.dependencies.injector import injector
 
             llm_provider = injector.get(LLMProvider)
-            llm = await llm_provider.get_model(provider_id)
+            llm = await llm_provider.get_model_for_node(provider_id, fallback_chain_id)
 
             memory = self.get_memory() if memory_enabled else None
 
@@ -246,8 +247,14 @@ class LLMModelNode(PIIAnonymizerMixin, BaseNode):
             # Extract and record token usage
             usage = extract_usage_from_aimessage(response)
             if usage:
+                # Attribute usage to the provider that actually answered. With a
+                # fallback chain a different provider may have served the request;
+                # FallbackChatModel stamps its id onto response_metadata.
+                from app.modules.workflow.llm.fallback_chat_model import FALLBACK_PROVIDER_ID_KEY
+
+                responding_id = (response.response_metadata or {}).get(FALLBACK_PROVIDER_ID_KEY) or provider_id
                 llm_service = injector.get(LlmProviderService)
-                provider_info = await llm_service.get_by_id(provider_id)
+                provider_info = await llm_service.get_by_id(responding_id)
                 provider = (provider_info.llm_model_provider or "").lower()
                 model = provider_info.llm_model or ""
                 self.get_state().add_llm_usage(

--- a/backend/app/modules/workflow/llm/fallback_chat_model.py
+++ b/backend/app/modules/workflow/llm/fallback_chat_model.py
@@ -1,0 +1,262 @@
+"""
+FallbackChatModel — an ordered list of chat models tried in sequence.
+
+Why a custom BaseChatModel subclass instead of LangChain's `.with_fallbacks()`?
+`RunnableWithFallbacks` is a plain Runnable and does NOT expose `bind_tools()`.
+LangGraph's `create_agent(model=...)` (used by ReActAgentLC) calls
+`model.bind_tools(...)`, so a `RunnableWithFallbacks` breaks that path. By
+subclassing `BaseChatModel` and re-wrapping children on `bind_tools`, this single
+object works for BOTH the direct `.ainvoke()` path and the LangGraph agent path.
+
+On a *transient* failure (see `fallback_exceptions.is_retryable`) the next model
+is tried; on a permanent failure (auth/bad-request) the error is re-raised
+immediately. The model that actually answered is recorded in
+`response_metadata["__fallback_provider_id__"]` so token usage can be attributed
+correctly downstream.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, AsyncIterator, Iterator, List, Optional, Sequence
+
+from langchain_core.callbacks import (
+    AsyncCallbackManagerForLLMRun,
+    CallbackManagerForLLMRun,
+)
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+
+from app.modules.workflow.llm.fallback_exceptions import (
+    FALLBACK_PROVIDER_ID_KEY,
+    is_retryable,
+)
+
+logger = logging.getLogger(__name__)
+
+# Re-exported for callers that import it from here (defined in fallback_exceptions
+# so lightweight modules like llm_usage_utils can use it without importing langchain).
+__all__ = ["FallbackChatModel", "FALLBACK_PROVIDER_ID_KEY"]
+
+
+class FallbackChatModel(BaseChatModel):
+    """Tries an ordered list of chat models, falling back on transient errors.
+
+    Each provider is attempted up to ``retry_count + 1`` times (exponential backoff
+    between attempts) before moving on to the next provider in the list. Retry is
+    implemented here rather than via ``Runnable.with_retry`` because the latter
+    returns a ``RunnableRetry`` that lacks ``bind_tools`` and would break the
+    LangGraph ``create_agent`` path.
+
+    Args:
+        models: Ordered list of chat models / runnables. Index 0 is the primary.
+            Entries may be `BaseChatModel` instances or `RunnableBinding` objects
+            (the result of `bind_tools`); only `.ainvoke` / `.astream` are required.
+        provider_ids: Provider-id strings parallel to `models`, used to stamp the
+            responding provider onto `response_metadata`. May be shorter/empty.
+        retry_count: Extra attempts per provider beyond the first (0 = no retry).
+        retry_backoff_seconds: Initial backoff; doubles each retry (0 = no wait).
+    """
+
+    models: List[Any]
+    provider_ids: List[str] = []
+    retry_count: int = 0
+    retry_backoff_seconds: float = 0.0
+
+    @property
+    def _llm_type(self) -> str:
+        return "fallback_chat_model"
+
+    def _provider_id_at(self, idx: int) -> Optional[str]:
+        if 0 <= idx < len(self.provider_ids):
+            return self.provider_ids[idx]
+        return None
+
+    def _backoff_for(self, attempt: int) -> float:
+        """Backoff before retry `attempt` (1-based) of the same provider."""
+        if self.retry_backoff_seconds <= 0:
+            return 0.0
+        return self.retry_backoff_seconds * (2 ** (attempt - 1))
+
+    def _stamp(self, message: BaseMessage, idx: int) -> BaseMessage:
+        provider_id = self._provider_id_at(idx)
+        if provider_id is not None and isinstance(message, (AIMessage,)):
+            if message.response_metadata is None:
+                message.response_metadata = {}
+            message.response_metadata.setdefault(FALLBACK_PROVIDER_ID_KEY, provider_id)
+        return message
+
+    def bind_tools(self, tools: Sequence[Any], **kwargs: Any) -> "FallbackChatModel":
+        """Re-wrap every child with its tool binding, preserving the fallback order.
+
+        Returning a FallbackChatModel (rather than a RunnableBinding) keeps the type
+        stable so LangGraph's create_agent — which calls bind_tools on the model —
+        continues to see a BaseChatModel that still fails over across providers.
+        """
+        return FallbackChatModel(
+            models=[m.bind_tools(tools, **kwargs) for m in self.models],
+            provider_ids=list(self.provider_ids),
+            retry_count=self.retry_count,
+            retry_backoff_seconds=self.retry_backoff_seconds,
+        )
+
+    # ----- async (primary path) --------------------------------------------
+
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        invoke_kwargs = dict(kwargs)
+        if stop is not None:
+            invoke_kwargs["stop"] = stop
+
+        last_exc: Optional[BaseException] = None
+        for idx, model in enumerate(self.models):
+            for attempt in range(self.retry_count + 1):
+                try:
+                    ai = await model.ainvoke(messages, **invoke_kwargs)
+                except BaseException as exc:  # noqa: BLE001 - re-raised below when not retryable
+                    if not is_retryable(exc):
+                        raise
+                    last_exc = exc
+                    if attempt < self.retry_count:
+                        delay = self._backoff_for(attempt + 1)
+                        logger.warning(
+                            "FallbackChatModel: provider index %s (%s) failed (%s); "
+                            "retry %s/%s after %.2fs",
+                            idx, self._provider_id_at(idx), type(exc).__name__,
+                            attempt + 1, self.retry_count, delay,
+                        )
+                        if delay:
+                            await asyncio.sleep(delay)
+                        continue
+                    logger.warning(
+                        "FallbackChatModel: provider index %s (%s) exhausted retries (%s); "
+                        "trying next provider",
+                        idx, self._provider_id_at(idx), type(exc).__name__,
+                    )
+                    break  # move to next provider
+                self._stamp(ai, idx)
+                return ChatResult(generations=[ChatGeneration(message=ai)])
+
+        assert last_exc is not None  # loop ran at least once and only continues on a caught exc
+        raise last_exc
+
+    async def _astream(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[ChatGenerationChunk]:
+        invoke_kwargs = dict(kwargs)
+        if stop is not None:
+            invoke_kwargs["stop"] = stop
+
+        last_exc: Optional[BaseException] = None
+        for idx, model in enumerate(self.models):
+            for attempt in range(self.retry_count + 1):
+                emitted = False
+                try:
+                    async for chunk in model.astream(messages, **invoke_kwargs):
+                        if not emitted:
+                            self._stamp(chunk, idx)
+                            emitted = True
+                        yield ChatGenerationChunk(message=chunk)
+                    return
+                except BaseException as exc:  # noqa: BLE001
+                    # Mid-stream failover is not supported: once tokens have been emitted
+                    # to the consumer we cannot cleanly replay them on another provider.
+                    if emitted or not is_retryable(exc):
+                        raise
+                    last_exc = exc
+                    if attempt < self.retry_count:
+                        delay = self._backoff_for(attempt + 1)
+                        if delay:
+                            await asyncio.sleep(delay)
+                        continue
+                    logger.warning(
+                        "FallbackChatModel(stream): provider index %s (%s) failed before first "
+                        "chunk (%s); trying next provider",
+                        idx, self._provider_id_at(idx), type(exc).__name__,
+                    )
+                    break  # move to next provider
+
+        assert last_exc is not None
+        raise last_exc
+
+    # ----- sync (not used in this async codebase; defined to satisfy the ABC) ----
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        invoke_kwargs = dict(kwargs)
+        if stop is not None:
+            invoke_kwargs["stop"] = stop
+
+        last_exc: Optional[BaseException] = None
+        for idx, model in enumerate(self.models):
+            for attempt in range(self.retry_count + 1):
+                try:
+                    ai = model.invoke(messages, **invoke_kwargs)
+                except BaseException as exc:  # noqa: BLE001
+                    if not is_retryable(exc):
+                        raise
+                    last_exc = exc
+                    if attempt < self.retry_count:
+                        delay = self._backoff_for(attempt + 1)
+                        if delay:
+                            time.sleep(delay)
+                        continue
+                    break  # move to next provider
+                self._stamp(ai, idx)
+                return ChatResult(generations=[ChatGeneration(message=ai)])
+
+        assert last_exc is not None
+        raise last_exc
+
+    def _stream(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> Iterator[ChatGenerationChunk]:
+        invoke_kwargs = dict(kwargs)
+        if stop is not None:
+            invoke_kwargs["stop"] = stop
+
+        last_exc: Optional[BaseException] = None
+        for idx, model in enumerate(self.models):
+            for attempt in range(self.retry_count + 1):
+                emitted = False
+                try:
+                    for chunk in model.stream(messages, **invoke_kwargs):
+                        if not emitted:
+                            self._stamp(chunk, idx)
+                            emitted = True
+                        yield ChatGenerationChunk(message=chunk)
+                    return
+                except BaseException as exc:  # noqa: BLE001
+                    if emitted or not is_retryable(exc):
+                        raise
+                    last_exc = exc
+                    if attempt < self.retry_count:
+                        delay = self._backoff_for(attempt + 1)
+                        if delay:
+                            time.sleep(delay)
+                        continue
+                    break  # move to next provider
+
+        assert last_exc is not None
+        raise last_exc

--- a/backend/app/modules/workflow/llm/fallback_chat_model.py
+++ b/backend/app/modules/workflow/llm/fallback_chat_model.py
@@ -59,12 +59,17 @@ class FallbackChatModel(BaseChatModel):
             responding provider onto `response_metadata`. May be shorter/empty.
         retry_count: Extra attempts per provider beyond the first (0 = no retry).
         retry_backoff_seconds: Initial backoff; doubles each retry (0 = no wait).
+        request_timeouts: Per-provider max wall-clock seconds to wait for a single
+            attempt's reply before cancelling it and treating it as a retryable
+            failure. Parallel to `models` (0 or missing = no limit for that
+            provider). For streaming this bounds time-to-first-token.
     """
 
     models: List[Any]
     provider_ids: List[str] = []
     retry_count: int = 0
     retry_backoff_seconds: float = 0.0
+    request_timeouts: List[float] = []
 
     @property
     def _llm_type(self) -> str:
@@ -74,6 +79,12 @@ class FallbackChatModel(BaseChatModel):
         if 0 <= idx < len(self.provider_ids):
             return self.provider_ids[idx]
         return None
+
+    def _timeout_at(self, idx: int) -> float:
+        """Response timeout for the provider at `idx` (0 = no limit)."""
+        if 0 <= idx < len(self.request_timeouts):
+            return self.request_timeouts[idx] or 0.0
+        return 0.0
 
     def _backoff_for(self, attempt: int) -> float:
         """Backoff before retry `attempt` (1-based) of the same provider."""
@@ -101,7 +112,23 @@ class FallbackChatModel(BaseChatModel):
             provider_ids=list(self.provider_ids),
             retry_count=self.retry_count,
             retry_backoff_seconds=self.retry_backoff_seconds,
+            request_timeouts=list(self.request_timeouts),
         )
+
+    async def _ainvoke_one(
+        self, model: Any, messages: List[BaseMessage], invoke_kwargs: dict, timeout: float
+    ) -> AIMessage:
+        """Invoke a single child, enforcing this provider's timeout if set.
+
+        A timeout raises asyncio.TimeoutError, which is_retryable() treats as a
+        transient failure, so the caller will retry / fall over to the next provider.
+        """
+        if timeout and timeout > 0:
+            return await asyncio.wait_for(
+                model.ainvoke(messages, **invoke_kwargs),
+                timeout=timeout,
+            )
+        return await model.ainvoke(messages, **invoke_kwargs)
 
     # ----- async (primary path) --------------------------------------------
 
@@ -118,9 +145,10 @@ class FallbackChatModel(BaseChatModel):
 
         last_exc: Optional[BaseException] = None
         for idx, model in enumerate(self.models):
+            timeout = self._timeout_at(idx)
             for attempt in range(self.retry_count + 1):
                 try:
-                    ai = await model.ainvoke(messages, **invoke_kwargs)
+                    ai = await self._ainvoke_one(model, messages, invoke_kwargs, timeout)
                 except BaseException as exc:  # noqa: BLE001 - re-raised below when not retryable
                     if not is_retryable(exc):
                         raise
@@ -161,15 +189,26 @@ class FallbackChatModel(BaseChatModel):
 
         last_exc: Optional[BaseException] = None
         for idx, model in enumerate(self.models):
+            _t = self._timeout_at(idx)
+            timeout = _t if _t > 0 else None
             for attempt in range(self.retry_count + 1):
                 emitted = False
                 try:
-                    async for chunk in model.astream(messages, **invoke_kwargs):
+                    aiter = model.astream(messages, **invoke_kwargs).__aiter__()
+                    while True:
+                        # Bound time-to-first-token by the request timeout. Subsequent
+                        # chunks are not individually timed (mid-stream stalls are rare
+                        # and can't be cleanly failed over once tokens are emitted).
+                        if not emitted and timeout is not None:
+                            chunk = await asyncio.wait_for(aiter.__anext__(), timeout=timeout)
+                        else:
+                            chunk = await aiter.__anext__()
                         if not emitted:
                             self._stamp(chunk, idx)
                             emitted = True
                         yield ChatGenerationChunk(message=chunk)
-                    return
+                except StopAsyncIteration:
+                    return  # stream finished normally
                 except BaseException as exc:  # noqa: BLE001
                     # Mid-stream failover is not supported: once tokens have been emitted
                     # to the consumer we cannot cleanly replay them on another provider.

--- a/backend/app/modules/workflow/llm/fallback_exceptions.py
+++ b/backend/app/modules/workflow/llm/fallback_exceptions.py
@@ -31,6 +31,25 @@ RETRYABLE_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
 # HTTP status codes that represent a permanent/client error — never retry these.
 FAIL_FAST_STATUS_CODES = frozenset({400, 401, 403, 404, 405, 406, 422})
 
+# AWS Bedrock / botocore error codes (exc.response["Error"]["Code"]) that are
+# transient. botocore doesn't expose a `.status_code`, so we match on these too.
+RETRYABLE_AWS_ERROR_CODES = frozenset(
+    {
+        "ThrottlingException",
+        "Throttling",
+        "TooManyRequestsException",
+        "ProvisionedThroughputExceededException",
+        "ServiceUnavailableException",
+        "ServiceUnavailable",
+        "InternalServerException",
+        "InternalFailure",
+        "ModelTimeoutException",
+        "ModelNotReadyException",
+        "RequestTimeout",
+        "RequestTimeoutException",
+    }
+)
+
 
 def _collect_base_exceptions() -> tuple[type[BaseException], ...]:
     """Build the broad tuple of exception classes worth catching.
@@ -61,6 +80,14 @@ def _collect_base_exceptions() -> tuple[type[BaseException], ...]:
         bases.append(httpx.HTTPError)
     except Exception:  # pragma: no cover - SDK optional
         logger.debug("httpx not importable; skipping its exceptions in fallback classification")
+
+    try:
+        import botocore.exceptions as boto_exc  # AWS Bedrock
+
+        bases.append(boto_exc.BotoCoreError)  # connection/read timeouts, etc.
+        bases.append(boto_exc.ClientError)  # throttling / service errors
+    except Exception:  # pragma: no cover - SDK optional
+        logger.debug("botocore not importable; skipping its exceptions in fallback classification")
 
     # De-duplicate while preserving order.
     seen: set[type[BaseException]] = set()
@@ -93,9 +120,25 @@ def _extract_status_code(exc: BaseException) -> int | None:
         return status
     response = getattr(exc, "response", None)
     if response is not None:
+        # openai/anthropic/httpx expose an object with .status_code ...
         status = getattr(response, "status_code", None)
         if isinstance(status, int):
             return status
+        # ... botocore (Bedrock) exposes a dict: response["ResponseMetadata"]["HTTPStatusCode"].
+        if isinstance(response, dict):
+            status = (response.get("ResponseMetadata") or {}).get("HTTPStatusCode")
+            if isinstance(status, int):
+                return status
+    return None
+
+
+def _aws_error_code(exc: BaseException) -> str | None:
+    """Extract the AWS/botocore error code (e.g. 'ThrottlingException'), if any."""
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        code = (response.get("Error") or {}).get("Code")
+        if isinstance(code, str):
+            return code
     return None
 
 
@@ -131,6 +174,30 @@ def is_retryable(exc: BaseException) -> bool:
                 return True
         except Exception:  # pragma: no cover - SDK optional
             continue
+
+    # AWS Bedrock (botocore): connection/read timeouts have no status code, and
+    # throttle/service errors carry the status in a dict + an error Code string.
+    try:
+        import botocore.exceptions as boto_exc
+
+        if isinstance(
+            exc,
+            (
+                boto_exc.ReadTimeoutError,
+                boto_exc.ConnectTimeoutError,
+                boto_exc.ConnectionError,
+                boto_exc.EndpointConnectionError,
+            ),
+        ):
+            return True
+    except Exception:  # pragma: no cover - SDK optional
+        pass
+
+    aws_code = _aws_error_code(exc)
+    if aws_code is not None:
+        if aws_code in RETRYABLE_AWS_ERROR_CODES:
+            return True
+        # fall through to the status-code check below (e.g. AccessDenied -> 403 -> fail fast)
 
     # Status-code based classification for everything else.
     status = _extract_status_code(exc)

--- a/backend/app/modules/workflow/llm/fallback_exceptions.py
+++ b/backend/app/modules/workflow/llm/fallback_exceptions.py
@@ -89,6 +89,13 @@ def _collect_base_exceptions() -> tuple[type[BaseException], ...]:
     except Exception:  # pragma: no cover - SDK optional
         logger.debug("botocore not importable; skipping its exceptions in fallback classification")
 
+    try:
+        import google.api_core.exceptions as g_exc  # Gemini / Vertex via LangChain
+
+        bases.append(g_exc.GoogleAPIError)
+    except Exception:  # pragma: no cover - SDK optional
+        logger.debug("google.api_core not importable; skipping its exceptions in fallback classification")
+
     # De-duplicate while preserving order.
     seen: set[type[BaseException]] = set()
     unique: list[type[BaseException]] = []
@@ -129,6 +136,12 @@ def _extract_status_code(exc: BaseException) -> int | None:
             status = (response.get("ResponseMetadata") or {}).get("HTTPStatusCode")
             if isinstance(status, int):
                 return status
+    # Google (google.api_core / google.genai) exposes the HTTP status as `.code`
+    # (an HTTPStatus IntEnum, which is an int). Accept it only in the HTTP range so
+    # we don't misread an unrelated int `.code` on some other exception type.
+    code = getattr(exc, "code", None)
+    if isinstance(code, int) and 100 <= int(code) <= 599:
+        return int(code)
     return None
 
 
@@ -198,6 +211,29 @@ def is_retryable(exc: BaseException) -> bool:
         if aws_code in RETRYABLE_AWS_ERROR_CODES:
             return True
         # fall through to the status-code check below (e.g. AccessDenied -> 403 -> fail fast)
+
+    # Google (Gemini / Vertex via google.api_core): transient types. Most also carry
+    # an HTTP `.code` handled below, but a few (e.g. RetryError) do not.
+    try:
+        import google.api_core.exceptions as g_exc
+
+        transient_google = tuple(
+            getattr(g_exc, n)
+            for n in (
+                "ServiceUnavailable",
+                "DeadlineExceeded",
+                "ResourceExhausted",
+                "TooManyRequests",
+                "InternalServerError",
+                "Aborted",
+                "RetryError",
+            )
+            if hasattr(g_exc, n)
+        )
+        if transient_google and isinstance(exc, transient_google):
+            return True
+    except Exception:  # pragma: no cover - SDK optional
+        pass
 
     # Status-code based classification for everything else.
     status = _extract_status_code(exc)

--- a/backend/app/modules/workflow/llm/fallback_exceptions.py
+++ b/backend/app/modules/workflow/llm/fallback_exceptions.py
@@ -1,0 +1,146 @@
+"""
+Provider-agnostic exception classification for LLM fallback chains.
+
+When a model call fails we must decide whether the failure is *transient*
+(worth retrying / falling back to the next provider) or *permanent* (fail fast —
+retrying a bad API key or a malformed request just wastes the whole chain).
+
+Two layers are combined:
+  1. A broad tuple of base SDK exception classes to *catch* (`retryable_catch_tuple`).
+     Imports are guarded so a missing optional SDK never breaks module import.
+  2. `is_retryable(exc)` — the actual fall-back vs. fail-fast decision, using both
+     isinstance checks for known timeout/connection errors and a generic HTTP
+     status-code probe (`429`/`5xx` retry, `4xx` fail fast).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Metadata key stamped onto the responding message so token usage can be attributed
+# to the provider that actually served the request (which may be a fallback).
+# Defined here (a lightweight module) so usage utilities can import it without
+# pulling in langchain via fallback_chat_model.
+FALLBACK_PROVIDER_ID_KEY = "__fallback_provider_id__"
+
+# HTTP status codes that represent a transient/recoverable condition.
+RETRYABLE_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
+# HTTP status codes that represent a permanent/client error — never retry these.
+FAIL_FAST_STATUS_CODES = frozenset({400, 401, 403, 404, 405, 406, 422})
+
+
+def _collect_base_exceptions() -> tuple[type[BaseException], ...]:
+    """Build the broad tuple of exception classes worth catching.
+
+    Always includes builtin timeout/connection errors. Provider SDK base classes
+    are added only if the SDK is importable, so optional dependencies never break
+    this module.
+    """
+    bases: list[type[BaseException]] = [TimeoutError, ConnectionError, asyncio.TimeoutError]
+
+    try:
+        import openai
+
+        bases.append(openai.OpenAIError)
+    except Exception:  # pragma: no cover - SDK optional
+        logger.debug("openai SDK not importable; skipping its exceptions in fallback classification")
+
+    try:
+        import anthropic
+
+        bases.append(anthropic.AnthropicError)
+    except Exception:  # pragma: no cover - SDK optional
+        logger.debug("anthropic SDK not importable; skipping its exceptions in fallback classification")
+
+    try:
+        import httpx
+
+        bases.append(httpx.HTTPError)
+    except Exception:  # pragma: no cover - SDK optional
+        logger.debug("httpx not importable; skipping its exceptions in fallback classification")
+
+    # De-duplicate while preserving order.
+    seen: set[type[BaseException]] = set()
+    unique: list[type[BaseException]] = []
+    for b in bases:
+        if b not in seen:
+            seen.add(b)
+            unique.append(b)
+    return tuple(unique)
+
+
+# Computed once at import time. Used both as the `except (...)` target inside
+# FallbackChatModel and as `retry_if_exception_type=...` for per-model retries.
+_RETRYABLE_CATCH_TUPLE = _collect_base_exceptions()
+
+
+def retryable_catch_tuple() -> tuple[type[BaseException], ...]:
+    """Broad tuple of base exception classes to catch around a model call.
+
+    Catching is intentionally broad; the fine-grained retry-vs-fail-fast decision
+    is made by `is_retryable`. Pass this to `Runnable.with_retry(retry_if_exception_type=...)`.
+    """
+    return _RETRYABLE_CATCH_TUPLE
+
+
+def _extract_status_code(exc: BaseException) -> int | None:
+    """Best-effort extraction of an HTTP status code from a provider exception."""
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        return status
+    response = getattr(exc, "response", None)
+    if response is not None:
+        status = getattr(response, "status_code", None)
+        if isinstance(status, int):
+            return status
+    return None
+
+
+def is_retryable(exc: BaseException) -> bool:
+    """Decide whether `exc` should trigger a retry / fallback to the next provider.
+
+    Fall back on: timeouts, connection errors, rate limits, and 5xx/transient HTTP
+    statuses. Fail fast on: authentication, permission, and bad-request (4xx) errors.
+    Unknown exceptions default to NOT retryable (fail fast) so genuine bugs surface
+    instead of silently burning through the whole chain.
+    """
+    # Connection-level failures never carry a status code but are always transient.
+    if isinstance(exc, (TimeoutError, asyncio.TimeoutError, ConnectionError)):
+        return True
+
+    try:
+        import httpx
+
+        if isinstance(exc, (httpx.TimeoutException, httpx.ConnectError, httpx.ConnectTimeout)):
+            return True
+    except Exception:  # pragma: no cover - SDK optional
+        pass
+
+    # Provider SDKs expose connection/timeout subclasses with no status code.
+    for mod_name, attrs in (
+        ("openai", ("APITimeoutError", "APIConnectionError")),
+        ("anthropic", ("APITimeoutError", "APIConnectionError")),
+    ):
+        try:
+            mod = __import__(mod_name)
+            classes = tuple(getattr(mod, a) for a in attrs if hasattr(mod, a))
+            if classes and isinstance(exc, classes):
+                return True
+        except Exception:  # pragma: no cover - SDK optional
+            continue
+
+    # Status-code based classification for everything else.
+    status = _extract_status_code(exc)
+    if status is not None:
+        if status in FAIL_FAST_STATUS_CODES:
+            return False
+        if status in RETRYABLE_STATUS_CODES:
+            return True
+        # Any other 5xx is transient; any other 4xx is a client error.
+        return 500 <= status < 600
+
+    # No status code and not a known transient type → fail fast.
+    return False

--- a/backend/app/modules/workflow/llm/provider.py
+++ b/backend/app/modules/workflow/llm/provider.py
@@ -164,6 +164,22 @@ class LLMProvider:
         else:
             llm_provider = await llm_provider_service.get_by_id(model_id)
 
+        return await self._build_from_provider(llm_provider)
+
+    async def _build_one(self, model_id: str) -> BaseChatModel:
+        """Build a single chat model from a stored provider id.
+
+        Shared by get_model and get_model_with_fallback so residency checks,
+        decryption, and init_chat_model stay in one place.
+        """
+        from app.dependencies.injector import injector
+        llm_provider_service = injector.get(LlmProviderService)
+
+        llm_provider = await llm_provider_service.get_by_id(model_id)
+        return await self._build_from_provider(llm_provider)
+
+    async def _build_from_provider(self, llm_provider) -> BaseChatModel:
+        from app.dependencies.injector import injector
         from app.core.data_residency import assert_provider_residency, bedrock_regions_from_connection_data
         from app.services.app_settings import AppSettingsService
 
@@ -199,3 +215,89 @@ class LLMProvider:
             raise
 
         return llm
+
+    async def get_model_for_node(
+        self,
+        provider_id: str | None,
+        fallback_chain_id: str | None = None,
+    ) -> BaseChatModel:
+        """Resolve the model a node should use, honoring an optional fallback chain.
+
+        Without a chain this behaves exactly like get_model(provider_id). With a
+        chain, the node's own provider stays the primary (highest priority) and the
+        chain's providers are appended as ordered fallbacks; the chain's retry policy
+        is applied per provider.
+        """
+        if not fallback_chain_id:
+            return await self.get_model(provider_id)
+
+        from app.dependencies.injector import injector
+        from app.services.fallback_chains import FallbackChainService
+
+        chain = await injector.get(FallbackChainService).get_by_id(fallback_chain_id)
+
+        chain_ids = [str(pid) for pid in (chain.provider_ids or []) if pid]
+        if provider_id:
+            effective_ids = [str(provider_id)] + [pid for pid in chain_ids if pid != str(provider_id)]
+        else:
+            effective_ids = chain_ids
+
+        retry_policy = chain.retry_policy.model_dump() if chain.retry_policy else None
+        return await self.get_model_with_fallback(effective_ids, retry_policy)
+
+    async def get_model_with_fallback(
+        self,
+        provider_ids: list[str],
+        retry_policy: Optional[Dict[str, Any]] = None,
+    ) -> BaseChatModel:
+        """Build a chat model that fails over across an ordered list of providers.
+
+        Each provider is built via _build_one and wrapped with per-model retry
+        (exponential backoff). The list is composed into a FallbackChatModel that
+        tries each provider in order on transient errors. When there is a single
+        provider and no retry policy, the bare model is returned unchanged so
+        existing single-provider nodes behave exactly as before.
+
+        Args:
+            provider_ids: Ordered provider ids; index 0 is the primary.
+            retry_policy: Optional ``{"retry_count": int, "backoff_seconds": float}``.
+        """
+        ids = [pid for pid in (provider_ids or []) if pid]
+        if not ids:
+            raise ValueError("get_model_with_fallback requires at least one provider id")
+
+        retry_count = int((retry_policy or {}).get("retry_count", 0) or 0)
+        backoff_seconds = float((retry_policy or {}).get("backoff_seconds", 0) or 0)
+        has_retry = retry_count > 0
+
+        # Fast path: single provider, no retries → no wrapper, zero behavior change.
+        if len(ids) == 1 and not has_retry:
+            return await self._build_one(ids[0])
+
+        from app.modules.workflow.llm.fallback_chat_model import FallbackChatModel
+
+        children: list[Any] = []
+        kept_ids: list[str] = []
+        for pid in ids:
+            try:
+                # Children stay as raw chat models (NOT wrapped with .with_retry, which
+                # returns a RunnableRetry lacking bind_tools and would break the agent
+                # path). Per-provider retry is handled inside FallbackChatModel instead.
+                model = await self._build_one(pid)
+            except Exception as e:
+                # A provider that can't even be instantiated (e.g. deleted) is skipped
+                # so the rest of the chain can still serve the request.
+                logger.error(f"Skipping fallback provider {pid}: failed to build ({e})")
+                continue
+            children.append(model)
+            kept_ids.append(pid)
+
+        if not children:
+            raise ValueError("get_model_with_fallback: no providers could be built")
+
+        return FallbackChatModel(
+            models=children,
+            provider_ids=kept_ids,
+            retry_count=retry_count,
+            retry_backoff_seconds=backoff_seconds,
+        )

--- a/backend/app/modules/workflow/llm/provider.py
+++ b/backend/app/modules/workflow/llm/provider.py
@@ -303,7 +303,7 @@ class LLMProvider:
             except Exception as e:
                 # A provider that can't even be instantiated (e.g. deleted) is skipped
                 # so the rest of the chain can still serve the request.
-                logger.error(f"Skipping fallback provider {pid}: failed to build ({e})")
+                logger.exception(f"Skipping fallback provider {pid}: failed to build ({e})")
                 continue
             children.append(model)
             kept_ids.append(pid)

--- a/backend/app/modules/workflow/llm/provider.py
+++ b/backend/app/modules/workflow/llm/provider.py
@@ -260,7 +260,10 @@ class LLMProvider:
 
         Args:
             provider_ids: Ordered provider ids; index 0 is the primary.
-            retry_policy: Optional ``{"retry_count": int, "backoff_seconds": float}``.
+            retry_policy: Optional dict with ``retry_count``, ``backoff_seconds``,
+                a default ``timeout_seconds``, and a per-provider
+                ``provider_timeouts`` map ``{provider_id: seconds}`` that overrides
+                the default for specific providers.
         """
         ids = [pid for pid in (provider_ids or []) if pid]
         if not ids:
@@ -268,10 +271,23 @@ class LLMProvider:
 
         retry_count = int((retry_policy or {}).get("retry_count", 0) or 0)
         backoff_seconds = float((retry_policy or {}).get("backoff_seconds", 0) or 0)
-        has_retry = retry_count > 0
+        default_timeout = float((retry_policy or {}).get("timeout_seconds", 0) or 0)
+        provider_timeouts = (retry_policy or {}).get("provider_timeouts") or {}
 
-        # Fast path: single provider, no retries → no wrapper, zero behavior change.
-        if len(ids) == 1 and not has_retry:
+        def _timeout_for(pid: str) -> float:
+            # Per-provider override falls back to the chain default (0 = no limit).
+            raw = provider_timeouts.get(pid, default_timeout)
+            try:
+                return float(raw or 0)
+            except (TypeError, ValueError):
+                return 0.0
+
+        has_retry = retry_count > 0
+        has_timeout = default_timeout > 0 or any(_timeout_for(pid) > 0 for pid in ids)
+
+        # Fast path: single provider, no retries, no timeout → no wrapper, zero
+        # behavior change for plain single-provider nodes.
+        if len(ids) == 1 and not has_retry and not has_timeout:
             return await self._build_one(ids[0])
 
         from app.modules.workflow.llm.fallback_chat_model import FallbackChatModel
@@ -300,4 +316,5 @@ class LLMProvider:
             provider_ids=kept_ids,
             retry_count=retry_count,
             retry_backoff_seconds=backoff_seconds,
+            request_timeouts=[_timeout_for(pid) for pid in kept_ids],
         )

--- a/backend/app/repositories/fallback_chains.py
+++ b/backend/app/repositories/fallback_chains.py
@@ -1,0 +1,54 @@
+from uuid import UUID
+
+from injector import inject
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.db.models.fallback_chain import FallbackChainModel
+
+
+@inject
+class FallbackChainRepository:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def create(self, data):
+        obj = FallbackChainModel(**data)
+        self.db.add(obj)
+        await self.db.commit()
+        await self.db.refresh(obj)
+        return obj
+
+    async def get_by_id(self, chain_id: UUID):
+        return await self.db.get(FallbackChainModel, chain_id)
+
+    async def update(self, obj: FallbackChainModel):
+        self.db.add(obj)
+        await self.db.commit()
+        await self.db.refresh(obj)
+        return obj
+
+    async def delete(self, obj: FallbackChainModel):
+        await self.db.delete(obj)
+        await self.db.commit()
+
+    async def get_all(self):
+        result = await self.db.execute(
+            select(FallbackChainModel)
+            .where(FallbackChainModel.is_deleted == 0)
+            .order_by(FallbackChainModel.created_at.asc())
+        )
+        return result.scalars().all()
+
+    async def get_all_minimal(self):
+        stmt = (
+            select(
+                FallbackChainModel.id,
+                FallbackChainModel.name,
+                FallbackChainModel.is_active,
+            )
+            .where(FallbackChainModel.is_deleted == 0)
+            .order_by(FallbackChainModel.created_at.asc())
+        )
+        result = await self.db.execute(stmt)
+        return result.all()

--- a/backend/app/schemas/dynamic_form_schemas/nodes/agent_schema.py
+++ b/backend/app/schemas/dynamic_form_schemas/nodes/agent_schema.py
@@ -16,6 +16,13 @@ AGENT_NODE_DIALOG_SCHEMA: List[FieldSchema] = [
         required=True
     ),
     FieldSchema(
+        name="fallbackChainId",
+        type="select",
+        label="Fallback Chain",
+        required=False,
+        description="Optional ordered list of backup providers to try if the primary fails (timeouts, rate limits, service errors)."
+    ),
+    FieldSchema(
         name="systemPrompt",
         type="text",
         label="System Prompt",

--- a/backend/app/schemas/dynamic_form_schemas/nodes/llm_model_schema.py
+++ b/backend/app/schemas/dynamic_form_schemas/nodes/llm_model_schema.py
@@ -16,6 +16,13 @@ LLM_MODEL_NODE_DIALOG_SCHEMA: List[FieldSchema] = [
         required=True
     ),
     FieldSchema(
+        name="fallbackChainId",
+        type="select",
+        label="Fallback Chain",
+        required=False,
+        description="Optional ordered list of backup providers to try if the primary fails (timeouts, rate limits, service errors)."
+    ),
+    FieldSchema(
         name="systemPrompt",
         type="text",
         label="System Prompt",

--- a/backend/app/schemas/fallback_chain.py
+++ b/backend/app/schemas/fallback_chain.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -7,6 +7,16 @@ from pydantic import BaseModel, ConfigDict, Field
 class RetryPolicy(BaseModel):
     retry_count: int = Field(default=0, ge=0, le=10, description="Extra attempts per provider beyond the first.")
     backoff_seconds: float = Field(default=0.0, ge=0, le=30, description="Initial backoff seconds; doubles each retry.")
+    timeout_seconds: float = Field(
+        default=0.0,
+        ge=0,
+        le=600,
+        description="Default max seconds to wait for a provider's reply before failing over (0 = no limit).",
+    )
+    provider_timeouts: Dict[str, float] = Field(
+        default_factory=dict,
+        description="Per-provider response timeout overrides, keyed by provider id (seconds). Overrides timeout_seconds for that provider.",
+    )
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/schemas/fallback_chain.py
+++ b/backend/app/schemas/fallback_chain.py
@@ -1,0 +1,44 @@
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RetryPolicy(BaseModel):
+    retry_count: int = Field(default=0, ge=0, le=10, description="Extra attempts per provider beyond the first.")
+    backoff_seconds: float = Field(default=0.0, ge=0, le=30, description="Initial backoff seconds; doubles each retry.")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class FallbackChainBase(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    provider_ids: Optional[List[str]] = Field(
+        default=None, description="Ordered LLM provider ids; index 0 is highest priority."
+    )
+    retry_policy: Optional[RetryPolicy] = None
+    is_active: Optional[int] = 1
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class FallbackChainMinimal(BaseModel):
+    id: UUID
+    name: Optional[str] = None
+    is_active: Optional[int] = 1
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class FallbackChainCreate(FallbackChainBase):
+    name: str
+    provider_ids: List[str]
+
+
+class FallbackChainRead(FallbackChainBase):
+    id: UUID
+
+
+class FallbackChainUpdate(FallbackChainBase):
+    pass

--- a/backend/app/services/fallback_chains.py
+++ b/backend/app/services/fallback_chains.py
@@ -1,0 +1,104 @@
+import logging
+from uuid import UUID
+
+from fastapi_cache.coder import PickleCoder
+from fastapi_cache.decorator import cache
+from injector import inject
+
+from app.cache.redis_cache import make_key_builder
+from app.core.exceptions.error_messages import ErrorKey
+from app.core.exceptions.exception_classes import AppException
+from app.repositories.fallback_chains import FallbackChainRepository
+from app.repositories.llm_providers import LlmProviderRepository
+from app.schemas.fallback_chain import (
+    FallbackChainCreate,
+    FallbackChainMinimal,
+    FallbackChainRead,
+    FallbackChainUpdate,
+)
+
+logger = logging.getLogger(__name__)
+
+fallback_chain_id_key_builder = make_key_builder("fallback_chain_id")
+fallback_chain_all_key_builder = make_key_builder("-")
+
+
+@inject
+class FallbackChainService:
+    def __init__(self, repository: FallbackChainRepository, llm_provider_repository: LlmProviderRepository):
+        self.repository = repository
+        self.llm_provider_repository = llm_provider_repository
+
+    async def _validate_provider_ids(self, provider_ids: list[str] | None):
+        """Reject chains that reference providers which don't exist."""
+        for pid in provider_ids or []:
+            try:
+                obj = await self.llm_provider_repository.get_by_id(UUID(str(pid)))
+            except (ValueError, TypeError):
+                obj = None
+            if not obj:
+                raise AppException(
+                    error_key=ErrorKey.FALLBACK_CHAIN_INVALID_PROVIDER,
+                    status_code=400,
+                    error_detail=str(pid),
+                )
+
+    @staticmethod
+    def _dump(data) -> dict:
+        """Serialize a pydantic create/update model to a column dict for the ORM."""
+        payload = data.model_dump(exclude_unset=True, mode="json")
+        # retry_policy nests under a RetryPolicy model; mode="json" already turns it
+        # into a plain dict, which is what the JSONB column stores.
+        return payload
+
+    async def create(self, data: FallbackChainCreate):
+        await self._validate_provider_ids(data.provider_ids)
+        payload = self._dump(data)
+        return await self.repository.create(payload)
+
+    @cache(
+        expire=300,
+        namespace="fallback_chains:get_by_id",
+        key_builder=fallback_chain_id_key_builder,
+        coder=PickleCoder,
+    )
+    async def get_by_id(self, chain_id: UUID):
+        obj = await self.repository.get_by_id(chain_id)
+        if not obj:
+            raise AppException(error_key=ErrorKey.FALLBACK_CHAIN_NOT_FOUND, status_code=404)
+        return FallbackChainRead.model_validate(obj)
+
+    @cache(
+        expire=300,
+        namespace="fallback_chains:get_all",
+        key_builder=fallback_chain_all_key_builder,
+        coder=PickleCoder,
+    )
+    async def get_all(self):
+        models = await self.repository.get_all()
+        return [FallbackChainRead.model_validate(obj) for obj in models]
+
+    async def get_all_minimal(self) -> list[FallbackChainMinimal]:
+        rows = await self.repository.get_all_minimal()
+        return [FallbackChainMinimal.model_validate(r, from_attributes=True) for r in rows]
+
+    async def update(self, chain_id: UUID, data: FallbackChainUpdate):
+        obj = await self.repository.get_by_id(chain_id)
+        if not obj:
+            raise AppException(error_key=ErrorKey.FALLBACK_CHAIN_NOT_FOUND, status_code=404)
+
+        update_data = self._dump(data)
+        if "provider_ids" in update_data:
+            await self._validate_provider_ids(update_data["provider_ids"])
+
+        for field, value in update_data.items():
+            setattr(obj, field, value)
+
+        return await self.repository.update(obj)
+
+    async def delete(self, chain_id: UUID):
+        obj = await self.repository.get_by_id(chain_id)
+        if not obj:
+            raise AppException(error_key=ErrorKey.FALLBACK_CHAIN_NOT_FOUND, status_code=404)
+        await self.repository.delete(obj)
+        return {"message": f"Deleted fallback chain with ID {chain_id}"}

--- a/backend/app/services/fallback_chains.py
+++ b/backend/app/services/fallback_chains.py
@@ -98,8 +98,8 @@ class FallbackChainService:
         key_builder=fallback_chain_id_key_builder,
         coder=PickleCoder,
     )
-    async def get_by_id(self, chain_id: UUID):
-        obj = await self.repository.get_by_id(chain_id)
+    async def get_by_id(self, fallback_chain_id: UUID):
+        obj = await self.repository.get_by_id(fallback_chain_id)
         if not obj:
             raise AppException(error_key=ErrorKey.FALLBACK_CHAIN_NOT_FOUND, status_code=404)
         return FallbackChainRead.model_validate(obj)

--- a/backend/app/services/fallback_chains.py
+++ b/backend/app/services/fallback_chains.py
@@ -29,19 +29,55 @@ class FallbackChainService:
         self.repository = repository
         self.llm_provider_repository = llm_provider_repository
 
+    async def _provider_exists(self, pid) -> bool:
+        try:
+            obj = await self.llm_provider_repository.get_by_id(UUID(str(pid)))
+        except (ValueError, TypeError):
+            obj = None
+        return bool(obj)
+
     async def _validate_provider_ids(self, provider_ids: list[str] | None):
-        """Reject chains that reference providers which don't exist."""
+        """Reject chains that reference providers which don't exist (used on create)."""
         for pid in provider_ids or []:
-            try:
-                obj = await self.llm_provider_repository.get_by_id(UUID(str(pid)))
-            except (ValueError, TypeError):
-                obj = None
-            if not obj:
+            if not await self._provider_exists(pid):
                 raise AppException(
                     error_key=ErrorKey.FALLBACK_CHAIN_INVALID_PROVIDER,
                     status_code=400,
                     error_detail=str(pid),
                 )
+
+    async def _prune_missing_providers(self, update_data: dict) -> None:
+        """Drop provider ids (and their timeout overrides) that no longer exist.
+
+        Used on update so a chain whose provider was deleted out from under it can
+        still be edited/saved instead of being blocked by strict validation.
+        Mutates update_data in place.
+        """
+        if "provider_ids" not in update_data:
+            return
+        kept: list[str] = []
+        for pid in update_data["provider_ids"] or []:
+            if await self._provider_exists(pid):
+                kept.append(str(pid))
+        update_data["provider_ids"] = kept
+
+        retry_policy = update_data.get("retry_policy")
+        if isinstance(retry_policy, dict):
+            pt = retry_policy.get("provider_timeouts")
+            if isinstance(pt, dict):
+                retry_policy["provider_timeouts"] = {
+                    k: v for k, v in pt.items() if k in kept
+                }
+
+    async def chains_referencing_provider(self, provider_id) -> list[str]:
+        """Return the names of active chains that reference the given provider id."""
+        pid = str(provider_id)
+        chains = await self.repository.get_all()
+        return [
+            (c.name or str(c.id))
+            for c in chains
+            if pid in [str(x) for x in (c.provider_ids or [])]
+        ]
 
     @staticmethod
     def _dump(data) -> dict:
@@ -88,8 +124,9 @@ class FallbackChainService:
             raise AppException(error_key=ErrorKey.FALLBACK_CHAIN_NOT_FOUND, status_code=404)
 
         update_data = self._dump(data)
-        if "provider_ids" in update_data:
-            await self._validate_provider_ids(update_data["provider_ids"])
+        # Prune references to providers that were deleted so the edit isn't blocked
+        # by a stale id the user never touched.
+        await self._prune_missing_providers(update_data)
 
         for field, value in update_data.items():
             setattr(obj, field, value)

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8333,7 +8333,7 @@
         ],
         "parameters": [
           {
-            "name": "x-tenant-id",
+            "name": "X-Tenant-ID",
             "in": "header",
             "required": false,
             "schema": {
@@ -23527,6 +23527,24 @@
             "title": "Input Disclaimer Html",
             "description": "HTML disclaimer shown below the chat input. Supports text, bold, font-size, and links."
           },
+          "greet_on_start": {
+            "type": "boolean",
+            "title": "Greet On Start",
+            "description": "When true, the agent greets the visitor as the conversation opens (and triggers a Human In The Loop node wired right after Chat Input).",
+            "default": false
+          },
+          "greeting_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Greeting Prompt",
+            "description": "Optional extra instructions appended to the default greeting prompt used when greet_on_start is enabled."
+          },
           "possible_queries": {
             "items": {
               "type": "string"
@@ -23891,6 +23909,24 @@
             ],
             "title": "Input Disclaimer Html",
             "description": "HTML disclaimer shown below the chat input. Supports text, bold, font-size, and links."
+          },
+          "greet_on_start": {
+            "type": "boolean",
+            "title": "Greet On Start",
+            "description": "When true, the agent greets the visitor as the conversation opens (and triggers a Human In The Loop node wired right after Chat Input).",
+            "default": false
+          },
+          "greeting_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Greeting Prompt",
+            "description": "Optional extra instructions appended to the default greeting prompt used when greet_on_start is enabled."
           },
           "possible_queries": {
             "items": {
@@ -24639,6 +24675,28 @@
               }
             ],
             "title": "Input Disclaimer Html"
+          },
+          "greet_on_start": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Greet On Start"
+          },
+          "greeting_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Greeting Prompt"
           },
           "possible_queries": {
             "anyOf": [

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -35806,6 +35806,22 @@
             "title": "Backoff Seconds",
             "description": "Initial backoff seconds; doubles each retry.",
             "default": 0.0
+          },
+          "timeout_seconds": {
+            "type": "number",
+            "maximum": 600.0,
+            "minimum": 0.0,
+            "title": "Timeout Seconds",
+            "description": "Default max seconds to wait for a provider's reply before failing over (0 = no limit).",
+            "default": 0.0
+          },
+          "provider_timeouts": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Provider Timeouts",
+            "description": "Per-provider response timeout overrides, keyed by provider id (seconds). Overrides timeout_seconds for that provider."
           }
         },
         "type": "object",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8545,6 +8545,282 @@
         }
       }
     },
+    "/api/fallback-chains": {
+      "get": {
+        "tags": [
+          "v1",
+          "FallbackChains"
+        ],
+        "summary": "Get All",
+        "operationId": "get_all_api_fallback_chains_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/FallbackChainRead"
+                  },
+                  "type": "array",
+                  "title": "Response Get All Api Fallback Chains Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "v1",
+          "FallbackChains"
+        ],
+        "summary": "Create",
+        "operationId": "create_api_fallback_chains_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FallbackChainCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FallbackChainRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/fallback-chains/minimal": {
+      "get": {
+        "tags": [
+          "v1",
+          "FallbackChains"
+        ],
+        "summary": "Get All Minimal",
+        "operationId": "get_all_minimal_api_fallback_chains_minimal_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/FallbackChainMinimal"
+                  },
+                  "type": "array",
+                  "title": "Response Get All Minimal Api Fallback Chains Minimal Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/fallback-chains/{chain_id}": {
+      "get": {
+        "tags": [
+          "v1",
+          "FallbackChains"
+        ],
+        "summary": "Get",
+        "operationId": "get_api_fallback_chains__chain_id__get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "chain_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Chain Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FallbackChainRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "v1",
+          "FallbackChains"
+        ],
+        "summary": "Update",
+        "operationId": "update_api_fallback_chains__chain_id__patch",
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "chain_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Chain Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FallbackChainUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FallbackChainRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "v1",
+          "FallbackChains"
+        ],
+        "summary": "Delete",
+        "operationId": "delete_api_fallback_chains__chain_id__delete",
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "chain_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Chain Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/audio-providers": {
       "get": {
         "tags": [
@@ -28173,6 +28449,235 @@
         "type": "object",
         "title": "ExistsRequest"
       },
+      "FallbackChainCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "provider_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Provider Ids"
+          },
+          "retry_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetryPolicy"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "is_active": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Active",
+            "default": 1
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "provider_ids"
+        ],
+        "title": "FallbackChainCreate"
+      },
+      "FallbackChainMinimal": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "is_active": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Active",
+            "default": 1
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "FallbackChainMinimal"
+      },
+      "FallbackChainRead": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "provider_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider Ids",
+            "description": "Ordered LLM provider ids; index 0 is highest priority."
+          },
+          "retry_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetryPolicy"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "is_active": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Active",
+            "default": 1
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "FallbackChainRead"
+      },
+      "FallbackChainUpdate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "provider_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider Ids",
+            "description": "Ordered LLM provider ids; index 0 is highest priority."
+          },
+          "retry_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RetryPolicy"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "is_active": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Active",
+            "default": 1
+          }
+        },
+        "type": "object",
+        "title": "FallbackChainUpdate"
+      },
       "FeatureFlagCreate": {
         "properties": {
           "key": {
@@ -35283,6 +35788,28 @@
         ],
         "title": "ReportedIssueRead",
         "description": "A message that an admin/supervisor commented on, plus its resolution status\nand the context needed to navigate to the conversation or the agent's workflow."
+      },
+      "RetryPolicy": {
+        "properties": {
+          "retry_count": {
+            "type": "integer",
+            "maximum": 10.0,
+            "minimum": 0.0,
+            "title": "Retry Count",
+            "description": "Extra attempts per provider beyond the first.",
+            "default": 0
+          },
+          "backoff_seconds": {
+            "type": "number",
+            "maximum": 30.0,
+            "minimum": 0.0,
+            "title": "Backoff Seconds",
+            "description": "Initial backoff seconds; doubles each retry.",
+            "default": 0.0
+          }
+        },
+        "type": "object",
+        "title": "RetryPolicy"
       },
       "RoleCreate": {
         "properties": {

--- a/backend/tests/unit/test_fallback_chains_service.py
+++ b/backend/tests/unit/test_fallback_chains_service.py
@@ -12,7 +12,7 @@ from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.repositories.fallback_chains import FallbackChainRepository
 from app.repositories.llm_providers import LlmProviderRepository
-from app.schemas.fallback_chain import FallbackChainCreate
+from app.schemas.fallback_chain import FallbackChainCreate, FallbackChainUpdate
 from app.services.fallback_chains import FallbackChainService
 
 
@@ -72,3 +72,39 @@ async def test_get_by_id_not_found_raises(service, mock_repository):
     with pytest.raises(AppException) as exc:
         await service.get_by_id(uuid4())
     assert exc.value.error_key == ErrorKey.FALLBACK_CHAIN_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_chains_referencing_provider_returns_names(service, mock_repository):
+    target = str(uuid4())
+    other = str(uuid4())
+    mock_repository.get_all.return_value = [
+        SimpleNamespace(id=uuid4(), name="prod-chain", provider_ids=[other, target]),
+        SimpleNamespace(id=uuid4(), name="unrelated", provider_ids=[other]),
+    ]
+    names = await service.chains_referencing_provider(target)
+    assert names == ["prod-chain"]
+
+
+@pytest.mark.asyncio
+async def test_update_prunes_missing_providers(service, mock_repository, mock_llm_repository):
+    good = str(uuid4())
+    missing = str(uuid4())
+    existing_chain = SimpleNamespace(id=uuid4(), name="c", provider_ids=[good, missing])
+    mock_repository.get_by_id.return_value = existing_chain
+    mock_repository.update.side_effect = lambda obj: obj
+
+    # `good` resolves, `missing` does not.
+    async def _get_by_id(pid):
+        return object() if str(pid) == good else None
+
+    mock_llm_repository.get_by_id.side_effect = _get_by_id
+
+    data = FallbackChainUpdate(
+        provider_ids=[good, missing],
+        retry_policy={"retry_count": 0, "backoff_seconds": 0, "provider_timeouts": {good: 5, missing: 9}},
+    )
+    result = await service.update(existing_chain.id, data)
+
+    assert result.provider_ids == [good]  # missing id pruned
+    assert result.retry_policy["provider_timeouts"] == {good: 5.0}  # its timeout dropped too

--- a/backend/tests/unit/test_fallback_chains_service.py
+++ b/backend/tests/unit/test_fallback_chains_service.py
@@ -1,0 +1,74 @@
+"""Unit tests for FallbackChainService — focused on provider-id validation."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi_cache import FastAPICache
+from fastapi_cache.backends.inmemory import InMemoryBackend
+
+from app.core.exceptions.error_messages import ErrorKey
+from app.core.exceptions.exception_classes import AppException
+from app.repositories.fallback_chains import FallbackChainRepository
+from app.repositories.llm_providers import LlmProviderRepository
+from app.schemas.fallback_chain import FallbackChainCreate
+from app.services.fallback_chains import FallbackChainService
+
+
+@pytest.fixture(autouse=True)
+def init_cache():
+    FastAPICache.init(InMemoryBackend())
+    yield
+    FastAPICache.reset()
+
+
+@pytest.fixture
+def mock_repository():
+    return AsyncMock(spec=FallbackChainRepository)
+
+
+@pytest.fixture
+def mock_llm_repository():
+    return AsyncMock(spec=LlmProviderRepository)
+
+
+@pytest.fixture
+def service(mock_repository, mock_llm_repository):
+    return FallbackChainService(
+        repository=mock_repository, llm_provider_repository=mock_llm_repository
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_success_when_all_providers_resolve(service, mock_repository, mock_llm_repository):
+    pid = str(uuid4())
+    mock_llm_repository.get_by_id.return_value = object()  # provider exists
+    created = SimpleNamespace(id=uuid4(), name="chain", provider_ids=[pid])
+    mock_repository.create.return_value = created
+
+    data = FallbackChainCreate(name="chain", provider_ids=[pid], retry_policy={"retry_count": 1, "backoff_seconds": 1})
+    result = await service.create(data)
+
+    assert result.name == "chain"
+    mock_repository.create.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_dangling_provider(service, mock_repository, mock_llm_repository):
+    mock_llm_repository.get_by_id.return_value = None  # provider does not exist
+
+    data = FallbackChainCreate(name="chain", provider_ids=[str(uuid4())])
+    with pytest.raises(AppException) as exc:
+        await service.create(data)
+
+    assert exc.value.error_key == ErrorKey.FALLBACK_CHAIN_INVALID_PROVIDER
+    mock_repository.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_not_found_raises(service, mock_repository):
+    mock_repository.get_by_id.return_value = None
+    with pytest.raises(AppException) as exc:
+        await service.get_by_id(uuid4())
+    assert exc.value.error_key == ErrorKey.FALLBACK_CHAIN_NOT_FOUND

--- a/backend/tests/unit/test_fallback_chat_model.py
+++ b/backend/tests/unit/test_fallback_chat_model.py
@@ -1,0 +1,149 @@
+"""Unit tests for the LLM provider fallback chain core.
+
+Covers exception classification (is_retryable) and the FallbackChatModel wrapper:
+ordering, per-provider retry, fail-fast on permanent errors, streaming failover,
+bind_tools type-stability, and responding-provider attribution.
+"""
+
+import httpx
+import openai
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+
+from app.modules.workflow.llm.fallback_chat_model import (
+    FALLBACK_PROVIDER_ID_KEY,
+    FallbackChatModel,
+)
+from app.modules.workflow.llm.fallback_exceptions import is_retryable
+
+
+def _openai_status_error(code: int) -> openai.APIStatusError:
+    req = httpx.Request("POST", "http://x")
+    return openai.APIStatusError("boom", response=httpx.Response(code, request=req), body=None)
+
+
+class _FakeModel(BaseChatModel):
+    """Configurable fake chat model for exercising the wrapper."""
+
+    behavior: str = "ok"  # "ok" | "rate" | "badreq"
+    text: str = "ok-response"
+    call_count: int = 0
+    tools_bound: list = []
+
+    @property
+    def _llm_type(self) -> str:
+        return "fake"
+
+    def _maybe_raise(self):
+        if self.behavior == "rate":
+            req = httpx.Request("POST", "http://x")
+            raise openai.RateLimitError(
+                "rate", response=httpx.Response(429, request=req), body=None
+            )
+        if self.behavior == "badreq":
+            req = httpx.Request("POST", "http://x")
+            raise openai.BadRequestError(
+                "bad", response=httpx.Response(400, request=req), body=None
+            )
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        self.call_count += 1
+        self._maybe_raise()
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content=self.text))])
+
+    async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        self.call_count += 1
+        self._maybe_raise()
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content=self.text))])
+
+    async def _astream(self, messages, stop=None, run_manager=None, **kwargs):
+        self.call_count += 1
+        self._maybe_raise()
+        yield ChatGenerationChunk(message=AIMessageChunk(content=self.text))
+
+    def bind_tools(self, tools, **kwargs):
+        return _FakeModel(behavior=self.behavior, text=self.text, tools_bound=list(tools))
+
+
+class TestIsRetryable:
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            (400, False), (401, False), (403, False), (404, False), (422, False),
+            (408, True), (409, True), (429, True), (500, True), (502, True),
+            (503, True), (504, True),
+        ],
+    )
+    def test_status_code_classification(self, code, expected):
+        assert is_retryable(_openai_status_error(code)) is expected
+
+    def test_timeout_is_retryable(self):
+        assert is_retryable(TimeoutError("slow")) is True
+        assert is_retryable(httpx.ConnectError("no route")) is True
+
+    def test_unknown_exception_fails_fast(self):
+        assert is_retryable(ValueError("nonsense")) is False
+
+
+@pytest.mark.asyncio
+class TestFallbackChatModel:
+    async def test_falls_over_on_transient_error_and_stamps_provider(self):
+        fm = FallbackChatModel(
+            models=[_FakeModel(behavior="rate"), _FakeModel(behavior="ok", text="from-fallback")],
+            provider_ids=["p1", "p2"],
+        )
+        resp = await fm.ainvoke([HumanMessage(content="hi")])
+        assert resp.content == "from-fallback"
+        assert resp.response_metadata.get(FALLBACK_PROVIDER_ID_KEY) == "p2"
+
+    async def test_permanent_error_fails_fast_without_fallback(self):
+        fallback = _FakeModel(behavior="ok")
+        fm = FallbackChatModel(
+            models=[_FakeModel(behavior="badreq"), fallback],
+            provider_ids=["p1", "p2"],
+        )
+        with pytest.raises(openai.BadRequestError):
+            await fm.ainvoke([HumanMessage(content="hi")])
+        assert fallback.call_count == 0  # never reached
+
+    async def test_retry_count_attempts_before_fallback(self):
+        primary = _FakeModel(behavior="rate")
+        fm = FallbackChatModel(
+            models=[primary, _FakeModel(behavior="ok", text="fb")],
+            provider_ids=["p1", "p2"],
+            retry_count=2,
+            retry_backoff_seconds=0,
+        )
+        resp = await fm.ainvoke([HumanMessage(content="hi")])
+        assert resp.content == "fb"
+        assert primary.call_count == 3  # 1 initial + 2 retries
+
+    async def test_all_providers_fail_raises_last_exception(self):
+        fm = FallbackChatModel(
+            models=[_FakeModel(behavior="rate"), _FakeModel(behavior="rate")],
+            provider_ids=["p1", "p2"],
+        )
+        with pytest.raises(openai.RateLimitError):
+            await fm.ainvoke([HumanMessage(content="hi")])
+
+    async def test_streaming_falls_over_before_first_chunk(self):
+        fm = FallbackChatModel(
+            models=[_FakeModel(behavior="rate"), _FakeModel(behavior="ok", text="streamed")],
+            provider_ids=["p1", "p2"],
+        )
+        out = "".join([chunk.content async for chunk in fm.astream([HumanMessage(content="hi")])])
+        assert out == "streamed"
+
+    async def test_bind_tools_preserves_wrapper_and_settings(self):
+        fm = FallbackChatModel(
+            models=[_FakeModel(behavior="ok"), _FakeModel(behavior="ok")],
+            provider_ids=["p1", "p2"],
+            retry_count=3,
+            retry_backoff_seconds=1.5,
+        )
+        bound = fm.bind_tools([{"type": "function"}])
+        assert isinstance(bound, FallbackChatModel)
+        assert bound.retry_count == 3 and bound.retry_backoff_seconds == 1.5
+        assert all(getattr(m, "tools_bound", None) for m in bound.models)

--- a/backend/tests/unit/test_fallback_chat_model.py
+++ b/backend/tests/unit/test_fallback_chat_model.py
@@ -136,14 +136,73 @@ class TestFallbackChatModel:
         out = "".join([chunk.content async for chunk in fm.astream([HumanMessage(content="hi")])])
         assert out == "streamed"
 
+    async def test_slow_provider_times_out_and_falls_over(self):
+        import asyncio as _asyncio
+
+        class _SlowModel(BaseChatModel):
+            @property
+            def _llm_type(self):
+                return "slow"
+
+            def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+                raise NotImplementedError
+
+            async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs):
+                await _asyncio.sleep(5)  # far longer than the timeout
+                return ChatResult(generations=[ChatGeneration(message=AIMessage(content="too late"))])
+
+            def bind_tools(self, tools, **kwargs):
+                return self
+
+        # Per-provider timeouts: slow provider gets 0.05s (times out), fast gets 0 (no limit).
+        fm = FallbackChatModel(
+            models=[_SlowModel(), _FakeModel(behavior="ok", text="fast-fallback")],
+            provider_ids=["slow", "fast"],
+            request_timeouts=[0.05, 0],
+        )
+        resp = await fm.ainvoke([HumanMessage(content="hi")])
+        assert resp.content == "fast-fallback"
+        assert resp.response_metadata.get(FALLBACK_PROVIDER_ID_KEY) == "fast"
+
+    async def test_per_provider_timeout_only_applies_to_its_own_provider(self):
+        import asyncio as _asyncio
+
+        class _SlowModel(BaseChatModel):
+            @property
+            def _llm_type(self):
+                return "slow"
+
+            def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+                raise NotImplementedError
+
+            async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs):
+                await _asyncio.sleep(0.2)
+                return ChatResult(generations=[ChatGeneration(message=AIMessage(content="slow-but-ok"))])
+
+            def bind_tools(self, tools, **kwargs):
+                return self
+
+        # First provider has a generous timeout (0.5s) so its 0.2s reply succeeds;
+        # it should answer and the fast fallback is never reached.
+        fm = FallbackChatModel(
+            models=[_SlowModel(), _FakeModel(behavior="ok", text="fallback")],
+            provider_ids=["slow", "fast"],
+            request_timeouts=[0.5, 0],
+        )
+        resp = await fm.ainvoke([HumanMessage(content="hi")])
+        assert resp.content == "slow-but-ok"
+        assert resp.response_metadata.get(FALLBACK_PROVIDER_ID_KEY) == "slow"
+
     async def test_bind_tools_preserves_wrapper_and_settings(self):
         fm = FallbackChatModel(
             models=[_FakeModel(behavior="ok"), _FakeModel(behavior="ok")],
             provider_ids=["p1", "p2"],
             retry_count=3,
             retry_backoff_seconds=1.5,
+            request_timeouts=[12, 30],
         )
         bound = fm.bind_tools([{"type": "function"}])
         assert isinstance(bound, FallbackChatModel)
         assert bound.retry_count == 3 and bound.retry_backoff_seconds == 1.5
+        assert bound.request_timeouts == [12, 30]
         assert all(getattr(m, "tools_bound", None) for m in bound.models)

--- a/backend/tests/unit/test_fallback_chat_model.py
+++ b/backend/tests/unit/test_fallback_chat_model.py
@@ -109,6 +109,21 @@ class TestIsRetryable:
         assert is_retryable(client_err("AccessDeniedException", 403)) is False
         assert is_retryable(client_err("ValidationException", 400)) is False
 
+    def test_gemini_google_classification(self):
+        """Gemini/Vertex errors come from google.api_core (HTTP status on `.code`)."""
+        import google.api_core.exceptions as g
+
+        # Transient → retryable
+        assert is_retryable(g.ResourceExhausted("rate")) is True       # 429
+        assert is_retryable(g.ServiceUnavailable("down")) is True      # 503
+        assert is_retryable(g.DeadlineExceeded("slow")) is True        # 504
+        assert is_retryable(g.InternalServerError("boom")) is True     # 500
+
+        # Permanent → fail fast
+        assert is_retryable(g.BadRequest("bad")) is False              # 400
+        assert is_retryable(g.Unauthorized("no")) is False             # 401
+        assert is_retryable(g.Forbidden("no")) is False                # 403
+
 
 @pytest.mark.asyncio
 class TestFallbackChatModel:

--- a/backend/tests/unit/test_fallback_chat_model.py
+++ b/backend/tests/unit/test_fallback_chat_model.py
@@ -86,6 +86,29 @@ class TestIsRetryable:
     def test_unknown_exception_fails_fast(self):
         assert is_retryable(ValueError("nonsense")) is False
 
+    def test_bedrock_botocore_classification(self):
+        """AWS Bedrock errors come from botocore (dict response, no .status_code)."""
+        import botocore.exceptions as be
+
+        def client_err(code: str, http: int) -> be.ClientError:
+            return be.ClientError(
+                {"Error": {"Code": code, "Message": "x"},
+                 "ResponseMetadata": {"HTTPStatusCode": http}},
+                "InvokeModel",
+            )
+
+        # Transient Bedrock errors → retryable
+        assert is_retryable(client_err("ThrottlingException", 429)) is True
+        assert is_retryable(client_err("ServiceUnavailableException", 503)) is True
+        assert is_retryable(client_err("ModelTimeoutException", 408)) is True
+        assert is_retryable(be.ReadTimeoutError(endpoint_url="https://b")) is True
+        assert is_retryable(be.ConnectTimeoutError(endpoint_url="https://b")) is True
+        assert is_retryable(be.EndpointConnectionError(endpoint_url="https://b")) is True
+
+        # Permanent Bedrock errors → fail fast
+        assert is_retryable(client_err("AccessDeniedException", 403)) is False
+        assert is_retryable(client_err("ValidationException", 400)) is False
+
 
 @pytest.mark.asyncio
 class TestFallbackChatModel:

--- a/backend/tests/unit/test_llm_usage_utils.py
+++ b/backend/tests/unit/test_llm_usage_utils.py
@@ -48,3 +48,23 @@ class TestExtractUsageFromAIMessage:
 
     def test_none_message_returns_none(self):
         assert extract_usage_from_aimessage(None) is None
+
+    def test_stamps_fallback_provider_id_when_present(self):
+        from app.modules.workflow.llm.fallback_exceptions import FALLBACK_PROVIDER_ID_KEY
+
+        class MockMessage:
+            response_metadata = {
+                "token_usage": {"prompt_tokens": 3, "completion_tokens": 4},
+                FALLBACK_PROVIDER_ID_KEY: "provider-2",
+            }
+
+        result = extract_usage_from_aimessage(MockMessage())
+        assert result["provider_id"] == "provider-2"
+        assert result["input_tokens"] == 3 and result["output_tokens"] == 4
+
+    def test_no_provider_id_key_when_absent(self):
+        class MockMessage:
+            response_metadata = {"token_usage": {"prompt_tokens": 1, "completion_tokens": 1}}
+
+        result = extract_usage_from_aimessage(MockMessage())
+        assert "provider_id" not in result

--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -27,6 +27,7 @@ import AuditLogs from "@/views/AuditLogs";
 import Unauthorized from "@/views/Unauthorized";
 import LlmAnalyst from "@/views/LlmAnalyst/Index";
 import LLMProviders from "@/views/LlmProviders/Index";
+import FallbackChains from "@/views/FallbackChains/Index";
 import AudioProviders from "@/views/AudioProviders/Index";
 import FineTune from "@/views/FineTune/Index";
 import FineTuneJobDetail from "@/views/FineTune/pages/FineTuneJobDetail";
@@ -285,6 +286,14 @@ export const RoutesProvider = () => {
               element: (
                 <ProtectedRoute requiredPermissions={["read:llm_provider"]}>
                   <LLMProviders />
+                </ProtectedRoute>
+              ),
+            },
+            {
+              path: "fallback-chains",
+              element: (
+                <ProtectedRoute requiredPermissions={["read:llm_provider"]}>
+                  <FallbackChains />
                 </ProtectedRoute>
               ),
             },

--- a/frontend/src/components/RadixTooltip.tsx
+++ b/frontend/src/components/RadixTooltip.tsx
@@ -13,15 +13,18 @@ const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className
-    )}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      collisionPadding={8}
+      className={cn(
+        "z-[1400] overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 

--- a/frontend/src/interfaces/fallbackChain.interface.ts
+++ b/frontend/src/interfaces/fallbackChain.interface.ts
@@ -1,6 +1,10 @@
 export interface RetryPolicy {
   retry_count: number;
   backoff_seconds: number;
+  /** Default max seconds to wait for a provider's reply before failing over (0 = no limit). */
+  timeout_seconds?: number;
+  /** Per-provider response timeout overrides, keyed by provider id (seconds). */
+  provider_timeouts?: Record<string, number>;
 }
 
 export interface FallbackChain {

--- a/frontend/src/interfaces/fallbackChain.interface.ts
+++ b/frontend/src/interfaces/fallbackChain.interface.ts
@@ -1,0 +1,22 @@
+export interface RetryPolicy {
+  retry_count: number;
+  backoff_seconds: number;
+}
+
+export interface FallbackChain {
+  id: string;
+  name: string;
+  description?: string | null;
+  /** Ordered list of LLM provider ids; index 0 is highest priority. */
+  provider_ids: string[];
+  retry_policy?: RetryPolicy | null;
+  is_active: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface FallbackChainMinimal {
+  id: string;
+  name: string;
+  is_active: number;
+}

--- a/frontend/src/layout/app-sidebar.tsx
+++ b/frontend/src/layout/app-sidebar.tsx
@@ -190,6 +190,11 @@ const menuItems: MenuItem[] = [
         permissionsRequired: ["read:llm_provider"],
       },
       {
+        title: "Fallback Chains",
+        url: "/fallback-chains",
+        permissionsRequired: ["read:llm_provider"],
+      },
+      {
         title: "Audio Providers",
         url: "/audio-providers",
         permissionsRequired: ["read:llm_provider"],

--- a/frontend/src/services/fallbackChains.ts
+++ b/frontend/src/services/fallbackChains.ts
@@ -1,0 +1,46 @@
+import { apiRequest } from "@/config/api";
+import {
+  FallbackChain,
+  FallbackChainMinimal,
+} from "@/interfaces/fallbackChain.interface";
+
+export const getAllFallbackChains = async (): Promise<FallbackChain[]> => {
+  return await apiRequest<FallbackChain[]>("GET", "fallback-chains/");
+};
+
+export const getFallbackChainsMinimal = async (): Promise<
+  FallbackChainMinimal[]
+> => {
+  return await apiRequest<FallbackChainMinimal[]>("GET", "fallback-chains/minimal");
+};
+
+export const getFallbackChain = async (
+  id: string
+): Promise<FallbackChain | null> => {
+  return await apiRequest<FallbackChain>("GET", `fallback-chains/${id}`);
+};
+
+export const createFallbackChain = async (
+  data: Omit<FallbackChain, "id" | "created_at" | "updated_at">
+): Promise<FallbackChain> => {
+  return await apiRequest<FallbackChain>(
+    "POST",
+    "fallback-chains",
+    JSON.parse(JSON.stringify(data))
+  );
+};
+
+export const updateFallbackChain = async (
+  id: string,
+  data: Partial<Omit<FallbackChain, "id" | "created_at" | "updated_at">>
+): Promise<FallbackChain> => {
+  return await apiRequest<FallbackChain>(
+    "PATCH",
+    `fallback-chains/${id}`,
+    JSON.parse(JSON.stringify(data))
+  );
+};
+
+export const deleteFallbackChain = async (id: string): Promise<void> => {
+  await apiRequest<void>("DELETE", `fallback-chains/${id}`);
+};

--- a/frontend/src/views/AIAgents/Workflows/components/ModelConfiguration.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/ModelConfiguration.tsx
@@ -9,7 +9,9 @@ import {
 } from "@/components/select";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getAllLLMProviders } from "@/services/llmProviders";
+import { getAllFallbackChains } from "@/services/fallbackChains";
 import { LLMProvider } from "@/interfaces/llmProvider.interface";
+import { FallbackChain } from "@/interfaces/fallbackChain.interface";
 import { Switch } from "@/components/switch";
 import { BaseLLMNodeData } from "../types/nodes";
 import { DraggableTextArea } from "./custom/DraggableTextArea";
@@ -53,6 +55,19 @@ export const ModelConfiguration: React.FC<ModelConfigurationProps> = ({
     queryFn: getAllLLMProviders,
     select: (data: LLMProvider[]) => data.filter((p) => p.is_active === 1),
   });
+
+  const { data: fallbackChains = [] } = useQuery({
+    queryKey: ["fallbackChains"],
+    queryFn: getAllFallbackChains,
+    select: (data: FallbackChain[]) => data.filter((c) => c.is_active === 1),
+  });
+
+  const handleFallbackChainSelect = (value: string) => {
+    onConfigChange({
+      ...config,
+      fallbackChainId: value === "__none__" ? undefined : value,
+    });
+  };
 
   // Reset local state when config changes
   useEffect(() => {
@@ -267,6 +282,25 @@ export const ModelConfiguration: React.FC<ModelConfigurationProps> = ({
               </SelectItem>
             ))}
             <CreateNewSelectItem />
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor={`fallback-chain-select-${id}`}>Fallback Chain (optional)</Label>
+        <Select
+          value={config.fallbackChainId || "__none__"}
+          onValueChange={handleFallbackChainSelect}
+        >
+          <SelectTrigger id={`fallback-chain-select-${id}`} className="w-full">
+            <SelectValue placeholder="None (use provider only)" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__none__">None</SelectItem>
+            {fallbackChains.map((chain) => (
+              <SelectItem key={chain.id} value={chain.id}>
+                {chain.name}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </div>

--- a/frontend/src/views/AIAgents/Workflows/components/ModelConfiguration.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/ModelConfiguration.tsx
@@ -11,7 +11,6 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getAllLLMProviders } from "@/services/llmProviders";
 import { getAllFallbackChains } from "@/services/fallbackChains";
 import { LLMProvider } from "@/interfaces/llmProvider.interface";
-import { FallbackChain } from "@/interfaces/fallbackChain.interface";
 import { Switch } from "@/components/switch";
 import { BaseLLMNodeData } from "../types/nodes";
 import { DraggableTextArea } from "./custom/DraggableTextArea";
@@ -56,11 +55,19 @@ export const ModelConfiguration: React.FC<ModelConfigurationProps> = ({
     select: (data: LLMProvider[]) => data.filter((p) => p.is_active === 1),
   });
 
-  const { data: fallbackChains = [] } = useQuery({
+  const { data: allFallbackChains = [] } = useQuery({
     queryKey: ["fallbackChains"],
     queryFn: getAllFallbackChains,
-    select: (data: FallbackChain[]) => data.filter((c) => c.is_active === 1),
   });
+
+  const activeFallbackChains = allFallbackChains.filter(
+    (c) => c.is_active === 1,
+  );
+  const selectedFallbackChain = allFallbackChains.find(
+    (c) => c.id === config.fallbackChainId,
+  );
+  const selectedFallbackChainInactive =
+    !!selectedFallbackChain && selectedFallbackChain.is_active !== 1;
 
   const handleFallbackChainSelect = (value: string) => {
     onConfigChange({
@@ -296,13 +303,24 @@ export const ModelConfiguration: React.FC<ModelConfigurationProps> = ({
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="__none__">None</SelectItem>
-            {fallbackChains.map((chain) => (
+            {activeFallbackChains.map((chain) => (
               <SelectItem key={chain.id} value={chain.id}>
                 {chain.name}
               </SelectItem>
             ))}
+            {selectedFallbackChainInactive && (
+              <SelectItem value={selectedFallbackChain.id} disabled>
+                {selectedFallbackChain.name} (inactive)
+              </SelectItem>
+            )}
           </SelectContent>
         </Select>
+        {selectedFallbackChainInactive && (
+          <p className="text-xs text-muted-foreground">
+            This fallback chain has been deactivated. Choose an active chain or
+            None to change it.
+          </p>
+        )}
       </div>
       <div className="space-y-2">
         <div className="flex items-center justify-between">

--- a/frontend/src/views/AIAgents/Workflows/types/nodes.ts
+++ b/frontend/src/views/AIAgents/Workflows/types/nodes.ts
@@ -187,6 +187,7 @@ export interface ExternalAgentNodeData extends BaseNodeData {
 // LLM Model node data
 export interface BaseLLMNodeData extends BaseNodeData {
   providerId: string;
+  fallbackChainId?: string;
   memory: boolean;
   piiMasking?: boolean;
   systemPrompt?: string;

--- a/frontend/src/views/FallbackChains/Index.tsx
+++ b/frontend/src/views/FallbackChains/Index.tsx
@@ -1,0 +1,3 @@
+import FallbackChains from "./pages/FallbackChains";
+
+export default FallbackChains;

--- a/frontend/src/views/FallbackChains/components/FallbackChainCard.tsx
+++ b/frontend/src/views/FallbackChains/components/FallbackChainCard.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from "react";
+import { DataTable } from "@/components/DataTable";
+import { ActionButtons } from "@/components/ActionButtons";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { TableCell, TableRow } from "@/components/table";
+import { Badge } from "@/components/badge";
+import { FallbackChain } from "@/interfaces/fallbackChain.interface";
+import { getAllFallbackChains, deleteFallbackChain } from "@/services/fallbackChains";
+import { getAllLLMProviders } from "@/services/llmProviders";
+import { LLMProvider } from "@/interfaces/llmProvider.interface";
+import { toast } from "react-hot-toast";
+import { useQueryClient } from "@tanstack/react-query";
+
+interface FallbackChainCardProps {
+  searchQuery: string;
+  refreshKey?: number;
+  onEdit: (chain: FallbackChain) => void;
+}
+
+export function FallbackChainCard({
+  searchQuery,
+  refreshKey = 0,
+  onEdit,
+}: FallbackChainCardProps) {
+  const [chains, setChains] = useState<FallbackChain[]>([]);
+  const [providersById, setProvidersById] = useState<Record<string, LLMProvider>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [chainToDelete, setChainToDelete] = useState<FallbackChain | null>(null);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    fetchChains();
+  }, [refreshKey]);
+
+  const fetchChains = async () => {
+    try {
+      setLoading(true);
+      const [chainData, providerData] = await Promise.all([
+        getAllFallbackChains(),
+        getAllLLMProviders(),
+      ]);
+      setChains(chainData);
+      setProvidersById(
+        Object.fromEntries(providerData.map((p) => [p.id, p]))
+      );
+      setError(null);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to fetch fallback chains"
+      );
+      toast.error("Failed to fetch fallback chains.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDeleteClick = (chain: FallbackChain) => {
+    setChainToDelete(chain);
+    setIsDeleteDialogOpen(true);
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!chainToDelete) return;
+    try {
+      setIsDeleting(true);
+      await deleteFallbackChain(chainToDelete.id);
+      toast.success("Fallback chain deleted successfully.");
+      queryClient.invalidateQueries({ queryKey: ["fallbackChains"] });
+      setChains((prev) => prev.filter((c) => c.id !== chainToDelete.id));
+    } catch {
+      toast.error("Failed to delete fallback chain.");
+    } finally {
+      setIsDeleting(false);
+      setIsDeleteDialogOpen(false);
+      setChainToDelete(null);
+    }
+  };
+
+  const providerLabel = (id: string) => providersById[id]?.name ?? id;
+
+  const filteredChains = chains.filter((c) =>
+    (c.name ?? "").toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  const headers = ["Name", "Providers (priority order)", "Retry", "Status", "Actions"];
+
+  const renderRow = (chain: FallbackChain) => (
+    <TableRow key={chain.id}>
+      <TableCell className="font-medium break-all">{chain.name}</TableCell>
+      <TableCell className="truncate">
+        {(chain.provider_ids ?? []).map(providerLabel).join(" → ")}
+      </TableCell>
+      <TableCell className="truncate">
+        {chain.retry_policy?.retry_count ?? 0}× / {chain.retry_policy?.backoff_seconds ?? 0}s
+      </TableCell>
+      <TableCell className="overflow-hidden whitespace-nowrap text-clip">
+        <Badge variant={chain.is_active ? "default" : "secondary"}>
+          {chain.is_active ? "Active" : "Inactive"}
+        </Badge>
+      </TableCell>
+      <TableCell>
+        <ActionButtons
+          onEdit={() => onEdit(chain)}
+          onDelete={() => handleDeleteClick(chain)}
+          editTitle="Edit"
+          deleteTitle="Delete"
+        />
+      </TableCell>
+    </TableRow>
+  );
+
+  return (
+    <>
+      <DataTable
+        data={filteredChains}
+        loading={loading}
+        error={error}
+        searchQuery={searchQuery}
+        headers={headers}
+        renderRow={renderRow}
+        emptyMessage="No fallback chains found"
+        searchEmptyMessage="No fallback chains matching your search"
+      />
+
+      <ConfirmDialog
+        isOpen={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+        onConfirm={handleDeleteConfirm}
+        isInProgress={isDeleting}
+        itemName={chainToDelete?.name || ""}
+        description={`This action cannot be undone. This will permanently delete the chain "${chainToDelete?.name}".`}
+      />
+    </>
+  );
+}

--- a/frontend/src/views/FallbackChains/components/FallbackChainCard.tsx
+++ b/frontend/src/views/FallbackChains/components/FallbackChainCard.tsx
@@ -85,7 +85,16 @@ export function FallbackChainCard({
     (c.name ?? "").toLowerCase().includes(searchQuery.toLowerCase())
   );
 
-  const headers = ["Name", "Providers (priority order)", "Retry / Timeout", "Status", "Actions"];
+  const headers = ["Name", "Providers (priority order)", "Retry", "Timeout", "Status", "Actions"];
+
+  const timeoutLabel = (chain: FallbackChain) => {
+    const def = chain.retry_policy?.timeout_seconds ?? 0;
+    const hasPerProvider = Object.keys(chain.retry_policy?.provider_timeouts ?? {}).length > 0;
+    const parts: string[] = [];
+    if (def) parts.push(`${def}s`);
+    if (hasPerProvider) parts.push("per-provider");
+    return parts.length ? parts.join(" + ") : "—";
+  };
 
   const renderRow = (chain: FallbackChain) => (
     <TableRow key={chain.id}>
@@ -95,10 +104,8 @@ export function FallbackChainCard({
       </TableCell>
       <TableCell className="truncate">
         {chain.retry_policy?.retry_count ?? 0}× / {chain.retry_policy?.backoff_seconds ?? 0}s
-        {chain.retry_policy?.timeout_seconds
-          ? ` · ${chain.retry_policy.timeout_seconds}s timeout`
-          : ""}
       </TableCell>
+      <TableCell className="truncate">{timeoutLabel(chain)}</TableCell>
       <TableCell className="overflow-hidden whitespace-nowrap text-clip">
         <Badge variant={chain.is_active ? "default" : "secondary"}>
           {chain.is_active ? "Active" : "Inactive"}

--- a/frontend/src/views/FallbackChains/components/FallbackChainCard.tsx
+++ b/frontend/src/views/FallbackChains/components/FallbackChainCard.tsx
@@ -85,7 +85,7 @@ export function FallbackChainCard({
     (c.name ?? "").toLowerCase().includes(searchQuery.toLowerCase())
   );
 
-  const headers = ["Name", "Providers (priority order)", "Retry", "Status", "Actions"];
+  const headers = ["Name", "Providers (priority order)", "Retry / Timeout", "Status", "Actions"];
 
   const renderRow = (chain: FallbackChain) => (
     <TableRow key={chain.id}>
@@ -95,6 +95,9 @@ export function FallbackChainCard({
       </TableCell>
       <TableCell className="truncate">
         {chain.retry_policy?.retry_count ?? 0}× / {chain.retry_policy?.backoff_seconds ?? 0}s
+        {chain.retry_policy?.timeout_seconds
+          ? ` · ${chain.retry_policy.timeout_seconds}s timeout`
+          : ""}
       </TableCell>
       <TableCell className="overflow-hidden whitespace-nowrap text-clip">
         <Badge variant={chain.is_active ? "default" : "secondary"}>

--- a/frontend/src/views/FallbackChains/components/FallbackChainDialog.tsx
+++ b/frontend/src/views/FallbackChains/components/FallbackChainDialog.tsx
@@ -48,6 +48,8 @@ export function FallbackChainDialog({
   const [providerIds, setProviderIds] = useState<string[]>([]);
   const [retryCount, setRetryCount] = useState(2);
   const [backoffSeconds, setBackoffSeconds] = useState(1);
+  const [timeoutSeconds, setTimeoutSeconds] = useState(0);
+  const [providerTimeouts, setProviderTimeouts] = useState<Record<string, number>>({});
   const [isActive, setIsActive] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const queryClient = useQueryClient();
@@ -65,6 +67,8 @@ export function FallbackChainDialog({
     setProviderIds(chainToEdit?.provider_ids ?? []);
     setRetryCount(chainToEdit?.retry_policy?.retry_count ?? 2);
     setBackoffSeconds(chainToEdit?.retry_policy?.backoff_seconds ?? 1);
+    setTimeoutSeconds(chainToEdit?.retry_policy?.timeout_seconds ?? 0);
+    setProviderTimeouts(chainToEdit?.retry_policy?.provider_timeouts ?? {});
     setIsActive(chainToEdit ? chainToEdit.is_active === 1 : true);
   }, [isOpen, chainToEdit]);
 
@@ -79,8 +83,17 @@ export function FallbackChainDialog({
     if (id && !providerIds.includes(id)) setProviderIds((prev) => [...prev, id]);
   };
 
-  const removeProvider = (id: string) =>
+  const removeProvider = (id: string) => {
     setProviderIds((prev) => prev.filter((p) => p !== id));
+    setProviderTimeouts((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  };
+
+  const setProviderTimeout = (id: string, value: number) =>
+    setProviderTimeouts((prev) => ({ ...prev, [id]: value }));
 
   const move = (index: number, delta: number) => {
     setProviderIds((prev) => {
@@ -110,6 +123,12 @@ export function FallbackChainDialog({
         retry_policy: {
           retry_count: Number(retryCount) || 0,
           backoff_seconds: Number(backoffSeconds) || 0,
+          timeout_seconds: Number(timeoutSeconds) || 0,
+          provider_timeouts: Object.fromEntries(
+            providerIds
+              .filter((id) => Number(providerTimeouts[id]) > 0)
+              .map((id) => [id, Number(providerTimeouts[id])])
+          ),
         },
         is_active: isActive ? 1 : 0,
       };
@@ -179,6 +198,17 @@ export function FallbackChainDialog({
                     <span className="flex-1 truncate text-sm">
                       {providerName(id)}
                     </span>
+                    <Input
+                      type="number"
+                      min={0}
+                      max={600}
+                      step={1}
+                      className="w-32"
+                      placeholder="timeout s"
+                      title="Response timeout for this provider (seconds). Empty/0 uses the default."
+                      value={providerTimeouts[id] ?? ""}
+                      onChange={(e) => setProviderTimeout(id, Number(e.target.value))}
+                    />
                     <Button
                       type="button"
                       variant="ghost"
@@ -232,7 +262,7 @@ export function FallbackChainDialog({
             </Select>
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-3 gap-4">
             <div className="space-y-2">
               <Label htmlFor="retry-count">Retries per provider</Label>
               <Input
@@ -256,7 +286,25 @@ export function FallbackChainDialog({
                 onChange={(e) => setBackoffSeconds(Number(e.target.value))}
               />
             </div>
+            <div className="space-y-2">
+              <Label htmlFor="timeout-seconds">Default timeout (s)</Label>
+              <Input
+                id="timeout-seconds"
+                type="number"
+                min={0}
+                max={600}
+                step={1}
+                value={timeoutSeconds}
+                onChange={(e) => setTimeoutSeconds(Number(e.target.value))}
+              />
+            </div>
           </div>
+          <p className="text-xs text-muted-foreground">
+            Response timeout: if a provider takes longer than this to reply, the
+            attempt is cancelled and treated as a failure so the next provider is
+            tried. Set a value per provider in the list above; the default applies
+            to providers without their own value. 0 = no limit.
+          </p>
 
           <div className="flex items-center gap-2">
             <Switch checked={isActive} onCheckedChange={setIsActive} id="chain-active" />

--- a/frontend/src/views/FallbackChains/components/FallbackChainDialog.tsx
+++ b/frontend/src/views/FallbackChains/components/FallbackChainDialog.tsx
@@ -1,0 +1,279 @@
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/label";
+import { Switch } from "@/components/switch";
+import { Button } from "@/components/button";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/select";
+import { Badge } from "@/components/badge";
+import { Loader2, ArrowUp, ArrowDown, X } from "lucide-react";
+import { toast } from "react-hot-toast";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createFallbackChain,
+  updateFallbackChain,
+} from "@/services/fallbackChains";
+import { getAllLLMProviders } from "@/services/llmProviders";
+import { FallbackChain } from "@/interfaces/fallbackChain.interface";
+
+interface FallbackChainDialogProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onChainSaved: () => void;
+  chainToEdit?: FallbackChain | null;
+  mode?: "create" | "edit";
+}
+
+export function FallbackChainDialog({
+  isOpen,
+  onOpenChange,
+  onChainSaved,
+  chainToEdit = null,
+  mode = "create",
+}: FallbackChainDialogProps) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [providerIds, setProviderIds] = useState<string[]>([]);
+  const [retryCount, setRetryCount] = useState(2);
+  const [backoffSeconds, setBackoffSeconds] = useState(1);
+  const [isActive, setIsActive] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const queryClient = useQueryClient();
+
+  const { data: providers = [] } = useQuery({
+    queryKey: ["llmProviders"],
+    queryFn: getAllLLMProviders,
+    enabled: isOpen,
+  });
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setName(chainToEdit?.name ?? "");
+    setDescription(chainToEdit?.description ?? "");
+    setProviderIds(chainToEdit?.provider_ids ?? []);
+    setRetryCount(chainToEdit?.retry_policy?.retry_count ?? 2);
+    setBackoffSeconds(chainToEdit?.retry_policy?.backoff_seconds ?? 1);
+    setIsActive(chainToEdit ? chainToEdit.is_active === 1 : true);
+  }, [isOpen, chainToEdit]);
+
+  const providerName = (id: string) =>
+    providers.find((p) => p.id === id)?.name ?? id;
+
+  const availableProviders = providers.filter(
+    (p) => p.is_active === 1 && !providerIds.includes(p.id)
+  );
+
+  const addProvider = (id: string) => {
+    if (id && !providerIds.includes(id)) setProviderIds((prev) => [...prev, id]);
+  };
+
+  const removeProvider = (id: string) =>
+    setProviderIds((prev) => prev.filter((p) => p !== id));
+
+  const move = (index: number, delta: number) => {
+    setProviderIds((prev) => {
+      const next = [...prev];
+      const target = index + delta;
+      if (target < 0 || target >= next.length) return prev;
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (!name.trim()) {
+      toast.error("Please enter a chain name.");
+      return;
+    }
+    if (providerIds.length < 1) {
+      toast.error("Add at least one provider to the chain.");
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const payload = {
+        name: name.trim(),
+        description: description.trim() || null,
+        provider_ids: providerIds,
+        retry_policy: {
+          retry_count: Number(retryCount) || 0,
+          backoff_seconds: Number(backoffSeconds) || 0,
+        },
+        is_active: isActive ? 1 : 0,
+      };
+      if (mode === "edit" && chainToEdit) {
+        await updateFallbackChain(chainToEdit.id, payload);
+        toast.success("Fallback chain updated.");
+      } else {
+        await createFallbackChain(payload as Omit<FallbackChain, "id" | "created_at" | "updated_at">);
+        toast.success("Fallback chain created.");
+      }
+      queryClient.invalidateQueries({ queryKey: ["fallbackChains"] });
+      onChainSaved();
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to save fallback chain."
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {mode === "edit" ? "Edit Fallback Chain" : "Add Fallback Chain"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label htmlFor="chain-name">Name</Label>
+            <Input
+              id="chain-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Production failover"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="chain-description">Description</Label>
+            <Input
+              id="chain-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Optional"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>Providers (priority order)</Label>
+            <p className="text-xs text-muted-foreground">
+              Tried top to bottom. The first provider is the primary; the rest are
+              fallbacks used when the previous one fails.
+            </p>
+            {providerIds.length > 0 && (
+              <div className="space-y-1">
+                {providerIds.map((id, index) => (
+                  <div
+                    key={id}
+                    className="flex items-center gap-2 rounded-md border p-2"
+                  >
+                    <Badge variant="outline">{index + 1}</Badge>
+                    <span className="flex-1 truncate text-sm">
+                      {providerName(id)}
+                    </span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      disabled={index === 0}
+                      onClick={() => move(index, -1)}
+                      title="Move up"
+                    >
+                      <ArrowUp className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      disabled={index === providerIds.length - 1}
+                      onClick={() => move(index, 1)}
+                      title="Move down"
+                    >
+                      <ArrowDown className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => removeProvider(id)}
+                      title="Remove"
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+            <Select value="" onValueChange={addProvider}>
+              <SelectTrigger>
+                <SelectValue placeholder="Add a provider…" />
+              </SelectTrigger>
+              <SelectContent>
+                {availableProviders.length === 0 ? (
+                  <SelectItem value="__none__" disabled>
+                    No more active providers
+                  </SelectItem>
+                ) : (
+                  availableProviders.map((p) => (
+                    <SelectItem key={p.id} value={p.id}>
+                      {p.name} ({p.llm_model_provider} - {p.llm_model})
+                    </SelectItem>
+                  ))
+                )}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="retry-count">Retries per provider</Label>
+              <Input
+                id="retry-count"
+                type="number"
+                min={0}
+                max={10}
+                value={retryCount}
+                onChange={(e) => setRetryCount(Number(e.target.value))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="backoff-seconds">Initial backoff (s)</Label>
+              <Input
+                id="backoff-seconds"
+                type="number"
+                min={0}
+                max={30}
+                step={0.5}
+                value={backoffSeconds}
+                onChange={(e) => setBackoffSeconds(Number(e.target.value))}
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Switch checked={isActive} onCheckedChange={setIsActive} id="chain-active" />
+            <Label htmlFor="chain-active">Active</Label>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={isSubmitting}>
+            {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {mode === "edit" ? "Save Changes" : "Create Chain"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/views/FallbackChains/components/FallbackChainDialog.tsx
+++ b/frontend/src/views/FallbackChains/components/FallbackChainDialog.tsx
@@ -18,7 +18,13 @@ import {
   SelectItem,
 } from "@/components/select";
 import { Badge } from "@/components/badge";
-import { Loader2, ArrowUp, ArrowDown, X } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/RadixTooltip";
+import { Loader2, ArrowUp, ArrowDown, X, Info } from "lucide-react";
 import { toast } from "react-hot-toast";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -283,52 +289,104 @@ export function FallbackChainDialog({
             </Select>
           </div>
 
-          <div className="grid grid-cols-3 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="retry-count">Retries per provider</Label>
-              <Input
-                id="retry-count"
-                type="number"
-                min={0}
-                max={10}
-                value={retryCount}
-                onChange={(e) => setRetryCount(Number(e.target.value))}
-              />
+          <TooltipProvider>
+            <div className="grid grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <div className="flex items-center gap-1.5">
+                  <Label htmlFor="retry-count" className="whitespace-nowrap">Retries</Label>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        className="inline-flex rounded-full text-muted-foreground hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                        aria-label="Retries per provider info"
+                      >
+                        <Info className="h-4 w-4" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-xs text-balance">
+                      Extra attempts for the same provider (on retryable errors like
+                      timeouts, rate limits, or 5xx) before moving to the next provider
+                      in the chain. Total attempts = retries + 1. 0 = try once, then fail
+                      over.
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+                <Input
+                  id="retry-count"
+                  type="number"
+                  min={0}
+                  max={10}
+                  value={retryCount}
+                  onChange={(e) => setRetryCount(Number(e.target.value))}
+                />
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center gap-1.5">
+                  <Label htmlFor="backoff-seconds" className="whitespace-nowrap">Backoff (s)</Label>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        className="inline-flex rounded-full text-muted-foreground hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                        aria-label="Initial backoff info"
+                      >
+                        <Info className="h-4 w-4" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-xs text-balance">
+                      Seconds to wait before retrying the same provider. It doubles each
+                      retry (exponential backoff): e.g. 1s → 2s → 4s. 0 = retry
+                      immediately with no wait.
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+                <Input
+                  id="backoff-seconds"
+                  type="number"
+                  min={0}
+                  max={30}
+                  step={0.5}
+                  value={backoffSeconds}
+                  onChange={(e) => setBackoffSeconds(Number(e.target.value))}
+                />
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center gap-1.5">
+                  <Label htmlFor="timeout-seconds" className="whitespace-nowrap">Timeout (s)</Label>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        className="inline-flex rounded-full text-muted-foreground hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                        aria-label="Default timeout info"
+                      >
+                        <Info className="h-4 w-4" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-xs text-balance">
+                      If a provider takes longer than this to reply, the attempt is
+                      cancelled and treated as a failure so the next provider is tried.
+                      Applies to providers without their own per-provider timeout set in
+                      the list above. Empty = no limit.
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+                <Input
+                  id="timeout-seconds"
+                  type="number"
+                  min={0}
+                  max={600}
+                  step={1}
+                  placeholder="no limit"
+                  value={timeoutSeconds}
+                  onChange={(e) =>
+                    setTimeoutSeconds(e.target.value === "" ? "" : Number(e.target.value))
+                  }
+                />
+              </div>
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="backoff-seconds">Initial backoff (s)</Label>
-              <Input
-                id="backoff-seconds"
-                type="number"
-                min={0}
-                max={30}
-                step={0.5}
-                value={backoffSeconds}
-                onChange={(e) => setBackoffSeconds(Number(e.target.value))}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="timeout-seconds">Default timeout (s)</Label>
-              <Input
-                id="timeout-seconds"
-                type="number"
-                min={0}
-                max={600}
-                step={1}
-                placeholder="no limit"
-                value={timeoutSeconds}
-                onChange={(e) =>
-                  setTimeoutSeconds(e.target.value === "" ? "" : Number(e.target.value))
-                }
-              />
-            </div>
-          </div>
-          <p className="text-xs text-muted-foreground">
-            Response timeout: if a provider takes longer than this to reply, the
-            attempt is cancelled and treated as a failure so the next provider is
-            tried. Set a value per provider in the list above; the default applies
-            to providers without their own value. 0 = no limit.
-          </p>
+          </TooltipProvider>
 
           <div className="flex items-center gap-2">
             <Switch checked={isActive} onCheckedChange={setIsActive} id="chain-active" />

--- a/frontend/src/views/FallbackChains/components/FallbackChainDialog.tsx
+++ b/frontend/src/views/FallbackChains/components/FallbackChainDialog.tsx
@@ -48,7 +48,7 @@ export function FallbackChainDialog({
   const [providerIds, setProviderIds] = useState<string[]>([]);
   const [retryCount, setRetryCount] = useState(2);
   const [backoffSeconds, setBackoffSeconds] = useState(1);
-  const [timeoutSeconds, setTimeoutSeconds] = useState(0);
+  const [timeoutSeconds, setTimeoutSeconds] = useState<number | "">("");
   const [providerTimeouts, setProviderTimeouts] = useState<Record<string, number>>({});
   const [isActive, setIsActive] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -67,8 +67,18 @@ export function FallbackChainDialog({
     setProviderIds(chainToEdit?.provider_ids ?? []);
     setRetryCount(chainToEdit?.retry_policy?.retry_count ?? 2);
     setBackoffSeconds(chainToEdit?.retry_policy?.backoff_seconds ?? 1);
-    setTimeoutSeconds(chainToEdit?.retry_policy?.timeout_seconds ?? 0);
-    setProviderTimeouts(chainToEdit?.retry_policy?.provider_timeouts ?? {});
+    setTimeoutSeconds(
+      Number(chainToEdit?.retry_policy?.timeout_seconds) > 0
+        ? (chainToEdit!.retry_policy!.timeout_seconds as number)
+        : ""
+    );
+    setProviderTimeouts(
+      Object.fromEntries(
+        Object.entries(chainToEdit?.retry_policy?.provider_timeouts ?? {}).filter(
+          ([, v]) => Number(v) > 0
+        )
+      )
+    );
     setIsActive(chainToEdit ? chainToEdit.is_active === 1 : true);
   }, [isOpen, chainToEdit]);
 
@@ -92,8 +102,19 @@ export function FallbackChainDialog({
     });
   };
 
-  const setProviderTimeout = (id: string, value: number) =>
-    setProviderTimeouts((prev) => ({ ...prev, [id]: value }));
+  // Blank/0/invalid clears the override (the provider then inherits the chain
+  // default), so the field shows empty rather than a confusing 0.
+  const setProviderTimeout = (id: string, raw: string) =>
+    setProviderTimeouts((prev) => {
+      const next = { ...prev };
+      const n = Number(raw);
+      if (raw === "" || Number.isNaN(n) || n <= 0) {
+        delete next[id];
+      } else {
+        next[id] = n;
+      }
+      return next;
+    });
 
   const move = (index: number, delta: number) => {
     setProviderIds((prev) => {
@@ -207,7 +228,7 @@ export function FallbackChainDialog({
                       placeholder="timeout s"
                       title="Response timeout for this provider (seconds). Empty/0 uses the default."
                       value={providerTimeouts[id] ?? ""}
-                      onChange={(e) => setProviderTimeout(id, Number(e.target.value))}
+                      onChange={(e) => setProviderTimeout(id, e.target.value)}
                     />
                     <Button
                       type="button"
@@ -294,8 +315,11 @@ export function FallbackChainDialog({
                 min={0}
                 max={600}
                 step={1}
+                placeholder="no limit"
                 value={timeoutSeconds}
-                onChange={(e) => setTimeoutSeconds(Number(e.target.value))}
+                onChange={(e) =>
+                  setTimeoutSeconds(e.target.value === "" ? "" : Number(e.target.value))
+                }
               />
             </div>
           </div>

--- a/frontend/src/views/FallbackChains/pages/FallbackChains.tsx
+++ b/frontend/src/views/FallbackChains/pages/FallbackChains.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import { PageLayout } from "@/components/PageLayout";
+import { PageHeader } from "@/components/PageHeader";
+import { FallbackChainCard } from "../components/FallbackChainCard";
+import { FallbackChainDialog } from "../components/FallbackChainDialog";
+import { FallbackChain } from "@/interfaces/fallbackChain.interface";
+
+export default function FallbackChains() {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [dialogMode, setDialogMode] = useState<"create" | "edit">("create");
+  const [chainToEdit, setChainToEdit] = useState<FallbackChain | null>(null);
+
+  const handleChainSaved = () => {
+    setRefreshKey((k) => k + 1);
+  };
+
+  const handleCreate = () => {
+    setDialogMode("create");
+    setChainToEdit(null);
+    setIsDialogOpen(true);
+  };
+
+  const handleEdit = (chain: FallbackChain) => {
+    setDialogMode("edit");
+    setChainToEdit(chain);
+    setIsDialogOpen(true);
+  };
+
+  return (
+    <PageLayout>
+      <PageHeader
+        title="Fallback Chains"
+        subtitle="Configure ordered LLM provider failover with retry policies"
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        searchPlaceholder="Search chains..."
+        actionButtonText="Add New Chain"
+        onActionClick={handleCreate}
+      />
+
+      <FallbackChainCard
+        searchQuery={searchQuery}
+        refreshKey={refreshKey}
+        onEdit={handleEdit}
+      />
+
+      <FallbackChainDialog
+        isOpen={isDialogOpen}
+        onOpenChange={setIsDialogOpen}
+        onChainSaved={handleChainSaved}
+        chainToEdit={chainToEdit}
+        mode={dialogMode}
+      />
+    </PageLayout>
+  );
+}

--- a/frontend/src/views/LlmProviders/components/LLMProviderCard.tsx
+++ b/frontend/src/views/LlmProviders/components/LLMProviderCard.tsx
@@ -9,6 +9,7 @@ import { getAllLLMProviders, deleteLLMProvider } from "@/services/llmProviders";
 import { toast } from "react-hot-toast";
 import { useQueryClient } from "@tanstack/react-query";
 import { CheckCircle, AlertCircle, HelpCircle } from 'lucide-react';
+import { AxiosError } from "axios";
 
 interface LLMProviderCardProps {
   searchQuery: string;
@@ -78,7 +79,10 @@ export function LLMProviderCard({
       queryClient.invalidateQueries({ queryKey: ["llmProviders"] });
       setProviders((prev) => prev.filter((p) => p.id !== providerToDelete.id));
     } catch (error) {
-      toast.error("Failed to delete LLM provider.");
+      const axiosError = error as AxiosError<{ error?: string }>;
+      toast.error(
+        axiosError.response?.data?.error ?? "Failed to delete LLM provider."
+      );
     } finally {
       setIsDeleting(false);
       setIsDeleteDialogOpen(false);


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

- Added fallback_chains table (+ migration) with full CRUD route (/fallback-chains), service, repository, and DI bindings                                                                                                                                                                                        
  - Added a Fallback Chains management page (create/edit/delete) with ordered provider list, retry count, backoff, and default + per-provider response timeouts                                                                                                                                                    
  - Added option to select a fallback chain in the AI Agent and Language Model nodes                                                                                                                                                                                                                               
  - Added FallbackChatModel that fails over across providers on transient errors (timeouts, rate limits, 5xx), with per-provider retry/backoff/timeout, and skips fail-fast on permanent errors (auth/bad request)                                                                                                 

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release