### PR TITLE
fix: correct Agent Studio workflow canvas undo/redo behavior

### DIFF
--- a/frontend/src/views/AIAgents/Workflows/GraphFlow.tsx
+++ b/frontend/src/views/AIAgents/Workflows/GraphFlow.tsx
@@ -14,6 +14,7 @@ import ReactFlow, {
 } from "reactflow";
 import "reactflow/dist/style.css";
 import { isEqual } from "lodash";
+import { stripTransientGraphFields } from "./utils/graphNormalization";
 import { getNodeTypes } from "./nodeTypes";
 import { getEdgeTypes } from "./edgeTypes";
 import nodeRegistry from "./registry/nodeRegistry";
@@ -61,6 +62,11 @@ const nodeTypes = getNodeTypes();
 const edgeTypes = getEdgeTypes();
 
 const PRO_OPTIONS = { hideAttribution: true }; // remove React Flow watermark
+
+// Skip canvas undo/redo when focus is in a field the user is typing in
+const isEditableEventTarget = (target: HTMLElement): boolean =>
+  target.isContentEditable ||
+  !!target.closest("input, textarea, select, [contenteditable='true'], .ace_editor");
 
 const GraphFlowContent: React.FC = () => {
   const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null);
@@ -259,15 +265,11 @@ const GraphFlowContent: React.FC = () => {
       const cleanWorkflow = (workflow: Workflow) => {
         const workflowCopy = JSON.parse(JSON.stringify(workflow));
         const { created_at, updated_at, ...remainingProps } = workflowCopy;
-        return {
-          ...remainingProps,
-          nodes: (remainingProps.nodes || []).map(
-            ({ selected, dragging, width, height, ...rest }: Node) => rest
-          ),
-          edges: (remainingProps.edges || []).map(
-            ({ selected, className, ...rest }) => rest
-          ),
-        };
+        const { nodes, edges } = stripTransientGraphFields(
+          remainingProps.nodes || [],
+          remainingProps.edges || []
+        );
+        return { ...remainingProps, nodes, edges };
       };
 
       const cleanWorkflow1 = cleanWorkflow(workflow1);
@@ -688,12 +690,6 @@ const GraphFlowContent: React.FC = () => {
 
   // Keyboard shortcuts for canvas interactions
   useEffect(() => {
-    const isTypingTarget = (target: HTMLElement) =>
-      target.tagName === "INPUT" ||
-      target.tagName === "TEXTAREA" ||
-      target.tagName === "SELECT" ||
-      target.isContentEditable;
-
     const handleKeyDown = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
 
@@ -705,7 +701,7 @@ const GraphFlowContent: React.FC = () => {
 
       // Skip undo/redo if typing or inside an open dialog
       if (isUndo || isRedo) {
-        if (isTypingTarget(target) || target.closest('[role="dialog"]')) return;
+        if (isEditableEventTarget(target) || target.closest('[role="dialog"]')) return;
         e.preventDefault();
         if (isUndo) undo();
         else redo();
@@ -954,9 +950,7 @@ const GraphFlowContent: React.FC = () => {
   useEffect(() => {
     const handleSearchKey = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
-      const isTyping = !!target.closest(
-        "input, textarea, select, [contenteditable='true'], .ace_editor"
-      );
+      const isTyping = isEditableEventTarget(target);
 
       if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
         e.preventDefault();

--- a/frontend/src/views/AIAgents/Workflows/GraphFlow.tsx
+++ b/frontend/src/views/AIAgents/Workflows/GraphFlow.tsx
@@ -240,14 +240,6 @@ const GraphFlowContent: React.FC = () => {
 
   const { validateConnection } = useSchemaValidation();
 
-  // Undo/Redo functionality
-  const { undo, redo, canUndo, canRedo, takeSnapshot } = useUndoRedo(
-    nodes,
-    edges,
-    setNodes,
-    setEdges
-  );
-
   const { agentId } = useParams<{ agentId: string }>();
   const edgeReconnectSuccessful = useRef(true);
 
@@ -317,39 +309,6 @@ const GraphFlowContent: React.FC = () => {
   const clipboardRef = useRef<{ nodes: Node[]; edges: typeof edges } | null>(null);
   const [selectedNodes, setSelectedNodes] = useState<Node[]>([]);
 
-  const loadWorkflow = useCallback(async (workflowId: string) => {
-    const workflow = await getWorkflowById(workflowId);
-    setWorkflow(workflow);
-    handleWorkflowLoaded(workflow);
-  }, []);
-
-  const loadAgent = useCallback(
-    async (agentId: string) => {
-      const agent = await getAgentConfig(agentId);
-      setAgent(agent);
-      loadWorkflow(agent.workflow_id);
-    },
-    [loadWorkflow]
-  );
-  const handleAgentUpdated = useCallback(async () => {
-    const agent = await getAgentConfig(agentId);
-    setAgent(agent);
-  }, [agentId]);
-
-  const handleActiveWorkflowChange = useCallback(
-    async (workflow: Workflow) => {
-      if (agentId) {
-        try {
-          await updateAgentConfig(agentId, { workflow_id: workflow.id });
-          await handleAgentUpdated();
-        } catch (error) {
-          // ignore
-        }
-      }
-    },
-    [agentId, handleAgentUpdated]
-  );
-
   // Update node data (used for saving input values)
   const updateNodeData = useCallback(
     (nodeId: string, newData: Partial<NodeData>) => {
@@ -384,27 +343,34 @@ const GraphFlowContent: React.FC = () => {
   });
 
   // Restore functions to nodes after loading
-  const restoreNodeFunctions = (loadedNodes: Node[]): Node[] => {
-    return loadedNodes.map((node) => {
-      // Create a deep copy to avoid modifying the original
-      const nodeCopy = { ...node, data: { ...node.data } };
+  const restoreNodeFunctions = useCallback(
+    (loadedNodes: Node[]): Node[] => {
+      return loadedNodes.map((node) => ({
+        ...node,
+        data: {
+          ...node.data,
+          updateNodeData,
+        },
+      }));
+    },
+    [updateNodeData]
+  );
 
-      nodeCopy.data = {
-        ...nodeCopy.data,
-        updateNodeData,
-      };
-
-      return nodeCopy;
+  // Undo/Redo functionality
+  const { undo, redo, canUndo, canRedo, takeSnapshot, resetHistory } =
+    useUndoRedo(nodes, edges, setNodes, setEdges, {
+      hydrateNodes: restoreNodeFunctions,
     });
-  };
 
   // Handle graph data loaded from file
   const handleWorkflowLoaded = useCallback(
     (loadedWorkflow: Workflow, isUploaded = false) => {
-      const nodesWithFunctions = restoreNodeFunctions(loadedWorkflow.nodes);
+      const loadedNodes = loadedWorkflow.nodes || [];
+      const loadedEdges = loadedWorkflow.edges || [];
+      const nodesWithFunctions = restoreNodeFunctions(loadedNodes);
 
       // Add arrow markers to existing edges
-      const edgesWithMarkers = loadedWorkflow.edges.map((edge) => ({
+      const edgesWithMarkers = loadedEdges.map((edge) => ({
         ...edge,
         type: "default",
         markerEnd: {
@@ -420,6 +386,8 @@ const GraphFlowContent: React.FC = () => {
         },
       }));
 
+      // Reset undo baseline to the loaded graph and discard any existing history
+      resetHistory({ nodes: nodesWithFunctions, edges: edgesWithMarkers });
       setNodes(nodesWithFunctions);
       setEdges(edgesWithMarkers);
       setWorkflow(loadedWorkflow);
@@ -429,7 +397,44 @@ const GraphFlowContent: React.FC = () => {
         setHasUnsavedChanges(false);
       }
     },
-    [restoreNodeFunctions, setNodes, setEdges, setWorkflow]
+    [resetHistory, restoreNodeFunctions, setNodes, setEdges, setWorkflow]
+  );
+
+  const loadWorkflow = useCallback(
+    async (workflowId: string) => {
+      const workflow = await getWorkflowById(workflowId);
+      setWorkflow(workflow);
+      handleWorkflowLoaded(workflow);
+    },
+    [handleWorkflowLoaded, setWorkflow]
+  );
+
+  const loadAgent = useCallback(
+    async (agentId: string) => {
+      const agent = await getAgentConfig(agentId);
+      setAgent(agent);
+      loadWorkflow(agent.workflow_id);
+    },
+    [loadWorkflow]
+  );
+
+  const handleAgentUpdated = useCallback(async () => {
+    const agent = await getAgentConfig(agentId);
+    setAgent(agent);
+  }, [agentId]);
+
+  const handleActiveWorkflowChange = useCallback(
+    async (workflow: Workflow) => {
+      if (agentId) {
+        try {
+          await updateAgentConfig(agentId, { workflow_id: workflow.id });
+          await handleAgentUpdated();
+        } catch (error) {
+          // ignore
+        }
+      }
+    },
+    [agentId, handleAgentUpdated]
   );
 
   // Drag and drop handlers using helper functions
@@ -511,7 +516,7 @@ const GraphFlowContent: React.FC = () => {
   // Add updateNodeData callback to all nodes that need it
   useEffect(() => {
     setNodes((nds) => restoreNodeFunctions(nds));
-  }, [setNodes]);
+  }, [restoreNodeFunctions, setNodes]);
 
   // Add a new node
   const addNewNode = (
@@ -683,8 +688,31 @@ const GraphFlowContent: React.FC = () => {
 
   // Keyboard shortcuts for canvas interactions
   useEffect(() => {
+    const isTypingTarget = (target: HTMLElement) =>
+      target.tagName === "INPUT" ||
+      target.tagName === "TEXTAREA" ||
+      target.tagName === "SELECT" ||
+      target.isContentEditable;
+
     const handleKeyDown = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
+
+      // Compare lowercase keys 
+      const isUndo =
+        (e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "z" && !e.shiftKey;
+      const isRedo =
+        (e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === "z";
+
+      // Skip undo/redo if typing or inside an open dialog
+      if (isUndo || isRedo) {
+        if (isTypingTarget(target) || target.closest('[role="dialog"]')) return;
+        e.preventDefault();
+        if (isUndo) undo();
+        else redo();
+        return;
+      }
+
+      // Copy/paste only on the canvas
       const isReactFlowCanvas =
         target.closest(".react-flow__viewport") ||
         target.closest(".react-flow__pane") ||
@@ -692,13 +720,7 @@ const GraphFlowContent: React.FC = () => {
 
       if (!isReactFlowCanvas) return;
 
-      if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
-        e.preventDefault();
-        undo();
-      } else if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === "z") {
-        e.preventDefault();
-        redo();
-      } else if ((e.ctrlKey || e.metaKey) && e.key === "c") {
+      if ((e.ctrlKey || e.metaKey) && e.key === "c") {
         e.preventDefault();
         copySelectedNodes();
       } else if ((e.ctrlKey || e.metaKey) && e.key === "v") {

--- a/frontend/src/views/AIAgents/Workflows/hooks/useUndoRedo.ts
+++ b/frontend/src/views/AIAgents/Workflows/hooks/useUndoRedo.ts
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { Edge, Node } from "reactflow";
 import { isEqual } from "lodash";
+import { stripTransientGraphFields } from "../utils/graphNormalization";
 
 interface HistoryState {
   nodes: Node[];
@@ -33,21 +34,8 @@ interface UseUndoRedoReturn {
   clear: () => void;
 }
 
-// Strip React Flow's transient UI fields (selection, drag, measured size) so
-// history tracks real edits
-const normalizeState = (state: HistoryState): HistoryState => ({
-  nodes: state.nodes.map(
-    ({
-      selected,
-      dragging,
-      width,
-      height,
-      positionAbsolute,
-      ...node
-    }: Node) => node
-  ),
-  edges: state.edges.map(({ selected, className, ...edge }: Edge) => edge),
-});
+const normalizeState = (state: HistoryState): HistoryState =>
+  stripTransientGraphFields(state.nodes, state.edges);
 
 const cloneState = (state: HistoryState): HistoryState =>
   JSON.parse(JSON.stringify(normalizeState(state))) as HistoryState;

--- a/frontend/src/views/AIAgents/Workflows/hooks/useUndoRedo.ts
+++ b/frontend/src/views/AIAgents/Workflows/hooks/useUndoRedo.ts
@@ -1,5 +1,13 @@
-import { useCallback, useRef, useState } from "react";
-import { Node, Edge, NodeChange, EdgeChange } from "reactflow";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+import { Edge, Node } from "reactflow";
+import { isEqual } from "lodash";
 
 interface HistoryState {
   nodes: Node[];
@@ -9,6 +17,8 @@ interface HistoryState {
 interface UseUndoRedoOptions {
   maxHistorySize?: number;
   debounceTime?: number;
+  // Puts back node data that JSON cloning strips out on undo/redo 
+  hydrateNodes?: (nodes: Node[]) => Node[];
 }
 
 interface UseUndoRedoReturn {
@@ -17,139 +27,264 @@ interface UseUndoRedoReturn {
   canUndo: boolean;
   canRedo: boolean;
   takeSnapshot: () => void;
+  // Seeds a fresh baseline and drops both stacks; used when a new workflow loads 
+  resetHistory: (state: HistoryState) => void;
+  // Drops both stacks but rebaselines to the live canvas without suppressing the next edit
   clear: () => void;
 }
 
+// Strip React Flow's transient UI fields (selection, drag, measured size) so
+// history tracks real edits
+const normalizeState = (state: HistoryState): HistoryState => ({
+  nodes: state.nodes.map(
+    ({
+      selected,
+      dragging,
+      width,
+      height,
+      positionAbsolute,
+      ...node
+    }: Node) => node
+  ),
+  edges: state.edges.map(({ selected, className, ...edge }: Edge) => edge),
+});
+
+const cloneState = (state: HistoryState): HistoryState =>
+  JSON.parse(JSON.stringify(normalizeState(state))) as HistoryState;
+
+const trimHistory = (
+  history: HistoryState[],
+  maxHistorySize: number
+): HistoryState[] => {
+  if (history.length <= maxHistorySize) return history;
+  return history.slice(history.length - maxHistorySize);
+};
+
 /**
- * Hook to manage undo/redo functionality for React Flow nodes and edges
- * Tracks history of node/edge states and provides undo/redo operations
+ * Undo/redo timeline for React Flow nodes and edges. Records the pre-change
+ * baseline on a debounce so rapid edits collapse into one history step
  */
 export const useUndoRedo = (
   nodes: Node[],
   edges: Edge[],
-  setNodes: (nodes: Node[]) => void,
-  setEdges: (edges: Edge[]) => void,
+  setNodes: Dispatch<SetStateAction<Node[]>>,
+  setEdges: Dispatch<SetStateAction<Edge[]>>,
   options: UseUndoRedoOptions = {}
 ): UseUndoRedoReturn => {
-  const { maxHistorySize = 50, debounceTime = 500 } = options;
+  const { maxHistorySize = 50, debounceTime = 500, hydrateNodes } = options;
 
-  // History stacks
   const [past, setPast] = useState<HistoryState[]>([]);
   const [future, setFuture] = useState<HistoryState[]>([]);
+  const [hasPendingSnapshot, setHasPendingSnapshot] = useState(false);
 
-  // Debounce timer
-  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
-  const isUndoRedoRef = useRef(false);
+  const latestStateRef = useRef<HistoryState>({ nodes, edges });
+  const pastRef = useRef<HistoryState[]>([]);
+  const futureRef = useRef<HistoryState[]>([]);
+  const lastSnapshotRef = useRef<HistoryState | null>(null);
+  const pendingUndoTargetRef = useRef<HistoryState | null>(null);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const suppressNextSnapshotRef = useRef(false);
 
-  /**
-   * Take a snapshot of the current state and add it to history
-   */
-  const takeSnapshot = useCallback(() => {
-    // Don't record if we're in the middle of undo/redo
-    if (isUndoRedoRef.current) return;
+  // Keep latest state available to timers/callbacks without stale closures
+  latestStateRef.current = { nodes, edges };
 
-    // Clear any pending debounce
+  const setPastHistory = useCallback((nextPast: HistoryState[]) => {
+    pastRef.current = nextPast;
+    setPast(nextPast);
+  }, []);
+
+  const setFutureHistory = useCallback((nextFuture: HistoryState[]) => {
+    futureRef.current = nextFuture;
+    setFuture(nextFuture);
+  }, []);
+
+  const clearDebounceTimer = useCallback(() => {
     if (debounceTimerRef.current) {
       clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+  }, []);
+
+  const clearPendingSnapshot = useCallback(() => {
+    clearDebounceTimer();
+    pendingUndoTargetRef.current = null;
+    setHasPendingSnapshot(false);
+  }, [clearDebounceTimer]);
+
+  const restoreState = useCallback(
+    (state: HistoryState) => {
+      const clonedState = cloneState(state);
+      lastSnapshotRef.current = clonedState;
+      // Skip the snapshot effect tick this restore is about to trigger
+      suppressNextSnapshotRef.current = true;
+
+      setNodes(
+        hydrateNodes ? hydrateNodes(clonedState.nodes) : clonedState.nodes
+      );
+      setEdges(clonedState.edges);
+    },
+    [hydrateNodes, setEdges, setNodes]
+  );
+
+  const takeSnapshot = useCallback(() => {
+    if (suppressNextSnapshotRef.current) {
+      suppressNextSnapshotRef.current = false;
+      clearPendingSnapshot();
+      return;
     }
 
-    // Debounce the snapshot to batch rapid changes (like dragging)
+    const lastSnapshot = lastSnapshotRef.current;
+
+    // First change seeds the baseline rather than recording a step
+    if (!lastSnapshot) {
+      lastSnapshotRef.current = cloneState(latestStateRef.current);
+      return;
+    }
+
+    if (!pendingUndoTargetRef.current) {
+      // Selection clicks, edge-class rewrites, and re-measure echoes change
+      // state identity without content, no undo window for those
+      if (isEqual(cloneState(latestStateRef.current), lastSnapshot)) {
+        return;
+      }
+      pendingUndoTargetRef.current = cloneState(lastSnapshot);
+
+      // A new edit starts a fresh branch, drop redo now
+      if (futureRef.current.length > 0) {
+        setFutureHistory([]);
+      }
+    }
+
+    clearDebounceTimer();
+    setHasPendingSnapshot(true);
+
     debounceTimerRef.current = setTimeout(() => {
-      const snapshot: HistoryState = {
-        nodes: [...nodes],
-        edges: [...edges],
-      };
+      const undoTarget = pendingUndoTargetRef.current;
 
-      setPast((prev) => {
-        const newPast = [...prev, snapshot];
-        // Limit history size
-        if (newPast.length > maxHistorySize) {
-          return newPast.slice(1);
-        }
-        return newPast;
-      });
+      if (!undoTarget) {
+        setHasPendingSnapshot(false);
+        debounceTimerRef.current = null;
+        return;
+      }
 
-      // Clear future when a new change is made
-      setFuture([]);
+      const latestState = cloneState(latestStateRef.current);
+
+      // Edits that net out to the baseline shouldn't record a step
+      if (
+        lastSnapshotRef.current &&
+        isEqual(latestState, lastSnapshotRef.current)
+      ) {
+        pendingUndoTargetRef.current = null;
+        setHasPendingSnapshot(false);
+        debounceTimerRef.current = null;
+        return;
+      }
+
+      setPastHistory(
+        trimHistory([...pastRef.current, cloneState(undoTarget)], maxHistorySize)
+      );
+      lastSnapshotRef.current = latestState;
+      pendingUndoTargetRef.current = null;
+      setHasPendingSnapshot(false);
+      debounceTimerRef.current = null;
     }, debounceTime);
-  }, [nodes, edges, maxHistorySize, debounceTime]);
+  }, [
+    clearDebounceTimer,
+    clearPendingSnapshot,
+    debounceTime,
+    maxHistorySize,
+    setFutureHistory,
+    setPastHistory,
+  ]);
 
-  /**
-   * Undo the last change
-   */
   const undo = useCallback(() => {
-    if (past.length === 0) return;
+    let pendingUndoTarget = pendingUndoTargetRef.current;
 
-    isUndoRedoRef.current = true;
+    if (!pendingUndoTarget && pastRef.current.length === 0) return;
 
-    // Get the last state from history
-    const newPast = [...past];
-    const previousState = newPast.pop()!;
+    const currentState =
+      suppressNextSnapshotRef.current && lastSnapshotRef.current
+        ? cloneState(lastSnapshotRef.current)
+        : cloneState(latestStateRef.current);
 
-    // Save current state to future
-    const currentState: HistoryState = {
-      nodes: [...nodes],
-      edges: [...edges],
-    };
 
-    setPast(newPast);
-    setFuture((prev) => [...prev, currentState]);
+    if (pendingUndoTarget && isEqual(pendingUndoTarget, currentState)) {
+      clearPendingSnapshot();
+      pendingUndoTarget = null;
+    }
 
-    // Restore previous state
-    setNodes(previousState.nodes);
-    setEdges(previousState.edges);
+    const previousState =
+      pendingUndoTarget ?? pastRef.current[pastRef.current.length - 1];
 
-    // Reset flag after a brief delay to allow state to settle
-    setTimeout(() => {
-      isUndoRedoRef.current = false;
-    }, 100);
-  }, [past, nodes, edges, setNodes, setEdges]);
+    if (!previousState) return;
 
-  /**
-   * Redo the last undone change
-   */
+    clearPendingSnapshot();
+
+    if (!pendingUndoTarget) {
+      setPastHistory(pastRef.current.slice(0, -1));
+    }
+
+    setFutureHistory([...futureRef.current, currentState]);
+    restoreState(previousState);
+  }, [clearPendingSnapshot, restoreState, setFutureHistory, setPastHistory]);
+
   const redo = useCallback(() => {
-    if (future.length === 0) return;
+    const nextState = futureRef.current[futureRef.current.length - 1];
 
-    isUndoRedoRef.current = true;
+    if (!nextState) return;
 
-    // Get the next state from future
-    const newFuture = [...future];
-    const nextState = newFuture.pop()!;
+    clearPendingSnapshot();
 
-    // Save current state to history
-    const currentState: HistoryState = {
-      nodes: [...nodes],
-      edges: [...edges],
-    };
+    const currentState =
+      suppressNextSnapshotRef.current && lastSnapshotRef.current
+        ? cloneState(lastSnapshotRef.current)
+        : cloneState(latestStateRef.current);
 
-    setFuture(newFuture);
-    setPast((prev) => [...prev, currentState]);
+    setFutureHistory(futureRef.current.slice(0, -1));
+    setPastHistory(
+      trimHistory([...pastRef.current, currentState], maxHistorySize)
+    );
+    restoreState(nextState);
+  }, [
+    clearPendingSnapshot,
+    maxHistorySize,
+    restoreState,
+    setFutureHistory,
+    setPastHistory,
+  ]);
 
-    // Restore next state
-    setNodes(nextState.nodes);
-    setEdges(nextState.edges);
+  const resetHistory = useCallback(
+    (state: HistoryState) => {
+      clearPendingSnapshot();
+      lastSnapshotRef.current = cloneState(state);
+      suppressNextSnapshotRef.current = true;
+      setPastHistory([]);
+      setFutureHistory([]);
+    },
+    [clearPendingSnapshot, setFutureHistory, setPastHistory]
+  );
 
-    // Reset flag after a brief delay to allow state to settle
-    setTimeout(() => {
-      isUndoRedoRef.current = false;
-    }, 100);
-  }, [future, nodes, edges, setNodes, setEdges]);
-
-  /**
-   * Clear all history
-   */
   const clear = useCallback(() => {
-    setPast([]);
-    setFuture([]);
-  }, []);
+    clearPendingSnapshot();
+    lastSnapshotRef.current = cloneState(latestStateRef.current);
+    suppressNextSnapshotRef.current = false;
+    setPastHistory([]);
+    setFutureHistory([]);
+  }, [clearPendingSnapshot, setFutureHistory, setPastHistory]);
+
+  useEffect(() => {
+    return () => {
+      clearDebounceTimer();
+    };
+  }, [clearDebounceTimer]);
 
   return {
     undo,
     redo,
-    canUndo: past.length > 0,
+    canUndo: past.length > 0 || hasPendingSnapshot,
     canRedo: future.length > 0,
     takeSnapshot,
+    resetHistory,
     clear,
   };
 };

--- a/frontend/src/views/AIAgents/Workflows/utils/graphNormalization.ts
+++ b/frontend/src/views/AIAgents/Workflows/utils/graphNormalization.ts
@@ -1,0 +1,13 @@
+import { Edge, Node } from 'reactflow';
+
+/**
+ * Strips React Flow's transient UI fields (selection, active-drag, measured/derived
+ * geometry) so undo and unsaved-changes use the same rules.
+ */
+export const stripTransientGraphFields = (
+  nodes: Node[],
+  edges: Edge[]
+): { nodes: Node[]; edges: Edge[] } => ({
+  nodes: nodes.map(({ selected, dragging, width, height, positionAbsolute, ...node }: Node) => node),
+  edges: edges.map(({ selected, className, ...edge }: Edge) => edge),
+});

--- a/frontend/src/views/AIAgents/Workflows/utils/versionDiff.ts
+++ b/frontend/src/views/AIAgents/Workflows/utils/versionDiff.ts
@@ -10,6 +10,7 @@ import {
   WorkflowDiff,
 } from '@/interfaces/workflow-diff.interface';
 import nodeRegistry from '../registry/nodeRegistry';
+import { stripTransientGraphFields } from './graphNormalization';
 
 /**
  * Pure diff engine for the Workflow Version Diff Checker (feature 005).
@@ -42,19 +43,14 @@ const asRecord = (value: unknown): UnknownRecord =>
  */
 export const normalizeForDiff = (workflow: Workflow): NormalizedWorkflow => {
   const clone = JSON.parse(JSON.stringify(workflow ?? {})) as Workflow;
+  const { nodes: baseNodes, edges } = stripTransientGraphFields(clone.nodes ?? [], clone.edges ?? []);
 
-  const nodes: Node[] = (clone.nodes ?? []).map((node) => {
-    const { selected, dragging, width, height, position, positionAbsolute, ...rest } = node as Node & {
-      positionAbsolute?: unknown;
-    };
+  // Diff also treats a node move (position) and the injected updateNodeData as non-meaningful
+  const nodes: Node[] = baseNodes.map((node) => {
+    const { position, ...rest } = node;
     const data = { ...asRecord(rest.data) };
     delete data.updateNodeData;
     return { ...rest, data } as Node;
-  });
-
-  const edges: Edge[] = (clone.edges ?? []).map((edge) => {
-    const { selected, className, ...rest } = edge as Edge & { className?: string };
-    return rest as Edge;
   });
 
   return { nodes, edges };


### PR DESCRIPTION
## Description

Fixes cases where undo/redo appeared broken or could wipe the entire workflow.

## Type of Change


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

- Removed canvas focus for undo/redo, and added guards so they don't fire while typing or with a dialog open.
- Fixed the redo shortcut by matching the key case-insensitive (pressing Shift reports it as uppercase Z, while it checked for the lowercase z.
- Switched history to store the pre-change state and strip transient React Flow fields: select, drag, size, edge class, which were considered as edit steps.
- Restores aren't re-recorded as edits regardless of render timing.
- Added a history reset on workflow load/switch/upload, so undo doesn't wipe the workflow, restoring the blank canvas.
- Re-hydrate node functions on restore, so node config dialogs keep saving after undo/redo.
- Moved the redo clear to the moment a new edit starts, instead of 500ms later, so redo is switched off after a new change. 
- Guarded against in-flight restores during repeated pressings of the key, and holding the key doesn't desync the stacks.

## Testing


- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues


Closes #

## Screenshots (if applicable)


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
