### PR TITLE
feat: implement workflow version diff checker with UI components

### DIFF
--- a/frontend/src/interfaces/workflow-diff.interface.ts
+++ b/frontend/src/interfaces/workflow-diff.interface.ts
@@ -1,0 +1,65 @@
+import { Workflow } from '@/interfaces/workflow.interface';
+
+/**
+ * View-model types for the Workflow Version Diff Checker (feature 005).
+ *
+ * A `WorkflowDiff` is the pure, read-only result of comparing two saved versions of the same
+ * workflow (`base` = older, `target` = newer). Both the grouped-list and side-by-side graph
+ * presentations read from this single model so they can never disagree (spec FR-13, AC-12).
+ */
+
+/** How a node changed between the two compared versions. */
+export type NodeDiffStatus = 'added' | 'removed' | 'modified' | 'unchanged';
+
+/** A single configuration field that differs between base and target for a modified node. */
+export interface FieldChange {
+  /** Field key within the node's `data` (or the synthetic `type` key when the node type changed). */
+  key: string;
+  /** Value in the base (older) version. */
+  before: unknown;
+  /** Value in the target (newer) version. */
+  after: unknown;
+}
+
+/** Per-node diff entry: identity, classification and (for modified nodes) its field-level changes. */
+export interface NodeDiff {
+  /** Stable node id used to pair nodes across versions. */
+  id: string;
+  /** Human-readable node identity (name / registry label / type / id). */
+  label: string;
+  /** The node's type (from the target version when present, otherwise the base version). */
+  type: string;
+  status: NodeDiffStatus;
+  /** Field-level old→new changes; only populated for `modified` nodes. */
+  fieldChanges: FieldChange[];
+}
+
+/** A connection (edge) that was added or removed between the two versions. */
+export interface EdgeDiff {
+  /** Identity of the edge (its id, or the source/target connection tuple). */
+  id: string;
+  status: 'added' | 'removed';
+  /** Human-readable label of the source node this connection starts from. */
+  sourceLabel: string;
+  /** Human-readable label of the target node this connection ends at. */
+  targetLabel: string;
+}
+
+/** Aggregate counts of node classifications for the summary header (spec FR-4). */
+export interface DiffSummary {
+  added: number;
+  removed: number;
+  modified: number;
+  unchanged: number;
+}
+
+/** The complete comparison of two workflow versions. */
+export interface WorkflowDiff {
+  /** The older version (base). */
+  base: Workflow;
+  /** The newer version (target). */
+  target: Workflow;
+  nodes: NodeDiff[];
+  edges: EdgeDiff[];
+  summary: DiffSummary;
+}

--- a/frontend/src/views/AIAgents/Workflows/components/diff/DiffGraphView.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/diff/DiffGraphView.tsx
@@ -1,0 +1,224 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  Edge,
+  MarkerType,
+  Node,
+  NodeMouseHandler,
+  NodeTypes,
+  ReactFlowProvider,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+import { cn } from '@/helpers/utils';
+import { ScrollArea } from '@/components/scroll-area';
+import { Workflow } from '@/interfaces/workflow.interface';
+import { NodeDiff, WorkflowDiff } from '@/interfaces/workflow-diff.interface';
+import { computeLayeredLayout } from '../../utils/executionLayout';
+import { getNodeLabel } from '../../utils/versionDiff';
+import { NodeHandler } from '../../types/nodes';
+import { DIFF_STATUS_STYLES } from './diffStatusStyles';
+import DiffStatusNode, { DiffStatusNodeData } from './DiffStatusNode';
+import FieldChangeRow from './FieldChangeRow';
+
+/**
+ * Side-by-side graph presentation of a workflow diff (spec FR-13/FR-14, AC-12). Renders the base
+ * and target versions as two read-only, pan/zoomable ReactFlow graphs laid out compactly with
+ * `computeLayeredLayout`; every node is coded by its diff status (icon + label + color, never color
+ * alone). Selecting a node on either side reveals its field-level changes in a shared detail panel.
+ * Mirrors the read-only ReactFlow setup of the Execution view's `ExecutionGraph`.
+ */
+export interface DiffGraphViewProps {
+  diff: WorkflowDiff;
+}
+
+const NODE_TYPES: NodeTypes = { diffStatus: DiffStatusNode };
+const PRO_OPTIONS = { hideAttribution: true };
+const FIT_VIEW_OPTIONS = { padding: 0.2, maxZoom: 1.1, minZoom: 0.2 };
+const DEFAULT_EDGE_OPTIONS = {
+  type: 'smoothstep',
+  markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16 },
+};
+
+interface DiffGraphPaneProps {
+  title: string;
+  subtitle: string;
+  workflow: Workflow;
+  diffById: Map<string, NodeDiff>;
+  selectedNodeId: string | null;
+  onSelectNode: (nodeId: string) => void;
+}
+
+const DiffGraphPane: React.FC<DiffGraphPaneProps> = ({
+  title,
+  subtitle,
+  workflow,
+  diffById,
+  selectedNodeId,
+  onSelectNode,
+}) => {
+  const sourceNodes = useMemo(() => workflow.nodes ?? [], [workflow.nodes]);
+  const sourceEdges = useMemo(() => workflow.edges ?? [], [workflow.edges]);
+
+  const positions = useMemo(
+    () =>
+      computeLayeredLayout(
+        sourceNodes.map((n) => n.id),
+        sourceEdges.map((e) => ({ source: e.source, target: e.target }))
+      ),
+    [sourceNodes, sourceEdges]
+  );
+
+  const displayNodes = useMemo<Node<DiffStatusNodeData>[]>(
+    () =>
+      sourceNodes.map((node) => {
+        const data = node.data as { name?: string; handlers?: NodeHandler[] };
+        const nodeDiff = diffById.get(node.id);
+        return {
+          id: node.id,
+          type: 'diffStatus',
+          position: positions[node.id] ?? node.position ?? { x: 0, y: 0 },
+          data: {
+            // Label from THIS pane's own node so the base graph shows base-version names and the
+            // target graph shows target-version names (diff status still comes from the shared map).
+            name: getNodeLabel(node),
+            handlers: data?.handlers,
+            status: nodeDiff?.status ?? 'unchanged',
+            fieldChangeCount: nodeDiff?.fieldChanges.length ?? 0,
+            isSelected: selectedNodeId === node.id,
+          },
+          draggable: false,
+          connectable: false,
+          selectable: true,
+        };
+      }),
+    [sourceNodes, positions, diffById, selectedNodeId]
+  );
+
+  const displayEdges = useMemo<Edge[]>(() => sourceEdges.map((edge) => ({ ...edge, animated: false })), [sourceEdges]);
+
+  const handleNodeClick = useMemo<NodeMouseHandler>(() => (_event, node) => onSelectNode(node.id), [onSelectNode]);
+
+  return (
+    <div className="flex min-w-0 flex-1 flex-col">
+      <div className="flex items-baseline justify-between gap-2 px-1 pb-1.5">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-400">{title}</span>
+        <span className="truncate text-xs font-medium text-slate-600" title={subtitle}>
+          {subtitle}
+        </span>
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-slate-200 bg-slate-50/60">
+        {displayNodes.length === 0 ? (
+          <div className="flex h-full items-center justify-center p-4 text-center text-xs text-slate-500">
+            This version has no nodes.
+          </div>
+        ) : (
+          <ReactFlowProvider>
+            <ReactFlow
+              nodes={displayNodes}
+              edges={displayEdges}
+              nodeTypes={NODE_TYPES}
+              defaultEdgeOptions={DEFAULT_EDGE_OPTIONS}
+              onNodeClick={handleNodeClick}
+              nodesDraggable={false}
+              nodesConnectable={false}
+              elementsSelectable
+              minZoom={0.1}
+              fitView
+              fitViewOptions={FIT_VIEW_OPTIONS}
+              proOptions={PRO_OPTIONS}
+              onlyRenderVisibleElements
+            >
+              <Background />
+              <Controls showInteractive={false} />
+            </ReactFlow>
+          </ReactFlowProvider>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const DiffGraphView: React.FC<DiffGraphViewProps> = ({ diff }) => {
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+  const diffById = useMemo(() => {
+    const map = new Map<string, NodeDiff>();
+    for (const node of diff.nodes) map.set(node.id, node);
+    return map;
+  }, [diff.nodes]);
+
+  const selectedNode = selectedNodeId ? diffById.get(selectedNodeId) : undefined;
+
+  const versionLabel = (workflow: Workflow): string =>
+    `${workflow.name}${workflow.version ? ` · v${workflow.version}` : ''}`;
+
+  const selectedStyle = selectedNode ? DIFF_STATUS_STYLES[selectedNode.status] : null;
+
+  return (
+    <div className="flex h-full flex-col gap-3">
+      <div className="flex min-h-0 flex-1 gap-3">
+        <DiffGraphPane
+          title="Base (older)"
+          subtitle={versionLabel(diff.base)}
+          workflow={diff.base}
+          diffById={diffById}
+          selectedNodeId={selectedNodeId}
+          onSelectNode={setSelectedNodeId}
+        />
+        <DiffGraphPane
+          title="Target (newer)"
+          subtitle={versionLabel(diff.target)}
+          workflow={diff.target}
+          diffById={diffById}
+          selectedNodeId={selectedNodeId}
+          onSelectNode={setSelectedNodeId}
+        />
+      </div>
+
+      {/* Shared detail panel: reveals the selected node's field-level changes (FR-13). */}
+      <div className="h-40 shrink-0 overflow-hidden rounded-lg border border-slate-200 bg-white">
+        {selectedNode && selectedStyle ? (
+          <div className="flex h-full flex-col">
+            <div className="flex items-center gap-2 border-b border-slate-100 bg-slate-50/60 px-3 py-2">
+              <span className={cn('h-2 w-2 shrink-0 rounded-full', selectedStyle.dotClass)} aria-hidden="true" />
+              <span className="truncate text-sm font-medium text-slate-700">{selectedNode.label}</span>
+              <span
+                className={cn(
+                  'inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] font-medium',
+                  selectedStyle.chipClass
+                )}
+              >
+                <selectedStyle.Icon className="h-3 w-3" aria-hidden="true" />
+                {selectedStyle.label}
+              </span>
+            </div>
+            <ScrollArea className="flex-1 p-3">
+              {selectedNode.fieldChanges.length > 0 ? (
+                <div className="space-y-2">
+                  {selectedNode.fieldChanges.map((change) => (
+                    <FieldChangeRow key={change.key} change={change} />
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs text-slate-500">
+                  {selectedNode.status === 'unchanged'
+                    ? 'This node is unchanged between the two versions.'
+                    : selectedNode.status === 'added'
+                      ? 'This node was added in the target version.'
+                      : 'This node was removed from the base version.'}
+                </p>
+              )}
+            </ScrollArea>
+          </div>
+        ) : (
+          <div className="flex h-full items-center justify-center px-3 text-center text-xs text-slate-500">
+            Select a node in either graph to see its changes.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default DiffGraphView;

--- a/frontend/src/views/AIAgents/Workflows/components/diff/DiffListView.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/diff/DiffListView.tsx
@@ -1,0 +1,237 @@
+import React, { useMemo } from 'react';
+import { Check, ArrowRight } from 'lucide-react';
+import { cn } from '@/helpers/utils';
+import { ScrollArea } from '@/components/scroll-area';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/accordion';
+import { NodeDiff, NodeDiffStatus, WorkflowDiff } from '@/interfaces/workflow-diff.interface';
+import { DIFF_STATUS_ORDER, DIFF_STATUS_STYLES } from './diffStatusStyles';
+import FieldChangeRow from './FieldChangeRow';
+
+/**
+ * Grouped-list presentation of a workflow diff (spec FR-4/FR-5/FR-6/FR-8, the default view). A
+ * segmented summary strip leads, followed by collapsible sections for Modified (expanding to
+ * field-level old→new rows), Added and Removed nodes, plus Added/Removed connections. Renders a
+ * clear "no differences" state when the two versions are identical (FR-9, AC-6).
+ */
+export interface DiffListViewProps {
+  diff: WorkflowDiff;
+}
+
+/** A node identity row with a left accent rail (added/removed sections). */
+const NodeIdentityRow: React.FC<{ node: NodeDiff }> = ({ node }) => {
+  const style = DIFF_STATUS_STYLES[node.status];
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2.5 rounded-md border border-slate-200 border-l-[3px] bg-white px-3 py-2',
+        style.railClass
+      )}
+    >
+      <span className={cn('h-1.5 w-1.5 shrink-0 rounded-full', style.dotClass)} aria-hidden="true" />
+      <span className="sr-only">{style.label}:</span>
+      <span className="flex-1 truncate text-sm font-medium text-slate-700" title={node.label}>
+        {node.label}
+      </span>
+      <span className="shrink-0 rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 font-mono text-[10px] text-slate-500">
+        {node.type}
+      </span>
+    </div>
+  );
+};
+
+/** Section header: uppercase label + count in a compact square. */
+const SectionLabel: React.FC<{ children: React.ReactNode; count: number }> = ({ children, count }) => (
+  <span className="flex items-center gap-2">
+    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{children}</span>
+    <span className="inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-md bg-slate-100 px-1 text-[11px] font-semibold tabular-nums text-slate-500">
+      {count}
+    </span>
+  </span>
+);
+
+const DiffListView: React.FC<DiffListViewProps> = ({ diff }) => {
+  const { summary, nodes, edges } = diff;
+
+  const modified = useMemo(() => nodes.filter((n) => n.status === 'modified'), [nodes]);
+  const added = useMemo(() => nodes.filter((n) => n.status === 'added'), [nodes]);
+  const removed = useMemo(() => nodes.filter((n) => n.status === 'removed'), [nodes]);
+  const addedEdges = useMemo(() => edges.filter((e) => e.status === 'added'), [edges]);
+  const removedEdges = useMemo(() => edges.filter((e) => e.status === 'removed'), [edges]);
+
+  const hasNodeChanges = summary.added + summary.removed + summary.modified > 0;
+  const hasChanges = hasNodeChanges || edges.length > 0;
+
+  const defaultOpen = useMemo(() => {
+    const open: string[] = [];
+    if (modified.length) open.push('modified');
+    if (added.length) open.push('added');
+    if (removed.length) open.push('removed');
+    if (edges.length) open.push('connections');
+    return open;
+  }, [modified.length, added.length, removed.length, edges.length]);
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Summary strip (FR-4): one calm segmented row of stat tiles. */}
+      <div
+        className="grid grid-cols-4 divide-x divide-slate-100 overflow-hidden rounded-lg border border-slate-200 bg-white"
+        role="list"
+        aria-label="Change summary"
+      >
+        {DIFF_STATUS_ORDER.map((status: NodeDiffStatus) => {
+          const style = DIFF_STATUS_STYLES[status];
+          const value = summary[status];
+          const active = value > 0 && status !== 'unchanged';
+          return (
+            <div key={status} role="listitem" className="flex items-center gap-2.5 px-3 py-2.5">
+              <span
+                className={cn('h-2 w-2 shrink-0 rounded-full', active ? style.dotClass : 'bg-slate-200')}
+                aria-hidden="true"
+              />
+              <div className="flex min-w-0 flex-col leading-tight">
+                <span
+                  className={cn('text-lg font-semibold tabular-nums', active ? 'text-slate-800' : 'text-slate-400')}
+                >
+                  {value}
+                </span>
+                <span className="truncate text-[11px] font-medium uppercase tracking-wide text-slate-400">
+                  {style.label}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {!hasChanges ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 py-12 text-center">
+          <span className="flex h-11 w-11 items-center justify-center rounded-full bg-emerald-50 ring-1 ring-emerald-100">
+            <Check className="h-5 w-5 text-emerald-600" aria-hidden="true" />
+          </span>
+          <p className="text-sm font-medium text-slate-700">No differences</p>
+          <p className="max-w-xs text-xs text-slate-500">
+            These two versions are identical — no nodes or connections were added, removed, or modified.
+          </p>
+        </div>
+      ) : (
+        <ScrollArea className="mt-4 flex-1 pr-3">
+          <Accordion type="multiple" defaultValue={defaultOpen} className="w-full space-y-3">
+            {modified.length > 0 && (
+              <AccordionItem value="modified" className="border-none">
+                <AccordionTrigger className="py-1 hover:no-underline">
+                  <SectionLabel count={modified.length}>Modified nodes</SectionLabel>
+                </AccordionTrigger>
+                <AccordionContent className="space-y-2 pt-1">
+                  <Accordion type="multiple" className="w-full space-y-2">
+                    {modified.map((node) => {
+                      const style = DIFF_STATUS_STYLES.modified;
+                      return (
+                        <AccordionItem
+                          key={node.id}
+                          value={node.id}
+                          className={cn(
+                            'overflow-hidden rounded-md border border-slate-200 border-l-[3px] bg-white',
+                            style.railClass
+                          )}
+                        >
+                          <AccordionTrigger className="px-3 py-2 hover:no-underline">
+                            <span className="flex min-w-0 flex-1 items-center gap-2.5">
+                              <span
+                                className={cn('h-1.5 w-1.5 shrink-0 rounded-full', style.dotClass)}
+                                aria-hidden="true"
+                              />
+                              <span className="truncate text-sm font-medium text-slate-700">{node.label}</span>
+                              <span className="shrink-0 rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 font-mono text-[10px] text-slate-500">
+                                {node.type}
+                              </span>
+                              <span className="ml-auto shrink-0 pr-2 text-[11px] tabular-nums text-slate-400">
+                                {node.fieldChanges.length} {node.fieldChanges.length === 1 ? 'field' : 'fields'}
+                              </span>
+                            </span>
+                          </AccordionTrigger>
+                          <AccordionContent className="space-y-2 border-t border-slate-100 bg-slate-50/40 px-3 py-2.5">
+                            {node.fieldChanges.map((change) => (
+                              <FieldChangeRow key={change.key} change={change} />
+                            ))}
+                          </AccordionContent>
+                        </AccordionItem>
+                      );
+                    })}
+                  </Accordion>
+                </AccordionContent>
+              </AccordionItem>
+            )}
+
+            {added.length > 0 && (
+              <AccordionItem value="added" className="border-none">
+                <AccordionTrigger className="py-1 hover:no-underline">
+                  <SectionLabel count={added.length}>Added nodes</SectionLabel>
+                </AccordionTrigger>
+                <AccordionContent className="space-y-2 pt-1">
+                  {added.map((node) => (
+                    <NodeIdentityRow key={node.id} node={node} />
+                  ))}
+                </AccordionContent>
+              </AccordionItem>
+            )}
+
+            {removed.length > 0 && (
+              <AccordionItem value="removed" className="border-none">
+                <AccordionTrigger className="py-1 hover:no-underline">
+                  <SectionLabel count={removed.length}>Removed nodes</SectionLabel>
+                </AccordionTrigger>
+                <AccordionContent className="space-y-2 pt-1">
+                  {removed.map((node) => (
+                    <NodeIdentityRow key={node.id} node={node} />
+                  ))}
+                </AccordionContent>
+              </AccordionItem>
+            )}
+
+            {edges.length > 0 && (
+              <AccordionItem value="connections" className="border-none">
+                <AccordionTrigger className="py-1 hover:no-underline">
+                  <span className="flex items-center gap-2">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">Connections</span>
+                    <span className="flex items-center gap-1.5 text-[11px] font-medium tabular-nums">
+                      <span className="text-emerald-600">+{addedEdges.length}</span>
+                      <span className="text-slate-300">/</span>
+                      <span className="text-rose-600">−{removedEdges.length}</span>
+                    </span>
+                  </span>
+                </AccordionTrigger>
+                <AccordionContent className="space-y-2 pt-1">
+                  {edges.map((edge) => {
+                    const style = edge.status === 'added' ? DIFF_STATUS_STYLES.added : DIFF_STATUS_STYLES.removed;
+                    return (
+                      <div
+                        key={`${edge.status}-${edge.id}`}
+                        className={cn(
+                          'flex items-center gap-2.5 rounded-md border border-slate-200 border-l-[3px] bg-white px-3 py-2 text-sm',
+                          style.railClass
+                        )}
+                      >
+                        <span
+                          className={cn('shrink-0 select-none font-mono text-sm font-semibold', style.accentClass)}
+                          aria-hidden="true"
+                        >
+                          {style.glyph}
+                        </span>
+                        <span className="sr-only">{style.label} connection:</span>
+                        <span className="truncate font-medium text-slate-700">{edge.sourceLabel}</span>
+                        <ArrowRight className="h-3.5 w-3.5 shrink-0 text-slate-300" aria-hidden="true" />
+                        <span className="truncate font-medium text-slate-700">{edge.targetLabel}</span>
+                      </div>
+                    );
+                  })}
+                </AccordionContent>
+              </AccordionItem>
+            )}
+          </Accordion>
+        </ScrollArea>
+      )}
+    </div>
+  );
+};
+
+export default DiffListView;

--- a/frontend/src/views/AIAgents/Workflows/components/diff/DiffStatusNode.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/diff/DiffStatusNode.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { NodeProps } from 'reactflow';
+import { cn } from '@/helpers/utils';
+import { NodeDiffStatus } from '@/interfaces/workflow-diff.interface';
+import { NodeData, NodeHandler } from '../../types/nodes';
+import { HandlersRenderer } from '../custom/HandleTooltip';
+import { DIFF_STATUS_STYLES } from './diffStatusStyles';
+
+/**
+ * Read-only reactflow node used by the side-by-side diff graph. It renders the node name and a
+ * diff-status badge (icon + text label + color, never color alone — spec FR-14). Edge handles are
+ * rendered from `data.handlers` via the shared `HandlersRenderer` so multi-handle/router edges
+ * still resolve their `sourceHandle`/`targetHandle`. Mirrors `ExecutionStatusNode`.
+ */
+export interface DiffStatusNodeData {
+  name: string;
+  handlers?: NodeHandler[];
+  status: NodeDiffStatus;
+  fieldChangeCount: number;
+  isSelected?: boolean;
+}
+
+const DiffStatusNodeComponent: React.FC<NodeProps<DiffStatusNodeData>> = ({ id, data }) => {
+  const style = DIFF_STATUS_STYLES[data.status] ?? DIFF_STATUS_STYLES.unchanged;
+  const { Icon } = style;
+
+  return (
+    <div
+      className={cn(
+        'relative w-[210px] rounded-lg border border-slate-200 border-l-[3px] bg-white px-3 py-2 shadow-sm transition-shadow',
+        style.railClass,
+        data.isSelected ? 'shadow-md ring-2 ring-brand-600 ring-offset-2' : 'hover:shadow-md'
+      )}
+    >
+      {/* Edge handles driven by the node's own handler config (reused renderer). */}
+      <HandlersRenderer id={id} data={data as unknown as NodeData} />
+
+      <div className="flex items-center gap-1.5">
+        <span className={cn('h-2 w-2 shrink-0 rounded-full', style.dotClass)} aria-hidden="true" />
+        <span className="truncate text-sm font-medium text-slate-700" title={data.name}>
+          {data.name}
+        </span>
+      </div>
+
+      <div className="mt-1.5 flex items-center justify-between gap-2">
+        <span
+          className={cn(
+            'inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] font-medium',
+            style.chipClass
+          )}
+        >
+          <Icon className="h-3 w-3" aria-hidden="true" />
+          {style.label}
+        </span>
+        {data.status === 'modified' && data.fieldChangeCount > 0 && (
+          <span className="text-[10px] tabular-nums text-slate-400">
+            {data.fieldChangeCount} {data.fieldChangeCount === 1 ? 'field' : 'fields'}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const DiffStatusNode = React.memo(DiffStatusNodeComponent);
+export default DiffStatusNode;

--- a/frontend/src/views/AIAgents/Workflows/components/diff/FieldChangeRow.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/diff/FieldChangeRow.tsx
@@ -1,0 +1,130 @@
+import React, { useMemo } from 'react';
+import { isEqual } from 'lodash';
+import { cn } from '@/helpers/utils';
+import { FieldChange } from '@/interfaces/workflow-diff.interface';
+
+/**
+ * One field-level change (old→new) for a modified node, rendered as a GitHub-style stacked diff
+ * (spec FR-6, AC-9): a removed (−) line over an added (+) line. Scalars sit inline in a mono font.
+ * For objects/arrays we don't dump the whole value twice — we recurse and surface only the nested
+ * leaf paths that actually differ (e.g. `message.description`), so the reader sees exactly what
+ * changed inside a large config. A missing side (field/leaf added or removed) is shown explicitly.
+ */
+export interface FieldChangeRowProps {
+  change: FieldChange;
+  className?: string;
+}
+
+interface LeafChange {
+  path: string;
+  before: unknown;
+  after: unknown;
+}
+
+const isObj = (value: unknown): boolean => value !== null && typeof value === 'object';
+
+/** Walk two values in parallel, collecting only the leaf paths whose values differ. */
+const collectLeafChanges = (before: unknown, after: unknown, path: string, out: LeafChange[]): void => {
+  if (isEqual(before, after)) return;
+  if (isObj(before) && isObj(after)) {
+    const b = before as Record<string, unknown>;
+    const a = after as Record<string, unknown>;
+    const keys = Array.from(new Set([...Object.keys(b), ...Object.keys(a)]));
+    for (const key of keys) {
+      collectLeafChanges(b[key], a[key], path ? `${path}.${key}` : key, out);
+    }
+    return;
+  }
+  out.push({ path, before, after });
+};
+
+const formatScalar = (value: unknown): string => {
+  if (value === undefined) return '—';
+  if (value === null) return 'null';
+  if (typeof value === 'string') return value === '' ? '""' : value;
+  return String(value);
+};
+
+const ValueLine: React.FC<{ side: 'before' | 'after'; value: unknown }> = ({ side, value }) => {
+  const removed = side === 'before';
+  const absent = value === undefined;
+  const complex = isObj(value);
+
+  return (
+    <div className={cn('flex items-start gap-2 px-2.5 py-1.5', removed ? 'bg-rose-50/50' : 'bg-emerald-50/50')}>
+      <span
+        className={cn(
+          'mt-px select-none font-mono text-xs font-semibold leading-5',
+          removed ? 'text-rose-500' : 'text-emerald-600'
+        )}
+        aria-hidden="true"
+      >
+        {removed ? '−' : '+'}
+      </span>
+      <span className="sr-only">{removed ? 'Before:' : 'After:'}</span>
+      {complex ? (
+        <pre className="min-w-0 flex-1 overflow-x-auto whitespace-pre font-mono text-[11px] leading-5 text-slate-600">
+          {JSON.stringify(value, null, 2)}
+        </pre>
+      ) : (
+        <span
+          className={cn(
+            'min-w-0 flex-1 whitespace-pre-wrap break-words font-mono text-xs leading-5',
+            absent ? 'italic text-slate-400' : removed ? 'text-rose-700' : 'text-emerald-700'
+          )}
+        >
+          {formatScalar(value)}
+        </span>
+      )}
+    </div>
+  );
+};
+
+const StackedDiff: React.FC<{ before: unknown; after: unknown }> = ({ before, after }) => (
+  <div className="divide-y divide-slate-100">
+    <ValueLine side="before" value={before} />
+    <ValueLine side="after" value={after} />
+  </div>
+);
+
+const FieldChangeRow: React.FC<FieldChangeRowProps> = ({ change, className }) => {
+  // For object/array values, surface only the nested leaves that changed rather than the whole blob.
+  const leaves = useMemo(() => {
+    if (!isObj(change.before) || !isObj(change.after)) return null;
+    const out: LeafChange[] = [];
+    collectLeafChanges(change.before, change.after, '', out);
+    return out;
+  }, [change.before, change.after]);
+
+  return (
+    <div className={cn('overflow-hidden rounded-md border border-slate-200 bg-white', className)}>
+      <div className="flex items-center justify-between border-b border-slate-100 bg-slate-50/80 px-2.5 py-1">
+        <span className="font-mono text-[11px] font-medium text-slate-600">{change.key}</span>
+        {leaves && leaves.length > 0 && (
+          <span className="text-[10px] tabular-nums text-slate-400">
+            {leaves.length} {leaves.length === 1 ? 'change' : 'changes'}
+          </span>
+        )}
+      </div>
+
+      {leaves ? (
+        leaves.length > 0 ? (
+          <div className="divide-y divide-slate-100">
+            {leaves.map((leaf) => (
+              <div key={leaf.path}>
+                <div className="bg-white px-2.5 pt-1.5 font-mono text-[10px] text-slate-400">{leaf.path}</div>
+                <StackedDiff before={leaf.before} after={leaf.after} />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="px-2.5 py-2 text-[11px] italic text-slate-400">Reordered — same values.</div>
+        )
+      ) : (
+        <StackedDiff before={change.before} after={change.after} />
+      )}
+    </div>
+  );
+};
+
+export default FieldChangeRow;

--- a/frontend/src/views/AIAgents/Workflows/components/diff/VersionDiffDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/diff/VersionDiffDialog.tsx
@@ -1,0 +1,163 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ArrowRight, Loader2, AlertTriangle, RefreshCw, List, Network } from 'lucide-react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/tabs';
+import { Button } from '@/components/button';
+import { cn } from '@/helpers/utils';
+import { Workflow } from '@/interfaces/workflow.interface';
+import { getWorkflowById } from '@/services/workflows';
+import { computeWorkflowDiff } from '../../utils/versionDiff';
+import DiffListView from './DiffListView';
+import DiffGraphView from './DiffGraphView';
+
+/**
+ * Host dialog for the Workflow Version Diff Checker (spec FR-1/FR-2/FR-9/FR-10/FR-11/FR-13). Shows
+ * which side is base (older) vs target (newer), and switches between the grouped-list and
+ * side-by-side graph presentations via tabs. The two versions may be passed as full `Workflow`
+ * objects (already loaded by the panel) or resolved on demand via `getWorkflowById`, with loading
+ * and error+retry states. Strictly read-only: closing returns to the panel unchanged.
+ */
+export interface VersionDiffDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** The older version (base). Full object preferred; if it lacks `nodes` it is fetched by id. */
+  base: Workflow;
+  /** The newer version (target). Full object preferred; if it lacks `nodes` it is fetched by id. */
+  target: Workflow;
+}
+
+const hasGraph = (workflow: Workflow | undefined): boolean => !!workflow && Array.isArray(workflow.nodes);
+
+const VersionDiffDialog: React.FC<VersionDiffDialogProps> = ({ open, onClose, base, target }) => {
+  const [resolvedBase, setResolvedBase] = useState<Workflow | undefined>();
+  const [resolvedTarget, setResolvedTarget] = useState<Workflow | undefined>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadVersions = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [nextBase, nextTarget] = await Promise.all([
+        hasGraph(base) ? Promise.resolve(base) : getWorkflowById(base.id ?? ''),
+        hasGraph(target) ? Promise.resolve(target) : getWorkflowById(target.id ?? ''),
+      ]);
+      setResolvedBase(nextBase);
+      setResolvedTarget(nextTarget);
+    } catch {
+      setError('Failed to load one or both versions. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [base, target]);
+
+  useEffect(() => {
+    if (open) {
+      loadVersions();
+    } else {
+      setResolvedBase(undefined);
+      setResolvedTarget(undefined);
+      setError(null);
+    }
+  }, [open, loadVersions]);
+
+  const diff = useMemo(() => {
+    if (!resolvedBase || !resolvedTarget) return null;
+    return computeWorkflowDiff(resolvedBase, resolvedTarget);
+  }, [resolvedBase, resolvedTarget]);
+
+  const versionChip = (workflow: Workflow, side: 'base' | 'target') => {
+    const isTarget = side === 'target';
+    return (
+      <span
+        className={cn(
+          'inline-flex min-w-0 items-center gap-2 rounded-lg border px-2.5 py-1.5',
+          isTarget ? 'border-brand-600/25 bg-brand-50' : 'border-slate-200 bg-slate-50'
+        )}
+      >
+        <span
+          className={cn(
+            'shrink-0 rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider',
+            isTarget ? 'bg-brand-600/10 text-brand-600' : 'bg-slate-200/70 text-slate-500'
+          )}
+        >
+          {isTarget ? 'Target · newer' : 'Base · older'}
+        </span>
+        <span className="truncate text-sm font-medium text-slate-800" title={workflow.name}>
+          {workflow.name}
+        </span>
+        <span
+          className={cn(
+            'shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] font-semibold tabular-nums',
+            isTarget ? 'border-brand-600/25 bg-white text-brand-600' : 'border-slate-200 bg-white text-slate-500'
+          )}
+        >
+          v{workflow.version}
+        </span>
+      </span>
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent className="flex h-[85vh] max-w-5xl flex-col gap-0 sm:max-w-5xl">
+        <DialogHeader>
+          <DialogTitle>Compare versions</DialogTitle>
+          <DialogDescription>
+            Read-only comparison of two saved versions — added, removed, and modified nodes and connections.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Base vs target identity (FR-2) */}
+        <div className="flex flex-wrap items-center gap-2 border-b border-slate-100 py-3">
+          {versionChip(base, 'base')}
+          <ArrowRight className="h-4 w-4 shrink-0 text-slate-400" aria-hidden="true" />
+          {versionChip(target, 'target')}
+        </div>
+
+        {loading && (
+          <div className="flex flex-1 flex-col items-center justify-center gap-2 text-sm text-slate-500">
+            <Loader2 className="h-6 w-6 animate-spin text-brand-600" aria-hidden="true" />
+            Loading versions…
+          </div>
+        )}
+
+        {!loading && error && (
+          <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center" role="alert">
+            <span className="flex h-11 w-11 items-center justify-center rounded-full bg-rose-50 ring-1 ring-rose-100">
+              <AlertTriangle className="h-5 w-5 text-rose-500" aria-hidden="true" />
+            </span>
+            <p className="text-sm text-slate-700">{error}</p>
+            <Button variant="outline" size="sm" onClick={loadVersions} className="gap-1.5">
+              <RefreshCw className="h-4 w-4" />
+              Retry
+            </Button>
+          </div>
+        )}
+
+        {!loading && !error && diff && (
+          <Tabs defaultValue="list" className="flex min-h-0 flex-1 flex-col pt-3">
+            <TabsList className="w-fit">
+              <TabsTrigger value="list" className="gap-1.5">
+                <List className="h-4 w-4" aria-hidden="true" />
+                List
+              </TabsTrigger>
+              <TabsTrigger value="graph" className="gap-1.5">
+                <Network className="h-4 w-4" aria-hidden="true" />
+                Graph
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="list" className="min-h-0 flex-1 pt-3 data-[state=inactive]:hidden">
+              <DiffListView diff={diff} />
+            </TabsContent>
+            <TabsContent value="graph" className="min-h-0 flex-1 pt-3 data-[state=inactive]:hidden">
+              <DiffGraphView diff={diff} />
+            </TabsContent>
+          </Tabs>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default VersionDiffDialog;

--- a/frontend/src/views/AIAgents/Workflows/components/diff/diffStatusStyles.ts
+++ b/frontend/src/views/AIAgents/Workflows/components/diff/diffStatusStyles.ts
@@ -1,0 +1,75 @@
+import { Plus, Minus, PenLine, Equal, LucideIcon } from 'lucide-react';
+import { NodeDiffStatus } from '@/interfaces/workflow-diff.interface';
+
+/**
+ * Visual language for the version diff. Deliberately restrained: colour is carried by a thin left
+ * accent rail + a small solid dot/icon rather than flooding whole cards with a tint, so the view
+ * reads calm and "engineered" rather than candy-coloured. Status is always backed by an icon + a
+ * text label + a glyph (never colour alone) to meet the a11y bar (spec FR-14 / NFR a11y).
+ *
+ * Palette: emerald (added) · rose (removed) · amber (modified) · slate (unchanged). Interactive
+ * accents (tabs, selection) use the app brand indigo elsewhere.
+ */
+export interface DiffStatusStyle {
+  label: string;
+  /** Compact glyph for dense contexts (+, −, ~, =). */
+  glyph: string;
+  Icon: LucideIcon;
+  /** Icon / accent text colour. */
+  accentClass: string;
+  /** Solid dot colour (summary tiles, node cards). */
+  dotClass: string;
+  /** Left accent rail colour (border-l). */
+  railClass: string;
+  /** Very subtle row/card wash — used sparingly. */
+  softClass: string;
+  /** Small outlined chip (graph node badge, detail header). */
+  chipClass: string;
+}
+
+export const DIFF_STATUS_STYLES: Record<NodeDiffStatus, DiffStatusStyle> = {
+  added: {
+    label: 'Added',
+    glyph: '+',
+    Icon: Plus,
+    accentClass: 'text-emerald-600',
+    dotClass: 'bg-emerald-500',
+    railClass: 'border-l-emerald-400',
+    softClass: 'bg-emerald-50/50',
+    chipClass: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  },
+  removed: {
+    label: 'Removed',
+    glyph: '−',
+    Icon: Minus,
+    accentClass: 'text-rose-600',
+    dotClass: 'bg-rose-500',
+    railClass: 'border-l-rose-400',
+    softClass: 'bg-rose-50/50',
+    chipClass: 'border-rose-200 bg-rose-50 text-rose-700',
+  },
+  modified: {
+    label: 'Modified',
+    glyph: '~',
+    Icon: PenLine,
+    // GenAssist brand indigo (only brand-50 / brand-600 are defined; softer shades via opacity).
+    accentClass: 'text-brand-600',
+    dotClass: 'bg-brand-600',
+    railClass: 'border-l-brand-600',
+    softClass: 'bg-brand-50',
+    chipClass: 'border-brand-600/20 bg-brand-50 text-brand-600',
+  },
+  unchanged: {
+    label: 'Unchanged',
+    glyph: '=',
+    Icon: Equal,
+    accentClass: 'text-slate-400',
+    dotClass: 'bg-slate-300',
+    railClass: 'border-l-slate-200',
+    softClass: 'bg-transparent',
+    chipClass: 'border-slate-200 bg-slate-50 text-slate-500',
+  },
+};
+
+/** Ordered statuses for summary tiles / grouped sections (most relevant first). */
+export const DIFF_STATUS_ORDER: NodeDiffStatus[] = ['added', 'removed', 'modified', 'unchanged'];

--- a/frontend/src/views/AIAgents/Workflows/components/panels/WorkflowsSavedPanel.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/panels/WorkflowsSavedPanel.tsx
@@ -1,8 +1,19 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { Button } from "@/components/button";
-import { Save, Plus, Trash2, Pencil, Power, MoreVertical } from "lucide-react";
+import {
+  Save,
+  Plus,
+  Trash2,
+  Pencil,
+  Power,
+  MoreVertical,
+  GitCompare,
+  X,
+} from "lucide-react";
+import { Checkbox } from "@/components/checkbox";
 import { Workflow } from "@/interfaces/workflow.interface";
 import { getAllWorkflows, deleteWorkflow } from "@/services/workflows";
+import VersionDiffDialog from "../diff/VersionDiffDialog";
 import {
   Dialog,
   DialogContent,
@@ -96,6 +107,53 @@ const WorkflowsSavedPanel: React.FC<WorkflowsSavedPanelProps> = ({
     null
   );
   const [isSwitching, setIsSwitching] = useState(false);
+
+  // Compare mode: pick exactly two versions of this agent and open a read-only diff (FR-1).
+  const [isCompareMode, setIsCompareMode] = useState(false);
+  const [compareSelection, setCompareSelection] = useState<string[]>([]);
+  const [isDiffDialogOpen, setIsDiffDialogOpen] = useState(false);
+
+  const exitCompareMode = () => {
+    setIsCompareMode(false);
+    setCompareSelection([]);
+    setIsDiffDialogOpen(false);
+  };
+
+  // Toggle a version's selection; never selects a third (FR-1).
+  const toggleCompareSelection = (workflow: Workflow) => {
+    const id = workflow.id;
+    if (!id) return;
+    setCompareSelection((prev) => {
+      if (prev.includes(id)) return prev.filter((x) => x !== id);
+      if (prev.length >= 2) return prev;
+      return [...prev, id];
+    });
+  };
+
+  // Resolve the two selected versions into base (older) / target (newer): base = earlier
+  // created_at, tie-broken by the lower version string, so the newer version is the target (FR-2).
+  const comparePair = useMemo(() => {
+    if (compareSelection.length !== 2) return null;
+    const first = workflows.find((w) => w.id === compareSelection[0]);
+    const second = workflows.find((w) => w.id === compareSelection[1]);
+    if (!first || !second) return null;
+
+    const timeFirst = new Date(first.created_at ?? 0).getTime();
+    const timeSecond = new Date(second.created_at ?? 0).getTime();
+
+    let firstIsBase: boolean;
+    if (timeFirst !== timeSecond) {
+      firstIsBase = timeFirst < timeSecond;
+    } else {
+      const versionFirst = parseFloat(first.version ?? "0");
+      const versionSecond = parseFloat(second.version ?? "0");
+      firstIsBase = versionFirst <= versionSecond;
+    }
+
+    return firstIsBase
+      ? { base: first, target: second }
+      : { base: second, target: first };
+  }, [compareSelection, workflows]);
 
   // Load workflows
   const loadWorkflows = async () => {
@@ -319,27 +377,68 @@ const WorkflowsSavedPanel: React.FC<WorkflowsSavedPanelProps> = ({
         <div className="p-4 border-b">
           <div className="flex items-center justify-between">
             <h2 className="text-lg font-semibold">Saved Versions</h2>
+            {workflows.length >= 2 &&
+              (isCompareMode ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={exitCompareMode}
+                  className="flex items-center gap-1"
+                >
+                  <X className="h-4 w-4" />
+                  Cancel
+                </Button>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setIsCompareMode(true)}
+                  className="flex items-center gap-1"
+                >
+                  <GitCompare className="h-4 w-4" />
+                  Compare
+                </Button>
+              ))}
           </div>
         </div>
 
         <div className="flex-1 overflow-y-auto p-4">
-          <div className="flex items-center space-x-2 mb-4">
-            <Button
-              onClick={() => {
-                setWorkflowName(currentWorkflow.name || "");
-                setWorkflowVersion(calculateNextVersion(workflows));
-                setWorkflowDescription(currentWorkflow.description || "");
-                setVersionError(null);
-                setCreateDialogOpen(true);
-              }}
-              size="sm"
-              variant="outline"
-              className="flex items-center gap-1"
-            >
-              <Plus className="h-4 w-4" />
-              New
-            </Button>
-          </div>
+          {isCompareMode ? (
+            <div className="mb-4 space-y-2">
+              <p className="text-xs text-gray-500">
+                {compareSelection.length < 2
+                  ? `Select two versions to compare (${compareSelection.length}/2).`
+                  : "Two versions selected. Deselect one to choose a different pair."}
+              </p>
+              <Button
+                onClick={() => setIsDiffDialogOpen(true)}
+                size="sm"
+                disabled={compareSelection.length !== 2}
+                className="flex items-center gap-1"
+              >
+                <GitCompare className="h-4 w-4" />
+                Compare ({compareSelection.length})
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center space-x-2 mb-4">
+              <Button
+                onClick={() => {
+                  setWorkflowName(currentWorkflow.name || "");
+                  setWorkflowVersion(calculateNextVersion(workflows));
+                  setWorkflowDescription(currentWorkflow.description || "");
+                  setVersionError(null);
+                  setCreateDialogOpen(true);
+                }}
+                size="sm"
+                variant="outline"
+                className="flex items-center gap-1"
+              >
+                <Plus className="h-4 w-4" />
+                New
+              </Button>
+            </div>
+          )}
 
           {error && (
             <div className="mb-4 bg-red-50 border border-red-200 text-red-600 p-2 rounded-md text-sm">
@@ -352,12 +451,32 @@ const WorkflowsSavedPanel: React.FC<WorkflowsSavedPanelProps> = ({
               <div
                 key={workflow.id}
                 className={`flex items-center space-x-2 p-2 rounded-md border cursor-pointer ${
-                  selectedWorkflowId === workflow.id
+                  (
+                    isCompareMode
+                      ? !!workflow.id && compareSelection.includes(workflow.id)
+                      : selectedWorkflowId === workflow.id
+                  )
                     ? "bg-blue-50 border-blue-200"
                     : "hover:bg-gray-50"
                 }`}
-                onClick={() => handleWorkflowSelect(workflow)}
+                onClick={() =>
+                  isCompareMode
+                    ? toggleCompareSelection(workflow)
+                    : handleWorkflowSelect(workflow)
+                }
               >
+                {isCompareMode && (
+                  <Checkbox
+                    checked={!!workflow.id && compareSelection.includes(workflow.id)}
+                    disabled={
+                      !(!!workflow.id && compareSelection.includes(workflow.id)) &&
+                      compareSelection.length >= 2
+                    }
+                    onCheckedChange={() => toggleCompareSelection(workflow)}
+                    onClick={(e) => e.stopPropagation()}
+                    aria-label={`Select ${workflow.name} v${workflow.version} to compare`}
+                  />
+                )}
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
                     <div className="font-medium truncate">{workflow.name}</div>
@@ -394,6 +513,7 @@ const WorkflowsSavedPanel: React.FC<WorkflowsSavedPanelProps> = ({
                   )}
                 </div>
                 <div className="flex items-center space-x-1">
+                  {!isCompareMode && (
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <Button variant="ghost" size="icon">
@@ -434,6 +554,7 @@ const WorkflowsSavedPanel: React.FC<WorkflowsSavedPanelProps> = ({
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>
+                  )}
                 </div>
               </div>
             ))}
@@ -553,6 +674,16 @@ const WorkflowsSavedPanel: React.FC<WorkflowsSavedPanelProps> = ({
         title="You have unsaved changes!"
         description="Would you like to save or discard them?"
       />
+
+      {/* Version Diff Checker (read-only) */}
+      {comparePair && (
+        <VersionDiffDialog
+          open={isDiffDialogOpen}
+          onClose={() => setIsDiffDialogOpen(false)}
+          base={comparePair.base}
+          target={comparePair.target}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/views/AIAgents/Workflows/utils/versionDiff.test.ts
+++ b/frontend/src/views/AIAgents/Workflows/utils/versionDiff.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect } from 'vitest';
+import { Edge, Node } from 'reactflow';
+import { Workflow } from '@/interfaces/workflow.interface';
+import nodeRegistry from '../registry/nodeRegistry';
+import { NodeData, NodeTypeDefinition } from '../types/nodes';
+import { computeWorkflowDiff, diffEdges, diffNodeData, getNodeLabel, normalizeForDiff } from './versionDiff';
+
+// --- Fixtures -------------------------------------------------------------------------------
+
+const makeNode = (id: string, overrides: Partial<Node> = {}, data: Record<string, unknown> = {}): Node => ({
+  id,
+  type: 'llmNode',
+  position: { x: 0, y: 0 },
+  data: { name: id, ...data },
+  ...overrides,
+});
+
+const makeEdge = (id: string, source: string, target: string, overrides: Partial<Edge> = {}): Edge => ({
+  id,
+  source,
+  target,
+  ...overrides,
+});
+
+const makeWorkflow = (nodes: Node[], edges: Edge[] = [], overrides: Partial<Workflow> = {}): Workflow => ({
+  id: 'wf',
+  name: 'Workflow',
+  version: '1.0',
+  nodes,
+  edges,
+  ...overrides,
+});
+
+// --- normalizeForDiff -----------------------------------------------------------------------
+
+describe('normalizeForDiff', () => {
+  it('strips workflow timestamps and cosmetic node/edge fields', () => {
+    const wf = makeWorkflow(
+      [
+        makeNode('a', {
+          selected: true,
+          dragging: true,
+          width: 200,
+          height: 100,
+          position: { x: 42, y: 99 },
+          positionAbsolute: { x: 42, y: 99 },
+        }),
+      ],
+      [makeEdge('e1', 'a', 'b', { selected: true, className: 'highlight' })],
+      { created_at: '2026-01-01', updated_at: '2026-02-02' }
+    );
+
+    const norm = normalizeForDiff(wf);
+    const node = norm.nodes[0] as Node & { positionAbsolute?: unknown };
+    expect(node.selected).toBeUndefined();
+    expect(node.dragging).toBeUndefined();
+    expect(node.width).toBeUndefined();
+    expect(node.height).toBeUndefined();
+    expect(node.position).toBeUndefined();
+    expect(node.positionAbsolute).toBeUndefined();
+
+    const edge = norm.edges[0] as Edge & { className?: string };
+    expect(edge.selected).toBeUndefined();
+    expect(edge.className).toBeUndefined();
+  });
+
+  it('strips the injected data.updateNodeData function', () => {
+    const wf = makeWorkflow([makeNode('a', {}, { updateNodeData: () => undefined, model: 'gpt-4' })]);
+    const norm = normalizeForDiff(wf);
+    const data = norm.nodes[0].data as Record<string, unknown>;
+    expect(data.updateNodeData).toBeUndefined();
+    expect(data.model).toBe('gpt-4');
+  });
+
+  it('handles empty / missing node & edge arrays', () => {
+    const norm = normalizeForDiff({ name: 'x', version: '1.0' } as Workflow);
+    expect(norm.nodes).toEqual([]);
+    expect(norm.edges).toEqual([]);
+  });
+});
+
+// --- getNodeLabel ---------------------------------------------------------------------------
+
+describe('getNodeLabel', () => {
+  it('prefers data.name', () => {
+    expect(getNodeLabel(makeNode('a', {}, { name: 'My LLM' }))).toBe('My LLM');
+  });
+
+  it('falls back to the registry label for the node type', () => {
+    const type = '__diffTestNode__';
+    nodeRegistry.register({
+      type,
+      label: 'Diff Test Node',
+      category: 'test',
+      defaultData: {},
+    } as unknown as NodeTypeDefinition<NodeData>);
+    const node = { id: 'n1', type, position: { x: 0, y: 0 }, data: {} } as Node;
+    expect(getNodeLabel(node)).toBe('Diff Test Node');
+  });
+
+  it('falls back to the type when no name/registry label', () => {
+    const node = { id: 'n1', type: 'unknownType', position: { x: 0, y: 0 }, data: {} } as Node;
+    expect(getNodeLabel(node)).toBe('unknownType');
+  });
+
+  it('falls back to the id when there is no type', () => {
+    const node = { id: 'n1', position: { x: 0, y: 0 }, data: {} } as unknown as Node;
+    expect(getNodeLabel(node)).toBe('n1');
+  });
+});
+
+// --- diffNodeData ---------------------------------------------------------------------------
+
+describe('diffNodeData', () => {
+  it('returns an empty list when data is identical', () => {
+    const a = makeNode('a', {}, { model: 'gpt-4', temp: 0.5 });
+    const b = makeNode('a', {}, { model: 'gpt-4', temp: 0.5 });
+    expect(diffNodeData(a, b)).toEqual([]);
+  });
+
+  it('reports a scalar field change with before/after', () => {
+    const a = makeNode('a', {}, { model: 'gpt-4' });
+    const b = makeNode('a', {}, { model: 'gpt-4o' });
+    const changes = diffNodeData(a, b);
+    expect(changes).toContainEqual({ key: 'model', before: 'gpt-4', after: 'gpt-4o' });
+  });
+
+  it('detects added and removed fields', () => {
+    const a = makeNode('a', {}, { onlyBase: 1 });
+    const b = makeNode('a', {}, { onlyTarget: 2 });
+    const changes = diffNodeData(a, b);
+    expect(changes).toContainEqual({ key: 'onlyBase', before: 1, after: undefined });
+    expect(changes).toContainEqual({ key: 'onlyTarget', before: undefined, after: 2 });
+  });
+
+  it('detects nested object field changes', () => {
+    const a = makeNode('a', {}, { config: { retries: 1, nested: { x: 1 } } });
+    const b = makeNode('a', {}, { config: { retries: 1, nested: { x: 2 } } });
+    const changes = diffNodeData(a, b);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].key).toBe('config');
+    expect(changes[0].before).toEqual({ retries: 1, nested: { x: 1 } });
+    expect(changes[0].after).toEqual({ retries: 1, nested: { x: 2 } });
+  });
+
+  it('does not report a change for deeply-equal nested objects', () => {
+    const a = makeNode('a', {}, { config: { list: [1, 2, 3] } });
+    const b = makeNode('a', {}, { config: { list: [1, 2, 3] } });
+    expect(diffNodeData(a, b)).toEqual([]);
+  });
+
+  it('synthesizes a `type` change when the node type differs', () => {
+    const a = makeNode('a', { type: 'llmNode' });
+    const b = makeNode('a', { type: 'toolNode' });
+    const changes = diffNodeData(a, b);
+    expect(changes).toContainEqual({ key: 'type', before: 'llmNode', after: 'toolNode' });
+  });
+});
+
+// --- diffEdges ------------------------------------------------------------------------------
+
+describe('diffEdges', () => {
+  it('classifies added and removed connections with node labels', () => {
+    const base = makeWorkflow(
+      [makeNode('a', {}, { name: 'Alpha' }), makeNode('b', {}, { name: 'Beta' })],
+      [makeEdge('e1', 'a', 'b')]
+    );
+    const target = makeWorkflow(
+      [makeNode('a', {}, { name: 'Alpha' }), makeNode('c', {}, { name: 'Gamma' })],
+      [makeEdge('e2', 'a', 'c')]
+    );
+
+    const diffs = diffEdges(base, target);
+    const added = diffs.find((d) => d.status === 'added');
+    const removed = diffs.find((d) => d.status === 'removed');
+
+    expect(added).toMatchObject({ sourceLabel: 'Alpha', targetLabel: 'Gamma' });
+    expect(removed).toMatchObject({ sourceLabel: 'Alpha', targetLabel: 'Beta' });
+  });
+
+  it('treats an edge with the same connection identity (different id) as unchanged', () => {
+    const base = makeWorkflow([makeNode('a'), makeNode('b')], [makeEdge('e1', 'a', 'b')]);
+    const target = makeWorkflow([makeNode('a'), makeNode('b')], [makeEdge('e999', 'a', 'b')]);
+    expect(diffEdges(base, target)).toEqual([]);
+  });
+
+  it('distinguishes edges by handle', () => {
+    const base = makeWorkflow([makeNode('a'), makeNode('b')], [makeEdge('e1', 'a', 'b', { sourceHandle: 'out1' })]);
+    const target = makeWorkflow([makeNode('a'), makeNode('b')], [makeEdge('e1', 'a', 'b', { sourceHandle: 'out2' })]);
+    const diffs = diffEdges(base, target);
+    expect(diffs).toHaveLength(2);
+    expect(diffs.filter((d) => d.status === 'added')).toHaveLength(1);
+    expect(diffs.filter((d) => d.status === 'removed')).toHaveLength(1);
+  });
+});
+
+// --- computeWorkflowDiff --------------------------------------------------------------------
+
+describe('computeWorkflowDiff', () => {
+  it('classifies added / removed / modified / unchanged and counts them', () => {
+    const base = makeWorkflow([
+      makeNode('keep', {}, { name: 'Keep', model: 'gpt-4' }),
+      makeNode('mod', {}, { name: 'Mod', model: 'gpt-4' }),
+      makeNode('gone', {}, { name: 'Gone' }),
+    ]);
+    const target = makeWorkflow([
+      makeNode('keep', {}, { name: 'Keep', model: 'gpt-4' }),
+      makeNode('mod', {}, { name: 'Mod', model: 'gpt-4o' }),
+      makeNode('new', {}, { name: 'New' }),
+    ]);
+
+    const diff = computeWorkflowDiff(base, target);
+    expect(diff.summary).toEqual({ added: 1, removed: 1, modified: 1, unchanged: 1 });
+
+    const byId = Object.fromEntries(diff.nodes.map((n) => [n.id, n]));
+    expect(byId.new.status).toBe('added');
+    expect(byId.gone.status).toBe('removed');
+    expect(byId.mod.status).toBe('modified');
+    expect(byId.keep.status).toBe('unchanged');
+    expect(byId.mod.fieldChanges).toContainEqual({ key: 'model', before: 'gpt-4', after: 'gpt-4o' });
+    expect(byId.keep.fieldChanges).toEqual([]);
+  });
+
+  it('reports a node that only moved as unchanged (position is cosmetic)', () => {
+    const base = makeWorkflow([makeNode('a', { position: { x: 0, y: 0 } }, { model: 'gpt-4' })]);
+    const target = makeWorkflow([makeNode('a', { position: { x: 500, y: 300 } }, { model: 'gpt-4' })]);
+    const diff = computeWorkflowDiff(base, target);
+    expect(diff.summary).toEqual({ added: 0, removed: 0, modified: 0, unchanged: 1 });
+    expect(diff.nodes[0].status).toBe('unchanged');
+  });
+
+  it('ignores cosmetic selection/drag/size differences', () => {
+    const base = makeWorkflow([
+      makeNode('a', { selected: false, dragging: false, width: 100, height: 50 }, { model: 'gpt-4' }),
+    ]);
+    const target = makeWorkflow([
+      makeNode('a', { selected: true, dragging: true, width: 999, height: 999 }, { model: 'gpt-4' }),
+    ]);
+    const diff = computeWorkflowDiff(base, target);
+    expect(diff.nodes[0].status).toBe('unchanged');
+  });
+
+  it('returns an all-unchanged, edge-free diff for identical workflows', () => {
+    const nodes = [makeNode('a', {}, { model: 'gpt-4' }), makeNode('b')];
+    const edges = [makeEdge('e1', 'a', 'b')];
+    const diff = computeWorkflowDiff(makeWorkflow(nodes, edges), makeWorkflow(nodes, edges));
+    expect(diff.summary).toEqual({ added: 0, removed: 0, modified: 0, unchanged: 2 });
+    expect(diff.edges).toEqual([]);
+  });
+
+  it('includes added/removed edges in the diff result', () => {
+    const base = makeWorkflow([makeNode('a'), makeNode('b')], [makeEdge('e1', 'a', 'b')]);
+    const target = makeWorkflow(
+      [makeNode('a'), makeNode('b'), makeNode('c')],
+      [makeEdge('e1', 'a', 'b'), makeEdge('e2', 'b', 'c')]
+    );
+    const diff = computeWorkflowDiff(base, target);
+    expect(diff.edges).toHaveLength(1);
+    expect(diff.edges[0]).toMatchObject({ status: 'added' });
+  });
+
+  it('preserves the original (un-normalized) base/target for display', () => {
+    const base = makeWorkflow([makeNode('a')], [], {
+      version: '1.0',
+      created_at: '2026-01-01',
+    });
+    const target = makeWorkflow([makeNode('a')], [], {
+      version: '2.0',
+      created_at: '2026-02-01',
+    });
+    const diff = computeWorkflowDiff(base, target);
+    expect(diff.base.version).toBe('1.0');
+    expect(diff.target.version).toBe('2.0');
+    expect(diff.base.created_at).toBe('2026-01-01');
+  });
+
+  it('uses the human-readable label for node diff entries', () => {
+    const base = makeWorkflow([]);
+    const target = makeWorkflow([makeNode('a', {}, { name: 'Greeter' })]);
+    const diff = computeWorkflowDiff(base, target);
+    expect(diff.nodes[0].label).toBe('Greeter');
+    expect(diff.nodes[0].status).toBe('added');
+  });
+});

--- a/frontend/src/views/AIAgents/Workflows/utils/versionDiff.ts
+++ b/frontend/src/views/AIAgents/Workflows/utils/versionDiff.ts
@@ -1,0 +1,214 @@
+import { isEqual } from 'lodash';
+import { Edge, Node } from 'reactflow';
+import { Workflow } from '@/interfaces/workflow.interface';
+import {
+  DiffSummary,
+  EdgeDiff,
+  FieldChange,
+  NodeDiff,
+  NodeDiffStatus,
+  WorkflowDiff,
+} from '@/interfaces/workflow-diff.interface';
+import nodeRegistry from '../registry/nodeRegistry';
+
+/**
+ * Pure diff engine for the Workflow Version Diff Checker (feature 005).
+ *
+ * Mirrors — and extends — the builder's `compareWorkflows` cosmetic-stripping rules
+ * (`GraphFlow.tsx`) so the notion of a "meaningful change" stays consistent with the rest of the
+ * app. In addition to the builder's stripped fields it also drops each node's `position`/
+ * `positionAbsolute` (a move is cosmetic per spec FR-7) and the runtime-injected
+ * `data.updateNodeData` function (not real configuration). Everything here is a deterministic pure
+ * function so it is fully unit-testable (see `versionDiff.test.ts`).
+ */
+
+type UnknownRecord = Record<string, unknown>;
+
+/** A workflow reduced to just the meaningful graph, cosmetic fields stripped. */
+export interface NormalizedWorkflow {
+  nodes: Node[];
+  edges: Edge[];
+}
+
+const asRecord = (value: unknown): UnknownRecord =>
+  value && typeof value === 'object' && !Array.isArray(value) ? (value as UnknownRecord) : {};
+
+/**
+ * Deep-clones a workflow and strips all non-meaningful/cosmetic fields:
+ * - workflow `created_at` / `updated_at`
+ * - per node: `selected`, `dragging`, `width`, `height`, `position`, `positionAbsolute`,
+ *   and `data.updateNodeData`
+ * - per edge: `selected`, `className`
+ */
+export const normalizeForDiff = (workflow: Workflow): NormalizedWorkflow => {
+  const clone = JSON.parse(JSON.stringify(workflow ?? {})) as Workflow;
+
+  const nodes: Node[] = (clone.nodes ?? []).map((node) => {
+    const { selected, dragging, width, height, position, positionAbsolute, ...rest } = node as Node & {
+      positionAbsolute?: unknown;
+    };
+    const data = { ...asRecord(rest.data) };
+    delete data.updateNodeData;
+    return { ...rest, data } as Node;
+  });
+
+  const edges: Edge[] = (clone.edges ?? []).map((edge) => {
+    const { selected, className, ...rest } = edge as Edge & { className?: string };
+    return rest as Edge;
+  });
+
+  return { nodes, edges };
+};
+
+/**
+ * Human-readable identity for a node, resolved in priority order:
+ * `data.name` → registry label for its type → its type → its id.
+ */
+export const getNodeLabel = (node: Node): string => {
+  const data = asRecord(node?.data);
+  const name = data.name;
+  if (typeof name === 'string' && name.trim()) return name;
+
+  const registryLabel = node?.type ? nodeRegistry.getNodeType(node.type)?.label : undefined;
+  if (registryLabel && registryLabel.trim()) return registryLabel;
+
+  if (node?.type) return node.type;
+  return node?.id ?? '';
+};
+
+/**
+ * Field-level comparison of two same-id nodes' normalized `data`. Compares every field present in
+ * either node via `isEqual`. If the node's `type` itself changed, that is surfaced as a synthetic
+ * `type` field change so the user sees the node was re-typed.
+ */
+export const diffNodeData = (baseNode: Node, targetNode: Node): FieldChange[] => {
+  const changes: FieldChange[] = [];
+
+  if (baseNode.type !== targetNode.type) {
+    changes.push({ key: 'type', before: baseNode.type, after: targetNode.type });
+  }
+
+  const baseData = asRecord(baseNode.data);
+  const targetData = asRecord(targetNode.data);
+  const keys = Array.from(new Set([...Object.keys(baseData), ...Object.keys(targetData)]));
+
+  for (const key of keys) {
+    if (!isEqual(baseData[key], targetData[key])) {
+      changes.push({ key, before: baseData[key], after: targetData[key] });
+    }
+  }
+
+  return changes;
+};
+
+/** Identity of a connection: its source/handles/target tuple, falling back to the edge id. */
+const edgeIdentity = (edge: Edge): string => {
+  const source = edge.source ?? '';
+  const target = edge.target ?? '';
+  if (source || target) {
+    return `${source}::${edge.sourceHandle ?? ''}::${target}::${edge.targetHandle ?? ''}`;
+  }
+  return `id:${edge.id ?? ''}`;
+};
+
+/**
+ * Classifies edges into added (present only in target) and removed (present only in base),
+ * matched by connection identity. Human-readable source/target labels are resolved from the node
+ * labels of whichever version owns the edge.
+ */
+export const diffEdges = (base: Workflow, target: Workflow): EdgeDiff[] => {
+  const baseNorm = normalizeForDiff(base);
+  const targetNorm = normalizeForDiff(target);
+
+  const labelFor = (nodes: Node[], nodeId: string): string => {
+    const node = nodes.find((n) => n.id === nodeId);
+    return node ? getNodeLabel(node) : nodeId;
+  };
+
+  const baseByIdentity = new Map<string, Edge>();
+  for (const edge of baseNorm.edges) baseByIdentity.set(edgeIdentity(edge), edge);
+
+  const targetByIdentity = new Map<string, Edge>();
+  for (const edge of targetNorm.edges) targetByIdentity.set(edgeIdentity(edge), edge);
+
+  const diffs: EdgeDiff[] = [];
+
+  // Added: in target but not base.
+  for (const [identity, edge] of targetByIdentity) {
+    if (!baseByIdentity.has(identity)) {
+      diffs.push({
+        id: edge.id ?? identity,
+        status: 'added',
+        sourceLabel: labelFor(targetNorm.nodes, edge.source),
+        targetLabel: labelFor(targetNorm.nodes, edge.target),
+      });
+    }
+  }
+
+  // Removed: in base but not target.
+  for (const [identity, edge] of baseByIdentity) {
+    if (!targetByIdentity.has(identity)) {
+      diffs.push({
+        id: edge.id ?? identity,
+        status: 'removed',
+        sourceLabel: labelFor(baseNorm.nodes, edge.source),
+        targetLabel: labelFor(baseNorm.nodes, edge.target),
+      });
+    }
+  }
+
+  return diffs;
+};
+
+/**
+ * Computes the full comparison of two workflow versions. Nodes are paired by stable `id`:
+ * present only in target ⇒ `added`, only in base ⇒ `removed`, in both with meaningful field
+ * changes ⇒ `modified`, in both with none ⇒ `unchanged`. The returned `base`/`target` are the
+ * original (un-normalized) workflows so callers can display their name/version/timestamps.
+ */
+export const computeWorkflowDiff = (base: Workflow, target: Workflow): WorkflowDiff => {
+  const baseNorm = normalizeForDiff(base);
+  const targetNorm = normalizeForDiff(target);
+
+  const baseById = new Map<string, Node>();
+  for (const node of baseNorm.nodes) baseById.set(node.id, node);
+
+  const targetById = new Map<string, Node>();
+  for (const node of targetNorm.nodes) targetById.set(node.id, node);
+
+  const nodes: NodeDiff[] = [];
+  const summary: DiffSummary = { added: 0, removed: 0, modified: 0, unchanged: 0 };
+
+  const pushNode = (node: Node, status: NodeDiffStatus, fieldChanges: FieldChange[]) => {
+    nodes.push({
+      id: node.id,
+      label: getNodeLabel(node),
+      type: node.type ?? '',
+      status,
+      fieldChanges,
+    });
+    summary[status] += 1;
+  };
+
+  // Iterate target order first (added / modified / unchanged) for a deterministic layout.
+  for (const targetNode of targetNorm.nodes) {
+    const baseNode = baseById.get(targetNode.id);
+    if (!baseNode) {
+      pushNode(targetNode, 'added', []);
+      continue;
+    }
+    const fieldChanges = diffNodeData(baseNode, targetNode);
+    pushNode(targetNode, fieldChanges.length ? 'modified' : 'unchanged', fieldChanges);
+  }
+
+  // Then base-only nodes (removed), in base order.
+  for (const baseNode of baseNorm.nodes) {
+    if (!targetById.has(baseNode.id)) {
+      pushNode(baseNode, 'removed', []);
+    }
+  }
+
+  const edges = diffEdges(base, target);
+
+  return { base, target, nodes, edges, summary };
+};


### PR DESCRIPTION
- Add DiffStatusNode component for rendering node status in the diff graph.
- Create FieldChangeRow component to display field-level changes in a GitHub-style diff format.
- Implement VersionDiffDialog to compare two workflow versions, showing differences in a tabbed interface.
- Introduce diffStatusStyles for consistent visual representation of diff statuses.
- Develop utility functions for computing workflow diffs, including normalization and edge comparison.
- Add comprehensive tests for versionDiff utilities to ensure accurate diff computation and edge handling.

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
