### PR TITLE
feat: file reader chat attachments

### DIFF
--- a/backend/app/modules/workflow/engine/nodes/file_reader_node.py
+++ b/backend/app/modules/workflow/engine/nodes/file_reader_node.py
@@ -1,11 +1,15 @@
 """
 File reader node implementation using the BaseNode class.
 
-Reads the content of an uploaded file and outputs it as text.
+Reads the content of a file and outputs it as text. The file source is either a
+fixed file configured on the node ("upload") or every document the user attaches
+in the chat at runtime ("chatAttachment"). Images are ignored in chat mode; they
+are handled by the Language Model node.
 """
 
 import logging
 from typing import Any, Dict
+from uuid import UUID
 
 from app.modules.data.utils.file_extractor import FileTextExtractor
 from app.modules.workflow.engine.base_node import BaseNode
@@ -14,18 +18,29 @@ logger = logging.getLogger(__name__)
 
 
 class FileReaderNode(BaseNode):
-    """Reads an uploaded file and outputs its text content."""
+    """Reads a file and outputs its text content."""
 
     async def process(self, config: Dict[str, Any]) -> Any:
         """
-        Download the file referenced by fileId or fileUrl and extract its text.
+        Extract text from the configured file or from chat-attached documents.
 
         Args:
-            config: Resolved node configuration containing fileId, fileUrl, fileName.
+            config: Resolved node configuration. `fileSource` selects the mode:
+                "upload" (default) reads fileId/fileUrl/fileName; "chatAttachment"
+                reads every document the user attached in the chat.
 
         Returns:
-            Extracted text content of the file, or an error dict on failure.
+            Extracted text content, or an error dict on failure.
         """
+        file_source = config.get("fileSource", "upload")
+
+        if file_source == "chatAttachment":
+            return await self._read_chat_documents()
+
+        return await self._read_configured_file(config)
+
+    async def _read_configured_file(self, config: Dict[str, Any]) -> Any:
+        """Read the single file configured on the node (fixed-upload mode)."""
         file_id = config.get("fileId")
         file_url = config.get("fileUrl")
         file_name = config.get("fileName", "")
@@ -41,7 +56,6 @@ class FileReaderNode(BaseNode):
             file_service = injector.get(FileManagerService)
 
             if file_id:
-                from uuid import UUID
                 file_model, content = await file_service.download_file(UUID(file_id))
                 file_name = file_name or file_model.original_filename or file_model.name
             else:
@@ -64,3 +78,58 @@ class FileReaderNode(BaseNode):
             error_msg = f"Error reading file: {str(e)}"
             logger.error(error_msg, exc_info=True)
             return {"error": error_msg}
+
+    async def _read_chat_documents(self) -> str:
+        """Read every document attached in the chat, skipping images."""
+        from app.dependencies.injector import injector
+        from app.services.file_manager import FileManagerService
+
+        file_service = injector.get(FileManagerService)
+
+        attachments = self.get_state().get_value("attachments", []) or []
+        documents = [att for att in attachments if not self._is_image(att)]
+
+        if not documents:
+            return "No document was attached in the chat."
+
+        sections = []
+        for attachment in documents:
+            sections.append(await self._read_attachment(file_service, attachment))
+
+        return "\n\n".join(sections)
+
+    async def _read_attachment(self, file_service, attachment: Dict[str, Any]) -> str:
+        """Extract one attached document into a labelled, fail-soft text section."""
+        file_id = attachment.get("file_id")
+        file_url = attachment.get("file_url") or attachment.get("url")
+        file_name = attachment.get("name") or attachment.get("file_name") or ""
+
+        try:
+            if file_id:
+                file_model, content = await file_service.download_file(UUID(file_id))
+                file_name = file_name or file_model.original_filename or file_model.name
+            else:
+                content = await file_service.get_file_content_from_url(file_url)
+
+            text = ""
+            if content:
+                extractor = FileTextExtractor()
+                text = extractor.extract_from_bytes(file_name or "file.bin", content)
+
+        except Exception as e:
+            logger.error(
+                f"FileReaderNode: failed to read attachment '{file_name}': {str(e)}",
+                exc_info=True,
+            )
+            text = ""
+
+        label = file_name or "document"
+        if not text.strip():
+            return f"=== {label} ===\n[Could not extract text from {label}]"
+
+        return f"=== {label} ===\n{text}"
+
+    def _is_image(self, attachment: Dict[str, Any]) -> bool:
+        """True when the attachment's mime type is an image."""
+        mime = attachment.get("type") or attachment.get("file_mime_type") or ""
+        return mime.startswith("image")

--- a/backend/app/modules/workflow/engine/nodes/llm_model_node.py
+++ b/backend/app/modules/workflow/engine/nodes/llm_model_node.py
@@ -283,49 +283,39 @@ class LLMModelNode(PIIAnonymizerMixin, BaseNode):
 
     def _build_attachments_message_content(self, attachments: list) -> list:
         """
-        Build message content with attachments.
+        Build message content for image attachments.
+
+        Only images are sent to the vision model here; documents are read by the
+        File Reader node.
 
         Args:
             attachments: List of attachment dictionaries
 
         Returns:
-            List of message content items (text, images, files)
+            List of image message content items
         """
         # create message content with attachments
         message_content = []
 
         if attachments:
             for attachment in attachments:
-                attachment_type = "image" if attachment.get("type").startswith("image") else "file"
+                mime_type = attachment.get("type") or attachment.get("file_mime_type") or ""
+                is_image = mime_type.startswith("image")
+
+                # Documents are read by the File Reader node, not the vision model.
+                if not is_image:
+                    continue
+
                 attachment_file_local_path = attachment.get("file_local_path")
                 attachment_mime_type = attachment.get("file_mime_type")
                 attachment_url = attachment.get("url")
-                attachment_file_id = attachment.get("openai_file_id")  # OpenAI file_id for file inputs
 
-                if attachment_type == "image":
-                    # if attachment_file_local_path is provided, convert to base64
-                    if attachment_file_local_path:
-                        # get file base64
-                        base64_content = self._convert_attachment_to_base64(attachment_file_local_path)
-                        attachment_url = f"data:{attachment_mime_type};base64,{base64_content}"
+                # if attachment_file_local_path is provided, convert to base64
+                if attachment_file_local_path:
+                    # get file base64
+                    base64_content = self._convert_attachment_to_base64(attachment_file_local_path)
+                    attachment_url = f"data:{attachment_mime_type};base64,{base64_content}"
 
-                    message_content.append({"type": "image_url", "image_url": {"url": attachment_url}})
-                else:
-                    # Priority: OpenAI file_id > URL > base64
-                    if attachment_file_id:
-                        # Use OpenAI file_id (preferred for PDFs and supported file types)
-                        message_content.append({"type": "file", "file": {"file_id": attachment_file_id}})
-                        logger.info(f"Using OpenAI file_id: {attachment_file_id} for file attachment")
-                    elif attachment_url:
-                        # Fallback to URL if file_id not available
-                        message_content.append(
-                            {
-                                "type": "file",
-                                "url": attachment_url,
-                            }
-                        )
-                        logger.warning("Using URL fallback for file attachment (file_id not available)")
-                    else:
-                        logger.warning("No file_id or URL available for attachment, skipping")
+                message_content.append({"type": "image_url", "image_url": {"url": attachment_url}})
 
         return message_content

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/FileReaderDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/FileReaderDialog.tsx
@@ -3,6 +3,13 @@ import { FileReaderNodeData } from "../types/nodes";
 import { Button } from "@/components/button";
 import { RichInput } from "@/components/richInput";
 import { Label } from "@/components/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/select";
 import { Save } from "lucide-react";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
@@ -13,10 +20,15 @@ type FileReaderDialogProps = BaseNodeDialogProps<
   FileReaderNodeData
 >;
 
+type FileSource = "chatAttachment" | "upload";
+
 export const FileReaderDialog: React.FC<FileReaderDialogProps> = (props) => {
   const { isOpen, onClose, data, onUpdate } = props;
 
   const [name, setName] = useState(data.name || "File Reader");
+  const [fileSource, setFileSource] = useState<FileSource>(
+    data.fileSource ?? "upload"
+  );
   const [fileName, setFileName] = useState(data.fileName ?? "");
   const [filePath, setFilePath] = useState(data.filePath ?? "");
   const [fileUrl, setFileUrl] = useState(data.fileUrl ?? "");
@@ -25,6 +37,7 @@ export const FileReaderDialog: React.FC<FileReaderDialogProps> = (props) => {
   useEffect(() => {
     if (isOpen) {
       setName(data.name || "File Reader");
+      setFileSource(data.fileSource ?? "upload");
       setFileName(data.fileName ?? "");
       setFilePath(data.filePath ?? "");
       setFileUrl(data.fileUrl ?? "");
@@ -32,10 +45,13 @@ export const FileReaderDialog: React.FC<FileReaderDialogProps> = (props) => {
     }
   }, [isOpen, data]);
 
+  const isChatAttachment = fileSource === "chatAttachment";
+
   const handleSave = () => {
     onUpdate({
       ...data,
       name,
+      fileSource,
       fileName,
       filePath,
       fileUrl,
@@ -58,7 +74,7 @@ export const FileReaderDialog: React.FC<FileReaderDialogProps> = (props) => {
         </>
       }
       {...props}
-      data={{ ...data, name, fileName, filePath, fileUrl, fileId }}
+      data={{ ...data, name, fileSource, fileName, filePath, fileUrl, fileId }}
     >
       <div className="space-y-4">
         <div>
@@ -72,24 +88,49 @@ export const FileReaderDialog: React.FC<FileReaderDialogProps> = (props) => {
           />
         </div>
 
-        <FileUploader
-          label="File"
-          initialOriginalFileName={fileName}
-          initialServerFilePath={filePath}
-          initialServerFileUrl={fileUrl}
-          onUploadComplete={(result) => {
-            setFileName(result.original_filename);
-            setFilePath(result.file_path ?? "");
-            setFileUrl(result.file_url ?? "");
-            setFileId(result.file_id ?? "");
-          }}
-          onRemove={() => {
-            setFileName("");
-            setFilePath("");
-            setFileUrl("");
-            setFileId("");
-          }}
-        />
+        <div className="space-y-2">
+          <Label htmlFor="file-source">File Source</Label>
+          <Select
+            value={fileSource}
+            onValueChange={(value) => setFileSource(value as FileSource)}
+          >
+            <SelectTrigger id="file-source">
+              <SelectValue placeholder="Select file source" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="chatAttachment">
+                Document attached in chat
+              </SelectItem>
+              <SelectItem value="upload">Uploaded file</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-sm text-muted-foreground">
+            {isChatAttachment
+              ? "Reads every document the user attaches in this chat. Images are handled by the Language Model node."
+              : "Reads a fixed file uploaded here."}
+          </p>
+        </div>
+
+        {!isChatAttachment && (
+          <FileUploader
+            label="File"
+            initialOriginalFileName={fileName}
+            initialServerFilePath={filePath}
+            initialServerFileUrl={fileUrl}
+            onUploadComplete={(result) => {
+              setFileName(result.original_filename);
+              setFilePath(result.file_path ?? "");
+              setFileUrl(result.file_url ?? "");
+              setFileId(result.file_id ?? "");
+            }}
+            onRemove={() => {
+              setFileName("");
+              setFilePath("");
+              setFileUrl("");
+              setFileId("");
+            }}
+          />
+        )}
       </div>
     </NodeConfigPanel>
   );

--- a/frontend/src/views/AIAgents/Workflows/nodeTypes/utils/definitions.ts
+++ b/frontend/src/views/AIAgents/Workflows/nodeTypes/utils/definitions.ts
@@ -216,11 +216,12 @@ export const FILE_READER_NODE_DEFINITION: NodeTypeDefinition<FileReaderNodeData>
   description: 'Reads the content of an uploaded file and outputs it as text.',
   shortDescription: 'Extract content of a file',
   helpContent: FILE_READER_HELP_CONTENT,
-  configSubtitle: 'Upload a file whose content will be extracted.',
+  configSubtitle: 'Extract text from a chat-attached document or an uploaded file.',
   category: 'utils',
   icon: 'FileText',
   defaultData: {
     name: 'File Reader',
+    fileSource: 'chatAttachment',
     handlers: [
       {
         id: 'input',

--- a/frontend/src/views/AIAgents/Workflows/nodeTypes/utils/fileReaderNode.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeTypes/utils/fileReaderNode.tsx
@@ -24,10 +24,15 @@ const FileReaderNode: React.FC<NodeProps<FileReaderNodeData>> = ({
     }
   };
 
+  const isChatAttachment = data.fileSource === "chatAttachment";
+  const fileValue = isChatAttachment
+    ? "Chat document(s)"
+    : data.fileName || "No file uploaded";
+
   const nodeContent: NodeContentRow[] = [
     {
       label: "File",
-      value: data.fileName || "No file uploaded",
+      value: fileValue,
     },
   ];
 

--- a/frontend/src/views/AIAgents/Workflows/types/nodes.ts
+++ b/frontend/src/views/AIAgents/Workflows/types/nodes.ts
@@ -490,6 +490,7 @@ export interface GuardrailNliNodeData extends BaseNodeData {
 
 // File Reader Node Data
 export interface FileReaderNodeData extends BaseNodeData {
+  fileSource?: "chatAttachment" | "upload";
   fileName?: string;
   filePath?: string;
   fileUrl?: string;


### PR DESCRIPTION
## Description

- File Reader node can now extract text from documents a user attaches in chat (new default mode). Fixed-upload mode kept for backward compatibility.
- Language Model node now attaches only images, not documents — documents are the File Reader's job, and they previously errored the OpenAI call.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
