### PR TITLE
feat: trace-aware grading for evaluations

### DIFF
--- a/backend/app/services/test_suite.py
+++ b/backend/app/services/test_suite.py
@@ -109,6 +109,52 @@ def _resolve_selector_value(
     return selector
 
 
+def _build_grading_context(execution_trace: Any) -> Dict[str, Any]:
+    """Stable, workflow-agnostic view of a run for evaluators to grade against."""
+    trace = execution_trace if isinstance(execution_trace, dict) else {}
+    state = trace.get("state") if isinstance(trace.get("state"), dict) else {}
+    node_status = state.get("nodeExecutionStatus")
+    node_status = node_status if isinstance(node_status, dict) else {}
+
+    nodes: Dict[str, Any] = {}
+    nodes_by_type: Dict[str, List[Any]] = {}
+    nodes_by_label: Dict[str, List[Any]] = {}
+    for node_id, info in node_status.items():
+        if not isinstance(info, dict):
+            continue
+        entry = {
+            "id": node_id,
+            "type": info.get("type"),
+            "label": info.get("name"),
+            "output": info.get("output"),
+            "status": info.get("status"),
+            "error": info.get("error"),
+        }
+        nodes[node_id] = entry
+        if entry["type"]:
+            nodes_by_type.setdefault(entry["type"], []).append(entry)
+        if entry["label"]:
+            nodes_by_label.setdefault(entry["label"], []).append(entry)
+
+    session = state.get("input") if isinstance(state.get("input"), dict) else {}
+
+    errors: List[Any] = list(state.get("errors") or [])
+    for entry in nodes.values():
+        if entry.get("error"):
+            errors.append({"node": entry["id"], "error": entry["error"]})
+
+    return {
+        "output": trace.get("output"),
+        "nodes": nodes,
+        "nodes_by_type": nodes_by_type,
+        "nodes_by_label": nodes_by_label,
+        "session": session,
+        "errors": errors,
+        "tokens": trace.get("token_usage") or {},
+        "cost": trace.get("cost_usd"),
+    }
+
+
 class SimpleEvaluatorRegistry:
     """
     Lightweight evaluator registry inspired by OpenEvals.
@@ -126,6 +172,8 @@ class SimpleEvaluatorRegistry:
             "exact_match": self._exact_match,
             "contains": self._contains,
             "json_match": self._json_match,
+            "field_equals": self._field_equals,
+            "no_errors": self._no_errors,
             "nli_eval": self._guardrail_nli,
             "provenance_eval": self._guardrail_provenance,
         }
@@ -140,6 +188,7 @@ class SimpleEvaluatorRegistry:
         inputs: Dict[str, Any],
         outputs: Any,
         reference_outputs: Any,
+        execution_trace: Any = None,
         technique_configs: Dict[str, Dict[str, Any]] | None = None,
     ) -> Dict[str, Dict[str, Any]]:
         results: Dict[str, Dict[str, Any]] = {}
@@ -147,6 +196,7 @@ class SimpleEvaluatorRegistry:
             "inputs": inputs,
             "outputs": outputs,
             "reference_outputs": reference_outputs,
+            "trace": _build_grading_context(execution_trace),
         }
         for key in techniques:
             fn = self._evaluators.get(key)
@@ -227,6 +277,54 @@ class SimpleEvaluatorRegistry:
             "score": passed,
             "passed": passed,
             "comment": None if passed else "JSON outputs do not match.",
+        }
+
+    async def _field_equals(
+        self,
+        *,
+        inputs: Dict[str, Any],  # noqa: ARG002 - reserved for unified signature
+        outputs: Any,
+        reference_outputs: Any,
+        payload: Dict[str, Any],
+        config: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Exact-match a value read from the run (dot-path ``field``) vs expected."""
+        field = config.get("field")
+        actual_value = _read_path(payload, field) if field else outputs
+        expected_value = config.get("expected", reference_outputs)
+
+        actual = _normalize_text(actual_value)
+        expected = _normalize_text(expected_value)
+        passed = bool(actual and expected and actual == expected)
+
+        return {
+            "key": "field_equals",
+            "score": passed,
+            "passed": passed,
+            "comment": (
+                None if passed else f"{field or 'outputs'}={actual!r} (expected {expected!r})"
+            ),
+        }
+
+    async def _no_errors(
+        self,
+        *,
+        inputs: Dict[str, Any],  # noqa: ARG002 - not used by this evaluator
+        outputs: Any,  # noqa: ARG002 - reserved for unified signature
+        reference_outputs: Any,  # noqa: ARG002 - reserved for unified signature
+        payload: Dict[str, Any],
+        config: Dict[str, Any],  # noqa: ARG002 - reserved for unified signature
+    ) -> Dict[str, Any]:
+        """Pass only when the run produced no node/run-level errors."""
+        trace = payload.get("trace") or {}
+        errors = trace.get("errors") or []
+        passed = len(errors) == 0
+
+        return {
+            "key": "no_errors",
+            "score": passed,
+            "passed": passed,
+            "comment": None if passed else f"{len(errors)} error(s) during run.",
         }
 
     async def _guardrail_nli(
@@ -634,6 +732,7 @@ class TestSuiteService:
                     inputs=merged_input,
                     outputs=output,
                     reference_outputs=case.expected_output,
+                    execution_trace=execution_trace,
                     technique_configs=technique_configs,
                 )
                 result = TestResultModel(

--- a/backend/tests/unit/test_evaluators.py
+++ b/backend/tests/unit/test_evaluators.py
@@ -1,0 +1,131 @@
+"""Unit tests for trace-aware grading (process evaluation)."""
+
+import pytest
+
+from app.services.test_suite import SimpleEvaluatorRegistry, _build_grading_context
+
+
+def _sample_trace(*, node_error=None, risk_level="low"):
+    return {
+        "output": "Risk assessment: low. The contract looks fine.",
+        "state": {
+            "input": {"risk_level": risk_level, "contract_text": "MASTER SERVICES AGREEMENT"},
+            "errors": [],
+            "nodeExecutionStatus": {
+                "n1": {
+                    "name": "File Reader",
+                    "type": "fileReaderNode",
+                    "output": "contract text...",
+                    "status": "success",
+                    "error": None,
+                },
+                "n2": {
+                    "name": "Knowledge Query",
+                    "type": "knowledgeBaseNode",
+                    "output": "retrieved clause",
+                    "status": "success",
+                    "error": node_error,
+                },
+            },
+        },
+        "token_usage": {"total_tokens": 100},
+        "cost_usd": 0.001,
+    }
+
+
+class TestBuildGradingContext:
+    def test_exposes_nodes_session_and_metrics(self):
+        ctx = _build_grading_context(_sample_trace())
+        assert ctx["nodes"]["n1"]["label"] == "File Reader"
+        assert ctx["nodes_by_type"]["knowledgeBaseNode"][0]["output"] == "retrieved clause"
+        assert ctx["session"]["risk_level"] == "low"
+        assert ctx["errors"] == []
+        assert ctx["tokens"]["total_tokens"] == 100
+
+    def test_collects_node_errors(self):
+        ctx = _build_grading_context(_sample_trace(node_error="NoneType has no len()"))
+        assert len(ctx["errors"]) == 1
+        assert ctx["errors"][0]["node"] == "n2"
+
+    def test_handles_missing_trace(self):
+        ctx = _build_grading_context(None)
+        assert ctx["nodes"] == {}
+        assert ctx["errors"] == []
+
+
+class TestTraceAwareEvaluators:
+    def setup_method(self):
+        self.registry = SimpleEvaluatorRegistry()
+
+    @pytest.mark.asyncio
+    async def test_field_equals_reads_internal_value(self):
+        metrics = await self.registry.evaluate(
+            ["field_equals"],
+            inputs={},
+            outputs="some final text that differs",
+            reference_outputs={"value": "low"},
+            execution_trace=_sample_trace(risk_level="low"),
+            technique_configs={"field_equals": {"field": "trace.session.risk_level"}},
+        )
+        assert metrics["field_equals"]["passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_field_equals_fails_on_wrong_internal_value(self):
+        metrics = await self.registry.evaluate(
+            ["field_equals"],
+            inputs={},
+            outputs="Risk assessment: low.",
+            reference_outputs=None,
+            execution_trace=_sample_trace(risk_level="low"),
+            technique_configs={
+                "field_equals": {"field": "trace.session.risk_level", "expected": "high"}
+            },
+        )
+        assert metrics["field_equals"]["passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_field_equals_reads_node_output(self):
+        metrics = await self.registry.evaluate(
+            ["field_equals"],
+            inputs={},
+            outputs="",
+            reference_outputs={"value": "retrieved clause"},
+            execution_trace=_sample_trace(),
+            technique_configs={"field_equals": {"field": "trace.nodes.n2.output"}},
+        )
+        assert metrics["field_equals"]["passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_no_errors_passes_on_clean_run(self):
+        metrics = await self.registry.evaluate(
+            ["no_errors"],
+            inputs={},
+            outputs="ok",
+            reference_outputs=None,
+            execution_trace=_sample_trace(),
+        )
+        assert metrics["no_errors"]["passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_process_grading_catches_error_behind_good_output(self):
+        # Same good final output, but a node errored: contains passes, no_errors fails.
+        trace = _sample_trace(node_error="ThreadScopedRAG: NoneType has no len()")
+        metrics = await self.registry.evaluate(
+            ["contains", "no_errors"],
+            inputs={},
+            outputs="Risk assessment: low. The contract looks fine.",
+            reference_outputs={"value": "low"},
+            execution_trace=trace,
+        )
+        assert metrics["contains"]["passed"] is True
+        assert metrics["no_errors"]["passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_existing_metrics_unchanged_without_trace(self):
+        metrics = await self.registry.evaluate(
+            ["contains"],
+            inputs={},
+            outputs="We are available 24/7",
+            reference_outputs={"value": "24/7"},
+        )
+        assert metrics["contains"]["passed"] is True


### PR DESCRIPTION
## Description

- Evaluation metrics can now grade the agent's full run process (steps, internal values, errors), not just the final output.
- Added field_equals (grade any internal value) and no_errors (catch hidden failures); metrics can point at any run field via dot-path.
- Provenance now reads the source from the run itself and not only from the Expected Output.
- Backward-compatible; unit-tested; verified in-app with OpenAI and Nova judges.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
