### PR TITLE
enhancement: add content format option

### DIFF
--- a/backend/alembic/versions/00091_add_content_format_to_url_and_zendesk_kbs.py
+++ b/backend/alembic/versions/00091_add_content_format_to_url_and_zendesk_kbs.py
@@ -1,0 +1,56 @@
+"""add content_format to url and zendesk kbs
+
+Revision ID: c09bc3d15d9b
+Revises: 66c71887a6da
+Create Date: 2026-07-08 15:38:56.959558
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = 'c09bc3d15d9b'
+down_revision: Union[str, None] = '66c71887a6da'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE knowledge_bases
+        SET extra_metadata = jsonb_set(
+            coalesce(extra_metadata, '{}'::jsonb),
+            '{content_format}',
+            to_jsonb(
+                CASE
+                    WHEN coalesce((extra_metadata->>'allow_html_content')::boolean, false)
+                    THEN 'html'
+                    ELSE 'text'
+                END
+            )
+        ) - 'allow_html_content'
+        WHERE type IN ('url', 'zendesk')
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE knowledge_bases
+        SET extra_metadata = jsonb_set(
+            coalesce(extra_metadata, '{}'::jsonb),
+            '{allow_html_content}',
+            to_jsonb(coalesce(extra_metadata->>'content_format', '') = 'html')
+        ) - 'content_format'
+        WHERE type = 'zendesk'
+        """
+    )
+    op.execute(
+        """
+        UPDATE knowledge_bases
+        SET extra_metadata = extra_metadata - 'content_format'
+        WHERE type = 'url'
+        """
+    )

--- a/backend/alembic/versions/00092_add_content_format_to_url_and_zendesk_kbs.py
+++ b/backend/alembic/versions/00092_add_content_format_to_url_and_zendesk_kbs.py
@@ -10,7 +10,7 @@ from typing import Sequence, Union
 from alembic import op
 
 revision: str = 'c09bc3d15d9b'
-down_revision: Union[str, None] = '66c71887a6da'
+down_revision: Union[str, None] = 'd7f3a9c1e8b2'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/core/utils/bi_utils.py
+++ b/backend/app/core/utils/bi_utils.py
@@ -12,7 +12,7 @@ from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.core.utils.enums.message_feedback_enum import Feedback
 from app.core.utils.enums.transcript_message_type import TranscriptMessageType
-from app.core.utils.html_utils import html2markdown
+from app.core.utils.html_utils import html2markdown, html2plaintext
 from app.core.utils.web_scraping_utils import fetch_from_url
 from app.db.models import ConversationModel
 from app.db.models.message_model import TranscriptMessageModel
@@ -344,10 +344,16 @@ def get_messages_string_by_type(
     return json.dumps(filtered_segments)
 
 
-def _format_html(html: str, is_json: bool, base_url: str | None = None) -> str:
+def _format_html(
+    html: str, is_json: bool, content_format: str, base_url: str | None = None
+) -> str:
     if is_json:
         return html
-    return html2markdown(html, base_url)
+    if content_format == "html":
+        return html or ""
+    if content_format == "markdown":
+        return html2markdown(html, base_url)
+    return html2plaintext(html)
 
 
 async def _fetch_url_content(item: KBBase) -> str:
@@ -359,12 +365,13 @@ async def _fetch_url_content(item: KBBase) -> str:
     headers_lower = {str(k).lower(): v for k, v in headers.items()}
     use_http_request = bool(item.extra_metadata.get("use_http_request"))
     is_json = headers_lower.get("content-type") == "application/json"
+    content_format = item.extra_metadata.get("content_format") or "text"
 
     # Fetch content from all URLs and combine
     all_content = []
     for url in item.urls:
         html = await fetch_from_url(url, headers, use_http_request)
-        all_content.append(_format_html(html, is_json, base_url=url))
+        all_content.append(_format_html(html, is_json, content_format, base_url=url))
     return "\n\n---\n\n".join(all_content)
 
 

--- a/backend/app/core/utils/html_utils.py
+++ b/backend/app/core/utils/html_utils.py
@@ -17,6 +17,7 @@ def _strip_link_titles(md: str) -> str:
 
 def html2markdown(html: str, base_url: str | None = None) -> str:
     """Convert HTML to Markdown.
+
     ``base_url`` resolves relative hrefs to absolute URLs.
     """
     import html2text as _html2text
@@ -27,3 +28,18 @@ def html2markdown(html: str, base_url: str | None = None) -> str:
     h.body_width = 0         # no hard wraps
     h.unicode_snob = True    # keep é, ü, —, © etc. instead of ASCII-mangling them
     return _normalize_whitespace(_strip_link_titles(h.handle(html or "")))
+
+
+def html2plaintext(html: str) -> str:
+    """Convert HTML to plain text.
+
+    Removes script/style/noscript content entirely and decodes HTML entities.
+    """
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html or "", "lxml")
+    for bad in soup(["script", "style", "noscript"]):
+        bad.extract()
+    text = soup.get_text(separator="\n")
+    text = re.sub(r"\n\s*\n", "\n\n", text)
+    return text.strip()

--- a/backend/app/tasks/zendesk_article_sync_tasks.py
+++ b/backend/app/tasks/zendesk_article_sync_tasks.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from celery import shared_task
 from croniter import croniter
 
-from app.core.utils.html_utils import html2markdown
+from app.core.utils.html_utils import html2markdown, html2plaintext
 from app.dependencies.injector import injector
 from app.modules.data.manager import AgentRAGServiceManager
 from app.modules.integration.zendesk import ZendeskConnector
@@ -322,15 +322,19 @@ async def import_zendesk_articles_to_kb_async(
 
             # Check if allow_unpublished_articles is false KB extra_metadata from UI panel
             allow_unpublished_articles = kb.extra_metadata.get("allow_unpublished_articles") or False
-            allow_html_content = kb.extra_metadata.get("allow_html_content") or False
+            content_format = kb.extra_metadata.get("content_format") or "text"
 
-            # Parse article body based on allow_html_content flag
+            # Parse article body in the configured content format
             def _parse_article_body(article: dict) -> str:
                 body = article.get("body", "") or ""
-                if allow_html_content or not body:
-                    return body  # raw HTML passthrough (or empty)
-                # base_url resolves relative HC links (e.g. /hc/en-us/articles/123 -> full URL)
-                return html2markdown(body, base_url=article.get("html_url") or "")
+                if not body:
+                    return body
+                if content_format == "html":
+                    return body
+                if content_format == "markdown":
+                    base_url = article.get("html_url") or ""
+                    return html2markdown(body, base_url)
+                return html2plaintext(body)
 
             articles = []
             if not allow_unpublished_articles:

--- a/frontend/src/views/KnowledgeBase/pages/KnowledgeBaseForm.tsx
+++ b/frontend/src/views/KnowledgeBase/pages/KnowledgeBaseForm.tsx
@@ -253,7 +253,10 @@ const KnowledgeBaseForm: React.FC = () => {
       save_output: Boolean(formData.save_output),
       save_output_path: formData.save_output_path ?? null,
       allow_unpublished_articles: formData.type === 'zendesk' ? Boolean(formData.extra_metadata?.allow_unpublished_articles) : undefined,
-      allow_html_content: formData.type === 'zendesk' || formData.type === 'salesforce' ? Boolean(formData.extra_metadata?.allow_html_content) : undefined,
+      allow_html_content: formData.type === 'salesforce' ? Boolean(formData.extra_metadata?.allow_html_content) : undefined,
+      content_format: formData.type === 'zendesk' || formData.type === 'url'
+        ? ((formData.extra_metadata?.content_format as string) || 'text')
+        : undefined,
       rag_config: formData.rag_config ?? {},
       filePaths: formData.type === 'file'
         ? (formData.files || []).map((f) => typeof f === 'string' ? f : (f as FileItem).file_path)
@@ -278,7 +281,10 @@ const KnowledgeBaseForm: React.FC = () => {
       save_output: Boolean(em.save_output),
       save_output_path: (em.save_output_path as string) ?? null,
       allow_unpublished_articles: orig.type === 'zendesk' ? Boolean(em.allow_unpublished_articles) : undefined,
-      allow_html_content: orig.type === 'zendesk' || orig.type === 'salesforce' ? Boolean(em.allow_html_content) : undefined,
+      allow_html_content: orig.type === 'salesforce' ? Boolean(em.allow_html_content) : undefined,
+      content_format: orig.type === 'zendesk' || orig.type === 'url'
+        ? ((em.content_format as string) || 'text')
+        : undefined,
       rag_config: orig.rag_config ?? {},
       filePaths: (orig.files || []).map((f) => typeof f === 'string' ? f : (f as FileItem).file_path),
       hasNewFiles: false,
@@ -527,7 +533,14 @@ const KnowledgeBaseForm: React.FC = () => {
         dataToSubmit.extra_metadata = {
           ...(dataToSubmit.extra_metadata || {}),
           allow_unpublished_articles: dataToSubmit.extra_metadata?.allow_unpublished_articles || false,
-          allow_html_content: dataToSubmit.extra_metadata?.allow_html_content || false,
+          content_format: dataToSubmit.extra_metadata?.content_format || 'text',
+        };
+      }
+
+      if (formData.type === 'url') {
+        dataToSubmit.extra_metadata = {
+          ...(dataToSubmit.extra_metadata || {}),
+          content_format: dataToSubmit.extra_metadata?.content_format || 'text',
         };
       }
 
@@ -771,6 +784,33 @@ const KnowledgeBaseForm: React.FC = () => {
                                   )}
                                 </div>
                               ))}
+                              <div className="mt-4">
+                                <div className="mb-1">Content Format</div>
+                                <Select
+                                  value={(formData.extra_metadata?.content_format as string) || 'text'}
+                                  onValueChange={(value) =>
+                                    setFormData(
+                                      (prev) =>
+                                        ({
+                                          ...prev,
+                                          extra_metadata: {
+                                            ...prev.extra_metadata,
+                                            content_format: value,
+                                          },
+                                        }) as KnowledgeItem
+                                    )
+                                  }
+                                >
+                                  <SelectTrigger className="w-full">
+                                    <SelectValue />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    <SelectItem value="text">Plain text</SelectItem>
+                                    <SelectItem value="markdown">Markdown</SelectItem>
+                                    <SelectItem value="html">HTML</SelectItem>
+                                  </SelectContent>
+                                </Select>
+                              </div>
                               <div className="mt-4 rounded-lg border bg-white p-4">
                                 <div className="flex items-center justify-between">
                                   <div className="flex-1 pr-4">
@@ -1028,6 +1068,33 @@ const KnowledgeBaseForm: React.FC = () => {
 
                               {formData.type === 'zendesk' && (
                                 <div className="flex flex-col gap-6 mt-6">
+                                  <div>
+                                    <div className="mb-1">Content Format</div>
+                                    <Select
+                                      value={(formData.extra_metadata?.content_format as string) || 'text'}
+                                      onValueChange={(value) =>
+                                        setFormData(
+                                          (prev) =>
+                                            ({
+                                              ...prev,
+                                              extra_metadata: {
+                                                ...prev.extra_metadata,
+                                                content_format: value,
+                                              },
+                                            }) as KnowledgeItem
+                                        )
+                                      }
+                                    >
+                                      <SelectTrigger className="w-full">
+                                        <SelectValue />
+                                      </SelectTrigger>
+                                      <SelectContent>
+                                        <SelectItem value="text">Plain text</SelectItem>
+                                        <SelectItem value="markdown">Markdown</SelectItem>
+                                        <SelectItem value="html">HTML</SelectItem>
+                                      </SelectContent>
+                                    </Select>
+                                  </div>
                                   <div className="rounded-lg border bg-white p-4">
                                     <div className="flex items-center justify-between">
                                       <div className="flex-1 pr-4">
@@ -1050,31 +1117,6 @@ const KnowledgeBaseForm: React.FC = () => {
                                                 extra_metadata: {
                                                   ...prev.extra_metadata,
                                                   allow_unpublished_articles: checked,
-                                                },
-                                              }) as KnowledgeItem
-                                          )
-                                        }
-                                      />
-                                    </div>
-                                  </div>
-                                  <div className="rounded-lg border bg-white p-4">
-                                    <div className="flex items-center justify-between">
-                                      <div className="flex-1 pr-4">
-                                        <div className="text-sm font-medium text-gray-900">Allow HTML Content</div>
-                                        <p className="text-sm text-gray-500 mt-1">
-                                          Allow HTML content to be indexed in the knowledge base.
-                                        </p>
-                                      </div>
-                                      <Switch
-                                        checked={(formData.extra_metadata?.allow_html_content as boolean) || false}
-                                        onCheckedChange={(checked) =>
-                                          setFormData(
-                                            (prev) =>
-                                              ({
-                                                ...prev,
-                                                extra_metadata: {
-                                                  ...prev.extra_metadata,
-                                                  allow_html_content: checked,
                                                 },
                                               }) as KnowledgeItem
                                           )


### PR DESCRIPTION
## Description

When creating a KB of type URLs or Zendesk, the user now has the option to select one of three content formats: HTML, Markdown, Plain text.
(This required an Alembic migration)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [X] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
