### PR TITLE
chore: filter logs for pii if logging level higher higher/stricter than debug

### DIFF
--- a/backend/app/core/config/logging.py
+++ b/backend/app/core/config/logging.py
@@ -15,9 +15,15 @@ from app.core.utils.sensitive_data_utils import redact_sensitive_substrings
 from app.core.utils.string_utils import truncate_for_log
 
 
+# Only redact PII when the configured log level is stricter than DEBUG (i.e. not
+# in development), so real values stay visible while debugging locally.
+_REDACT_PII = logging.getLevelName(settings.LOG_LEVEL) > logging.DEBUG
+
+
 def _pii_filter(record: dict) -> bool:
     """Redact PII/secrets from the message before it reaches any persistent sink."""
-    record["message"] = redact_sensitive_substrings(record["message"])
+    if _REDACT_PII:
+        record["message"] = redact_sensitive_substrings(record["message"])
     return True
 
 


### PR DESCRIPTION
## Description

- dont filter pii if logging level debug or lower, filter only in prod for levels like info/warning etc

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release