### PR TITLE
feat: add web search node

### DIFF
--- a/backend/app/api/v1/routes/workflows.py
+++ b/backend/app/api/v1/routes/workflows.py
@@ -68,6 +68,7 @@ SUPPORTED_NODE_TYPES = [
     "voiceAgentNode",
     "createWorkflowScheduleNode",
     "webScraperNode",
+    "webSearchNode",
     "htmlToImageNode",
     "nlpNode",
 ]

--- a/backend/app/core/config/settings.py
+++ b/backend/app/core/config/settings.py
@@ -318,6 +318,14 @@ class ProjectSettings(BaseSettings):
     # Conversation history max messages for chat input node
     CONVERSATION_HISTORY_NODE_MAX_MESSAGES: int = 100
 
+    # === Web Search Node ===
+    # Kill switch: when False every search returns a structured failure envelope
+    # immediately and no upstream traffic is sent.
+    WEB_SEARCH_ENABLED: bool = True
+    # Max searches per tenant per minute. Only the request that actually runs the
+    # search counts; duplicate in-flight requests reuse that result and are not charged.
+    WEB_SEARCH_TENANT_PER_MINUTE: int = 30
+
     @property
     def _zendesk_base(self) -> str:
         return f"https://{self.ZENDESK_SUBDOMAIN}.zendesk.com/api/v2"

--- a/backend/app/core/observability/__init__.py
+++ b/backend/app/core/observability/__init__.py
@@ -3,6 +3,7 @@
 from app.core.observability.otel import (
     init_opentelemetry,
     is_otel_runtime_enabled,
+    record_web_search_event,
     record_workflow_node_duration,
     shutdown_opentelemetry,
 )
@@ -11,5 +12,6 @@ __all__ = [
     "init_opentelemetry",
     "shutdown_opentelemetry",
     "record_workflow_node_duration",
+    "record_web_search_event",
     "is_otel_runtime_enabled",
 ]

--- a/backend/app/core/observability/otel.py
+++ b/backend/app/core/observability/otel.py
@@ -32,6 +32,29 @@ logger = logging.getLogger(__name__)
 
 _initialized: bool = False
 _node_duration_histogram: Any = None
+_web_search_counter: Any = None
+_web_search_duration_histogram: Any = None
+_web_search_results_histogram: Any = None
+
+# Only these fixed labels are allowed on web-search metrics. That keeps metric
+# series countable, and blocks queries/URLs/domains from ever being recorded.
+_WEB_SEARCH_OUTCOMES = frozenset(
+    {
+        "ok",
+        "zero",
+        "blocked",
+        "timeout",
+        "selector_drift",
+        "rate_limited",
+        "circuit_open",
+        "negative_cached",
+        "invalid_config",
+        "disabled",
+        "error",
+    }
+)
+_WEB_SEARCH_RUNGS = frozenset({"html", "lite", "none"})
+_WEB_SEARCH_CACHE_STATES = frozenset({"hit", "miss", "neg", "off"})
 
 
 def _otel_sdk_disabled() -> bool:
@@ -177,6 +200,7 @@ def init_opentelemetry(app: Optional["FastAPI"] = None) -> None:
     trace.set_tracer_provider(provider)
 
     global _node_duration_histogram  # pylint: disable=global-statement
+    global _web_search_counter, _web_search_duration_histogram, _web_search_results_histogram  # pylint: disable=global-statement
     if grpc_endpoint and settings.OTEL_METRICS_VIA_GRPC:
         try:
             from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
@@ -200,6 +224,21 @@ def init_opentelemetry(app: Optional["FastAPI"] = None) -> None:
                 unit="s",
                 description="Wall time for workflow node execute()",
             )
+            _web_search_counter = meter.create_counter(
+                "genassist.web_search.events",
+                unit="1",
+                description="Web search events by outcome/rung/cache state",
+            )
+            _web_search_duration_histogram = meter.create_histogram(
+                "genassist.web_search.duration_seconds",
+                unit="s",
+                description="Wall time for a web search execution",
+            )
+            _web_search_results_histogram = meter.create_histogram(
+                "genassist.web_search.result_count",
+                unit="1",
+                description="Result count per web search",
+            )
             logger.info(
                 "OpenTelemetry: OTLP gRPC metrics export enabled (histogram for node duration)"
             )
@@ -217,6 +256,7 @@ def init_opentelemetry(app: Optional["FastAPI"] = None) -> None:
 
 def shutdown_opentelemetry() -> None:
     global _initialized, _node_duration_histogram  # pylint: disable=global-statement
+    global _web_search_counter, _web_search_duration_histogram, _web_search_results_histogram  # pylint: disable=global-statement
     if not _initialized:
         return
     from opentelemetry import metrics, trace
@@ -232,6 +272,9 @@ def shutdown_opentelemetry() -> None:
         shutdown_m()
 
     _node_duration_histogram = None
+    _web_search_counter = None
+    _web_search_duration_histogram = None
+    _web_search_results_histogram = None
     _initialized = False
     logger.debug("OpenTelemetry shut down")
 
@@ -249,3 +292,25 @@ def record_workflow_node_duration(
             "genassist.success": "true" if success else "false",
         },
     )
+
+
+def record_web_search_event(
+    outcome: str, rung: str, cache_state: str, duration_seconds: float, result_count: int
+) -> None:
+    """Record one web search: a count event, plus latency and result-count histograms.
+    Does nothing until metrics are set up. Labels are forced to the fixed sets
+    above, so a bad caller value can't create endless new metric series.
+    """
+    counter = _web_search_counter
+    if counter is None:
+        return
+    attributes = {
+        "genassist.web_search.outcome": outcome if outcome in _WEB_SEARCH_OUTCOMES else "error",
+        "genassist.web_search.rung": rung if rung in _WEB_SEARCH_RUNGS else "none",
+        "genassist.web_search.cache": cache_state if cache_state in _WEB_SEARCH_CACHE_STATES else "off",
+    }
+    counter.add(1, attributes)
+    if _web_search_duration_histogram is not None:
+        _web_search_duration_histogram.record(max(0.0, duration_seconds), attributes)
+    if _web_search_results_histogram is not None:
+        _web_search_results_histogram.record(max(0, int(result_count)), attributes)

--- a/backend/app/core/observability/otel.py
+++ b/backend/app/core/observability/otel.py
@@ -53,7 +53,6 @@ _WEB_SEARCH_OUTCOMES = frozenset(
         "error",
     }
 )
-_WEB_SEARCH_RUNGS = frozenset({"html", "lite", "none"})
 _WEB_SEARCH_CACHE_STATES = frozenset({"hit", "miss", "neg", "off"})
 
 
@@ -227,7 +226,7 @@ def init_opentelemetry(app: Optional["FastAPI"] = None) -> None:
             _web_search_counter = meter.create_counter(
                 "genassist.web_search.events",
                 unit="1",
-                description="Web search events by outcome/rung/cache state",
+                description="Web search events by outcome/cache state",
             )
             _web_search_duration_histogram = meter.create_histogram(
                 "genassist.web_search.duration_seconds",
@@ -295,7 +294,7 @@ def record_workflow_node_duration(
 
 
 def record_web_search_event(
-    outcome: str, rung: str, cache_state: str, duration_seconds: float, result_count: int
+    outcome: str, cache_state: str, duration_seconds: float, result_count: int
 ) -> None:
     """Record one web search: a count event, plus latency and result-count histograms.
     Does nothing until metrics are set up. Labels are forced to the fixed sets
@@ -306,7 +305,6 @@ def record_web_search_event(
         return
     attributes = {
         "genassist.web_search.outcome": outcome if outcome in _WEB_SEARCH_OUTCOMES else "error",
-        "genassist.web_search.rung": rung if rung in _WEB_SEARCH_RUNGS else "none",
         "genassist.web_search.cache": cache_state if cache_state in _WEB_SEARCH_CACHE_STATES else "off",
     }
     counter.add(1, attributes)

--- a/backend/app/core/observability/otel.py
+++ b/backend/app/core/observability/otel.py
@@ -51,6 +51,9 @@ _WEB_SEARCH_OUTCOMES = frozenset(
         "invalid_config",
         "disabled",
         "error",
+        "fallback_ok",
+        "fallback_zero",
+        "fallback_error",
     }
 )
 _WEB_SEARCH_CACHE_STATES = frozenset({"hit", "miss", "neg", "off"})

--- a/backend/app/core/utils/content_relevance.py
+++ b/backend/app/core/utils/content_relevance.py
@@ -1,18 +1,17 @@
-"""Pick the parts of a page most relevant to the search query (advanced enrichment).
+"""Pick the page sections most relevant to the search query (advanced enrichment).
 
-Splits page markdown into chunks (each section kept with its heading) and ranks
-them against the query with a small BM25 scorer built. Only visible
-text is scored: link URLs and bare URLs are ignored, so a query that includes a
-company URL can't be gamed by pages that repeat that URL in hrefs. If the query
-gives nothing useful to rank on (no tokens, no matches, or every chunk looks the
-same — and no exact phrase or heading match), the caller gets the first ``budget`` characters of the page.
+Splits markdown into heading-aware chunks and ranks them with BM25. Only visible
+text is scored (not URLs). Chunks never cross headings; gaps use an omission
+marker and missing headings are restored on render. If ranking has nothing useful
+to go on, returns the first ``budget`` characters of the page.
 """
 
 import math
 import re
 from collections import Counter
+from dataclasses import dataclass
 
-_TOKEN_RE = re.compile(r"[^\W_]{2,}")  
+_TOKEN_RE = re.compile(r"[^\W_]{2,}")
 _STOPWORDS = frozenset(
     {
         "about",
@@ -89,8 +88,10 @@ _STOPWORDS = frozenset(
 _URL_STOPWORDS = frozenset({"http", "https", "www", "com", "org", "net", "io"})
 _LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")
 _BARE_URL_RE = re.compile(r"<?https?://\S+>?")
-_HEADING_RE = re.compile(r"#{1,6} ")
+_HEADING_RE = re.compile(r"^(#{1,6}) ")
 _SENTENCE_RE = re.compile(r"(?<=[.!?])\s+")
+_INVISIBLE = "​‌‍⁠﻿"
+_INVISIBLE_NOISE_RE = re.compile(rf"(?:^|(?<=\s))[{_INVISIBLE}]+|[{_INVISIBLE}]+(?=\s|$)")
 _TARGET_CHUNK_CHARS = 700
 _MAX_CHUNK_CHARS = 1400
 _MIN_TAIL_CHARS = 40  # stop filling once the leftover budget can't hold useful text
@@ -100,6 +101,26 @@ _BM25_K1 = 1.5
 _BM25_B = 0.75
 _PHRASE_BONUS = 1.5
 _HEADING_BONUS = 0.5
+_ELISION = "[...]"
+_JOIN = "\n\n"  
+_ELISION_JOIN = f"\n\n{_ELISION}\n\n"  
+_HEADING_SEP = "\n\n" 
+
+
+@dataclass
+class _Chunk:
+    """One rankable unit of a page. ``context`` (heading + ancestors) is scored but not part of ``text``."""
+
+    text: str
+    heading: str  # nearest heading line, "" for pre-heading content
+    context: str  # heading + open ancestor headings, for scoring only
+    needs_prefix: bool  # text lost its heading and should get it re-prepended on render
+
+
+def strip_invisible(text: str) -> str:
+    """Remove stray invisible characters, then remove the extra blank lines they leave."""
+    cleaned = _INVISIBLE_NOISE_RE.sub("", text)
+    return re.sub(r"\n{3,}", "\n\n", cleaned)
 
 
 def _tokenize(text: str) -> list[str]:
@@ -111,26 +132,25 @@ def _visible_text(chunk: str) -> str:
     return _BARE_URL_RE.sub(" ", _LINK_RE.sub(r"\1", chunk))
 
 
-def _heading_tokens(chunk: str) -> set[str]:
-    lines = [line for line in chunk.split("\n") if _HEADING_RE.match(line)]
-    return set(_tokenize(" ".join(lines))) if lines else set()
+def _heading_level(block: str) -> int:
+    match = _HEADING_RE.match(block)
+    return len(match.group(1)) if match else 0
 
 
-def _glue_headings(blocks: list[str]) -> list[str]:
-    """Attach heading-only blocks to the following body block so headings never stand alone."""
-    units: list[str] = []
-    pending: list[str] = []
-    for block in blocks:
-        if _HEADING_RE.match(block) and "\n" not in block:
-            pending.append(block)
+def _iter_blocks(text: str):
+    """Blank-line-delimited blocks, splitting a heading off any body that shares its block."""
+    for block in text.split("\n\n"):
+        block = block.strip()
+        if not block:
             continue
-        if pending:
-            block = "\n\n".join((*pending, block))
-            pending = []
-        units.append(block)
-    if pending:
-        units.append("\n\n".join(pending))
-    return units
+        if _heading_level(block) and "\n" in block:
+            line, _, rest = block.partition("\n")
+            yield line.strip()
+            rest = rest.strip()
+            if rest:
+                yield rest
+        else:
+            yield block
 
 
 def _split_oversized(unit: str) -> list[str]:
@@ -159,6 +179,7 @@ def _split_oversized(unit: str) -> list[str]:
 
 
 def _merge_small(units: list[str]) -> list[str]:
+    """Merge small body units up to the target size; callers pass one section's body only."""
     chunks: list[str] = []
     current = ""
     for unit in units:
@@ -172,12 +193,49 @@ def _merge_small(units: list[str]) -> list[str]:
     return chunks
 
 
-def _chunk_markdown(text: str) -> list[str]:
-    """Document-order chunks: glue headings, split oversized units, merge small ones."""
-    blocks = [block for block in text.split("\n\n") if block.strip()]
-    units = _glue_headings(blocks)
-    pieces = [piece for unit in units for piece in _split_oversized(unit)]
+def _section_pieces(body: list[str]) -> list[str]:
+    pieces = [piece for block in body for piece in _split_oversized(block)]
     return _merge_small(pieces)
+
+
+def _chunk_markdown(text: str) -> list[_Chunk]:
+    """Split the page into chunks in reading order.
+
+    Each chunk remembers its heading and parent headings. Body text never
+    crosses a heading, so different sections stay separate.
+    """
+    chunks: list[_Chunk] = []
+    stack: list[tuple[int, str]] = []
+    heading = ""
+    ancestors: list[str] = []
+    body: list[str] = []
+
+    def flush() -> None:
+        nonlocal body
+        if any(block.strip() for block in body):
+            context = "\n".join([heading, *ancestors]).strip()
+            for i, piece in enumerate(_section_pieces(body)):
+                if heading and i == 0:
+                    chunks.append(_Chunk(f"{heading}{_HEADING_SEP}{piece}", heading, context, needs_prefix=False))
+                elif heading:
+                    chunks.append(_Chunk(piece, heading, context, needs_prefix=True))
+                else:
+                    chunks.append(_Chunk(piece, "", "", needs_prefix=False))
+        body = []
+
+    for block in _iter_blocks(text):
+        level = _heading_level(block)
+        if level:
+            flush()
+            while stack and stack[-1][0] >= level:
+                stack.pop()
+            ancestors = [line for _, line in stack]
+            stack.append((level, block))
+            heading = block
+        else:
+            body.append(block)
+    flush()
+    return chunks
 
 
 def _bm25_scores(chunk_tokens: list[list[str]], query_tokens: set[str]) -> tuple[list[float], dict[str, int]]:
@@ -204,11 +262,27 @@ def _bm25_scores(chunk_tokens: list[list[str]], query_tokens: set[str]) -> tuple
     return scores, df
 
 
+def _render(chunks: list[_Chunk], order: list[int], budget: int) -> str:
+    parts: list[str] = []
+    last_heading: str | None = None
+    prev_idx: int | None = None
+    for idx in order:
+        chunk = chunks[idx]
+        if parts:
+            parts.append(_JOIN if idx == prev_idx + 1 else _ELISION_JOIN)
+        if chunk.needs_prefix and chunk.heading != last_heading:
+            parts.append(f"{chunk.heading}{_HEADING_SEP}")
+        parts.append(chunk.text)
+        last_heading = chunk.heading
+        prev_idx = idx
+    return "".join(parts)[:budget]
+
+
 def select_relevant_content(markdown: str, query: str, budget: int) -> str:
     """Return the most query-relevant markdown within ``budget`` characters."""
     if budget <= 0:
         return ""
-    text = markdown.strip()
+    text = strip_invisible(markdown).strip()
     if len(text) <= budget:
         return text
     ordered_terms = _tokenize(query)
@@ -217,21 +291,25 @@ def select_relevant_content(markdown: str, query: str, budget: int) -> str:
         return text[:budget]
 
     chunks = _chunk_markdown(text[:_MAX_SCAN_CHARS])
-    chunk_tokens = [_tokenize(_visible_text(chunk)) for chunk in chunks]
+    if not chunks:
+        return text[:budget]
+    body_tokens = [_tokenize(_visible_text(chunk.text)) for chunk in chunks]
+    context_sets = [set(_tokenize(_visible_text(chunk.context))) for chunk in chunks]
+    chunk_tokens = [tokens + list(context) for tokens, context in zip(body_tokens, context_sets)]
     scores, df = _bm25_scores(chunk_tokens, query_tokens)
 
     n = len(chunks)
     discriminative = {term for term, count in df.items() if count and count / n <= _MAX_DF_RATIO}
     phrase = " ".join(ordered_terms) if len(ordered_terms) >= 2 else ""
     has_signal = [False] * n
-    for i, tokens in enumerate(chunk_tokens):
-        phrase_hit = bool(phrase) and f" {phrase} " in f" {' '.join(tokens)} "
-        heading_hit = bool(query_tokens & _heading_tokens(chunks[i]))
+    for i in range(n):
+        phrase_hit = bool(phrase) and f" {phrase} " in f" {' '.join(body_tokens[i])} "
+        heading_hit = bool(query_tokens & context_sets[i])
         if phrase_hit:
             scores[i] += _PHRASE_BONUS
         if heading_hit:
             scores[i] += _HEADING_BONUS
-        has_signal[i] = phrase_hit or heading_hit or bool(discriminative & set(tokens))
+        has_signal[i] = phrase_hit or heading_hit or bool(discriminative & set(chunk_tokens[i]))
     if not any(has_signal):
         return text[:budget]
 
@@ -240,19 +318,19 @@ def select_relevant_content(markdown: str, query: str, budget: int) -> str:
     seen: set[str] = set()
     remaining = budget
     for i in ranked:
-        normalized = " ".join(chunks[i].split()).lower()  # dedupes exact repetition only
+        normalized = " ".join(chunks[i].text.split()).lower()  # dedupes exact repetition only
         if normalized in seen:
             continue
-        cost = len(chunks[i]) + (2 if selected else 0)
+        prefix_cost = len(chunks[i].heading) + len(_HEADING_SEP) if chunks[i].needs_prefix else 0
+        cost = len(chunks[i].text) + prefix_cost + (len(_ELISION_JOIN) if selected else 0)
         if cost <= remaining:
             selected.append(i)
             seen.add(normalized)
             remaining -= cost
         elif not selected:
-            # the single best chunk overflows: its head beats a weaker whole chunk
-            return chunks[i][:budget]
+            return chunks[i].text[:budget]
         if remaining < _MIN_TAIL_CHARS:
             break
     if not selected:
         return text[:budget]
-    return "\n\n".join(chunks[i] for i in sorted(selected))
+    return _render(chunks, sorted(selected), budget)

--- a/backend/app/core/utils/content_relevance.py
+++ b/backend/app/core/utils/content_relevance.py
@@ -1,0 +1,258 @@
+"""Pick the parts of a page most relevant to the search query (advanced enrichment).
+
+Splits page markdown into chunks (each section kept with its heading) and ranks
+them against the query with a small BM25 scorer built. Only visible
+text is scored: link URLs and bare URLs are ignored, so a query that includes a
+company URL can't be gamed by pages that repeat that URL in hrefs. If the query
+gives nothing useful to rank on (no tokens, no matches, or every chunk looks the
+same — and no exact phrase or heading match), the caller gets the first ``budget`` characters of the page.
+"""
+
+import math
+import re
+from collections import Counter
+
+_TOKEN_RE = re.compile(r"[^\W_]{2,}")  
+_STOPWORDS = frozenset(
+    {
+        "about",
+        "after",
+        "all",
+        "also",
+        "an",
+        "and",
+        "any",
+        "are",
+        "as",
+        "at",
+        "be",
+        "been",
+        "but",
+        "by",
+        "can",
+        "could",
+        "did",
+        "do",
+        "does",
+        "for",
+        "from",
+        "had",
+        "has",
+        "have",
+        "how",
+        "if",
+        "in",
+        "into",
+        "is",
+        "it",
+        "its",
+        "may",
+        "might",
+        "more",
+        "most",
+        "no",
+        "not",
+        "of",
+        "on",
+        "or",
+        "our",
+        "should",
+        "so",
+        "some",
+        "than",
+        "that",
+        "the",
+        "their",
+        "then",
+        "there",
+        "these",
+        "they",
+        "this",
+        "those",
+        "to",
+        "was",
+        "were",
+        "what",
+        "when",
+        "where",
+        "which",
+        "who",
+        "why",
+        "will",
+        "with",
+        "would",
+        "you",
+        "your",
+    }
+)
+# URL artifacts: a query pasted as a company URL should reduce to the name itself
+_URL_STOPWORDS = frozenset({"http", "https", "www", "com", "org", "net", "io"})
+_LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")
+_BARE_URL_RE = re.compile(r"<?https?://\S+>?")
+_HEADING_RE = re.compile(r"#{1,6} ")
+_SENTENCE_RE = re.compile(r"(?<=[.!?])\s+")
+_TARGET_CHUNK_CHARS = 700
+_MAX_CHUNK_CHARS = 1400
+_MIN_TAIL_CHARS = 40  # stop filling once the leftover budget can't hold useful text
+_MAX_SCAN_CHARS = 200_000  # bounds selection CPU only
+_MAX_DF_RATIO = 0.5  # a term in more than half the chunks doesn't distinguish them
+_BM25_K1 = 1.5
+_BM25_B = 0.75
+_PHRASE_BONUS = 1.5
+_HEADING_BONUS = 0.5
+
+
+def _tokenize(text: str) -> list[str]:
+    return _TOKEN_RE.findall(text.lower())
+
+
+def _visible_text(chunk: str) -> str:
+    """Ranking input only: keep link labels, drop destinations and bare URLs."""
+    return _BARE_URL_RE.sub(" ", _LINK_RE.sub(r"\1", chunk))
+
+
+def _heading_tokens(chunk: str) -> set[str]:
+    lines = [line for line in chunk.split("\n") if _HEADING_RE.match(line)]
+    return set(_tokenize(" ".join(lines))) if lines else set()
+
+
+def _glue_headings(blocks: list[str]) -> list[str]:
+    """Attach heading-only blocks to the following body block so headings never stand alone."""
+    units: list[str] = []
+    pending: list[str] = []
+    for block in blocks:
+        if _HEADING_RE.match(block) and "\n" not in block:
+            pending.append(block)
+            continue
+        if pending:
+            block = "\n\n".join((*pending, block))
+            pending = []
+        units.append(block)
+    if pending:
+        units.append("\n\n".join(pending))
+    return units
+
+
+def _split_oversized(unit: str) -> list[str]:
+    """Split a unit over the max size on sentence boundaries; hard-slice sentences that never end."""
+    if len(unit) <= _MAX_CHUNK_CHARS:
+        return [unit]
+    pieces: list[str] = []
+    current = ""
+    for sentence in _SENTENCE_RE.split(unit):
+        if not sentence:
+            continue
+        if len(sentence) > _MAX_CHUNK_CHARS:
+            if current:
+                pieces.append(current)
+                current = ""
+            pieces.extend(sentence[i : i + _MAX_CHUNK_CHARS] for i in range(0, len(sentence), _MAX_CHUNK_CHARS))
+            continue
+        if current and len(current) + 1 + len(sentence) > _TARGET_CHUNK_CHARS:
+            pieces.append(current)
+            current = sentence
+        else:
+            current = f"{current} {sentence}" if current else sentence
+    if current:
+        pieces.append(current)
+    return pieces
+
+
+def _merge_small(units: list[str]) -> list[str]:
+    chunks: list[str] = []
+    current = ""
+    for unit in units:
+        if current and len(current) + 2 + len(unit) > _TARGET_CHUNK_CHARS:
+            chunks.append(current)
+            current = unit
+        else:
+            current = f"{current}\n\n{unit}" if current else unit
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _chunk_markdown(text: str) -> list[str]:
+    """Document-order chunks: glue headings, split oversized units, merge small ones."""
+    blocks = [block for block in text.split("\n\n") if block.strip()]
+    units = _glue_headings(blocks)
+    pieces = [piece for unit in units for piece in _split_oversized(unit)]
+    return _merge_small(pieces)
+
+
+def _bm25_scores(chunk_tokens: list[list[str]], query_tokens: set[str]) -> tuple[list[float], dict[str, int]]:
+    """BM25 over token counts; returns per-chunk scores and per-term document frequency."""
+    n = len(chunk_tokens)
+    scores = [0.0] * n
+    lengths = [len(tokens) for tokens in chunk_tokens]
+    total = sum(lengths)
+    if not total:
+        return scores, {}
+    avg_len = total / n
+    counters = [Counter(tokens) for tokens in chunk_tokens]
+    df = {term: sum(1 for counter in counters if term in counter) for term in query_tokens}
+    for term, term_df in df.items():
+        if not term_df:
+            continue
+        idf = math.log(1 + (n - term_df + 0.5) / (term_df + 0.5))
+        for i, counter in enumerate(counters):
+            tf = counter[term]
+            if not tf:
+                continue
+            norm = _BM25_K1 * (1 - _BM25_B + _BM25_B * lengths[i] / avg_len)
+            scores[i] += idf * tf * (_BM25_K1 + 1) / (tf + norm)
+    return scores, df
+
+
+def select_relevant_content(markdown: str, query: str, budget: int) -> str:
+    """Return the most query-relevant markdown within ``budget`` characters."""
+    if budget <= 0:
+        return ""
+    text = markdown.strip()
+    if len(text) <= budget:
+        return text
+    ordered_terms = _tokenize(query)
+    query_tokens = set(ordered_terms) - _STOPWORDS - _URL_STOPWORDS
+    if not query_tokens:
+        return text[:budget]
+
+    chunks = _chunk_markdown(text[:_MAX_SCAN_CHARS])
+    chunk_tokens = [_tokenize(_visible_text(chunk)) for chunk in chunks]
+    scores, df = _bm25_scores(chunk_tokens, query_tokens)
+
+    n = len(chunks)
+    discriminative = {term for term, count in df.items() if count and count / n <= _MAX_DF_RATIO}
+    phrase = " ".join(ordered_terms) if len(ordered_terms) >= 2 else ""
+    has_signal = [False] * n
+    for i, tokens in enumerate(chunk_tokens):
+        phrase_hit = bool(phrase) and f" {phrase} " in f" {' '.join(tokens)} "
+        heading_hit = bool(query_tokens & _heading_tokens(chunks[i]))
+        if phrase_hit:
+            scores[i] += _PHRASE_BONUS
+        if heading_hit:
+            scores[i] += _HEADING_BONUS
+        has_signal[i] = phrase_hit or heading_hit or bool(discriminative & set(tokens))
+    if not any(has_signal):
+        return text[:budget]
+
+    ranked = sorted((i for i in range(n) if has_signal[i] and scores[i] > 0), key=lambda i: (-scores[i], i))
+    selected: list[int] = []
+    seen: set[str] = set()
+    remaining = budget
+    for i in ranked:
+        normalized = " ".join(chunks[i].split()).lower()  # dedupes exact repetition only
+        if normalized in seen:
+            continue
+        cost = len(chunks[i]) + (2 if selected else 0)
+        if cost <= remaining:
+            selected.append(i)
+            seen.add(normalized)
+            remaining -= cost
+        elif not selected:
+            # the single best chunk overflows: its head beats a weaker whole chunk
+            return chunks[i][:budget]
+        if remaining < _MIN_TAIL_CHARS:
+            break
+    if not selected:
+        return text[:budget]
+    return "\n\n".join(chunks[i] for i in sorted(selected))

--- a/backend/app/core/utils/content_relevance.py
+++ b/backend/app/core/utils/content_relevance.py
@@ -100,7 +100,12 @@ _MAX_DF_RATIO = 0.5  # a term in more than half the chunks doesn't distinguish t
 _BM25_K1 = 1.5
 _BM25_B = 0.75
 _PHRASE_BONUS = 1.5
-_HEADING_BONUS = 0.5
+_OWN_HEADING_BONUS = 1.0  # meaningful own-heading match
+_NAV_PENALTY = 0.25  # demote link-dense nav blocks 
+_NAV_MIN_LINKS = 3
+_NAV_LABEL_RATIO = 0.6  # link-label share of visible tokens that marks a chunk as navigation
+_MAX_DESCENDANT_SECTIONS = 3
+_DESCENDANT_BUDGET_RATIO = 0.5  # page-budget share reserved for child-section leads under a matched heading
 _ELISION = "[...]"
 _JOIN = "\n\n"  
 _ELISION_JOIN = f"\n\n{_ELISION}\n\n"  
@@ -109,12 +114,14 @@ _HEADING_SEP = "\n\n"
 
 @dataclass
 class _Chunk:
-    """One rankable unit of a page. ``context`` (heading + ancestors) is scored but not part of ``text``."""
+    """One rankable unit of a page. Own heading and ancestors are scored separately, not folded together."""
 
     text: str
-    heading: str  # nearest heading line, "" for pre-heading content
-    context: str  # heading + open ancestor headings, for scoring only
-    needs_prefix: bool  # text lost its heading and should get it re-prepended on render
+    heading: str  
+    ancestors: tuple[str, ...] 
+    section: int  
+    piece: int  
+    needs_prefix: bool  
 
 
 def strip_invisible(text: str) -> str:
@@ -207,20 +214,21 @@ def _chunk_markdown(text: str) -> list[_Chunk]:
     chunks: list[_Chunk] = []
     stack: list[tuple[int, str]] = []
     heading = ""
-    ancestors: list[str] = []
+    ancestors: tuple[str, ...] = ()
     body: list[str] = []
+    section = 0
 
     def flush() -> None:
-        nonlocal body
+        nonlocal body, section
         if any(block.strip() for block in body):
-            context = "\n".join([heading, *ancestors]).strip()
             for i, piece in enumerate(_section_pieces(body)):
                 if heading and i == 0:
-                    chunks.append(_Chunk(f"{heading}{_HEADING_SEP}{piece}", heading, context, needs_prefix=False))
+                    chunks.append(_Chunk(f"{heading}{_HEADING_SEP}{piece}", heading, ancestors, section, i, needs_prefix=False))
                 elif heading:
-                    chunks.append(_Chunk(piece, heading, context, needs_prefix=True))
+                    chunks.append(_Chunk(piece, heading, ancestors, section, i, needs_prefix=True))
                 else:
-                    chunks.append(_Chunk(piece, "", "", needs_prefix=False))
+                    chunks.append(_Chunk(piece, "", (), section, i, needs_prefix=False))
+            section += 1
         body = []
 
     for block in _iter_blocks(text):
@@ -229,7 +237,7 @@ def _chunk_markdown(text: str) -> list[_Chunk]:
             flush()
             while stack and stack[-1][0] >= level:
                 stack.pop()
-            ancestors = [line for _, line in stack]
+            ancestors = tuple(line for _, line in stack)
             stack.append((level, block))
             heading = block
         else:
@@ -260,6 +268,28 @@ def _bm25_scores(chunk_tokens: list[list[str]], query_tokens: set[str]) -> tuple
             norm = _BM25_K1 * (1 - _BM25_B + _BM25_B * lengths[i] / avg_len)
             scores[i] += idf * tf * (_BM25_K1 + 1) / (tf + norm)
     return scores, df
+
+
+def _strong_heading_match(heading_tokens: set[str], query_tokens: set[str], discriminative: set[str]) -> bool:
+    """Whether a heading matches the query meaningfully, not just by sharing one ubiquitous word."""
+    matched = query_tokens & heading_tokens
+    if not matched:
+        return False
+    if len(query_tokens) == 1:  
+        return True
+    if not (matched & discriminative):  
+        return False
+    return len(matched) * 2 >= len(query_tokens) or len(matched) >= 2
+
+
+def _is_nav_heavy(text: str) -> bool:
+    """Whether a chunk is mostly link labels (a table of contents or nav list) rather than prose."""
+    labels = _LINK_RE.findall(text)
+    if len(labels) < _NAV_MIN_LINKS:
+        return False
+    label_tokens = sum(len(_tokenize(label)) for label in labels)
+    visible = len(_tokenize(_visible_text(text)))
+    return bool(visible) and label_tokens / visible >= _NAV_LABEL_RATIO
 
 
 def _render(chunks: list[_Chunk], order: list[int], budget: int) -> str:
@@ -293,44 +323,95 @@ def select_relevant_content(markdown: str, query: str, budget: int) -> str:
     chunks = _chunk_markdown(text[:_MAX_SCAN_CHARS])
     if not chunks:
         return text[:budget]
-    body_tokens = [_tokenize(_visible_text(chunk.text)) for chunk in chunks]
-    context_sets = [set(_tokenize(_visible_text(chunk.context))) for chunk in chunks]
-    chunk_tokens = [tokens + list(context) for tokens, context in zip(body_tokens, context_sets)]
-    scores, df = _bm25_scores(chunk_tokens, query_tokens)
-
     n = len(chunks)
+    body_tokens = [_tokenize(_visible_text(chunk.text)) for chunk in chunks]
+    own_heading_sets = [set(_tokenize(_visible_text(chunk.heading))) for chunk in chunks]
+    ancestor_sets = [set(_tokenize(_visible_text("\n".join(chunk.ancestors)))) for chunk in chunks]
+    bag = [body_tokens[i] + (list(own_heading_sets[i]) if chunks[i].needs_prefix else []) for i in range(n)]
+    scores, df = _bm25_scores(bag, query_tokens)
+
     discriminative = {term for term, count in df.items() if count and count / n <= _MAX_DF_RATIO}
     phrase = " ".join(ordered_terms) if len(ordered_terms) >= 2 else ""
     has_signal = [False] * n
+    own_strong = [False] * n
     for i in range(n):
         phrase_hit = bool(phrase) and f" {phrase} " in f" {' '.join(body_tokens[i])} "
-        heading_hit = bool(query_tokens & context_sets[i])
+        own_strong[i] = _strong_heading_match(own_heading_sets[i], query_tokens, discriminative)
+        ancestor_strong = _strong_heading_match(ancestor_sets[i], query_tokens, discriminative)
         if phrase_hit:
             scores[i] += _PHRASE_BONUS
-        if heading_hit:
-            scores[i] += _HEADING_BONUS
-        has_signal[i] = phrase_hit or heading_hit or bool(discriminative & set(chunk_tokens[i]))
+        if own_strong[i]:
+            scores[i] += _OWN_HEADING_BONUS
+        if _is_nav_heavy(chunks[i].text):
+            scores[i] *= _NAV_PENALTY
+        lead_inherits = chunks[i].piece == 0 and ancestor_strong
+        has_signal[i] = phrase_hit or own_strong[i] or bool(discriminative & set(bag[i])) or lead_inherits
     if not any(has_signal):
         return text[:budget]
 
-    ranked = sorted((i for i in range(n) if has_signal[i] and scores[i] > 0), key=lambda i: (-scores[i], i))
+    section_leads: dict[int, int] = {}
+    for i in range(n):
+        section_leads.setdefault(chunks[i].section, i)  # first chunk seen for a section is its lead
+
     selected: list[int] = []
+    chosen: set[int] = set()
     seen: set[str] = set()
     remaining = budget
-    for i in ranked:
-        normalized = " ".join(chunks[i].text.split()).lower()  # dedupes exact repetition only
-        if normalized in seen:
+
+    def _consider(order: list[int], cap: int, allow_truncate: bool) -> str | None:
+        nonlocal remaining
+        for i in order:
+            if i in chosen:
+                continue
+            normalized = " ".join(chunks[i].text.split()).lower()  # dedupes exact repetition only
+            if normalized in seen:
+                continue
+            prefix_cost = len(chunks[i].heading) + len(_HEADING_SEP) if chunks[i].needs_prefix else 0
+            cost = len(chunks[i].text) + prefix_cost + (len(_ELISION_JOIN) if selected else 0)
+            if cost <= min(cap, remaining):
+                selected.append(i)
+                chosen.add(i)
+                seen.add(normalized)
+                remaining -= cost
+            elif allow_truncate and not selected:
+                return chunks[i].text[:budget] 
+            if remaining < _MIN_TAIL_CHARS:
+                break
+        return None
+
+    ranked = sorted((i for i in range(n) if has_signal[i] and scores[i] > 0), key=lambda i: (-scores[i], i))
+
+    # When a heading strongly matches the query, keep some budget for the first
+    # chunks of its child sections
+    anchor: int | None = None
+    best_key: tuple[float, int] | None = None
+    for sid, lead in section_leads.items():
+        if not own_strong[lead]:
             continue
-        prefix_cost = len(chunks[i].heading) + len(_HEADING_SEP) if chunks[i].needs_prefix else 0
-        cost = len(chunks[i].text) + prefix_cost + (len(_ELISION_JOIN) if selected else 0)
-        if cost <= remaining:
-            selected.append(i)
-            seen.add(normalized)
-            remaining -= cost
-        elif not selected:
-            return chunks[i].text[:budget]
-        if remaining < _MIN_TAIL_CHARS:
-            break
+        key = (scores[lead], _heading_level(chunks[lead].heading))  # strongest score, deepest heading on ties
+        if best_key is None or key > best_key:
+            best_key, anchor = key, sid
+    if anchor is not None:
+        anchor_heading = chunks[section_leads[anchor]].heading
+        descendants = [
+            lead
+            for sid, lead in section_leads.items()
+            if sid != anchor and anchor_heading in chunks[lead].ancestors
+        ]
+        descendants.sort(key=lambda i: (-scores[i], i))  
+        reserved = int(budget * _DESCENDANT_BUDGET_RATIO)
+        _consider(descendants[:_MAX_DESCENDANT_SECTIONS], reserved, allow_truncate=False)
+
+    best_in_section: dict[int, int] = {}
+    for i in ranked:
+        best_in_section.setdefault(chunks[i].section, i)
+    stage1 = [i for i in ranked if best_in_section[chunks[i].section] == i]
+    stage2 = [i for i in ranked if best_in_section[chunks[i].section] != i]
+    truncated = _consider(stage1, budget, allow_truncate=True)
+    if truncated is not None:
+        return truncated
+    _consider(stage2, budget, allow_truncate=False)
+
     if not selected:
         return text[:budget]
     return _render(chunks, sorted(selected), budget)

--- a/backend/app/core/utils/web_scrape_cache.py
+++ b/backend/app/core/utils/web_scrape_cache.py
@@ -1,7 +1,8 @@
-"""Tenant-scoped, opt-in Redis cache for web-scraper results.
+"""Tenant-scoped Redis cache for web-scraper and web-search node results.
 
 The client is resolved lazily from the injector so there is no import cycle and no request scope is required.
 Every path is wrapped so a cache miss, stale entry, or Redis outage silently degrades to a live fetch.
+Callers share one keyspace format, separated by ``key_prefix`` (defaults to the web-scraper prefix).
 """
 
 import hashlib
@@ -24,7 +25,7 @@ def _redis():
     return injector.get(RedisString)
 
 
-def build_cache_key(url: str, options: dict[str, Any]) -> str:
+def build_cache_key(url: str, options: dict[str, Any], *, key_prefix: str = _KEY_PREFIX) -> str:
     """Tenant-scoped key: same url + options collapse to one entry per tenant.
 
     ``options`` carries request headers, so differing auth hashes to a distinct
@@ -34,16 +35,18 @@ def build_cache_key(url: str, options: dict[str, Any]) -> str:
 
     raw = url + "|" + json.dumps(options, sort_keys=True, default=str)
     digest = hashlib.sha256(raw.encode()).hexdigest()
-    return f"tenant:{get_tenant_context()}:{_KEY_PREFIX}:{digest}"
+    return f"tenant:{get_tenant_context()}:{key_prefix}:{digest}"
 
 
-async def get_cached(url: str, options: dict[str, Any], max_age: int) -> dict[str, Any] | None:
+async def get_cached(
+    url: str, options: dict[str, Any], max_age: int, *, key_prefix: str = _KEY_PREFIX
+) -> dict[str, Any] | None:
     """Return a fresh cached result (with ``cacheState``/``cachedAt``) or ``None``."""
     max_age = min(max_age, _MAX_AGE_CAP)
     if max_age <= 0:
         return None
     try:
-        raw = await _redis().get(build_cache_key(url, options))
+        raw = await _redis().get(build_cache_key(url, options, key_prefix=key_prefix))
         if not raw:
             return None
         payload = json.loads(raw)  # str: RedisString runs with decode_responses
@@ -56,13 +59,17 @@ async def get_cached(url: str, options: dict[str, Any], max_age: int) -> dict[st
         return None
 
 
-async def store(url: str, options: dict[str, Any], max_age: int, result: dict[str, Any]) -> None:
+async def store(
+    url: str, options: dict[str, Any], max_age: int, result: dict[str, Any], *, key_prefix: str = _KEY_PREFIX
+) -> None:
     """Cache a successful result under a self-expiring TTL; no-op otherwise."""
     max_age = min(max_age, _MAX_AGE_CAP)
     if max_age <= 0 or not result.get("success"):
         return
     try:
         payload = {"_cachedAt": time.time(), "result": result}
-        await _redis().set(build_cache_key(url, options), json.dumps(payload, default=str), ex=max_age)
+        await _redis().set(
+            build_cache_key(url, options, key_prefix=key_prefix), json.dumps(payload, default=str), ex=max_age
+        )
     except Exception as exc:
         logger.warning("web scrape cache write failed for %s: %s", url, exc)

--- a/backend/app/core/utils/web_search_guard.py
+++ b/backend/app/core/utils/web_search_guard.py
@@ -1,7 +1,8 @@
 """Operational guards for the web-search engine.
 
 Kill switch, per-tenant rate limit, per-process single-flight coalescing and global
-concurrency, tenant-scoped negative caching, and a deployment-global circuit breaker.
+concurrency, tenant-scoped negative caching, a deployment-global DuckDuckGo circuit
+breaker, and a short deployment-global Mwmbl fallback cooldown.
 
 Every Redis-backed guard degrades open — an unreachable Redis never blocks a search.
 No key or log line carries a raw query, URL, or snippet: callers pass an opaque request fingerprint built over
@@ -25,8 +26,8 @@ _GLOBAL_CONCURRENCY = 4
 _RATE_WINDOW_SECONDS = 60
 _NEGATIVE_TTL_SECONDS = 60
 _NEGATIVE_BLOCKED_TTL_SECONDS = 120
-_CIRCUIT_THRESHOLD = 5  # block events per minute that open the circuit
-_CIRCUIT_OPEN_TTL_SECONDS = 120
+_CIRCUIT_OPEN_TTL_SECONDS = 900  # fixed 15-minute cooldown
+_MWMBL_COOLDOWN_TTL_SECONDS = 300  # short pause after a Mwmbl failure, deployment-wide
 
 _global_semaphore = asyncio.Semaphore(_GLOBAL_CONCURRENCY)
 _inflight: dict[str, asyncio.Future] = {}
@@ -176,18 +177,24 @@ async def circuit_is_open() -> bool:
 
 
 async def record_block_event() -> None:
-    """Count a provider block. Too many in a short window trips the circuit breaker.
-
-    Blocks apply to the whole IP, so this breaker is shared across the deployment —
-    not per tenant. Redis keys store only counters, never tenant or query data.
-    """
-    minute = int(time.time() // 60)
+    """Trip the shared DuckDuckGo circuit breaker on the first block."""
     try:
-        redis = _redis()
-        count = await redis.incr(f"websearch:cb:events:{minute}")
-        if count == 1:
-            await redis.expire(f"websearch:cb:events:{minute}", _CIRCUIT_OPEN_TTL_SECONDS)
-        if count >= _CIRCUIT_THRESHOLD:
-            await redis.set("websearch:cb:open", "1", ex=_CIRCUIT_OPEN_TTL_SECONDS)
+        await _redis().set("websearch:cb:open", "1", ex=_CIRCUIT_OPEN_TTL_SECONDS)
     except Exception as exc:
         logger.warning("web search circuit record degraded open: %s", exc)
+
+
+async def mwmbl_circuit_is_open() -> bool:
+    try:
+        return bool(await _redis().get("websearch:mwmbl:cooldown"))
+    except Exception as exc:
+        logger.warning("web search mwmbl cooldown check degraded open: %s", exc)
+        return False
+
+
+async def record_mwmbl_failure() -> None:
+    """Pause Mwmbl fallback for a short cooldown after it fails."""
+    try:
+        await _redis().set("websearch:mwmbl:cooldown", "1", ex=_MWMBL_COOLDOWN_TTL_SECONDS)
+    except Exception as exc:
+        logger.warning("web search mwmbl cooldown record degraded open: %s", exc)

--- a/backend/app/core/utils/web_search_guard.py
+++ b/backend/app/core/utils/web_search_guard.py
@@ -1,0 +1,193 @@
+"""Operational guards for the web-search engine.
+
+Kill switch, per-tenant rate limit, per-process single-flight coalescing and global
+concurrency, tenant-scoped negative caching, and a deployment-global circuit breaker.
+
+Every Redis-backed guard degrades open — an unreachable Redis never blocks a search. 
+No key or log line carries a raw query, URL, or snippet: callers pass an opaque request fingerprint built over
+every result-affecting option.
+"""
+
+import asyncio
+import copy
+import hashlib
+import json
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from app.core.utils.web_search_utils import _sanitize_error
+
+logger = logging.getLogger(__name__)
+
+_GLOBAL_CONCURRENCY = 4
+_RATE_WINDOW_SECONDS = 60
+_NEGATIVE_TTL_SECONDS = 60
+_NEGATIVE_BLOCKED_TTL_SECONDS = 120  
+_CIRCUIT_THRESHOLD = 5  # block events per minute that open the circuit
+_CIRCUIT_OPEN_TTL_SECONDS = 120  
+
+_global_semaphore = asyncio.Semaphore(_GLOBAL_CONCURRENCY)
+_inflight: dict[str, asyncio.Future] = {}
+
+
+def _redis():
+    # Avoids an injector import cycle at module load
+    from app.dependencies.dependency_injection import RedisString
+    from app.dependencies.injector import injector
+
+    return injector.get(RedisString)
+
+
+def build_request_fingerprint(query: str, options: dict[str, Any]) -> str:
+    """Hash of the query and every option that can change the results.
+
+    ``maxAge`` is left out because it only affects cache freshness, not the
+    answer itself. Lists are sorted so the same options in a different order
+    still match. Cache hits and in-flight deduping both use this key, so two
+    searches share a result only when they would return the same thing.
+    """
+    canonical = {
+        key: sorted(value) if isinstance(value, (list, tuple)) else value
+        for key, value in options.items()
+        if key != "maxAge"
+    }
+    raw = json.dumps({"query": query, "options": canonical}, sort_keys=True, default=str)
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def check_enabled() -> bool:
+    """Kill switch; False means fail fast with no upstream traffic."""
+    from app.core.config.settings import settings
+
+    return bool(settings.WEB_SEARCH_ENABLED)
+
+
+def acquire_global_slot() -> asyncio.Semaphore:
+    """Per-process concurrency bound around SERP fetches."""
+    return _global_semaphore
+
+
+async def check_tenant_rate(tenant: str) -> bool:
+    """Per-tenant rate limit over a one-minute window. Returns True if the search may run.
+
+    Only the request that actually performs the search spends a slot; duplicates
+    waiting on the same in-flight search are not counted. The Redis key stores
+    only the tenant id and a counter — never the query.
+    """
+    from app.core.config.settings import settings
+
+    key = f"websearch:rl:{tenant}:{int(time.time() // _RATE_WINDOW_SECONDS)}"
+    try:
+        redis = _redis()
+        count = await redis.incr(key)
+        if count == 1:
+            # outlive the window; the epoch-minute key never rolls into the next one
+            await redis.expire(key, _RATE_WINDOW_SECONDS * 2)
+        return count <= settings.WEB_SEARCH_TENANT_PER_MINUTE
+    except Exception as exc:
+        logger.warning("web search rate-limit check degraded open: %s", exc)
+        return True
+
+
+def _producer_failure_envelope(exc: Exception) -> dict[str, Any]:
+    """Standard failure response when the search run crashes."""
+    message = _sanitize_error(exc)
+    return {
+        "success": False,
+        "query": "",
+        "error": message,
+        "count": 0,
+        "results": [],
+        "text": f"Web search failed: {message}",
+        "enrichedCount": 0,
+        "partial": False,
+        "warnings": [],
+    }
+
+
+async def single_flight(
+    tenant: str, fingerprint: str, producer: Callable[[], Awaitable[dict[str, Any]]]
+) -> dict[str, Any]:
+    """If several identical searches start at once, run ``producer()`` only once.
+
+    The first caller does the real work (search, enrich, cache). The others wait
+    for that same result and each get their own deep copy, so they don't share
+    one mutable response object. If the producer fails, everyone gets a standard
+    failure response — followers never see a raised exception.
+    """
+    key = f"{tenant}:{fingerprint}"
+    existing = _inflight.get(key)
+    if existing is not None:
+        return copy.deepcopy(await asyncio.shield(existing))
+
+    future: asyncio.Future = asyncio.get_running_loop().create_future()
+    _inflight[key] = future
+    try:
+        try:
+            result = await producer()
+        except Exception as exc:
+            logger.warning("web search single-flight producer failed: %s", _sanitize_error(exc))
+            result = _producer_failure_envelope(exc)
+        if not future.done():
+            future.set_result(result)
+        return result
+    finally:
+        _inflight.pop(key, None)
+        if not future.done():
+            future.cancel()  
+
+
+def _negative_key(fingerprint: str) -> str:
+    from app.core.tenant_scope import get_tenant_context
+
+    return f"tenant:{get_tenant_context()}:websearch-neg:{fingerprint}"
+
+
+async def get_negative(fingerprint: str) -> str | None:
+    """Return the recently-failed category for this fingerprint, or ``None``."""
+    try:
+        raw = await _redis().get(_negative_key(fingerprint))
+        if not raw:
+            return None
+        return json.loads(raw).get("category") or None
+    except Exception as exc:
+        logger.warning("web search negative-cache read degraded open: %s", exc)
+        return None
+
+
+async def store_negative(fingerprint: str, category: str) -> None:
+    """Cache a provider failure briefly so the same search isn't retried immediately."""
+    ttl = _NEGATIVE_BLOCKED_TTL_SECONDS if category == "blocked" else _NEGATIVE_TTL_SECONDS
+    try:
+        payload = json.dumps({"category": category, "at": time.time()})
+        await _redis().set(_negative_key(fingerprint), payload, ex=ttl)
+    except Exception as exc:
+        logger.warning("web search negative-cache write degraded open: %s", exc)
+
+
+async def circuit_is_open() -> bool:
+    try:
+        return bool(await _redis().get("websearch:cb:open"))
+    except Exception as exc:
+        logger.warning("web search circuit check degraded open: %s", exc)
+        return False
+
+
+async def record_block_event() -> None:
+    """Count a provider block. Too many in a short window trips the circuit breaker.
+
+    Blocks apply to the whole IP, so this breaker is shared across the deployment —
+    not per tenant. Redis keys store only counters, never tenant or query data.
+    """
+    minute = int(time.time() // 60)
+    try:
+        redis = _redis()
+        count = await redis.incr(f"websearch:cb:events:{minute}")
+        if count == 1:
+            await redis.expire(f"websearch:cb:events:{minute}", _CIRCUIT_OPEN_TTL_SECONDS)
+        if count >= _CIRCUIT_THRESHOLD:
+            await redis.set("websearch:cb:open", "1", ex=_CIRCUIT_OPEN_TTL_SECONDS)
+    except Exception as exc:
+        logger.warning("web search circuit record degraded open: %s", exc)

--- a/backend/app/core/utils/web_search_guard.py
+++ b/backend/app/core/utils/web_search_guard.py
@@ -3,7 +3,7 @@
 Kill switch, per-tenant rate limit, per-process single-flight coalescing and global
 concurrency, tenant-scoped negative caching, and a deployment-global circuit breaker.
 
-Every Redis-backed guard degrades open — an unreachable Redis never blocks a search. 
+Every Redis-backed guard degrades open — an unreachable Redis never blocks a search.
 No key or log line carries a raw query, URL, or snippet: callers pass an opaque request fingerprint built over
 every result-affecting option.
 """
@@ -17,16 +17,16 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from app.core.utils.web_search_utils import _sanitize_error
+from app.core.utils.web_search_utils import WebSearchEnvelope, _sanitize_error
 
 logger = logging.getLogger(__name__)
 
 _GLOBAL_CONCURRENCY = 4
 _RATE_WINDOW_SECONDS = 60
 _NEGATIVE_TTL_SECONDS = 60
-_NEGATIVE_BLOCKED_TTL_SECONDS = 120  
+_NEGATIVE_BLOCKED_TTL_SECONDS = 120
 _CIRCUIT_THRESHOLD = 5  # block events per minute that open the circuit
-_CIRCUIT_OPEN_TTL_SECONDS = 120  
+_CIRCUIT_OPEN_TTL_SECONDS = 120
 
 _global_semaphore = asyncio.Semaphore(_GLOBAL_CONCURRENCY)
 _inflight: dict[str, asyncio.Future] = {}
@@ -91,7 +91,7 @@ async def check_tenant_rate(tenant: str) -> bool:
         return True
 
 
-def _producer_failure_envelope(exc: Exception) -> dict[str, Any]:
+def _producer_failure_envelope(exc: Exception) -> WebSearchEnvelope:
     """Standard failure response when the search run crashes."""
     message = _sanitize_error(exc)
     return {
@@ -108,8 +108,8 @@ def _producer_failure_envelope(exc: Exception) -> dict[str, Any]:
 
 
 async def single_flight(
-    tenant: str, fingerprint: str, producer: Callable[[], Awaitable[dict[str, Any]]]
-) -> dict[str, Any]:
+    tenant: str, fingerprint: str, producer: Callable[[], Awaitable[WebSearchEnvelope]]
+) -> WebSearchEnvelope:
     """If several identical searches start at once, run ``producer()`` only once.
 
     The first caller does the real work (search, enrich, cache). The others wait
@@ -136,7 +136,7 @@ async def single_flight(
     finally:
         _inflight.pop(key, None)
         if not future.done():
-            future.cancel()  
+            future.cancel()
 
 
 def _negative_key(fingerprint: str) -> str:

--- a/backend/app/core/utils/web_search_utils.py
+++ b/backend/app/core/utils/web_search_utils.py
@@ -1,0 +1,397 @@
+"""Web search via DuckDuckGo HTML pages.
+
+Tries ``html.duckduckgo.com/html/`` first, then falls back to
+``lite.duckduckgo.com/lite/``. Search-page fetches use a dedicated httpx client.
+Redirects are followed manually and only to an allowlisted set of DuckDuckGo hosts. 
+Result links are unwrapped from DDG's ``uddg`` redirect, safety-checked, and skipped if unsafe.
+"""
+
+import logging
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from urllib.parse import parse_qs, urljoin, urlparse
+
+import httpx
+from bs4 import BeautifulSoup
+
+from app.core.utils.web_scraping_utils import _validate_url
+
+logger = logging.getLogger(__name__)
+
+_HTML_ENDPOINT = "https://html.duckduckgo.com/html/"
+_LITE_ENDPOINT = "https://lite.duckduckgo.com/lite/"
+# Exact hosts only — no suffix matching — so a redirect can never leave DuckDuckGo.
+_SERP_HOST_ALLOWLIST = frozenset({"html.duckduckgo.com", "lite.duckduckgo.com", "duckduckgo.com", "www.duckduckgo.com"})
+_SERP_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/131.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+_SERP_TIMEOUT = 10  # seconds
+_MAX_REDIRECTS = 5
+_MAX_SERP_BYTES = 2 * 1024 * 1024  # stream-enforced body cap
+_MAX_SERP_URL_LEN = 2048
+_MAX_QUERY_LEN = 400
+_MAX_TITLE_LEN = 300
+_MAX_SNIPPET_LEN = 500
+_MAX_RESULTS_CAP = 20
+_MAX_EXCLUDE_DOMAINS = 10
+_MAX_ERROR_LEN = 500
+
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+_TIME_RANGE_MAP = {"any": "", "day": "d", "week": "w", "month": "m", "year": "y"}
+_SAFESEARCH_MAP = {"strict": "1", "moderate": "-1", "off": "-2"}
+_DEFAULT_REGION = "wt-wt"
+_REGION_ALLOWLIST = frozenset(
+    {
+        "wt-wt",
+        "us-en",
+        "uk-en",
+        "ca-en",
+        "au-en",
+        "in-en",
+        "za-en",
+        "de-de",
+        "fr-fr",
+        "es-es",
+        "it-it",
+        "nl-nl",
+        "pl-pl",
+        "pt-pt",
+        "br-pt",
+        "mx-es",
+        "ar-es",
+        "se-sv",
+        "no-no",
+        "dk-da",
+        "fi-fi",
+        "tr-tr",
+        "gr-el",
+        "ru-ru",
+        "jp-jp",
+        "kr-kr",
+        "cn-zh",
+        "hk-tzh",
+        "tw-tzh",
+        "id-en",
+        "sg-en",
+        "th-en",
+        "vn-en",
+    }
+)
+
+# Strings seen on DuckDuckGo's bot-check page. That page returns HTTP 200, so we detect it by content.
+_BLOCK_MARKERS = ("anomaly-modal", "challenge-form", "bots use duckduckgo")
+# Empty-result markers: the HTML endpoint uses a ``no-results`` div; the lite endpoint uses plain text.
+_NO_RESULTS_MARKERS = ("no-results", "no results", "no more results")
+
+_DOMAIN_RE = re.compile(r"^(?!-)[a-z0-9-]{1,63}(?<!-)(\.(?!-)[a-z0-9-]{1,63}(?<!-))+$")
+_URL_LIKE_RE = re.compile(r"(?:https?:)?//\S+|[?&][\w%+=&.~-]+", re.IGNORECASE)
+
+
+class WebSearchError(ValueError):
+
+    def __init__(self, message: str, *, category: str = "error") -> None:
+        super().__init__(message)
+        self.category = category
+
+
+@dataclass
+class SearchResult:
+
+    title: str
+    url: str
+    snippet: str
+    domain: str
+    position: int
+
+
+def _sanitize_error(exc: Exception) -> str:
+    """Render an exception without URL-like substrings or query strings."""
+    if isinstance(exc, httpx.TimeoutException):
+        return "Timeout contacting search provider"
+    text = f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__
+    return _URL_LIKE_RE.sub("<redacted>", text)[:_MAX_ERROR_LEN]
+
+
+def _normalize_domain(raw: str) -> str:
+    """Normalize a user-supplied domain entry; raises ``invalid_config`` on bad syntax."""
+    value = (raw or "").strip().lower()
+    if "://" in value:
+        value = urlparse(value).hostname or ""
+    elif "/" in value:
+        value = value.split("/", 1)[0]
+    value = value.removesuffix(".")
+    if not value or len(value) > 253 or "@" in value or not _DOMAIN_RE.match(value):
+        raise WebSearchError("Invalid domain in search configuration", category="invalid_config")
+    return value
+
+
+def _matches_domains(host: str, domains: Sequence[str]) -> bool:
+    """Suffix-safe match: ``example.com`` covers ``sub.example.com`` but not ``notexample.com``."""
+    return any(host == domain or host.endswith("." + domain) for domain in domains)
+
+
+def _resolve_result_url(href: str) -> str | None:
+    """Turn a DuckDuckGo ``/l/?uddg=`` redirect into the real URL, or keep a direct http(s) link."""
+    href = (href or "").strip()
+    if not href:
+        return None
+    if href.startswith("//"):
+        href = "https:" + href
+    try:
+        parsed = urlparse(href)
+        host = (parsed.hostname or "").lower()
+        is_ddg_link = (host.endswith("duckduckgo.com") or (not host and parsed.path.startswith("/l/"))) and (
+            "uddg=" in parsed.query
+        )
+        if is_ddg_link:
+            values = parse_qs(parsed.query).get("uddg")
+            if not values:
+                return None
+            candidate = values[0]
+        elif parsed.scheme in ("http", "https"):
+            candidate = href
+        else:
+            return None
+        destination = urlparse(candidate)
+        if destination.scheme not in ("http", "https") or not destination.hostname:
+            return None
+        if destination.username or destination.password:
+            return None
+        return candidate
+    except ValueError:
+        return None
+
+
+def _normalize_result_url(url: str) -> str:
+    """Lowercase the host and strip the fragment so dedup keys are stable."""
+    parsed = urlparse(url)
+    return parsed._replace(netloc=parsed.netloc.lower(), fragment="").geturl()
+
+
+def _is_blocked_page(html: str) -> bool:
+    lowered = html.lower()
+    return any(marker in lowered for marker in _BLOCK_MARKERS)
+
+
+def _has_no_results_marker(html: str) -> bool:
+    collapsed = " ".join(html.lower().split())
+    return any(marker in collapsed for marker in _NO_RESULTS_MARKERS)
+
+
+def _parse_html_serp(html: str) -> list[tuple[str, str, str]]:
+    """Extract (title, href, snippet) rows from the html rung, skipping ads."""
+    soup = BeautifulSoup(html, "lxml")
+    entries: list[tuple[str, str, str]] = []
+    for result in soup.select("div.result"):
+        if "result--ad" in (result.get("class") or []):
+            continue
+        anchor = result.select_one("a.result__a")
+        href = anchor.get("href") if anchor else None
+        if not href or "y.js" in href:
+            continue
+        snippet_el = result.select_one(".result__snippet")
+        snippet = snippet_el.get_text(" ", strip=True) if snippet_el else ""
+        entries.append((anchor.get_text(" ", strip=True), href, snippet))
+    return entries
+
+
+def _parse_lite_serp(html: str) -> list[tuple[str, str, str]]:
+    """Extract rows from the lite rung's table layout; the snippet sits on the next row."""
+    soup = BeautifulSoup(html, "lxml")
+    entries: list[tuple[str, str, str]] = []
+    for anchor in soup.select("a.result-link"):
+        href = anchor.get("href")
+        if not href or "y.js" in href:
+            continue
+        snippet = ""
+        row = anchor.find_parent("tr")
+        next_row = row.find_next_sibling("tr") if row else None
+        if next_row is not None:
+            cell = next_row.select_one("td.result-snippet")
+            if cell is not None:
+                snippet = cell.get_text(" ", strip=True)
+        entries.append((anchor.get_text(" ", strip=True), href, snippet))
+    return entries
+
+
+async def _validate_serp_url(url: str) -> None:
+    """Per-hop guard: scheme, no credentials, exact-host allowlist, then the IP/DNS check."""
+    if len(url) > _MAX_SERP_URL_LEN:
+        raise WebSearchError("Search request URL exceeds the maximum length", category="blocked")
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise WebSearchError("Search redirect used a disallowed scheme", category="blocked")
+    if parsed.username or parsed.password:
+        raise WebSearchError("Search redirect contained credentials", category="blocked")
+    host = (parsed.hostname or "").lower().removesuffix(".")
+    if host not in _SERP_HOST_ALLOWLIST:
+        raise WebSearchError("Search redirect left the allowed provider hosts", category="blocked")
+    try:
+        await _validate_url(url)
+    except ValueError as exc:
+        raise WebSearchError("Search provider address failed safety validation", category="blocked") from exc
+
+
+def _decode_body(data: bytes, charset: str | None) -> str:
+    try:
+        return data.decode(charset or "utf-8", errors="replace")
+    except LookupError:
+        return data.decode("utf-8", errors="replace")
+
+
+async def _fetch_serp(url: str, params: dict[str, str], *, transport: httpx.AsyncBaseTransport | None = None) -> str:
+    """Fetch one search-results page, following redirects by hand."""
+    current = str(httpx.URL(url, params=params))
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=False, headers=_SERP_HEADERS, timeout=_SERP_TIMEOUT, transport=transport
+        ) as client:
+            for _ in range(_MAX_REDIRECTS + 1):
+                await _validate_serp_url(current)
+                async with client.stream("GET", current) as response:
+                    if response.status_code in _REDIRECT_STATUSES:
+                        location = response.headers.get("location", "")
+                        if not location:
+                            raise WebSearchError("Search provider redirect had no destination")
+                        current = urljoin(current, location)
+                        continue
+                    if response.status_code in (403, 429):
+                        raise WebSearchError(
+                            f"Search provider blocked the request (HTTP {response.status_code})", category="blocked"
+                        )
+                    if not (200 <= response.status_code < 300):
+                        raise WebSearchError(f"Search provider returned HTTP {response.status_code}")
+                    content_type = response.headers.get("content-type", "")
+                    if "text/html" not in content_type and "application/xhtml+xml" not in content_type:
+                        raise WebSearchError("Search provider returned a non-HTML response")
+                    chunks: list[bytes] = []
+                    received = 0
+                    async for chunk in response.aiter_bytes():
+                        received += len(chunk)
+                        if received > _MAX_SERP_BYTES:
+                            raise WebSearchError("Search provider response exceeded the size limit")
+                        chunks.append(chunk)
+                    return _decode_body(b"".join(chunks), response.charset_encoding)
+            raise WebSearchError("Too many redirects from search provider", category="blocked")
+    except httpx.TimeoutException as exc:
+        raise WebSearchError("Timeout contacting search provider", category="timeout") from exc
+    except httpx.HTTPError as exc:
+        raise WebSearchError(_sanitize_error(exc)) from exc
+
+
+def _build_results(
+    entries: list[tuple[str, str, str]], *, max_results: int, exclude_domains: Sequence[str]
+) -> list[SearchResult]:
+    """Unwrap, validate, filter, dedupe, truncate, then renumber positions 1..N."""
+    results: list[SearchResult] = []
+    seen: set[str] = set()
+    for title, href, snippet in entries:
+        candidate = _resolve_result_url(href)
+        if candidate is None:
+            continue
+        url = _normalize_result_url(candidate)
+        host = urlparse(url).hostname or ""
+        if _matches_domains(host, exclude_domains):
+            continue
+        if url in seen:
+            continue
+        seen.add(url)
+        results.append(
+            SearchResult(
+                title=title.strip()[:_MAX_TITLE_LEN],
+                url=url,
+                snippet=snippet.strip()[:_MAX_SNIPPET_LEN],
+                domain=host,
+                position=0,
+            )
+        )
+        if len(results) == max_results:
+            break
+    for position, result in enumerate(results, start=1):
+        result.position = position
+    return results
+
+
+def _combined_category(categories: Sequence[str]) -> str:
+    for category in ("blocked", "timeout", "selector_drift"):
+        if category in categories:
+            return category
+    return "error"
+
+
+async def search_web(
+    query: str,
+    *,
+    max_results: int = 5,
+    region: str = _DEFAULT_REGION,
+    time_range: str = "any",
+    safesearch: str = "moderate",
+    include_domain: str = "",
+    exclude_domains: Sequence[str] = (),
+) -> list[SearchResult]:
+    """Search DuckDuckGo and return up to ``max_results`` ranked hits."""
+    query = (query or "").strip()
+    if not query:
+        raise WebSearchError("Search query is required", category="invalid_config")
+    if len(query) > _MAX_QUERY_LEN:
+        raise WebSearchError(f"Search query exceeds {_MAX_QUERY_LEN} characters", category="invalid_config")
+    try:
+        max_results = max(1, min(int(max_results), _MAX_RESULTS_CAP))
+    except (TypeError, ValueError):
+        raise WebSearchError("maxResults must be a number", category="invalid_config") from None
+
+    include = _normalize_domain(include_domain) if (include_domain or "").strip() else ""
+    excludes = [_normalize_domain(domain) for domain in exclude_domains if str(domain).strip()]
+    if len(excludes) > _MAX_EXCLUDE_DOMAINS:
+        raise WebSearchError(
+            f"excludeDomains supports at most {_MAX_EXCLUDE_DOMAINS} domains", category="invalid_config"
+        )
+    if include and include in excludes:
+        raise WebSearchError("A domain cannot be both included and excluded", category="invalid_config")
+
+    params = {
+        "q": f"{query} site:{include}" if include else query,
+        "kl": region if region in _REGION_ALLOWLIST else _DEFAULT_REGION,
+        "kp": _SAFESEARCH_MAP.get(safesearch, _SAFESEARCH_MAP["moderate"]),
+    }
+    date_filter = _TIME_RANGE_MAP.get(time_range, "")
+    if date_filter:
+        params["df"] = date_filter
+    if len(str(httpx.URL(_HTML_ENDPOINT, params=params))) > _MAX_SERP_URL_LEN:
+        raise WebSearchError("Search request URL exceeds the maximum length", category="invalid_config")
+
+    failures: list[tuple[str, WebSearchError]] = []
+    for rung, endpoint, parse in (
+        ("html", _HTML_ENDPOINT, _parse_html_serp),
+        ("lite", _LITE_ENDPOINT, _parse_lite_serp),
+    ):
+        try:
+            page = await _fetch_serp(endpoint, params)
+            entries = parse(page)
+            if not entries:
+                if _is_blocked_page(page):
+                    raise WebSearchError("Search provider served a challenge page", category="blocked")
+                if _has_no_results_marker(page):
+                    return []
+                raise WebSearchError("No results parsed; provider markup may have changed", category="selector_drift")
+            return _build_results(entries, max_results=max_results, exclude_domains=excludes)
+        except WebSearchError as exc:
+            failures.append((rung, exc))
+            logger.warning("web search rung %s failed (%s): %s", rung, exc.category, exc)
+        except Exception as exc:  # any rung surprise (parse crash, odd payload) falls to the next rung
+            wrapped = WebSearchError(_sanitize_error(exc))
+            failures.append((rung, wrapped))
+            logger.warning("web search rung %s failed unexpectedly: %s", rung, wrapped)
+
+    detail = "; ".join(f"{rung}: {exc}" for rung, exc in failures)
+    raise WebSearchError(
+        f"Web search failed on all providers ({detail})"[:_MAX_ERROR_LEN],
+        category=_combined_category([exc.category for _, exc in failures]),
+    )

--- a/backend/app/core/utils/web_search_utils.py
+++ b/backend/app/core/utils/web_search_utils.py
@@ -1,16 +1,21 @@
-"""Web search via DuckDuckGo HTML pages.
+"""Web search via DuckDuckGo HTML pages, with a keyless Mwmbl fallback.
 
 Tries ``html.duckduckgo.com/html/`` first, then falls back to
 ``lite.duckduckgo.com/lite/``. Search-page fetches use a dedicated httpx client.
 Redirects are followed manually and only to an allowlisted set of DuckDuckGo hosts.
 Result links are unwrapped from DDG's ``uddg`` redirect, safety-checked, and skipped if unsafe.
+
+``search_mwmbl`` is a separate, entry point used by the node only when DDG
+explicitly restricts us; it hits a single fixed JSON endpoint and reuses the same
+result normalization. It has no provider abstraction and no region/date/safe-search support.
 """
 
+import json
 import logging
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import NotRequired, TypedDict
+from typing import Any, NotRequired, TypedDict
 from urllib.parse import parse_qs, urljoin, urlparse
 
 import httpx
@@ -43,6 +48,14 @@ _MAX_SNIPPET_LEN = 500
 _MAX_RESULTS_CAP = 20
 _MAX_EXCLUDE_DOMAINS = 10
 _MAX_ERROR_LEN = 500
+
+_MWMBL_ENDPOINT = "https://api.mwmbl.org/api/v2/search/"
+_MWMBL_HOST = "api.mwmbl.org"
+_MWMBL_HEADERS = {"Accept": "application/json", "User-Agent": "GenAssist-WebSearch/1.0"}
+_MWMBL_TIMEOUT = 10  # seconds
+_MWMBL_MAX_BYTES = 1024 * 1024
+_MWMBL_MAX_RESULTS = 2  # hard ceiling on fallback results, regardless of the caller's maxResults
+_FALLBACK_CATEGORY = "fallback"  # internal WebSearchError category for any Mwmbl failure
 
 _REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
 _TIME_RANGE_MAP = {"any": "", "day": "d", "week": "w", "month": "m", "year": "y"}
@@ -413,6 +426,8 @@ async def search_web(
         except WebSearchError as exc:
             failures.append((rung, exc))
             logger.warning("web search rung %s failed (%s): %s", rung, exc.category, exc)
+            if exc.category == "blocked":
+                raise
         except Exception as exc:  # any rung surprise (parse crash, odd payload) falls to the next rung
             wrapped = WebSearchError(_sanitize_error(exc))
             failures.append((rung, wrapped))
@@ -423,3 +438,119 @@ async def search_web(
         f"Web search failed on all providers ({detail})"[:_MAX_ERROR_LEN],
         category=_combined_category([exc.category for _, exc in failures]),
     )
+
+
+async def _fetch_mwmbl(query: str, *, transport: httpx.AsyncBaseTransport | None = None) -> Any:
+    """Request one Mwmbl v2 JSON response. On failure, raise a sanitized ``WebSearchError``. """
+    url = str(httpx.URL(_MWMBL_ENDPOINT, params={"q": query}))
+    if urlparse(url).hostname != _MWMBL_HOST:
+        raise WebSearchError("Fallback provider host is not allowed", category=_FALLBACK_CATEGORY)
+    try:
+        await _validate_url(url)  # shared SSRF / IP / DNS guard on the fixed endpoint
+    except ValueError as exc:
+        raise WebSearchError("Fallback provider address failed safety validation", category=_FALLBACK_CATEGORY) from exc
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=False, headers=_MWMBL_HEADERS, timeout=_MWMBL_TIMEOUT, transport=transport
+        ) as client:
+            async with client.stream("GET", url) as response:
+                if response.status_code in _REDIRECT_STATUSES:
+                    raise WebSearchError("Fallback provider redirected", category=_FALLBACK_CATEGORY)
+                if not (200 <= response.status_code < 300):
+                    raise WebSearchError(
+                        f"Fallback provider returned HTTP {response.status_code}", category=_FALLBACK_CATEGORY
+                    )
+                if "application/json" not in response.headers.get("content-type", ""):
+                    raise WebSearchError("Fallback provider returned a non-JSON response", category=_FALLBACK_CATEGORY)
+                chunks: list[bytes] = []
+                received = 0
+                async for chunk in response.aiter_bytes():
+                    received += len(chunk)
+                    if received > _MWMBL_MAX_BYTES:
+                        raise WebSearchError(
+                            "Fallback provider response exceeded the size limit", category=_FALLBACK_CATEGORY
+                        )
+                    chunks.append(chunk)
+        try:
+            return json.loads(b"".join(chunks))
+        except (ValueError, UnicodeDecodeError) as exc:
+            raise WebSearchError("Fallback provider returned malformed JSON", category=_FALLBACK_CATEGORY) from exc
+    except httpx.TimeoutException as exc:
+        raise WebSearchError("Timeout contacting fallback provider", category=_FALLBACK_CATEGORY) from exc
+    except httpx.HTTPError as exc:
+        raise WebSearchError(_sanitize_error(exc), category=_FALLBACK_CATEGORY) from exc
+
+
+def _normalize_mwmbl_results(
+    payload: Any, *, max_results: int, include: str, exclude_domains: Sequence[str]
+) -> list[SearchResult]:
+    """Turn Mwmbl JSON entries into ``SearchResult`` objects; skip bad ones.
+
+    Domain include/exclude filters run here on normalized hosts (Mwmbl has no
+    ``site:`` query). At most two results are kept. A valid
+    response with nothing usable is an empty success; a wrong top-level JSON
+    shape is a fallback failure.
+    """
+    if not isinstance(payload, dict):
+        raise WebSearchError("Fallback provider returned an unexpected response shape", category=_FALLBACK_CATEGORY)
+    raw = payload.get("results")
+    if not isinstance(raw, list):
+        raise WebSearchError("Fallback provider response was missing results", category=_FALLBACK_CATEGORY)
+    limit = min(max_results, _MWMBL_MAX_RESULTS)
+    results: list[SearchResult] = []
+    seen: set[str] = set()
+    for entry in raw:
+        if len(results) >= limit:
+            break
+        if not isinstance(entry, dict):
+            continue
+        title, url_raw, content = entry.get("title"), entry.get("url"), entry.get("content")
+        if not isinstance(title, str) or not isinstance(url_raw, str):
+            continue
+        candidate = _resolve_result_url(url_raw)  # rejects credentials, non-http(s), empties
+        if candidate is None:
+            continue
+        url = _normalize_result_url(candidate)
+        host = urlparse(url).hostname or ""
+        if include and not _matches_domains(host, [include]):
+            continue
+        if exclude_domains and _matches_domains(host, exclude_domains):
+            continue
+        if url in seen:
+            continue
+        seen.add(url)
+        results.append(
+            SearchResult(
+                title=title.strip()[:_MAX_TITLE_LEN],
+                url=url,
+                snippet=(content.strip()[:_MAX_SNIPPET_LEN] if isinstance(content, str) else ""),
+                domain=host,
+                position=0,
+            )
+        )
+    for position, result in enumerate(results, start=1):
+        result.position = position
+    return results
+
+
+async def search_mwmbl(
+    query: str,
+    *,
+    max_results: int = 5,
+    include_domain: str = "",
+    exclude_domains: Sequence[str] = (),
+) -> list[SearchResult]:
+    """Fallback search via the Mwmbl community index. Returns at most two hits."""
+    query = (query or "").strip()
+    if not query:
+        raise WebSearchError("Search query is required", category="invalid_config")
+    if len(query) > _MAX_QUERY_LEN:
+        raise WebSearchError(f"Search query exceeds {_MAX_QUERY_LEN} characters", category="invalid_config")
+    try:
+        max_results = max(1, min(int(max_results), _MAX_RESULTS_CAP))
+    except (TypeError, ValueError):
+        raise WebSearchError("maxResults must be a number", category="invalid_config") from None
+    include = _normalize_domain(include_domain) if (include_domain or "").strip() else ""
+    excludes = [_normalize_domain(domain) for domain in exclude_domains if str(domain).strip()]
+    payload = await _fetch_mwmbl(query)
+    return _normalize_mwmbl_results(payload, max_results=max_results, include=include, exclude_domains=excludes)

--- a/backend/app/core/utils/web_search_utils.py
+++ b/backend/app/core/utils/web_search_utils.py
@@ -2,7 +2,7 @@
 
 Tries ``html.duckduckgo.com/html/`` first, then falls back to
 ``lite.duckduckgo.com/lite/``. Search-page fetches use a dedicated httpx client.
-Redirects are followed manually and only to an allowlisted set of DuckDuckGo hosts. 
+Redirects are followed manually and only to an allowlisted set of DuckDuckGo hosts.
 Result links are unwrapped from DDG's ``uddg`` redirect, safety-checked, and skipped if unsafe.
 """
 
@@ -10,6 +10,7 @@ import logging
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import NotRequired, TypedDict
 from urllib.parse import parse_qs, urljoin, urlparse
 
 import httpx
@@ -109,6 +110,33 @@ class SearchResult:
     snippet: str
     domain: str
     position: int
+
+
+class WebSearchResultItem(TypedDict):
+    """One serialized hit in a node envelope; ``content`` is filled only by advanced enrichment."""
+
+    title: str
+    url: str
+    snippet: str
+    content: str
+    position: int
+    domain: str
+
+
+class WebSearchEnvelope(TypedDict):
+    """Public web-search node output. Cache keys are added by the cache layer, not the node."""
+
+    success: bool
+    query: str
+    error: str
+    count: int
+    results: list[WebSearchResultItem]
+    text: str
+    enrichedCount: int
+    partial: bool
+    warnings: list[str]
+    cacheState: NotRequired[str]
+    cachedAt: NotRequired[float]
 
 
 def _sanitize_error(exc: Exception) -> str:

--- a/backend/app/modules/workflow/engine/nodes/__init__.py
+++ b/backend/app/modules/workflow/engine/nodes/__init__.py
@@ -43,6 +43,7 @@ from .tool_builder_node import ToolBuilderNode
 from .tts_node import TTSNode
 from .voice_agent_node import VoiceAgentNode
 from .web_scraper_node import WebScraperNode
+from .web_search_node import WebSearchNode
 from .whatsapp_tool_node import WhatsAppToolNode
 from .workflow_executor_node import WorkflowExecutorNode
 from .zendesk_tool_node import ZendeskToolNode
@@ -88,6 +89,7 @@ __all__ = [
     "STTNode",
     "VoiceAgentNode",
     "WebScraperNode",
+    "WebSearchNode",
     "HtmlToImageNode",
     "FinalizeConversationNode",
     "NLPNode",

--- a/backend/app/modules/workflow/engine/nodes/web_search_node.py
+++ b/backend/app/modules/workflow/engine/nodes/web_search_node.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List
 
 from app.core.observability import record_web_search_event
 from app.core.tenant_scope import get_tenant_context
+from app.core.utils.content_relevance import select_relevant_content
 from app.core.utils.web_content_utils import extract_main_content
 from app.core.utils.web_scrape_cache import get_cached, store
 from app.core.utils.web_scraping_utils import fetch_from_url
@@ -33,7 +34,7 @@ from app.modules.workflow.engine import BaseNode
 
 logger = logging.getLogger(__name__)
 
-_MAX_INCLUDE_DOMAINS = 1  
+_MAX_INCLUDE_DOMAINS = 1
 _MAX_EXCLUDE_DOMAINS = 10
 _MAX_ENRICH = 5  # top results enriched in advanced depth; not user-scalable
 _ENRICH_CONCURRENCY = 3
@@ -43,6 +44,8 @@ _MAX_WARNINGS = 5
 _WARNING_LEN = 200
 
 _KEY_PREFIX = "websearch"
+# Bumps the advanced fingerprint when the enrichment selection algorithm changes
+_CONTENT_SELECTION_VERSION = "relevance-v1"
 
 # Category-specific messages surfaced when a recent provider failure is remembered.
 _NEG_MESSAGES = {
@@ -75,7 +78,7 @@ class WebSearchNode(BaseNode):
         metric = {"outcome": "error", "rung": "none", "cache": "off", "count": 0}
         try:
             return await self._execute(config, query, started, metric)
-        except Exception as exc:  
+        except Exception as exc:
             logger.error("web search node failed unexpectedly: %s", _sanitize_error(exc))
             metric["outcome"] = "error"
             return self._error(query, _sanitize_error(exc))
@@ -134,6 +137,10 @@ class WebSearchNode(BaseNode):
             "maxContentChars": max_content_chars,
             "maxTotalContentChars": max_total,
         }
+        if depth == "advanced":
+            # cached envelopes from the old top-of-page truncation must not be
+            # served as query-selected content; basic-depth keys are unchanged
+            options["contentSelection"] = _CONTENT_SELECTION_VERSION
         fingerprint = build_request_fingerprint(query, options)
         cache_key = f"search:{fingerprint}"
         cache_options = dict(options)
@@ -187,9 +194,9 @@ class WebSearchNode(BaseNode):
                 metric=metric,
             )
 
-        metric["outcome"] = None  
+        metric["outcome"] = None
         result = await single_flight(tenant, fingerprint, producer)
-        if metric["outcome"] is None:  
+        if metric["outcome"] is None:
             metric["outcome"] = self._hit_outcome(result) if result.get("success") else "error"
         metric["count"] = result.get("count", 0)
         if metric["cache"] == "off" and isinstance(result.get("cacheState"), str):
@@ -237,7 +244,7 @@ class WebSearchNode(BaseNode):
         serialized = self._serialize(results)
         enriched_count, partial, warnings = 0, False, []
         if depth == "advanced" and serialized:
-            enriched_count, partial, warnings = await self._enrich(serialized, max_content_chars, max_total)
+            enriched_count, partial, warnings = await self._enrich(serialized, query, max_content_chars, max_total)
 
         envelope: Dict[str, Any] = {
             "success": True,
@@ -258,13 +265,15 @@ class WebSearchNode(BaseNode):
             metric["cache"] = "miss"
         return envelope
 
-    async def _enrich(self, results: List[dict], max_content_chars: int, max_total: int) -> tuple[int, bool, list]:
+    async def _enrich(
+        self, results: List[dict], query: str, max_content_chars: int, max_total: int
+    ) -> tuple[int, bool, list]:
         """Fetch full page text into ``content`` for the top results, up to a total size budget.
 
         Results are filled in rank order. Each page gets at most ``max_content_chars``,
-        and only while the shared total budget remains. Fetches run a few at a time with
-        an overall timeout. If a page fails, isn't HTML, times out, or has no budget left,
-        it keeps only its snippet and ``partial`` is set to True.
+        holding its most query-relevant sections, and only while the shared total budget remains. 
+        Fetches run a few at a time with an overall timeout. If a page fails, isn't HTML, times out,
+        or has no budget left, it keeps only its snippet and ``partial`` is set to True.
         """
         candidates = results[: min(_MAX_ENRICH, len(results))]
         budgets: dict[int, int] = {}
@@ -285,7 +294,7 @@ class WebSearchNode(BaseNode):
                 if not fetched.ok or "html" not in (fetched.content_type or "").lower():
                     return idx, None
                 markdown, _ = extract_main_content(fetched.html, candidates[idx]["url"])
-                return idx, markdown.strip()[:budget]
+                return idx, select_relevant_content(markdown, query, budget)
 
         tasks = [asyncio.create_task(_fetch_one(idx, budget)) for idx, budget in budgets.items()]
         enriched = fetch_failures = 0

--- a/backend/app/modules/workflow/engine/nodes/web_search_node.py
+++ b/backend/app/modules/workflow/engine/nodes/web_search_node.py
@@ -19,18 +19,22 @@ from app.core.utils.web_search_guard import (
     check_tenant_rate,
     circuit_is_open,
     get_negative,
+    mwmbl_circuit_is_open,
     record_block_event,
+    record_mwmbl_failure,
     single_flight,
     store_negative,
 )
 from app.core.utils.web_search_utils import (
     _MAX_EXCLUDE_DOMAINS,
     _MAX_QUERY_LEN,
+    SearchResult,
     WebSearchEnvelope,
     WebSearchError,
     WebSearchResultItem,
     _normalize_domain,
     _sanitize_error,
+    search_mwmbl,
     search_web,
 )
 from app.modules.workflow.engine import BaseNode
@@ -48,6 +52,8 @@ _WARNING_LEN = 200
 _KEY_PREFIX = "websearch"
 # Bumps the advanced fingerprint when the enrichment selection algorithm changes
 _CONTENT_SELECTION_VERSION = "relevance-v3"
+# Prepended to warnings whenever results came from the Mwmbl fallback rather than DDG.
+_FALLBACK_WARNING = "DuckDuckGo was unavailable; up to two results were provided by the Mwmbl community index."
 
 # Category-specific messages surfaced when a recent provider failure is remembered.
 _NEG_MESSAGES = {
@@ -159,14 +165,20 @@ class WebSearchNode(BaseNode):
                 metric.update(outcome=self._hit_outcome(cached), cache="hit", count=cached.get("count", 0))
                 return cached
 
+        # If DuckDuckGo is blocked (remembered for this tenant, or the shared circuit is
+        # open), go straight to Mwmbl — still via the producer so rate limit, in-flight
+        # dedupe, and caching still apply.
+        force_fallback = False
         neg = await get_negative(fingerprint)
         if neg is not None:
-            metric.update(outcome="negative_cached", cache="neg")
-            return self._error(query, _NEG_MESSAGES.get(neg, "Web search is temporarily unavailable; retry later"))
+            if neg == "blocked":
+                force_fallback = True
+            else:
+                metric.update(outcome="negative_cached", cache="neg")
+                return self._error(query, _NEG_MESSAGES.get(neg, "Web search is temporarily unavailable; retry later"))
 
-        if await circuit_is_open():
-            metric["outcome"] = "circuit_open"
-            return self._error(query, "Web search temporarily unavailable (provider throttling); retry later")
+        if not force_fallback and await circuit_is_open():
+            force_fallback = True
 
         tenant = get_tenant_context()
 
@@ -195,6 +207,7 @@ class WebSearchNode(BaseNode):
                 safesearch=safesearch,
                 include_domain=include_domain,
                 exclude_domains=exclude_domains,
+                force_fallback=force_fallback,
                 metric=metric,
             )
 
@@ -224,31 +237,49 @@ class WebSearchNode(BaseNode):
         safesearch: str,
         include_domain: str,
         exclude_domains: List[str],
+        force_fallback: bool,
         metric: Dict[str, Any],
     ) -> WebSearchEnvelope:
-        try:
+        used_fallback = False
+        if not force_fallback:
             async with acquire_global_slot():
-                results = await search_web(
-                    query,
-                    max_results=max_results,
-                    region=region,
-                    time_range=time_range,
-                    safesearch=safesearch,
-                    include_domain=include_domain,
-                    exclude_domains=exclude_domains,
-                )
-        except WebSearchError as exc:
-            if exc.category in ("blocked", "timeout", "selector_drift"):
-                await store_negative(fingerprint, exc.category)
-            if exc.category == "blocked":
-                await record_block_event()
-            metric["outcome"] = exc.category if exc.category in _OUTCOME_CATEGORIES else "error"
-            return self._error(query, str(exc))
+                if await circuit_is_open():
+                    force_fallback = True
+                else:
+                    try:
+                        results = await search_web(
+                            query,
+                            max_results=max_results,
+                            region=region,
+                            time_range=time_range,
+                            safesearch=safesearch,
+                            include_domain=include_domain,
+                            exclude_domains=exclude_domains,
+                        )
+                    except WebSearchError as exc:
+                        if exc.category == "blocked":
+                            await store_negative(fingerprint, "blocked")
+                            await record_block_event()
+                            force_fallback = True  # fall to Mwmbl once the slot is released
+                        else:
+                            if exc.category in ("timeout", "selector_drift"):
+                                await store_negative(fingerprint, exc.category)
+                            metric["outcome"] = exc.category if exc.category in _OUTCOME_CATEGORIES else "error"
+                            return self._error(query, str(exc))
+
+        if force_fallback:
+            fallback = await self._fallback_results(query, max_results, include_domain, exclude_domains)
+            if fallback is None:
+                metric["outcome"] = "fallback_error"
+                return self._error(query, "Web search is temporarily unavailable")
+            results, used_fallback = fallback, True
 
         serialized = self._serialize(results)
         enriched_count, partial, warnings = 0, False, []
         if depth == "advanced" and serialized:
             enriched_count, partial, warnings = await self._enrich(serialized, query, max_content_chars, max_total)
+        if used_fallback:
+            warnings = [_FALLBACK_WARNING, *warnings][:_MAX_WARNINGS]
 
         envelope: WebSearchEnvelope = {
             "success": True,
@@ -261,13 +292,35 @@ class WebSearchNode(BaseNode):
             "partial": partial,
             "warnings": warnings,
         }
-        metric.update(outcome="ok" if serialized else "zero", count=len(serialized))
+        if used_fallback:
+            metric.update(outcome="fallback_ok" if serialized else "fallback_zero", count=len(serialized))
+        else:
+            metric.update(outcome="ok" if serialized else "zero", count=len(serialized))
 
         if max_age > 0:
             await store(cache_key, cache_options, max_age, envelope, key_prefix=_KEY_PREFIX)
             envelope = {**envelope, "cacheState": "miss"}
             metric["cache"] = "miss"
         return envelope
+
+    async def _fallback_results(
+        self, query: str, max_results: int, include_domain: str, exclude_domains: List[str]
+    ) -> List[SearchResult] | None:
+        try:
+            async with acquire_global_slot():
+                if await mwmbl_circuit_is_open():
+                    return None
+                return await search_mwmbl(
+                    query, max_results=max_results, include_domain=include_domain, exclude_domains=exclude_domains
+                )
+        except WebSearchError as exc:
+            logger.warning("web search fallback failed (%s)", exc.category)
+            await record_mwmbl_failure()
+            return None
+        except Exception as exc:
+            logger.warning("web search fallback failed unexpectedly: %s", _sanitize_error(exc))
+            await record_mwmbl_failure()
+            return None
 
     async def _enrich(
         self, results: List[WebSearchResultItem], query: str, max_content_chars: int, max_total: int

--- a/backend/app/modules/workflow/engine/nodes/web_search_node.py
+++ b/backend/app/modules/workflow/engine/nodes/web_search_node.py
@@ -47,7 +47,7 @@ _WARNING_LEN = 200
 
 _KEY_PREFIX = "websearch"
 # Bumps the advanced fingerprint when the enrichment selection algorithm changes
-_CONTENT_SELECTION_VERSION = "relevance-v2"
+_CONTENT_SELECTION_VERSION = "relevance-v3"
 
 # Category-specific messages surfaced when a recent provider failure is remembered.
 _NEG_MESSAGES = {

--- a/backend/app/modules/workflow/engine/nodes/web_search_node.py
+++ b/backend/app/modules/workflow/engine/nodes/web_search_node.py
@@ -1,0 +1,375 @@
+"""Workflow node: DuckDuckGo search, with optional full-page content fetch."""
+
+import asyncio
+import hashlib
+import logging
+import time
+from typing import Any, Dict, List
+
+from app.core.observability import record_web_search_event
+from app.core.tenant_scope import get_tenant_context
+from app.core.utils.web_content_utils import extract_main_content
+from app.core.utils.web_scrape_cache import get_cached, store
+from app.core.utils.web_scraping_utils import fetch_from_url
+from app.core.utils.web_search_guard import (
+    acquire_global_slot,
+    build_request_fingerprint,
+    check_enabled,
+    check_tenant_rate,
+    circuit_is_open,
+    get_negative,
+    record_block_event,
+    single_flight,
+    store_negative,
+)
+from app.core.utils.web_search_utils import (
+    _MAX_QUERY_LEN,
+    WebSearchError,
+    _normalize_domain,
+    _sanitize_error,
+    search_web,
+)
+from app.modules.workflow.engine import BaseNode
+
+logger = logging.getLogger(__name__)
+
+_MAX_INCLUDE_DOMAINS = 1  
+_MAX_EXCLUDE_DOMAINS = 10
+_MAX_ENRICH = 5  # top results enriched in advanced depth; not user-scalable
+_ENRICH_CONCURRENCY = 3
+_ENRICH_PHASE_TIMEOUT = 30  # seconds; slow page fetches are cancelled and those results keep only their snippets
+_MAX_DIGEST = 20000
+_MAX_WARNINGS = 5
+_WARNING_LEN = 200
+
+_KEY_PREFIX = "websearch"
+
+# Category-specific messages surfaced when a recent provider failure is remembered.
+_NEG_MESSAGES = {
+    "blocked": "Web search temporarily unavailable (provider throttling); retry later",
+    "timeout": "Web search timed out contacting the provider; retry shortly",
+    "selector_drift": "Web search is temporarily unavailable; retry later",
+}
+# Failure categories that populate the metric outcome directly.
+_OUTCOME_CATEGORIES = {"blocked", "timeout", "selector_drift", "invalid_config"}
+
+
+def _as_int(value: Any, default: int) -> int:
+    # config values may arrive as None/""/str/float after template resolution
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _clamp(value: int, low: int, high: int) -> int:
+    return max(low, min(value, high))
+
+
+class WebSearchNode(BaseNode):
+    """Run a web search and return ranked results plus a short digest for the LLM."""
+
+    async def process(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        started = time.perf_counter()
+        query = (config.get("query") or "").strip()
+        metric = {"outcome": "error", "rung": "none", "cache": "off", "count": 0}
+        try:
+            return await self._execute(config, query, started, metric)
+        except Exception as exc:  
+            logger.error("web search node failed unexpectedly: %s", _sanitize_error(exc))
+            metric["outcome"] = "error"
+            return self._error(query, _sanitize_error(exc))
+        finally:
+            record_web_search_event(
+                metric["outcome"], metric["rung"], metric["cache"], time.perf_counter() - started, metric["count"]
+            )
+
+    async def _execute(self, config: Dict[str, Any], query: str, started: float, metric: dict) -> Dict[str, Any]:
+        depth = (config.get("searchDepth") or "basic").lower()
+        max_results = _clamp(_as_int(config.get("maxResults"), 5), 1, 20)
+        max_content_chars = _clamp(_as_int(config.get("maxContentChars"), 2000), 200, 4000)
+        max_total = _clamp(_as_int(config.get("maxTotalContentChars"), 8000), 1000, 16000)
+        max_age = _clamp(_as_int(config.get("maxAge"), 600), 0, 604800)
+        region = (config.get("region") or "wt-wt").strip()
+        time_range = (config.get("timeRange") or "any").strip()
+        safesearch = (config.get("safeSearch") or "moderate").strip()
+
+        query_digest = hashlib.sha256(query.encode()).hexdigest()[:12]
+        logger.debug("web search node start (digest=%s, depth=%s)", query_digest, depth)
+
+        if not query:
+            metric["outcome"] = "invalid_config"
+            return self._error(query, "Search query is required")
+        if len(query) > _MAX_QUERY_LEN:
+            metric["outcome"] = "invalid_config"
+            return self._error(query, f"Search query exceeds {_MAX_QUERY_LEN} characters")
+
+        try:
+            include_domains = self._parse_domains(config.get("includeDomains"))
+            exclude_domains = self._parse_domains(config.get("excludeDomains"))
+        except WebSearchError as exc:
+            metric["outcome"] = "invalid_config"
+            return self._error(query, str(exc))
+        if len(include_domains) > _MAX_INCLUDE_DOMAINS:
+            metric["outcome"] = "invalid_config"
+            return self._error(query, "includeDomains supports a single domain in this version")
+        if len(exclude_domains) > _MAX_EXCLUDE_DOMAINS:
+            metric["outcome"] = "invalid_config"
+            return self._error(query, f"excludeDomains supports at most {_MAX_EXCLUDE_DOMAINS} domains")
+        include_domain = include_domains[0] if include_domains else ""
+        if include_domain and include_domain in exclude_domains:
+            metric["outcome"] = "invalid_config"
+            return self._error(query, "A domain cannot be both included and excluded")
+
+        # Fingerprint covers every result-affecting option; cache_options mirrors it
+        # but carries no raw query, so nothing sensitive reaches Redis keys or logs.
+        options = {
+            "maxResults": max_results,
+            "searchDepth": depth,
+            "includeDomain": include_domain,
+            "excludeDomains": sorted(exclude_domains),
+            "timeRange": time_range,
+            "region": region,
+            "safeSearch": safesearch,
+            "maxContentChars": max_content_chars,
+            "maxTotalContentChars": max_total,
+        }
+        fingerprint = build_request_fingerprint(query, options)
+        cache_key = f"search:{fingerprint}"
+        cache_options = dict(options)
+
+        if not check_enabled():
+            metric["outcome"] = "disabled"
+            return self._error(query, "Web search is disabled by the administrator")
+
+        if max_age > 0:
+            cached = await get_cached(cache_key, cache_options, max_age, key_prefix=_KEY_PREFIX)
+            if cached is not None:
+                metric.update(outcome=self._hit_outcome(cached), cache="hit", count=cached.get("count", 0))
+                return cached
+
+        neg = await get_negative(fingerprint)
+        if neg is not None:
+            metric.update(outcome="negative_cached", cache="neg")
+            return self._error(query, _NEG_MESSAGES.get(neg, "Web search is temporarily unavailable; retry later"))
+
+        if await circuit_is_open():
+            metric["outcome"] = "circuit_open"
+            return self._error(query, "Web search temporarily unavailable (provider throttling); retry later")
+
+        tenant = get_tenant_context()
+
+        async def producer() -> Dict[str, Any]:
+            # Recheck cache, then spend quota and run the full search.
+            if max_age > 0:
+                again = await get_cached(cache_key, cache_options, max_age, key_prefix=_KEY_PREFIX)
+                if again is not None:
+                    metric.update(outcome=self._hit_outcome(again), cache="hit", count=again.get("count", 0))
+                    return again
+            if not await check_tenant_rate(tenant):
+                metric["outcome"] = "rate_limited"
+                return self._error(query, "Web search rate limit exceeded; retry shortly")
+            return await self._search_and_build(
+                query=query,
+                fingerprint=fingerprint,
+                cache_key=cache_key,
+                cache_options=cache_options,
+                max_age=max_age,
+                depth=depth,
+                max_results=max_results,
+                max_content_chars=max_content_chars,
+                max_total=max_total,
+                region=region,
+                time_range=time_range,
+                safesearch=safesearch,
+                include_domain=include_domain,
+                exclude_domains=exclude_domains,
+                metric=metric,
+            )
+
+        metric["outcome"] = None  
+        result = await single_flight(tenant, fingerprint, producer)
+        if metric["outcome"] is None:  
+            metric["outcome"] = self._hit_outcome(result) if result.get("success") else "error"
+        metric["count"] = result.get("count", 0)
+        if metric["cache"] == "off" and isinstance(result.get("cacheState"), str):
+            metric["cache"] = result["cacheState"]
+        return result
+
+    async def _search_and_build(
+        self,
+        *,
+        query,
+        fingerprint,
+        cache_key,
+        cache_options,
+        max_age,
+        depth,
+        max_results,
+        max_content_chars,
+        max_total,
+        region,
+        time_range,
+        safesearch,
+        include_domain,
+        exclude_domains,
+        metric,
+    ) -> Dict[str, Any]:
+        try:
+            async with acquire_global_slot():
+                results = await search_web(
+                    query,
+                    max_results=max_results,
+                    region=region,
+                    time_range=time_range,
+                    safesearch=safesearch,
+                    include_domain=include_domain,
+                    exclude_domains=exclude_domains,
+                )
+        except WebSearchError as exc:
+            if exc.category in ("blocked", "timeout", "selector_drift"):
+                await store_negative(fingerprint, exc.category)
+            if exc.category == "blocked":
+                await record_block_event()
+            metric["outcome"] = exc.category if exc.category in _OUTCOME_CATEGORIES else "error"
+            return self._error(query, str(exc))
+
+        serialized = self._serialize(results)
+        enriched_count, partial, warnings = 0, False, []
+        if depth == "advanced" and serialized:
+            enriched_count, partial, warnings = await self._enrich(serialized, max_content_chars, max_total)
+
+        envelope: Dict[str, Any] = {
+            "success": True,
+            "query": query,
+            "error": "",
+            "count": len(serialized),
+            "results": serialized,
+            "text": self._build_digest(query, serialized),
+            "enrichedCount": enriched_count,
+            "partial": partial,
+            "warnings": warnings,
+        }
+        metric.update(outcome="ok" if serialized else "zero", count=len(serialized))
+
+        if max_age > 0:
+            await store(cache_key, cache_options, max_age, envelope, key_prefix=_KEY_PREFIX)
+            envelope = {**envelope, "cacheState": "miss"}
+            metric["cache"] = "miss"
+        return envelope
+
+    async def _enrich(self, results: List[dict], max_content_chars: int, max_total: int) -> tuple[int, bool, list]:
+        """Fetch full page text into ``content`` for the top results, up to a total size budget.
+
+        Results are filled in rank order. Each page gets at most ``max_content_chars``,
+        and only while the shared total budget remains. Fetches run a few at a time with
+        an overall timeout. If a page fails, isn't HTML, times out, or has no budget left,
+        it keeps only its snippet and ``partial`` is set to True.
+        """
+        candidates = results[: min(_MAX_ENRICH, len(results))]
+        budgets: dict[int, int] = {}
+        remaining = max_total
+        for idx in range(len(candidates)):
+            if remaining <= 0:
+                break
+            budget = min(max_content_chars, remaining)
+            budgets[idx] = budget
+            remaining -= budget
+
+        semaphore = asyncio.Semaphore(_ENRICH_CONCURRENCY)
+
+        async def _fetch_one(idx: int, budget: int) -> tuple[int, str | None]:
+            async with semaphore:
+                # use_http_request routes through the shared SSRF/IP guard on arbitrary result URLs
+                fetched = await fetch_from_url(candidates[idx]["url"], use_http_request=True)
+                if not fetched.ok or "html" not in (fetched.content_type or "").lower():
+                    return idx, None
+                markdown, _ = extract_main_content(fetched.html, candidates[idx]["url"])
+                return idx, markdown.strip()[:budget]
+
+        tasks = [asyncio.create_task(_fetch_one(idx, budget)) for idx, budget in budgets.items()]
+        enriched = fetch_failures = 0
+        timed_out = 0
+        if tasks:
+            done, pending = await asyncio.wait(tasks, timeout=_ENRICH_PHASE_TIMEOUT)
+            timed_out = len(pending)
+            for task in pending:
+                task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+            for task in done:
+                try:
+                    idx, content = task.result()
+                except Exception:
+                    fetch_failures += 1
+                    continue
+                if content:
+                    candidates[idx]["content"] = content
+                    enriched += 1
+                else:
+                    fetch_failures += 1
+
+        budget_skipped = len(candidates) - len(budgets)
+        partial = enriched < len(candidates)
+        warnings: list[str] = []
+        if fetch_failures:
+            warnings.append(f"{fetch_failures} of {len(candidates)} pages could not be fetched; snippets kept")
+        if timed_out:
+            warnings.append(f"{timed_out} page(s) timed out; snippets kept")
+        if budget_skipped:
+            warnings.append(f"{budget_skipped} page(s) skipped; content budget reached")
+        warnings = [w[:_WARNING_LEN] for w in warnings[:_MAX_WARNINGS]]
+        return enriched, partial, warnings
+
+    @staticmethod
+    def _serialize(results) -> List[dict]:
+        return [
+            {
+                "title": r.title,
+                "url": r.url,
+                "snippet": r.snippet,
+                "content": "",
+                "position": r.position,
+                "domain": r.domain,
+            }
+            for r in results
+        ]
+
+    @staticmethod
+    def _build_digest(query: str, results: List[dict]) -> str:
+        """Numbered, LLM-ready digest; numbering matches each result's position."""
+        if not results:
+            return f'No results found for: "{query}"'
+        blocks = []
+        for r in results:
+            block = f"{r['position']}. {r['title']}\n   URL: {r['url']}"
+            if r.get("snippet"):
+                block += f"\n   {r['snippet']}"
+            if r.get("content"):
+                block += f"\n   {r['content']}"
+            blocks.append(block)
+        return "\n\n".join(blocks)[:_MAX_DIGEST]
+
+    @staticmethod
+    def _hit_outcome(envelope: Dict[str, Any]) -> str:
+        return "ok" if envelope.get("count") else "zero"
+
+    @staticmethod
+    def _parse_domains(raw: Any) -> List[str]:
+        """Split a comma-separated domain field into normalized domains; raises on bad syntax."""
+        items = [part.strip() for part in str(raw or "").split(",") if part.strip()]
+        return [_normalize_domain(item) for item in items]
+
+    @staticmethod
+    def _error(query: str, message: str) -> Dict[str, Any]:
+        return {
+            "success": False,
+            "query": query,
+            "error": message,
+            "count": 0,
+            "results": [],
+            "text": f"Web search failed: {message}",
+            "enrichedCount": 0,
+            "partial": False,
+            "warnings": [],
+        }

--- a/backend/app/modules/workflow/engine/nodes/web_search_node.py
+++ b/backend/app/modules/workflow/engine/nodes/web_search_node.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List
 
 from app.core.observability import record_web_search_event
 from app.core.tenant_scope import get_tenant_context
-from app.core.utils.content_relevance import select_relevant_content
+from app.core.utils.content_relevance import _MAX_SCAN_CHARS, select_relevant_content, strip_invisible
 from app.core.utils.web_content_utils import extract_main_content
 from app.core.utils.web_scrape_cache import get_cached, store
 from app.core.utils.web_scraping_utils import fetch_from_url
@@ -24,8 +24,11 @@ from app.core.utils.web_search_guard import (
     store_negative,
 )
 from app.core.utils.web_search_utils import (
+    _MAX_EXCLUDE_DOMAINS,
     _MAX_QUERY_LEN,
+    WebSearchEnvelope,
     WebSearchError,
+    WebSearchResultItem,
     _normalize_domain,
     _sanitize_error,
     search_web,
@@ -35,7 +38,6 @@ from app.modules.workflow.engine import BaseNode
 logger = logging.getLogger(__name__)
 
 _MAX_INCLUDE_DOMAINS = 1
-_MAX_EXCLUDE_DOMAINS = 10
 _MAX_ENRICH = 5  # top results enriched in advanced depth; not user-scalable
 _ENRICH_CONCURRENCY = 3
 _ENRICH_PHASE_TIMEOUT = 30  # seconds; slow page fetches are cancelled and those results keep only their snippets
@@ -45,7 +47,7 @@ _WARNING_LEN = 200
 
 _KEY_PREFIX = "websearch"
 # Bumps the advanced fingerprint when the enrichment selection algorithm changes
-_CONTENT_SELECTION_VERSION = "relevance-v1"
+_CONTENT_SELECTION_VERSION = "relevance-v2"
 
 # Category-specific messages surfaced when a recent provider failure is remembered.
 _NEG_MESSAGES = {
@@ -72,10 +74,10 @@ def _clamp(value: int, low: int, high: int) -> int:
 class WebSearchNode(BaseNode):
     """Run a web search and return ranked results plus a short digest for the LLM."""
 
-    async def process(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    async def process(self, config: Dict[str, Any]) -> WebSearchEnvelope:
         started = time.perf_counter()
         query = (config.get("query") or "").strip()
-        metric = {"outcome": "error", "rung": "none", "cache": "off", "count": 0}
+        metric = {"outcome": "error", "cache": "off", "count": 0}
         try:
             return await self._execute(config, query, started, metric)
         except Exception as exc:
@@ -84,10 +86,12 @@ class WebSearchNode(BaseNode):
             return self._error(query, _sanitize_error(exc))
         finally:
             record_web_search_event(
-                metric["outcome"], metric["rung"], metric["cache"], time.perf_counter() - started, metric["count"]
+                metric["outcome"], metric["cache"], time.perf_counter() - started, metric["count"]
             )
 
-    async def _execute(self, config: Dict[str, Any], query: str, started: float, metric: dict) -> Dict[str, Any]:
+    async def _execute(
+        self, config: Dict[str, Any], query: str, started: float, metric: Dict[str, Any]
+    ) -> WebSearchEnvelope:
         depth = (config.get("searchDepth") or "basic").lower()
         max_results = _clamp(_as_int(config.get("maxResults"), 5), 1, 20)
         max_content_chars = _clamp(_as_int(config.get("maxContentChars"), 2000), 200, 4000)
@@ -138,8 +142,8 @@ class WebSearchNode(BaseNode):
             "maxTotalContentChars": max_total,
         }
         if depth == "advanced":
-            # cached envelopes from the old top-of-page truncation must not be
-            # served as query-selected content; basic-depth keys are unchanged
+            # advanced enrichment is query-selected, so its cache key is versioned:
+            # envelopes from a different selection version are never reused. Basic keys are unchanged.
             options["contentSelection"] = _CONTENT_SELECTION_VERSION
         fingerprint = build_request_fingerprint(query, options)
         cache_key = f"search:{fingerprint}"
@@ -166,7 +170,7 @@ class WebSearchNode(BaseNode):
 
         tenant = get_tenant_context()
 
-        async def producer() -> Dict[str, Any]:
+        async def producer() -> WebSearchEnvelope:
             # Recheck cache, then spend quota and run the full search.
             if max_age > 0:
                 again = await get_cached(cache_key, cache_options, max_age, key_prefix=_KEY_PREFIX)
@@ -206,22 +210,22 @@ class WebSearchNode(BaseNode):
     async def _search_and_build(
         self,
         *,
-        query,
-        fingerprint,
-        cache_key,
-        cache_options,
-        max_age,
-        depth,
-        max_results,
-        max_content_chars,
-        max_total,
-        region,
-        time_range,
-        safesearch,
-        include_domain,
-        exclude_domains,
-        metric,
-    ) -> Dict[str, Any]:
+        query: str,
+        fingerprint: str,
+        cache_key: str,
+        cache_options: Dict[str, Any],
+        max_age: int,
+        depth: str,
+        max_results: int,
+        max_content_chars: int,
+        max_total: int,
+        region: str,
+        time_range: str,
+        safesearch: str,
+        include_domain: str,
+        exclude_domains: List[str],
+        metric: Dict[str, Any],
+    ) -> WebSearchEnvelope:
         try:
             async with acquire_global_slot():
                 results = await search_web(
@@ -246,7 +250,7 @@ class WebSearchNode(BaseNode):
         if depth == "advanced" and serialized:
             enriched_count, partial, warnings = await self._enrich(serialized, query, max_content_chars, max_total)
 
-        envelope: Dict[str, Any] = {
+        envelope: WebSearchEnvelope = {
             "success": True,
             "query": query,
             "error": "",
@@ -266,39 +270,25 @@ class WebSearchNode(BaseNode):
         return envelope
 
     async def _enrich(
-        self, results: List[dict], query: str, max_content_chars: int, max_total: int
+        self, results: List[WebSearchResultItem], query: str, max_content_chars: int, max_total: int
     ) -> tuple[int, bool, list]:
-        """Fetch full page text into ``content`` for the top results, up to a total size budget.
-
-        Results are filled in rank order. Each page gets at most ``max_content_chars``,
-        holding its most query-relevant sections, and only while the shared total budget remains. 
-        Fetches run a few at a time with an overall timeout. If a page fails, isn't HTML, times out,
-        or has no budget left, it keeps only its snippet and ``partial`` is set to True.
-        """
+        """Fetch full page text into ``content`` for the top results, within a total size budget."""
         candidates = results[: min(_MAX_ENRICH, len(results))]
-        budgets: dict[int, int] = {}
-        remaining = max_total
-        for idx in range(len(candidates)):
-            if remaining <= 0:
-                break
-            budget = min(max_content_chars, remaining)
-            budgets[idx] = budget
-            remaining -= budget
-
         semaphore = asyncio.Semaphore(_ENRICH_CONCURRENCY)
 
-        async def _fetch_one(idx: int, budget: int) -> tuple[int, str | None]:
+        async def _fetch_one(idx: int) -> tuple[int, str | None]:
             async with semaphore:
                 # use_http_request routes through the shared SSRF/IP guard on arbitrary result URLs
                 fetched = await fetch_from_url(candidates[idx]["url"], use_http_request=True)
                 if not fetched.ok or "html" not in (fetched.content_type or "").lower():
                     return idx, None
                 markdown, _ = extract_main_content(fetched.html, candidates[idx]["url"])
-                return idx, select_relevant_content(markdown, query, budget)
+                markdown = strip_invisible(markdown)[:_MAX_SCAN_CHARS]
+                return idx, (markdown if markdown.strip() else None)
 
-        tasks = [asyncio.create_task(_fetch_one(idx, budget)) for idx, budget in budgets.items()]
-        enriched = fetch_failures = 0
-        timed_out = 0
+        tasks = [asyncio.create_task(_fetch_one(idx)) for idx in range(len(candidates))]
+        pages: dict[int, str] = {}
+        fetch_failures = timed_out = 0
         if tasks:
             done, pending = await asyncio.wait(tasks, timeout=_ENRICH_PHASE_TIMEOUT)
             timed_out = len(pending)
@@ -308,17 +298,29 @@ class WebSearchNode(BaseNode):
                 await asyncio.gather(*pending, return_exceptions=True)
             for task in done:
                 try:
-                    idx, content = task.result()
+                    idx, markdown = task.result()
                 except Exception:
                     fetch_failures += 1
                     continue
+                if markdown is None:
+                    fetch_failures += 1
+                else:
+                    pages[idx] = markdown
+
+        enriched = budget_skipped = 0
+        if pages:
+            per_page = min(max_content_chars, max_total // len(pages))
+            remaining = max_total
+            for idx in sorted(pages):  # rank order
+                budget = min(per_page, remaining)
+                content = select_relevant_content(pages[idx], query, budget) if budget > 0 else ""
                 if content:
                     candidates[idx]["content"] = content
                     enriched += 1
+                    remaining -= len(content)
                 else:
-                    fetch_failures += 1
+                    budget_skipped += 1
 
-        budget_skipped = len(candidates) - len(budgets)
         partial = enriched < len(candidates)
         warnings: list[str] = []
         if fetch_failures:
@@ -331,7 +333,7 @@ class WebSearchNode(BaseNode):
         return enriched, partial, warnings
 
     @staticmethod
-    def _serialize(results) -> List[dict]:
+    def _serialize(results) -> List[WebSearchResultItem]:
         return [
             {
                 "title": r.title,
@@ -345,7 +347,7 @@ class WebSearchNode(BaseNode):
         ]
 
     @staticmethod
-    def _build_digest(query: str, results: List[dict]) -> str:
+    def _build_digest(query: str, results: List[WebSearchResultItem]) -> str:
         """Numbered, LLM-ready digest; numbering matches each result's position."""
         if not results:
             return f'No results found for: "{query}"'
@@ -370,7 +372,7 @@ class WebSearchNode(BaseNode):
         return [_normalize_domain(item) for item in items]
 
     @staticmethod
-    def _error(query: str, message: str) -> Dict[str, Any]:
+    def _error(query: str, message: str) -> WebSearchEnvelope:
         return {
             "success": False,
             "query": query,

--- a/backend/app/modules/workflow/engine/workflow_engine.py
+++ b/backend/app/modules/workflow/engine/workflow_engine.py
@@ -58,6 +58,7 @@ from app.modules.workflow.engine.nodes import (
     TrainPreprocessNode,
     VoiceAgentNode,
     WebScraperNode,
+    WebSearchNode,
     WhatsAppToolNode,
     WorkflowExecutorNode,
     ZendeskToolNode,
@@ -143,6 +144,7 @@ class WorkflowEngine:
         cls._node_registry["sttNode"] = STTNode
         cls._node_registry["voiceAgentNode"] = VoiceAgentNode
         cls._node_registry["webScraperNode"] = WebScraperNode
+        cls._node_registry["webSearchNode"] = WebSearchNode
         cls._node_registry["htmlToImageNode"] = HtmlToImageNode
         cls._node_registry["finalizeConversationNode"] = FinalizeConversationNode
         cls._node_registry["nlpNode"] = NLPNode
@@ -178,6 +180,7 @@ class WorkflowEngine:
             "humanInTheLoopNode",
             "setStateNode",
             "nlpNode",
+            "webSearchNode",
         }
 
         # Return True if node is NOT in the no-DB list (i.e., it needs DB)

--- a/backend/app/schemas/dynamic_form_schemas/nodes/__init__.py
+++ b/backend/app/schemas/dynamic_form_schemas/nodes/__init__.py
@@ -33,6 +33,7 @@ from .stt_schema import STT_NODE_DIALOG_SCHEMA
 from .voice_agent_schema import VOICE_AGENT_NODE_DIALOG_SCHEMA
 from .finalize_conversation_schema import FINALIZE_CONVERSATION_NODE_DIALOG_SCHEMA
 from .web_scraper_schema import WEB_SCRAPER_NODE_DIALOG_SCHEMA
+from .web_search_schema import WEB_SEARCH_NODE_DIALOG_SCHEMA
 from .html_to_image_schema import HTML_TO_IMAGE_NODE_DIALOG_SCHEMA
 from .nlp_schema import NLP_NODE_DIALOG_SCHEMA
 
@@ -70,6 +71,7 @@ NODE_TYPE_LABELS: Dict[str, str] = {
     "voiceAgentNode": "Voice Agent",
     "finalizeConversationNode": "End Conversation",
     "webScraperNode": "Web Scraper",
+    "webSearchNode": "Web Search",
     "htmlToImageNode": "HTML to Image",
     "nlpNode": "Text Analysis",
 }
@@ -108,6 +110,7 @@ NODE_DIALOG_SCHEMAS: Dict[str, List[FieldSchema]] = {
     "voiceAgentNode": VOICE_AGENT_NODE_DIALOG_SCHEMA,
     "finalizeConversationNode": FINALIZE_CONVERSATION_NODE_DIALOG_SCHEMA,
     "webScraperNode": WEB_SCRAPER_NODE_DIALOG_SCHEMA,
+    "webSearchNode": WEB_SEARCH_NODE_DIALOG_SCHEMA,
     "htmlToImageNode": HTML_TO_IMAGE_NODE_DIALOG_SCHEMA,
     "nlpNode": NLP_NODE_DIALOG_SCHEMA,
 }
@@ -268,6 +271,11 @@ NODE_HANDLERS_SCHEMAS: Dict[str, List[FieldSchema]] = {
   ],
 
   "webScraperNode": [
+    { "id": "input", "type": "target", "position": "left", "compatibility": "any" },
+    { "id": "output", "type": "source", "position": "right", "compatibility": "any" }
+  ],
+
+  "webSearchNode": [
     { "id": "input", "type": "target", "position": "left", "compatibility": "any" },
     { "id": "output", "type": "source", "position": "right", "compatibility": "any" }
   ],

--- a/backend/app/schemas/dynamic_form_schemas/nodes/web_search_schema.py
+++ b/backend/app/schemas/dynamic_form_schemas/nodes/web_search_schema.py
@@ -1,0 +1,79 @@
+from typing import List
+
+from ..base import FieldSchema
+
+WEB_SEARCH_NODE_DIALOG_SCHEMA: List[FieldSchema] = [
+    FieldSchema(
+        name="name",
+        type="text",
+        label="Node Name",
+        required=False,
+    ),
+    FieldSchema(
+        name="query",
+        type="text",
+        label="Query",
+        required=True,
+    ),
+    FieldSchema(
+        name="maxResults",
+        type="number",
+        label="Max Results",
+        default=5,
+        min=1,
+        max=20,
+    ),
+    FieldSchema(
+        name="searchDepth",
+        type="select",
+        label="Search Depth",
+        default="basic",
+        options=[
+            {"label": "Basic", "value": "basic"},
+            {"label": "Advanced", "value": "advanced"},
+        ],
+    ),
+    FieldSchema(
+        name="includeDomains",
+        type="text",
+        label="Include Domain",
+        required=False,
+        advanced=True,
+    ),
+    FieldSchema(
+        name="excludeDomains",
+        type="text",
+        label="Exclude Domains",
+        required=False,
+        advanced=True,
+    ),
+    # per-result content cap for advanced depth
+    FieldSchema(
+        name="maxContentChars",
+        type="number",
+        label="Max Content Chars (per result)",
+        default=2000,
+        min=200,
+        max=4000,
+        advanced=True,
+    ),
+    # total enrichment budget for advanced depth; bounds worst-case payload
+    FieldSchema(
+        name="maxTotalContentChars",
+        type="number",
+        label="Max Total Content Chars",
+        default=8000,
+        min=1000,
+        max=16000,
+        advanced=True,
+    ),
+    # default-on result cache; 0 disables. Tenant-scoped, capped at 7d server-side
+    FieldSchema(
+        name="maxAge",
+        type="number",
+        label="Cache Max Age (seconds)",
+        default=600,
+        min=0,
+        advanced=True,
+    ),
+]

--- a/backend/tests/unit/core/utils/test_content_relevance.py
+++ b/backend/tests/unit/core/utils/test_content_relevance.py
@@ -1,6 +1,6 @@
 """Unit tests for query-aware markdown chunk selection."""
 
-from app.core.utils.content_relevance import select_relevant_content
+from app.core.utils.content_relevance import select_relevant_content, strip_invisible
 
 
 def _filler(word: str, size: int = 680) -> str:
@@ -191,3 +191,84 @@ def test_unicode_query_and_text():
     md = "\n\n".join([_filler("alpha"), target, _filler("beta")])
     out = select_relevant_content(md, "coûts expédition", 200)
     assert "42 €" in out
+
+
+# section integrity
+
+
+def test_sections_do_not_merge_across_headings():
+    md = "\n\n".join(
+        [
+            "### PayPal\n\n" + "PayPal is a global online payments platform used across many markets today. " * 2,
+            "### Payline Data\n\n" + "Payline delivers flexible friendly payment solutions for growing teams. " * 2,
+        ]
+    )
+    out = select_relevant_content(md, "payline flexible payment solutions", 250)
+    assert "Payline delivers flexible" in out
+    assert "### Payline Data" in out
+    assert "PayPal is a global" not in out
+
+
+def test_continuation_chunk_regains_its_heading():
+    body = "General background about the company history and mission today. " * 12
+    md = "## Returns\n\n" + body + "\n\nRefund policy grants a full refund within thirty days."
+    out = select_relevant_content(md, "refund policy thirty days", 300)
+    assert "Refund policy grants" in out
+    assert "## Returns" in out
+    assert len(out) <= 300
+
+
+def test_elision_marker_separates_nonadjacent_chunks():
+    early = "Alpha pricing tier costs ten dollars monthly per seat."
+    mid = "General filler about unrelated onboarding steps and tutorials here. " * 12
+    late = "Beta pricing tier costs twenty dollars monthly per seat."
+    md = "\n\n".join([early, mid, late])
+    out = select_relevant_content(md, "pricing tier costs", 300)
+    assert "Alpha pricing" in out
+    assert "Beta pricing" in out
+    assert "[...]" in out
+    assert out.index("Alpha") < out.index("[...]") < out.index("Beta")
+
+
+def test_structural_budget_keeps_markers_and_headings_intact():
+    s1 = "## First\n\nAlpha ratio measures one hundred units precisely today."
+    mid = "Filler about unrelated onboarding tutorials and setup steps here. " * 12
+    s2 = "## Second\n\nAlpha ratio measures two hundred units precisely today."
+    md = "\n\n".join([s1, mid, s2])
+    for budget in range(40, 260, 10):
+        out = select_relevant_content(md, "alpha ratio hundred", budget)
+        assert len(out) <= budget
+        stripped = out.replace("[...]", "")
+        assert "[" not in stripped and "]" not in stripped
+        for line in out.splitlines():
+            if line.startswith("#"):
+                assert line in ("## First", "## Second")
+
+
+# invisible characters
+
+
+def test_strip_invisible_removes_standalone_runs():
+    assert strip_invisible("a\n\n‍​\n\nb") == "a\n\nb"
+
+
+def test_strip_invisible_removes_line_leading_run():
+    assert strip_invisible("intro\n\n‍**Headquarters:** Chicago") == "intro\n\n**Headquarters:** Chicago"
+
+
+def test_strip_invisible_preserves_emoji_zwj():
+    family = "\U0001f468‍\U0001f469‍\U0001f467"
+    assert strip_invisible(f"Team {family} rocks") == f"Team {family} rocks"
+
+
+def test_standalone_zero_width_absent_from_selection():
+    md = "\n\n".join(
+        [
+            "## Overview\n\nThe pricing plans cover every tier with clear billing details.",
+            "‍",
+            "Extra pricing notes describe discounts and billing cycles thoroughly enough.",
+        ]
+    )
+    out = select_relevant_content(md, "pricing billing details", 120)
+    assert "‍" not in out
+    assert len(out) <= 120

--- a/backend/tests/unit/core/utils/test_content_relevance.py
+++ b/backend/tests/unit/core/utils/test_content_relevance.py
@@ -1,0 +1,193 @@
+"""Unit tests for query-aware markdown chunk selection."""
+
+from app.core.utils.content_relevance import select_relevant_content
+
+
+def _filler(word: str, size: int = 680) -> str:
+    """Neutral paragraph of ~size chars; ~680 keeps it a standalone chunk (merges would pass 700)."""
+    sentence = f"General {word} notes archive routine updates without surprises. "
+    return (sentence * (size // len(sentence) + 1))[:size].strip()
+
+
+# selection
+
+
+def test_heading_glued_to_following_block():
+    md = "\n\n".join(
+        [
+            "# Setup",
+            "Install the package with pip and configure credentials before first use.",
+            _filler("alpha"),
+            _filler("beta"),
+        ]
+    )
+    out = select_relevant_content(md, "install package credentials", 300)
+    assert "# Setup" in out
+    assert "Install the package" in out
+    assert len(out) <= 300
+
+
+def test_selects_relevant_section_from_long_page():
+    md = "\n\n".join(
+        [
+            _filler("alpha"),
+            _filler("beta"),
+            "## Pricing\n\nThe pro plan costs $99 per month with unlimited seats.",
+            _filler("gamma"),
+        ]
+    )
+    out = select_relevant_content(md, "pricing pro plan", 300)
+    assert "$99" in out
+    assert "alpha" not in out
+    assert len(out) <= 300
+
+
+def test_result_never_exceeds_budget():
+    md = "\n\n".join(
+        [_filler(word) for word in ("alpha", "beta", "gamma", "delta", "epsilon", "zeta")]
+        + ["## Pricing\n\nThe pro plan costs $99 per month with unlimited seats."]
+    )
+    assert len(md) > 4000
+    for budget in (50, 150, 300, 700, 2000, 4000):
+        out = select_relevant_content(md, "pricing pro plan", budget)
+        assert len(out) <= budget
+
+
+def test_selected_chunks_keep_document_order():
+    early = "Shipping options include ground delivery for most regions."
+    late = "Express shipping and overnight shipping cost extra; shipping insurance is optional."
+    md = "\n\n".join([early, _filler("alpha"), _filler("beta"), late, _filler("gamma")])
+    out = select_relevant_content(md, "shipping", 700)
+    assert "ground delivery" in out
+    assert "Express shipping" in out
+    assert out.index("ground delivery") < out.index("Express shipping")
+
+
+def test_tie_scores_prefer_earlier_chunk():
+    first = "Alpha section covers warranty terms for enrolled devices today."
+    second = "Gamma section covers warranty terms for enrolled devices today."
+    md = "\n\n".join([first, _filler("delta"), second, _filler("epsilon")])
+    out = select_relevant_content(md, "warranty terms", 70)
+    assert "Alpha" in out
+    assert "Gamma" not in out
+
+
+def test_duplicate_chunks_selected_once():
+    dup = "Overnight shipping rates stay flat at $42 for domestic parcels."
+    md = "\n\n".join([_filler("alpha"), dup, _filler("beta"), dup])
+    out = select_relevant_content(md, "overnight shipping rates", 400)
+    assert out.count("$42") == 1
+
+
+def test_oversized_block_split_on_sentences():
+    opening = "Opening line about corporate history and heritage values."
+    matching = "Refund policy grants a full refund within thirty days of purchase."
+    sentences = [opening] + [f"Neutral filler sentence number {i} covering assorted topics." for i in range(30)]
+    sentences.insert(20, matching)
+    md = " ".join(sentences) + "\n\n" + _filler("alpha")
+    out = select_relevant_content(md, "refund policy", 700)
+    assert "full refund within thirty days" in out
+    assert opening not in out
+
+
+def test_first_choice_larger_than_budget_is_truncated():
+    block = ("Quantum pricing tiers scale with usage volume across accounts. " * 11).strip()
+    md = "\n\n".join([_filler("alpha"), block, _filler("beta")])
+    out = select_relevant_content(md, "quantum pricing tiers", 50)
+    assert out == block[:50]
+
+
+# fallbacks
+
+
+def test_stopword_only_query_falls_back():
+    md = "\n\n".join([_filler("alpha"), _filler("beta"), _filler("gamma")])
+    assert select_relevant_content(md, "what is the", 200) == md[:200]
+
+
+def test_single_char_query_falls_back():
+    md = "\n\n".join([_filler("alpha"), _filler("beta")])
+    assert select_relevant_content(md, "q", 200) == md[:200]
+
+
+def test_zero_match_query_falls_back():
+    md = "\n\n".join([_filler("alpha"), _filler("beta")])
+    assert select_relevant_content(md, "zzqx unmatched", 200) == md[:200]
+
+
+def test_ubiquitous_term_without_distinguishing_signal_falls_back():
+    md = "\n\n".join(
+        [
+            "Acme ships widgets worldwide and Acme leads the market.",
+            _filler("alpha") + " Acme remains involved.",
+            _filler("beta") + " Acme remains committed.",
+            "Copyright Acme. Acme and the Acme logo are trademarks of Acme Incorporated.",
+        ]
+    )
+    assert select_relevant_content(md, "acme", 200) == md[:200]
+
+
+def test_exact_phrase_overrides_flat_term_distribution():
+    md = "\n\n".join(
+        [
+            _filler("alpha") + " Acme documents exist while the plan details vary by region.",
+            "The acme plan tier costs $49 monthly.",
+            _filler("beta") + " Acme grows steadily and every plan evolves.",
+        ]
+    )
+    out = select_relevant_content(md, "acme plan", 200)
+    assert "$49" in out
+    assert "alpha" not in out
+
+
+def test_heading_match_passes_low_information_gate():
+    md = "\n\n".join(
+        [
+            _filler("alpha") + " Widgets ship weekly.",
+            "## Widgets catalog\n\nBrowse every widgets model with detailed specifications and photos.",
+            _filler("beta") + " Widgets sell well.",
+        ]
+    )
+    out = select_relevant_content(md, "widgets", 300)
+    assert "specifications" in out
+    assert "alpha" not in out
+
+
+# markdown links
+
+
+def test_url_query_scores_visible_text_not_link_destinations():
+    link_chunk = " ".join(f"[Post {i}](https://acme.com/blog/{i})" for i in range(1, 30)) + " Latest roundup entries."
+    visible_chunk = "Acme pricing starts at $10 per seat with volume discounts."
+    md = "\n\n".join([link_chunk, _filler("alpha"), visible_chunk])
+    out = select_relevant_content(md, "https://acme.com pricing", 200)
+    assert "$10" in out
+    assert "roundup" not in out
+
+
+def test_output_preserves_markdown_links_verbatim():
+    target = "See the [pricing guide](https://acme.com/pricing) for tier comparisons and costs."
+    md = "\n\n".join([_filler("alpha"), target, _filler("beta")])
+    out = select_relevant_content(md, "pricing guide tier", 200)
+    assert "[pricing guide](https://acme.com/pricing)" in out
+
+
+# boundaries
+
+
+def test_empty_inputs_return_empty():
+    assert select_relevant_content("", "anything", 500) == ""
+    assert select_relevant_content("   \n\n  ", "anything", 500) == ""
+    assert select_relevant_content("content here", "anything", 0) == ""
+
+
+def test_whole_page_within_budget_returned_verbatim():
+    md = "## Pricing\n\nPlans start at $5."
+    assert select_relevant_content(md, "pricing", 4000) == md
+
+
+def test_unicode_query_and_text():
+    target = "Les coûts d'expédition s'élèvent à 42 € pour les commandes internationales."
+    md = "\n\n".join([_filler("alpha"), target, _filler("beta")])
+    out = select_relevant_content(md, "coûts expédition", 200)
+    assert "42 €" in out

--- a/backend/tests/unit/core/utils/test_content_relevance.py
+++ b/backend/tests/unit/core/utils/test_content_relevance.py
@@ -245,6 +245,109 @@ def test_structural_budget_keeps_markers_and_headings_intact():
                 assert line in ("## First", "## Second")
 
 
+# hierarchy and navigation
+
+
+def test_child_sections_outrank_author_bio():
+    bio = ("Written by a longtime staff correspondentprofile covering global markets. " * 10).strip()
+    md = "\n\n".join(
+        [
+            "# Payment Industry Report",
+            bio,
+            "## Payment Competitors\n\nThe payment competitor landscape spans several established firms.",
+            "### PayPal\n\nPayPal offers global online checkout across many markets today.",
+            "### Adyen\n\nAdyen provides a unified commerce platform for large enterprises today.",
+            "### Square\n\nSquare sells point of sale hardware for small merchants today.",
+        ]
+    )
+    out = select_relevant_content(md, "payment competitors", 900)
+    assert sum(name in out for name in ("PayPal", "Adyen", "Square")) >= 2
+    assert "correspondentprofile" not in out
+
+
+def test_substantive_section_outranks_link_dense_toc():
+    toc = "[Home](/home) [Company](/company) [Pricing overview](/pricing) [Careersblog](/careers) [Contact](/contact)"
+    md = "\n\n".join(
+        [
+            "## Table of contents\n\n" + toc,
+            "## Pricing overview\n\nThe pricing overview explains each subscription tier and its monthly cost.",
+            _filler("alpha"),
+            _filler("beta"),
+        ]
+    )
+    out = select_relevant_content(md, "pricing overview", 200)
+    assert "subscription tier" in out
+    assert "Careersblog" not in out
+
+
+def test_entity_only_heading_does_not_outrank_intent_section():
+    md = "\n\n".join(
+        [
+            "# Stripe Overview\n\nStripe is a payments company serving many businesses worldwide.",
+            "## Stripe and its strengths\n\nStripe excels at developer experience and Stripe documentation is strong.",
+            "## Stripe Competitors\n\nSeveral firms compete with Stripe across the payments market.",
+            "### Adyen\n\nAdyen is a global payment platform rivaling Stripe.",
+            "### Braintree\n\nBraintree offers merchant services competing with Stripe.",
+            _filler("gamma"),
+        ]
+    )
+    out = select_relevant_content(md, "stripe competitors", 500)
+    assert sum(name in out for name in ("Adyen", "Braintree")) >= 2
+    assert "strengths" not in out
+
+
+def test_ancestor_context_qualifies_only_section_leads():
+    lead_body = ("Acme Corp FOUNDINGYEAR background covers general operations and staffing. " * 6).strip()
+    cont_body = ("Additional QUARTERLYNOTE remarks about routine logistics and vendor scheduling. " * 6).strip()
+    md = "\n\n".join(
+        [
+            "## Competitor Analysis\n\nOverview of the competitor analysis across the sector.",
+            "### Acme Corp",
+            lead_body,
+            cont_body,
+            _filler("alpha"),
+        ]
+    )
+    out = select_relevant_content(md, "competitor analysis", 1200)
+    assert "FOUNDINGYEAR" in out  # child section lead qualifies via its matched parent
+    assert "QUARTERLYNOTE" not in out  # continuation piece does not inherit relevance
+
+
+def test_pricing_hierarchy_expands_plans():
+    md = "\n\n".join(
+        [
+            "## Pricing\n\nOur pricing is structured across three subscription plans.",
+            "### Starter\n\nThe starter plan costs ten dollars monthly for individuals.",
+            "### Pro\n\nThe pro plan costs thirty dollars monthly for small teams.",
+            "### Enterprise\n\nThe enterprise plan offers custom quotes for large organizations.",
+            _filler("alpha"),
+        ]
+    )
+    out = select_relevant_content(md, "pricing plans", 500)
+    assert sum(name in out for name in ("Starter", "Pro", "Enterprise")) >= 2
+
+
+def test_policy_hierarchy_expands_clauses():
+    md = "\n\n".join(
+        [
+            "## Refund Policy\n\nOur refund policy is divided into several clauses.",
+            "### Eligibility\n\nRefunds are available for unused services within the billing period.",
+            "### Window\n\nRequests must be submitted within thirty days of purchase.",
+            "### Exclusions\n\nSetup fees and consumed credits are non-refundable.",
+            _filler("alpha"),
+        ]
+    )
+    out = select_relevant_content(md, "refund policy", 500)
+    assert sum(name in out for name in ("Eligibility", "Window", "Exclusions")) >= 2
+
+
+def test_nav_heavy_chunk_still_fallback_selected():
+    nav = "[Home](/home) [About](/about) [Pricing details](/pricing) [Contact](/contact) [Blog](/blog)"
+    md = "\n\n".join([nav, _filler("alpha"), _filler("beta")])
+    out = select_relevant_content(md, "pricing details", 200)
+    assert "[Pricing details](/pricing)" in out  # demoted, never excluded when it is the only signal
+
+
 # invisible characters
 
 

--- a/backend/tests/unit/core/utils/test_web_scrape_cache.py
+++ b/backend/tests/unit/core/utils/test_web_scrape_cache.py
@@ -34,6 +34,30 @@ def test_build_cache_key_is_tenant_scoped_and_stable():
     assert key == again  # sorted options ⇒ deterministic digest
 
 
+def test_build_cache_key_prefix_defaults_and_overrides():
+    with patch("app.core.tenant_scope.get_tenant_context", return_value="acme"):
+        default_key = build_cache_key(_URL, _OPTIONS)
+        explicit = build_cache_key(_URL, _OPTIONS, key_prefix="webscraper")
+        search = build_cache_key("search:fp123", {"depth": "basic"}, key_prefix="websearch")
+    assert default_key.startswith("tenant:acme:webscraper:")  # scraper keys byte-identical when omitted
+    assert default_key == explicit
+    assert search.startswith("tenant:acme:websearch:")
+
+
+@pytest.mark.asyncio
+async def test_get_and_store_thread_key_prefix():
+    redis = _fake_redis()
+    p_redis, p_tenant = _patch(redis)
+    with p_redis, p_tenant:
+        await store("search:fp123", {"depth": "basic"}, 120, {"success": True, "count": 2}, key_prefix="websearch")
+        stored_key = redis.set.call_args.args[0]
+        redis.get.return_value = redis.set.call_args.args[1]
+        hit = await get_cached("search:fp123", {"depth": "basic"}, 120, key_prefix="websearch")
+    assert stored_key.startswith("tenant:acme:websearch:")
+    assert hit["count"] == 2
+    assert hit["cacheState"] == "hit"
+
+
 def test_build_cache_key_differs_on_headers():
     with patch("app.core.tenant_scope.get_tenant_context", return_value="acme"):
         anon = build_cache_key(_URL, {"headers": {}})

--- a/backend/tests/unit/core/utils/test_web_search_guard.py
+++ b/backend/tests/unit/core/utils/test_web_search_guard.py
@@ -14,7 +14,9 @@ from app.core.utils.web_search_guard import (
     check_tenant_rate,
     circuit_is_open,
     get_negative,
+    mwmbl_circuit_is_open,
     record_block_event,
+    record_mwmbl_failure,
     single_flight,
     store_negative,
 )
@@ -125,7 +127,7 @@ async def test_single_flight_coalesces_and_charges_the_leader_once():
 
     async def producer():
         producer_calls.append(1)
-        await rate_charges("acme")  
+        await rate_charges("acme")
         await release.wait()
         return {"success": True, "results": [{"title": "x"}]}
 
@@ -199,7 +201,7 @@ async def test_single_flight_leader_failure_resolves_followers_without_raising()
     await asyncio.sleep(0)
     await asyncio.sleep(0)
     release.set()
-    results = await asyncio.gather(*tasks)  
+    results = await asyncio.gather(*tasks)
 
     assert all(result["success"] is False for result in results)
     assert all(set(result) == _ENVELOPE_KEYS for result in results)
@@ -229,10 +231,10 @@ async def test_negative_cache_roundtrip_ttls_and_expiry():
         assert await get_negative(_FP) == "blocked"
         key = redis.set.call_args.args[0]
         assert key.startswith("tenant:acme:websearch-neg:")
-        assert redis.ttls[key] == 120  
+        assert redis.ttls[key] == 120
         await store_negative(_FP, "timeout")
         assert redis.ttls[key] == 60
-        redis.store.pop(key)  
+        redis.store.pop(key)
         assert await get_negative(_FP) is None
 
 
@@ -243,29 +245,49 @@ async def test_negative_cache_degrades_open_on_redis_error():
     )
     p_redis, p_tenant = _patch(redis)
     with p_redis, p_tenant:
-        await store_negative(_FP, "blocked")  
+        await store_negative(_FP, "blocked")
         assert await get_negative(_FP) is None
 
 
 @pytest.mark.asyncio
-async def test_circuit_opens_at_threshold_and_closes_on_expiry():
+async def test_circuit_opens_on_first_block_and_closes_on_expiry():
     redis = _stateful_redis()
     with patch.object(web_search_guard, "_redis", return_value=redis), _freeze_time():
-        for _ in range(4):
-            await record_block_event()
         assert await circuit_is_open() is False
-        await record_block_event()  
+        await record_block_event()
         assert await circuit_is_open() is True
-        assert redis.ttls["websearch:cb:open"] == 120
-        redis.store.pop("websearch:cb:open")  
+        assert redis.ttls["websearch:cb:open"] == 900
+        redis.store.pop("websearch:cb:open")
         assert await circuit_is_open() is False
 
 
 @pytest.mark.asyncio
 async def test_circuit_degrades_open_on_redis_error():
     redis = SimpleNamespace(
-        get=AsyncMock(side_effect=RuntimeError("down")), incr=AsyncMock(side_effect=RuntimeError("down"))
+        get=AsyncMock(side_effect=RuntimeError("down")), set=AsyncMock(side_effect=RuntimeError("down"))
     )
     with patch.object(web_search_guard, "_redis", return_value=redis):
         await record_block_event()  # must not raise
         assert await circuit_is_open() is False
+
+
+@pytest.mark.asyncio
+async def test_mwmbl_cooldown_opens_on_failure_and_closes_on_expiry():
+    redis = _stateful_redis()
+    with patch.object(web_search_guard, "_redis", return_value=redis), _freeze_time():
+        assert await mwmbl_circuit_is_open() is False
+        await record_mwmbl_failure()
+        assert await mwmbl_circuit_is_open() is True
+        assert redis.ttls["websearch:mwmbl:cooldown"] == 300
+        redis.store.pop("websearch:mwmbl:cooldown")
+        assert await mwmbl_circuit_is_open() is False
+
+
+@pytest.mark.asyncio
+async def test_mwmbl_cooldown_degrades_open_on_redis_error():
+    redis = SimpleNamespace(
+        get=AsyncMock(side_effect=RuntimeError("down")), set=AsyncMock(side_effect=RuntimeError("down"))
+    )
+    with patch.object(web_search_guard, "_redis", return_value=redis):
+        await record_mwmbl_failure()  # must not raise
+        assert await mwmbl_circuit_is_open() is False

--- a/backend/tests/unit/core/utils/test_web_search_guard.py
+++ b/backend/tests/unit/core/utils/test_web_search_guard.py
@@ -1,0 +1,271 @@
+"""Unit tests for the web-search operational guards."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.core.config.settings import settings
+from app.core.utils import web_search_guard
+from app.core.utils.web_search_guard import (
+    build_request_fingerprint,
+    check_enabled,
+    check_tenant_rate,
+    circuit_is_open,
+    get_negative,
+    record_block_event,
+    single_flight,
+    store_negative,
+)
+
+_FP = "f" * 64
+_ENVELOPE_KEYS = {"success", "query", "error", "count", "results", "text", "enrichedCount", "partial", "warnings"}
+
+
+def _stateful_redis():
+    store: dict[str, str] = {}
+    ttls: dict[str, int] = {}
+
+    async def _get(key):
+        return store.get(key)
+
+    async def _set(key, value, ex=None):
+        store[key] = value
+        if ex is not None:
+            ttls[key] = ex
+
+    async def _incr(key):
+        store[key] = str(int(store.get(key, "0")) + 1)
+        return int(store[key])
+
+    async def _expire(key, ttl):
+        ttls[key] = ttl
+        return True
+
+    return SimpleNamespace(
+        get=AsyncMock(side_effect=_get),
+        set=AsyncMock(side_effect=_set),
+        incr=AsyncMock(side_effect=_incr),
+        expire=AsyncMock(side_effect=_expire),
+        store=store,
+        ttls=ttls,
+    )
+
+
+def _patch(redis, tenant="acme"):
+    return (
+        patch.object(web_search_guard, "_redis", return_value=redis),
+        patch("app.core.tenant_scope.get_tenant_context", return_value=tenant),
+    )
+
+
+def _freeze_time(at=1_000_000.0):
+    return patch.object(web_search_guard, "time", SimpleNamespace(time=lambda: at))
+
+
+def test_fingerprint_covers_every_result_affecting_option():
+    base = {"maxResults": 5, "searchDepth": "basic", "region": "wt-wt", "excludeDomains": ["a.com"]}
+    fingerprint = build_request_fingerprint("q", base)
+
+    assert build_request_fingerprint("q", {**base, "region": "de-de"}) != fingerprint
+    assert build_request_fingerprint("q", {**base, "searchDepth": "advanced"}) != fingerprint
+    assert build_request_fingerprint("q", {**base, "excludeDomains": ["b.com"]}) != fingerprint
+    assert build_request_fingerprint("other", base) != fingerprint
+
+
+def test_fingerprint_ignores_option_order_list_order_and_max_age():
+    a = build_request_fingerprint("q", {"maxResults": 5, "excludeDomains": ["b.com", "a.com"], "maxAge": 600})
+    b = build_request_fingerprint("q", {"excludeDomains": ["a.com", "b.com"], "maxResults": 5, "maxAge": 0})
+    c = build_request_fingerprint("q", {"excludeDomains": ["a.com", "b.com"], "maxResults": 5})
+
+    assert a == b == c
+
+
+def test_check_enabled_reads_the_kill_switch(monkeypatch):
+    monkeypatch.setattr(settings, "WEB_SEARCH_ENABLED", False)
+    assert check_enabled() is False
+    monkeypatch.setattr(settings, "WEB_SEARCH_ENABLED", True)
+    assert check_enabled() is True
+
+
+@pytest.mark.asyncio
+async def test_acquire_global_slot_bounds_concurrency():
+    free = web_search_guard._global_semaphore._value
+    async with web_search_guard.acquire_global_slot():
+        assert web_search_guard._global_semaphore._value == free - 1
+    assert web_search_guard._global_semaphore._value == free
+
+
+@pytest.mark.asyncio
+async def test_tenant_rate_increments_and_trips_at_the_limit(monkeypatch):
+    monkeypatch.setattr(settings, "WEB_SEARCH_TENANT_PER_MINUTE", 3)
+    redis = _stateful_redis()
+    with patch.object(web_search_guard, "_redis", return_value=redis), _freeze_time():
+        allowed = [await check_tenant_rate("acme") for _ in range(4)]
+
+    assert allowed == [True, True, True, False]
+    key = redis.incr.call_args.args[0]
+    assert key.startswith("websearch:rl:acme:")
+    redis.expire.assert_awaited_once()  # TTL set only when the window key is created
+
+
+@pytest.mark.asyncio
+async def test_tenant_rate_degrades_open_on_redis_error():
+    redis = SimpleNamespace(incr=AsyncMock(side_effect=RuntimeError("down")))
+    with patch.object(web_search_guard, "_redis", return_value=redis):
+        assert await check_tenant_rate("acme") is True
+
+
+@pytest.mark.asyncio
+async def test_single_flight_coalesces_and_charges_the_leader_once():
+    release = asyncio.Event()
+    rate_charges = AsyncMock()
+    producer_calls: list[int] = []
+
+    async def producer():
+        producer_calls.append(1)
+        await rate_charges("acme")  
+        await release.wait()
+        return {"success": True, "results": [{"title": "x"}]}
+
+    tasks = [asyncio.create_task(single_flight("acme", _FP, producer)) for _ in range(5)]
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    release.set()
+    results = await asyncio.gather(*tasks)
+
+    assert len(producer_calls) == 1
+    rate_charges.assert_awaited_once()
+    assert all(result == results[0] for result in results)
+
+
+@pytest.mark.asyncio
+async def test_single_flight_followers_get_deep_copies():
+    release = asyncio.Event()
+
+    async def producer():
+        await release.wait()
+        return {"success": True, "results": [{"title": "x"}]}
+
+    tasks = [asyncio.create_task(single_flight("acme", _FP, producer)) for _ in range(3)]
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    release.set()
+    leader, follower_a, follower_b = await asyncio.gather(*tasks)
+
+    assert leader == follower_a == follower_b
+    assert follower_a is not follower_b
+    assert follower_a["results"] is not follower_b["results"]
+    follower_a["results"].append({"title": "mutation"})
+    assert len(follower_b["results"]) == 1
+    assert len(leader["results"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_single_flight_distinct_fingerprints_do_not_coalesce():
+    release = asyncio.Event()
+    producer_calls: list[str] = []
+
+    def make_producer(name):
+        async def producer():
+            producer_calls.append(name)
+            await release.wait()
+            return {"success": True}
+
+        return producer
+
+    tasks = [
+        asyncio.create_task(single_flight("acme", "a" * 64, make_producer("a"))),
+        asyncio.create_task(single_flight("acme", "b" * 64, make_producer("b"))),
+    ]
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    release.set()
+    await asyncio.gather(*tasks)
+
+    assert sorted(producer_calls) == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_single_flight_leader_failure_resolves_followers_without_raising():
+    release = asyncio.Event()
+
+    async def producer():
+        await release.wait()
+        raise RuntimeError("boom at https://duckduckgo.com/html/?q=XYZZY-CANARY-QUERY")
+
+    tasks = [asyncio.create_task(single_flight("acme", _FP, producer)) for _ in range(3)]
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    release.set()
+    results = await asyncio.gather(*tasks)  
+
+    assert all(result["success"] is False for result in results)
+    assert all(set(result) == _ENVELOPE_KEYS for result in results)
+    assert all("XYZZY-CANARY-QUERY" not in result["error"] for result in results)
+
+
+@pytest.mark.asyncio
+async def test_single_flight_cleans_the_inflight_map():
+    async def producer():
+        return {"success": True}
+
+    async def failing_producer():
+        raise RuntimeError("boom")
+
+    await single_flight("acme", _FP, producer)
+    assert web_search_guard._inflight == {}
+    await single_flight("acme", _FP, failing_producer)
+    assert web_search_guard._inflight == {}
+
+
+@pytest.mark.asyncio
+async def test_negative_cache_roundtrip_ttls_and_expiry():
+    redis = _stateful_redis()
+    p_redis, p_tenant = _patch(redis)
+    with p_redis, p_tenant, _freeze_time():
+        await store_negative(_FP, "blocked")
+        assert await get_negative(_FP) == "blocked"
+        key = redis.set.call_args.args[0]
+        assert key.startswith("tenant:acme:websearch-neg:")
+        assert redis.ttls[key] == 120  
+        await store_negative(_FP, "timeout")
+        assert redis.ttls[key] == 60
+        redis.store.pop(key)  
+        assert await get_negative(_FP) is None
+
+
+@pytest.mark.asyncio
+async def test_negative_cache_degrades_open_on_redis_error():
+    redis = SimpleNamespace(
+        get=AsyncMock(side_effect=RuntimeError("down")), set=AsyncMock(side_effect=RuntimeError("down"))
+    )
+    p_redis, p_tenant = _patch(redis)
+    with p_redis, p_tenant:
+        await store_negative(_FP, "blocked")  
+        assert await get_negative(_FP) is None
+
+
+@pytest.mark.asyncio
+async def test_circuit_opens_at_threshold_and_closes_on_expiry():
+    redis = _stateful_redis()
+    with patch.object(web_search_guard, "_redis", return_value=redis), _freeze_time():
+        for _ in range(4):
+            await record_block_event()
+        assert await circuit_is_open() is False
+        await record_block_event()  
+        assert await circuit_is_open() is True
+        assert redis.ttls["websearch:cb:open"] == 120
+        redis.store.pop("websearch:cb:open")  
+        assert await circuit_is_open() is False
+
+
+@pytest.mark.asyncio
+async def test_circuit_degrades_open_on_redis_error():
+    redis = SimpleNamespace(
+        get=AsyncMock(side_effect=RuntimeError("down")), incr=AsyncMock(side_effect=RuntimeError("down"))
+    )
+    with patch.object(web_search_guard, "_redis", return_value=redis):
+        await record_block_event()  # must not raise
+        assert await circuit_is_open() is False

--- a/backend/tests/unit/core/utils/test_web_search_utils.py
+++ b/backend/tests/unit/core/utils/test_web_search_utils.py
@@ -105,12 +105,24 @@ async def test_no_results_marker_returns_empty_without_lite_fallback(monkeypatch
     monkeypatch.setattr(web_search_utils, "_fetch_serp", fetch)
 
     assert await search_web("gibberish qwertyzxcv") == []
-    fetch.assert_awaited_once()  
+    fetch.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_challenge_page_falls_back_to_lite(monkeypatch):
+async def test_challenge_page_stops_ddg_without_lite(monkeypatch):
     fetch = AsyncMock(side_effect=[_CHALLENGE_PAGE, _LITE_SERP])
+    monkeypatch.setattr(web_search_utils, "_fetch_serp", fetch)
+
+    with pytest.raises(WebSearchError) as err:
+        await search_web("python")
+
+    assert err.value.category == "blocked"
+    fetch.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ddg_timeout_still_falls_back_to_lite(monkeypatch):
+    fetch = AsyncMock(side_effect=[WebSearchError("t", category="timeout"), _LITE_SERP])
     monkeypatch.setattr(web_search_utils, "_fetch_serp", fetch)
 
     results = await search_web("python")
@@ -121,17 +133,6 @@ async def test_challenge_page_falls_back_to_lite(monkeypatch):
     ]
     assert results[0].url == "https://example.com/lite"
     assert results[0].snippet == "Lite snippet here"
-
-
-@pytest.mark.asyncio
-async def test_both_rungs_blocked_raises_naming_both(monkeypatch):
-    monkeypatch.setattr(web_search_utils, "_fetch_serp", AsyncMock(side_effect=[_CHALLENGE_PAGE, _CHALLENGE_PAGE]))
-
-    with pytest.raises(WebSearchError) as err:
-        await search_web("python")
-
-    assert "html:" in str(err.value) and "lite:" in str(err.value)
-    assert err.value.category == "blocked"
 
 
 @pytest.mark.asyncio
@@ -186,7 +187,7 @@ async def test_max_results_truncates_and_large_values_are_clamped(monkeypatch):
     monkeypatch.setattr(web_search_utils, "_fetch_serp", AsyncMock(return_value=page))
 
     assert len(await search_web("q", max_results=1)) == 1
-    assert len(await search_web("q", max_results=999)) == 3  
+    assert len(await search_web("q", max_results=999)) == 3
 
 
 @pytest.mark.asyncio
@@ -241,7 +242,6 @@ async def test_invalid_config_is_rejected_before_any_fetch(monkeypatch):
     fetch.assert_not_awaited()
 
 
-
 def _no_dns(monkeypatch):
     monkeypatch.setattr(web_search_utils, "_validate_url", AsyncMock(return_value=None))
 
@@ -284,7 +284,7 @@ async def test_fetch_serp_rejects_redirect_off_the_allowlist(monkeypatch):
         )
 
     assert err.value.category == "blocked"
-    assert len(seen) == 1  
+    assert len(seen) == 1
 
 
 @pytest.mark.asyncio
@@ -380,3 +380,207 @@ def test_sanitize_error_strips_urls_and_query_strings():
     assert "leaky" not in text
     assert "RuntimeError" in text
     assert web_search_utils._sanitize_error(httpx.ConnectTimeout("t")) == "Timeout contacting search provider"
+
+
+def _mwmbl_entry(url: str, title: str = "Title", content: str = "Snippet") -> dict:
+    return {"url": url, "title": title, "content": content}
+
+
+def _mwmbl_payload(*entries: dict) -> dict:
+    return {"results": list(entries)}
+
+
+@pytest.mark.asyncio
+async def test_search_mwmbl_maps_content_to_snippet_and_caps_two(monkeypatch):
+    payload = _mwmbl_payload(
+        _mwmbl_entry("https://a.example.com/1", title="A", content="First"),
+        _mwmbl_entry("https://b.example.com/2", title="B", content="Second"),
+        _mwmbl_entry("https://c.example.com/3", title="C", content="Third"),
+    )
+    monkeypatch.setattr(web_search_utils, "_fetch_mwmbl", AsyncMock(return_value=payload))
+
+    results = await web_search_utils.search_mwmbl("q")
+
+    assert [(r.title, r.url, r.snippet, r.position) for r in results] == [
+        ("A", "https://a.example.com/1", "First", 1),
+        ("B", "https://b.example.com/2", "Second", 2),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_mwmbl_respects_max_results_one(monkeypatch):
+    payload = _mwmbl_payload(_mwmbl_entry("https://a.example.com/1"), _mwmbl_entry("https://b.example.com/2"))
+    monkeypatch.setattr(web_search_utils, "_fetch_mwmbl", AsyncMock(return_value=payload))
+
+    assert len(await web_search_utils.search_mwmbl("q", max_results=1)) == 1
+
+
+@pytest.mark.asyncio
+async def test_search_mwmbl_skips_malformed_credentialed_and_bad_scheme(monkeypatch):
+    payload = _mwmbl_payload(
+        _mwmbl_entry("https://good.example.com/ok", title="Good", content="ok"),
+        {"title": "Missing url", "content": "x"},
+        {"url": "https://x.example.com", "content": "no title"},
+        _mwmbl_entry("javascript:alert(1)", title="Bad scheme"),
+        _mwmbl_entry("https://user:pass@evil.example/", title="Credentials"),
+        _mwmbl_entry("https://good.example.com/ok#dup", title="Dup"),
+        _mwmbl_entry("https://second.example.com/ok", title="Second"),
+    )
+    monkeypatch.setattr(web_search_utils, "_fetch_mwmbl", AsyncMock(return_value=payload))
+
+    results = await web_search_utils.search_mwmbl("q")
+
+    assert [r.url for r in results] == ["https://good.example.com/ok", "https://second.example.com/ok"]
+    assert [r.position for r in results] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_search_mwmbl_domain_filters_suffix_safe_and_renumber(monkeypatch):
+    payload = _mwmbl_payload(
+        _mwmbl_entry("https://example.com/a", title="A"),
+        _mwmbl_entry("https://sub.example.com/b", title="B"),
+        _mwmbl_entry("https://notexample.com/c", title="C"),
+    )
+    monkeypatch.setattr(web_search_utils, "_fetch_mwmbl", AsyncMock(return_value=payload))
+
+    excluded = await web_search_utils.search_mwmbl("q", exclude_domains=["example.com"])
+    assert [r.domain for r in excluded] == ["notexample.com"]
+    assert excluded[0].position == 1
+
+    included = await web_search_utils.search_mwmbl("q", include_domain="example.com")
+    assert [r.url for r in included] == ["https://example.com/a", "https://sub.example.com/b"]
+
+
+@pytest.mark.asyncio
+async def test_search_mwmbl_filtering_can_yield_zero(monkeypatch):
+    payload = _mwmbl_payload(_mwmbl_entry("https://example.com/a"))
+    monkeypatch.setattr(web_search_utils, "_fetch_mwmbl", AsyncMock(return_value=payload))
+
+    assert await web_search_utils.search_mwmbl("q", exclude_domains=["example.com"]) == []
+
+
+@pytest.mark.asyncio
+async def test_search_mwmbl_valid_empty_results(monkeypatch):
+    monkeypatch.setattr(web_search_utils, "_fetch_mwmbl", AsyncMock(return_value={"results": []}))
+
+    assert await web_search_utils.search_mwmbl("q") == []
+
+
+@pytest.mark.asyncio
+async def test_search_mwmbl_missing_results_key_is_fallback_error(monkeypatch):
+    monkeypatch.setattr(web_search_utils, "_fetch_mwmbl", AsyncMock(return_value={"noresults": []}))
+
+    with pytest.raises(WebSearchError) as err:
+        await web_search_utils.search_mwmbl("q")
+    assert err.value.category == "fallback"
+
+
+@pytest.mark.asyncio
+async def test_search_mwmbl_wrong_top_level_shape_is_fallback_error(monkeypatch):
+    monkeypatch.setattr(web_search_utils, "_fetch_mwmbl", AsyncMock(return_value=[1, 2, 3]))
+
+    with pytest.raises(WebSearchError) as err:
+        await web_search_utils.search_mwmbl("q")
+    assert err.value.category == "fallback"
+
+
+@pytest.mark.asyncio
+async def test_fetch_mwmbl_decodes_json_object(monkeypatch):
+    _no_dns(monkeypatch)
+    payload = {"results": [{"url": "https://a.example.com/1", "title": "A", "content": "x"}]}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=payload)
+
+    body = await web_search_utils._fetch_mwmbl("q", transport=httpx.MockTransport(handler))
+
+    assert body == payload
+
+
+@pytest.mark.asyncio
+async def test_fetch_mwmbl_rejects_non_json_content_type(monkeypatch):
+    _no_dns(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"<html/>", headers={"content-type": "text/html"})
+
+    with pytest.raises(WebSearchError) as err:
+        await web_search_utils._fetch_mwmbl("q", transport=httpx.MockTransport(handler))
+    assert err.value.category == "fallback"
+
+
+@pytest.mark.asyncio
+async def test_fetch_mwmbl_rejects_malformed_json(monkeypatch):
+    _no_dns(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"{not json", headers={"content-type": "application/json"})
+
+    with pytest.raises(WebSearchError) as err:
+        await web_search_utils._fetch_mwmbl("q", transport=httpx.MockTransport(handler))
+    assert err.value.category == "fallback"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [403, 429, 500])
+async def test_fetch_mwmbl_rejects_non_2xx(monkeypatch, status):
+    _no_dns(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, json={"results": []})
+
+    with pytest.raises(WebSearchError) as err:
+        await web_search_utils._fetch_mwmbl("q", transport=httpx.MockTransport(handler))
+    assert err.value.category == "fallback"
+
+
+@pytest.mark.asyncio
+async def test_fetch_mwmbl_rejects_redirect(monkeypatch):
+    _no_dns(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(302, headers={"location": "https://api.mwmbl.org/other"})
+
+    with pytest.raises(WebSearchError) as err:
+        await web_search_utils._fetch_mwmbl("q", transport=httpx.MockTransport(handler))
+    assert err.value.category == "fallback"
+
+
+@pytest.mark.asyncio
+async def test_fetch_mwmbl_maps_timeout(monkeypatch):
+    _no_dns(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("slow", request=request)
+
+    with pytest.raises(WebSearchError) as err:
+        await web_search_utils._fetch_mwmbl("q", transport=httpx.MockTransport(handler))
+    assert err.value.category == "fallback"
+
+
+@pytest.mark.asyncio
+async def test_fetch_mwmbl_rejects_oversized_body(monkeypatch):
+    _no_dns(monkeypatch)
+    oversized = b'{"results": []}' + b" " * (web_search_utils._MWMBL_MAX_BYTES + 1)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=oversized, headers={"content-type": "application/json"})
+
+    with pytest.raises(WebSearchError) as err:
+        await web_search_utils._fetch_mwmbl("q", transport=httpx.MockTransport(handler))
+    assert err.value.category == "fallback"
+
+
+@pytest.mark.asyncio
+async def test_fetch_mwmbl_sanitizes_transport_error_and_query(monkeypatch):
+    _no_dns(monkeypatch)
+    canary = "XYZZY-CANARY-QUERY"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError(f"cannot reach https://api.mwmbl.org/?q={canary}", request=request)
+
+    with pytest.raises(WebSearchError) as err:
+        await web_search_utils._fetch_mwmbl(canary, transport=httpx.MockTransport(handler))
+
+    assert err.value.category == "fallback"
+    assert canary not in str(err.value)

--- a/backend/tests/unit/core/utils/test_web_search_utils.py
+++ b/backend/tests/unit/core/utils/test_web_search_utils.py
@@ -1,0 +1,382 @@
+"""Unit tests for DuckDuckGo web search."""
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from app.core.utils import web_search_utils
+from app.core.utils.web_search_utils import WebSearchError, search_web
+
+
+def _html_result(href: str, title: str = "Title", snippet: str = "Snippet", extra_class: str = "") -> str:
+    return (
+        f'<div class="result results_links web-result {extra_class}">'
+        f'<h2 class="result__title"><a class="result__a" href="{href}">{title}</a></h2>'
+        f'<a class="result__snippet" href="#">{snippet}</a></div>'
+    )
+
+
+def _html_page(*rows: str) -> str:
+    return f'<html><body><div id="links">{"".join(rows)}</div></body></html>'
+
+
+_HTML_SERP = _html_page(
+    _html_result(
+        "//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fdocs&amp;rut=abc",
+        title="Example Docs",
+        snippet="First <b>snippet</b>",
+    ),
+    _html_result("https://duckduckgo.com/y.js?ad_provider=x", title="Sponsored", extra_class="result--ad"),
+    _html_result("https://direct.example.org/page", title="Direct", snippet="Second snippet"),
+)
+
+_LITE_SERP = (
+    "<html><body><table>"
+    '<tr><td>1.</td><td><a rel="nofollow" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Flite"'
+    ' class="result-link">Lite Result</a></td></tr>'
+    '<tr><td></td><td class="result-snippet">Lite snippet here</td></tr>'
+    "</table></body></html>"
+)
+
+_CHALLENGE_PAGE = (
+    '<html><body><div class="anomaly-modal__modal"><form class="challenge-form"></form>'
+    "<p>Unfortunately, bots use DuckDuckGo too.</p></div></body></html>"
+)
+
+_NO_RESULTS_PAGE = '<html><body><div class="no-results">No  results.</div></body></html>'
+
+_DRIFT_PAGE = '<html><body><div class="brand-new-layout">nothing familiar here</div></body></html>'
+
+
+@pytest.mark.asyncio
+async def test_search_unwraps_uddg_skips_ads_and_ranks(monkeypatch):
+    fetch = AsyncMock(return_value=_HTML_SERP)
+    monkeypatch.setattr(web_search_utils, "_fetch_serp", fetch)
+
+    results = await search_web("python asyncio")
+
+    assert [r.url for r in results] == ["https://example.com/docs", "https://direct.example.org/page"]
+    assert [r.position for r in results] == [1, 2]
+    assert results[0].title == "Example Docs"
+    assert results[0].snippet == "First snippet"
+    assert results[0].domain == "example.com"
+    fetch.assert_awaited_once()
+    assert fetch.call_args.args[0] == web_search_utils._HTML_ENDPOINT
+
+
+@pytest.mark.asyncio
+async def test_uddg_value_is_not_double_decoded(monkeypatch):
+    page = _html_page(_html_result("/l/?uddg=https%3A%2F%2Fexample.com%2Fa%252520b", title="Encoded"))
+    monkeypatch.setattr(web_search_utils, "_fetch_serp", AsyncMock(return_value=page))
+
+    results = await search_web("encoded")
+
+    assert results[0].url == "https://example.com/a%2520b"
+
+
+@pytest.mark.asyncio
+async def test_invalid_uddg_destinations_are_skipped(monkeypatch):
+    page = _html_page(
+        _html_result("/l/?uddg=javascript%3Aalert(1)", title="Bad scheme"),
+        _html_result("/l/?uddg=https%3A%2F%2Fuser%3Apass%40evil.example%2F", title="Credentials"),
+        _html_result("/l/?uddg=%2Fjust-a-path", title="No host"),
+        _html_result("/l/?uddg=https%3A%2F%2Fgood.example.com%2Fok", title="Good"),
+    )
+    monkeypatch.setattr(web_search_utils, "_fetch_serp", AsyncMock(return_value=page))
+
+    results = await search_web("mixed")
+
+    assert [r.url for r in results] == ["https://good.example.com/ok"]
+    assert results[0].position == 1
+
+
+def test_parse_lite_serp_extracts_title_href_and_snippet():
+    entries = web_search_utils._parse_lite_serp(_LITE_SERP)
+
+    assert entries == [
+        ("Lite Result", "//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Flite", "Lite snippet here")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_no_results_marker_returns_empty_without_lite_fallback(monkeypatch):
+    fetch = AsyncMock(return_value=_NO_RESULTS_PAGE)
+    monkeypatch.setattr(web_search_utils, "_fetch_serp", fetch)
+
+    assert await search_web("gibberish qwertyzxcv") == []
+    fetch.assert_awaited_once()  
+
+
+@pytest.mark.asyncio
+async def test_challenge_page_falls_back_to_lite(monkeypatch):
+    fetch = AsyncMock(side_effect=[_CHALLENGE_PAGE, _LITE_SERP])
+    monkeypatch.setattr(web_search_utils, "_fetch_serp", fetch)
+
+    results = await search_web("python")
+
+    assert [call.args[0] for call in fetch.call_args_list] == [
+        web_search_utils._HTML_ENDPOINT,
+        web_search_utils._LITE_ENDPOINT,
+    ]
+    assert results[0].url == "https://example.com/lite"
+    assert results[0].snippet == "Lite snippet here"
+
+
+@pytest.mark.asyncio
+async def test_both_rungs_blocked_raises_naming_both(monkeypatch):
+    monkeypatch.setattr(web_search_utils, "_fetch_serp", AsyncMock(side_effect=[_CHALLENGE_PAGE, _CHALLENGE_PAGE]))
+
+    with pytest.raises(WebSearchError) as err:
+        await search_web("python")
+
+    assert "html:" in str(err.value) and "lite:" in str(err.value)
+    assert err.value.category == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_selector_drift_is_classified_and_raised(monkeypatch):
+    monkeypatch.setattr(web_search_utils, "_fetch_serp", AsyncMock(side_effect=[_DRIFT_PAGE, _DRIFT_PAGE]))
+
+    with pytest.raises(WebSearchError) as err:
+        await search_web("python")
+
+    assert err.value.category == "selector_drift"
+
+
+@pytest.mark.asyncio
+async def test_exclude_domains_filter_is_suffix_safe(monkeypatch):
+    page = _html_page(
+        _html_result("https://example.com/a", title="A"),
+        _html_result("https://sub.example.com/b", title="B"),
+        _html_result("https://notexample.com/c", title="C"),
+    )
+    monkeypatch.setattr(web_search_utils, "_fetch_serp", AsyncMock(return_value=page))
+
+    results = await search_web("q", exclude_domains=["example.com"])
+
+    assert [r.domain for r in results] == ["notexample.com"]
+    assert results[0].position == 1
+
+
+@pytest.mark.asyncio
+async def test_dedup_strips_fragments_lowercases_host_and_renumbers(monkeypatch):
+    page = _html_page(
+        _html_result("https://example.com/page#one", title="One"),
+        _html_result("https://EXAMPLE.com/page#two", title="Two"),
+        _html_result("https://other.example.net/x", title="Other"),
+    )
+    monkeypatch.setattr(web_search_utils, "_fetch_serp", AsyncMock(return_value=page))
+
+    results = await search_web("q")
+
+    assert [(r.title, r.url, r.position) for r in results] == [
+        ("One", "https://example.com/page", 1),
+        ("Other", "https://other.example.net/x", 2),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_max_results_truncates_and_large_values_are_clamped(monkeypatch):
+    page = _html_page(
+        _html_result("https://a.example.com/1"),
+        _html_result("https://b.example.com/2"),
+        _html_result("https://c.example.com/3"),
+    )
+    monkeypatch.setattr(web_search_utils, "_fetch_serp", AsyncMock(return_value=page))
+
+    assert len(await search_web("q", max_results=1)) == 1
+    assert len(await search_web("q", max_results=999)) == 3  
+
+
+@pytest.mark.asyncio
+async def test_param_mapping_for_region_time_safesearch_and_site(monkeypatch):
+    fetch = AsyncMock(return_value=_HTML_SERP)
+    monkeypatch.setattr(web_search_utils, "_fetch_serp", fetch)
+
+    await search_web(
+        "genassist platform",
+        region="de-de",
+        time_range="week",
+        safesearch="off",
+        include_domain="Example.COM.",
+    )
+
+    params = fetch.call_args.args[1]
+    assert params["q"] == "genassist platform site:example.com"
+    assert params["kl"] == "de-de"
+    assert params["df"] == "w"
+    assert params["kp"] == "-2"
+
+
+@pytest.mark.asyncio
+async def test_unknown_region_falls_back_and_any_time_range_omits_df(monkeypatch):
+    fetch = AsyncMock(return_value=_HTML_SERP)
+    monkeypatch.setattr(web_search_utils, "_fetch_serp", fetch)
+
+    await search_web("q", region="zz-nope", time_range="any")
+
+    params = fetch.call_args.args[1]
+    assert params["kl"] == "wt-wt"
+    assert "df" not in params
+
+
+@pytest.mark.asyncio
+async def test_invalid_config_is_rejected_before_any_fetch(monkeypatch):
+    fetch = AsyncMock(return_value=_HTML_SERP)
+    monkeypatch.setattr(web_search_utils, "_fetch_serp", fetch)
+
+    cases = [
+        {"query": ""},
+        {"query": "x" * 401},
+        {"query": "q", "include_domain": "not a domain!"},
+        {"query": "q", "include_domain": "localhost"},
+        {"query": "q", "exclude_domains": [f"d{i}.example.com" for i in range(11)]},
+        {"query": "q", "include_domain": "example.com", "exclude_domains": ["example.com"]},
+    ]
+    for case in cases:
+        with pytest.raises(WebSearchError) as err:
+            await search_web(case.pop("query"), **case)
+        assert err.value.category == "invalid_config"
+    fetch.assert_not_awaited()
+
+
+
+def _no_dns(monkeypatch):
+    monkeypatch.setattr(web_search_utils, "_validate_url", AsyncMock(return_value=None))
+
+
+def _ok_response() -> httpx.Response:
+    return httpx.Response(200, content=b"<html>ok</html>", headers={"content-type": "text/html"})
+
+
+@pytest.mark.asyncio
+async def test_fetch_serp_follows_relative_redirect_on_allowlisted_host(monkeypatch):
+    _no_dns(monkeypatch)
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        if len(seen) == 1:
+            return httpx.Response(302, headers={"location": "/html/moved"})
+        return _ok_response()
+
+    body = await web_search_utils._fetch_serp(
+        web_search_utils._HTML_ENDPOINT, {"q": "x"}, transport=httpx.MockTransport(handler)
+    )
+
+    assert body == "<html>ok</html>"
+    assert seen[1] == "https://html.duckduckgo.com/html/moved"
+
+
+@pytest.mark.asyncio
+async def test_fetch_serp_rejects_redirect_off_the_allowlist(monkeypatch):
+    _no_dns(monkeypatch)
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        return httpx.Response(302, headers={"location": "https://evil.example.com/serp"})
+
+    with pytest.raises(WebSearchError) as err:
+        await web_search_utils._fetch_serp(
+            web_search_utils._HTML_ENDPOINT, {"q": "x"}, transport=httpx.MockTransport(handler)
+        )
+
+    assert err.value.category == "blocked"
+    assert len(seen) == 1  
+
+
+@pytest.mark.asyncio
+async def test_fetch_serp_rejects_redirect_with_credentials(monkeypatch):
+    _no_dns(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(302, headers={"location": "https://user:pass@duckduckgo.com/html/"})
+
+    with pytest.raises(WebSearchError) as err:
+        await web_search_utils._fetch_serp(
+            web_search_utils._HTML_ENDPOINT, {"q": "x"}, transport=httpx.MockTransport(handler)
+        )
+
+    assert err.value.category == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_fetch_serp_gives_up_after_max_hops(monkeypatch):
+    _no_dns(monkeypatch)
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        return httpx.Response(302, headers={"location": f"/html/hop{len(seen)}"})
+
+    with pytest.raises(WebSearchError) as err:
+        await web_search_utils._fetch_serp(
+            web_search_utils._HTML_ENDPOINT, {"q": "x"}, transport=httpx.MockTransport(handler)
+        )
+
+    assert "Too many redirects" in str(err.value)
+    assert len(seen) == web_search_utils._MAX_REDIRECTS + 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_serp_normalizes_uppercase_and_trailing_dot_hosts(monkeypatch):
+    _no_dns(monkeypatch)
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        if len(seen) == 1:
+            return httpx.Response(302, headers={"location": "https://DuckDuckGo.COM./html/x"})
+        return _ok_response()
+
+    body = await web_search_utils._fetch_serp(
+        web_search_utils._HTML_ENDPOINT, {"q": "x"}, transport=httpx.MockTransport(handler)
+    )
+
+    assert body == "<html>ok</html>"
+    assert len(seen) == 2
+
+
+@pytest.mark.asyncio
+async def test_fetch_serp_rejects_oversized_body(monkeypatch):
+    _no_dns(monkeypatch)
+    oversized = b"x" * (web_search_utils._MAX_SERP_BYTES + 1)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=oversized, headers={"content-type": "text/html"})
+
+    with pytest.raises(WebSearchError) as err:
+        await web_search_utils._fetch_serp(
+            web_search_utils._HTML_ENDPOINT, {"q": "x"}, transport=httpx.MockTransport(handler)
+        )
+
+    assert "size limit" in str(err.value)
+
+
+@pytest.mark.asyncio
+async def test_fetch_serp_rejects_non_html_content_type(monkeypatch):
+    _no_dns(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"{}", headers={"content-type": "application/json"})
+
+    with pytest.raises(WebSearchError) as err:
+        await web_search_utils._fetch_serp(
+            web_search_utils._HTML_ENDPOINT, {"q": "x"}, transport=httpx.MockTransport(handler)
+        )
+
+    assert "non-HTML" in str(err.value)
+
+
+def test_sanitize_error_strips_urls_and_query_strings():
+    exc = RuntimeError("boom at https://duckduckgo.com/html/?q=XYZZY-CANARY-QUERY and ?q=leaky&kl=us-en")
+
+    text = web_search_utils._sanitize_error(exc)
+
+    assert "XYZZY-CANARY-QUERY" not in text
+    assert "duckduckgo" not in text
+    assert "leaky" not in text
+    assert "RuntimeError" in text
+    assert web_search_utils._sanitize_error(httpx.ConnectTimeout("t")) == "Timeout contacting search provider"

--- a/backend/tests/unit/workflow/test_web_search_node.py
+++ b/backend/tests/unit/workflow/test_web_search_node.py
@@ -145,7 +145,7 @@ async def test_advanced_enriches_top_results_within_total_budget(guards):
         {"query": "q", "searchDepth": "advanced", "maxContentChars": 2000, "maxTotalContentChars": 8000}
     )
 
-    assert result["enrichedCount"] == 4  
+    assert result["enrichedCount"] == 4
     assert result["partial"] is True
     assert any("budget" in w for w in result["warnings"])
     assert sum(len(r["content"]) for r in result["results"]) <= 8000
@@ -169,7 +169,7 @@ async def test_advanced_per_page_failure_and_non_html_degrade_to_snippet(guards)
 
     result = await _make_node().process({"query": "q", "searchDepth": "advanced"})
 
-    assert result["success"] is True  
+    assert result["success"] is True
     assert result["enrichedCount"] == 1
     assert result["partial"] is True
     assert any("could not be fetched" in w for w in result["warnings"])
@@ -178,12 +178,52 @@ async def test_advanced_per_page_failure_and_non_html_degrade_to_snippet(guards)
     assert result["results"][2]["content"] != ""
 
 
+_RELEVANT_PAGE = (
+    "# Acme Store\n\n"
+    + "The committee archives general notes and routine updates quietly. " * 12
+    + "\n\n## Shipping Rates\n\nOvernight shipping costs $42 for domestic orders.\n\n"
+    + "The committee reviews general notes and routine updates quietly. " * 12
+)
+
+
+@pytest.mark.asyncio
+async def test_advanced_content_prefers_query_relevant_sections(guards, monkeypatch):
+    monkeypatch.setattr(web_search_node, "extract_main_content", lambda html, url: (_RELEVANT_PAGE, "<html/>"))
+
+    result = await _make_node().process(
+        {"query": "overnight shipping costs", "searchDepth": "advanced", "maxContentChars": 400}
+    )
+
+    content = result["results"][0]["content"]
+    assert "$42" in content
+    assert "committee" not in content
+    assert len(content) <= 400
+    assert result["enrichedCount"] == 3
+
+
+@pytest.mark.asyncio
+async def test_advanced_content_falls_back_without_query_signal(guards):
+    result = await _make_node().process({"query": "q", "searchDepth": "advanced"})
+
+    assert result["results"][0]["content"] == "A" * 2000
+
+
+@pytest.mark.asyncio
+async def test_advanced_options_include_content_selection_marker(guards):
+    await _make_node().process({"query": "q", "searchDepth": "advanced"})
+    assert guards.get_cached.call_args.args[1]["contentSelection"] == "relevance-v1"
+
+    guards.get_cached.reset_mock()
+    await _make_node().process({"query": "q"})
+    assert "contentSelection" not in guards.get_cached.call_args.args[1]
+
+
 @pytest.mark.asyncio
 async def test_numeric_clamps_and_maxage_default(guards):
     await _make_node().process({"query": "q", "maxResults": 999})
 
-    assert guards.search_web.call_args.kwargs["max_results"] == 20  
-    assert guards.get_cached.call_args.args[2] == 600  
+    assert guards.search_web.call_args.kwargs["max_results"] == 20
+    assert guards.get_cached.call_args.args[2] == 600
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/workflow/test_web_search_node.py
+++ b/backend/tests/unit/workflow/test_web_search_node.py
@@ -137,7 +137,7 @@ async def test_zero_hit_envelope(guards):
 
 
 @pytest.mark.asyncio
-async def test_advanced_enriches_top_results_within_total_budget(guards):
+async def test_advanced_enriches_all_successes_under_even_split(guards):
     guards.search_web.return_value = _results(6)
     node = _make_node()
 
@@ -145,12 +145,48 @@ async def test_advanced_enriches_top_results_within_total_budget(guards):
         {"query": "q", "searchDepth": "advanced", "maxContentChars": 2000, "maxTotalContentChars": 8000}
     )
 
+    assert result["enrichedCount"] == 5
+    assert result["partial"] is False
+    assert not any("budget" in w for w in result["warnings"])
+    assert all(len(r["content"]) <= 1600 for r in result["results"][:5])
+    assert sum(len(r["content"]) for r in result["results"]) <= 8000
+    assert result["results"][5]["content"] == ""
+
+
+@pytest.mark.asyncio
+async def test_advanced_failed_page_does_not_waste_budget(guards):
+    results = _results(5)
+    guards.search_web.return_value = results
+
+    async def _fetch(url, use_http_request=False):
+        if url == results[0].url:
+            raise RuntimeError("connection reset")
+        return _html_page()
+
+    guards.fetch_from_url.side_effect = _fetch
+
+    result = await _make_node().process(
+        {"query": "q", "searchDepth": "advanced", "maxContentChars": 2000, "maxTotalContentChars": 8000}
+    )
+
     assert result["enrichedCount"] == 4
     assert result["partial"] is True
-    assert any("budget" in w for w in result["warnings"])
-    assert sum(len(r["content"]) for r in result["results"]) <= 8000
-    assert result["results"][4]["content"] == ""
-    assert result["results"][5]["content"] == ""
+    assert result["results"][0]["content"] == ""
+    assert all(r["content"] != "" for r in result["results"][1:5])
+    assert not any("budget" in w for w in result["warnings"])
+    assert any("could not be fetched" in w for w in result["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_advanced_empty_extraction_counted_unavailable(guards, monkeypatch):
+    monkeypatch.setattr(web_search_node, "extract_main_content", lambda html, url: ("   ‍  ", "<html/>"))
+
+    result = await _make_node().process({"query": "q", "searchDepth": "advanced"})
+
+    assert result["enrichedCount"] == 0
+    assert result["partial"] is True
+    assert all(r["content"] == "" for r in result["results"])
+    assert any("could not be fetched" in w for w in result["warnings"])
 
 
 @pytest.mark.asyncio
@@ -211,7 +247,7 @@ async def test_advanced_content_falls_back_without_query_signal(guards):
 @pytest.mark.asyncio
 async def test_advanced_options_include_content_selection_marker(guards):
     await _make_node().process({"query": "q", "searchDepth": "advanced"})
-    assert guards.get_cached.call_args.args[1]["contentSelection"] == "relevance-v1"
+    assert guards.get_cached.call_args.args[1]["contentSelection"] == "relevance-v2"
 
     guards.get_cached.reset_mock()
     await _make_node().process({"query": "q"})

--- a/backend/tests/unit/workflow/test_web_search_node.py
+++ b/backend/tests/unit/workflow/test_web_search_node.py
@@ -1,0 +1,288 @@
+"""Tests for WebSearchNode.process().
+
+Covers: always-same response shape and never raising; check order (feature off,
+caches, circuit breaker, rate limit); advanced mode page fetches within a size
+budget; and that the raw query never appears in logs or cache keys.
+"""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core.utils.web_search_utils import SearchResult, WebSearchError
+from app.modules.workflow.engine.nodes import web_search_node
+from app.modules.workflow.engine.nodes.web_search_node import WebSearchNode
+
+_ENVELOPE_KEYS = {"success", "query", "error", "count", "results", "text", "enrichedCount", "partial", "warnings"}
+
+
+def _make_node():
+    config = {"type": "webSearchNode", "data": {"name": "Web Search"}}
+    return WebSearchNode("n1", config, SimpleNamespace())
+
+
+def _results(n=3):
+    return [
+        SearchResult(title=f"T{i}", url=f"https://ex{i}.com/p", snippet=f"S{i}", domain=f"ex{i}.com", position=i)
+        for i in range(1, n + 1)
+    ]
+
+
+def _html_page(ok=True, content_type="text/html", html="<p>body</p>"):
+    return SimpleNamespace(ok=ok, content_type=content_type, html=html)
+
+
+@pytest.fixture
+def guards(monkeypatch):
+    """Patch every Redis/cache/provider boundary in the node module with safe defaults."""
+    mocks = SimpleNamespace(
+        search_web=AsyncMock(return_value=_results()),
+        get_cached=AsyncMock(return_value=None),
+        store=AsyncMock(),
+        get_negative=AsyncMock(return_value=None),
+        circuit_is_open=AsyncMock(return_value=False),
+        check_tenant_rate=AsyncMock(return_value=True),
+        store_negative=AsyncMock(),
+        record_block_event=AsyncMock(),
+        check_enabled=lambda: True,
+        fetch_from_url=AsyncMock(return_value=_html_page()),
+        extract_main_content=lambda html, url: ("A" * 5000, "<html/>"),
+    )
+    for name in vars(mocks):
+        monkeypatch.setattr(web_search_node, name, getattr(mocks, name))
+    return mocks
+
+
+@pytest.mark.asyncio
+async def test_missing_query_returns_config_error(guards):
+    result = await _make_node().process({})
+    assert result["success"] is False
+    assert result["error"] == "Search query is required"
+    assert set(result) == _ENVELOPE_KEYS
+    guards.search_web.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_oversized_query_rejected(guards):
+    result = await _make_node().process({"query": "x" * 401})
+    assert result["success"] is False
+    assert "exceeds" in result["error"]
+    guards.search_web.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_multiple_include_domains_rejected(guards):
+    result = await _make_node().process({"query": "q", "includeDomains": "a.com, b.com"})
+    assert result["success"] is False
+    assert result["error"] == "includeDomains supports a single domain in this version"
+    guards.search_web.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_too_many_exclude_domains_rejected(guards):
+    excludes = ",".join(f"d{i}.com" for i in range(11))
+    result = await _make_node().process({"query": "q", "excludeDomains": excludes})
+    assert result["success"] is False
+    assert "at most 10" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_domain_in_both_lists_rejected(guards):
+    result = await _make_node().process(
+        {"query": "q", "includeDomains": "example.com", "excludeDomains": "example.com"}
+    )
+    assert result["success"] is False
+    assert result["error"] == "A domain cannot be both included and excluded"
+
+
+@pytest.mark.asyncio
+async def test_invalid_domain_syntax_rejected(guards):
+    result = await _make_node().process({"query": "q", "includeDomains": "not a domain!"})
+    assert result["success"] is False
+    assert "Invalid domain" in result["error"]
+    guards.search_web.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_basic_success_digest_positions_and_cache_store(guards):
+    result = await _make_node().process({"query": "genassist"})
+
+    assert result["success"] is True
+    assert result["count"] == 3
+    assert result["enrichedCount"] == 0
+    assert result["partial"] is False
+    assert result["warnings"] == []
+    assert all(r["content"] == "" for r in result["results"])
+    assert [r["position"] for r in result["results"]] == [1, 2, 3]
+    assert result["text"].startswith("1. T1")
+    assert "URL: https://ex1.com/p" in result["text"]
+    assert "3. T3" in result["text"]
+    guards.store.assert_awaited_once()
+    assert result["cacheState"] == "miss"
+    assert "cacheState" not in guards.store.call_args.args[3]
+
+
+@pytest.mark.asyncio
+async def test_zero_hit_envelope(guards):
+    guards.search_web.return_value = []
+    result = await _make_node().process({"query": "asdfqwerty"})
+
+    assert result["success"] is True
+    assert result["count"] == 0
+    assert result["results"] == []
+    assert result["text"] == 'No results found for: "asdfqwerty"'
+    assert result["enrichedCount"] == 0
+
+
+@pytest.mark.asyncio
+async def test_advanced_enriches_top_results_within_total_budget(guards):
+    guards.search_web.return_value = _results(6)
+    node = _make_node()
+
+    result = await node.process(
+        {"query": "q", "searchDepth": "advanced", "maxContentChars": 2000, "maxTotalContentChars": 8000}
+    )
+
+    assert result["enrichedCount"] == 4  
+    assert result["partial"] is True
+    assert any("budget" in w for w in result["warnings"])
+    assert sum(len(r["content"]) for r in result["results"]) <= 8000
+    assert result["results"][4]["content"] == ""
+    assert result["results"][5]["content"] == ""
+
+
+@pytest.mark.asyncio
+async def test_advanced_per_page_failure_and_non_html_degrade_to_snippet(guards):
+    results = _results(3)
+    guards.search_web.return_value = results
+
+    async def _fetch(url, use_http_request=False):
+        if url == results[0].url:
+            raise RuntimeError("connection reset")
+        if url == results[1].url:
+            return _html_page(content_type="application/pdf")
+        return _html_page()
+
+    guards.fetch_from_url.side_effect = _fetch
+
+    result = await _make_node().process({"query": "q", "searchDepth": "advanced"})
+
+    assert result["success"] is True  
+    assert result["enrichedCount"] == 1
+    assert result["partial"] is True
+    assert any("could not be fetched" in w for w in result["warnings"])
+    assert result["results"][0]["content"] == ""
+    assert result["results"][1]["content"] == ""
+    assert result["results"][2]["content"] != ""
+
+
+@pytest.mark.asyncio
+async def test_numeric_clamps_and_maxage_default(guards):
+    await _make_node().process({"query": "q", "maxResults": 999})
+
+    assert guards.search_web.call_args.kwargs["max_results"] == 20  
+    assert guards.get_cached.call_args.args[2] == 600  
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_short_circuits(guards, monkeypatch):
+    monkeypatch.setattr(web_search_node, "check_enabled", lambda: False)
+    result = await _make_node().process({"query": "q"})
+
+    assert result["success"] is False
+    assert result["error"] == "Web search is disabled by the administrator"
+    guards.search_web.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rate_limited_returns_failure_without_search(guards):
+    guards.check_tenant_rate.return_value = False
+    result = await _make_node().process({"query": "q"})
+
+    assert result["success"] is False
+    assert "rate limit" in result["error"]
+    guards.search_web.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_circuit_open_returns_failure_without_search(guards):
+    guards.circuit_is_open.return_value = True
+    result = await _make_node().process({"query": "q"})
+
+    assert result["success"] is False
+    assert "throttling" in result["error"]
+    guards.search_web.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_negative_cache_hit_returns_failure_without_search(guards):
+    guards.get_negative.return_value = "blocked"
+    result = await _make_node().process({"query": "q"})
+
+    assert result["success"] is False
+    assert "throttling" in result["error"]
+    guards.search_web.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_positive_cache_hit_short_circuits(guards):
+    cached = {"success": True, "count": 2, "results": [], "text": "cached", "cacheState": "hit"}
+    guards.get_cached.return_value = cached
+    result = await _make_node().process({"query": "q"})
+
+    assert result is cached
+    guards.search_web.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_websearcherror_maps_to_failure_and_records_block(guards):
+    guards.search_web.side_effect = WebSearchError("blocked on all providers", category="blocked")
+    result = await _make_node().process({"query": "q"})
+
+    assert result["success"] is False
+    assert result["error"] == "blocked on all providers"
+    assert set(result) == _ENVELOPE_KEYS
+    guards.store_negative.assert_awaited_once()
+    assert guards.store_negative.call_args.args[1] == "blocked"
+    guards.record_block_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_generic_search_exception_never_raises(guards):
+    guards.search_web.side_effect = RuntimeError("unexpected")
+    result = await _make_node().process({"query": "q"})
+
+    assert result["success"] is False
+    assert set(result) == _ENVELOPE_KEYS
+
+
+@pytest.mark.asyncio
+async def test_unexpected_error_swallowed_preserving_query(guards):
+    guards.get_cached.side_effect = RuntimeError("cache backend down")
+    result = await _make_node().process({"query": "keepme"})
+
+    assert result["success"] is False
+    assert result["query"] == "keepme"
+    assert set(result) == _ENVELOPE_KEYS
+
+
+@pytest.mark.asyncio
+async def test_log_hygiene_query_never_logged_or_used_as_key(guards, caplog):
+    canary = "XYZZY-CANARY-QUERY"
+
+    with caplog.at_level(logging.DEBUG):
+        # provider failure path
+        guards.search_web.side_effect = WebSearchError("provider blocked", category="blocked")
+        await _make_node().process({"query": canary})
+        # cache-backend failure path (node's own except)
+        guards.get_cached.side_effect = RuntimeError("redis down")
+        await _make_node().process({"query": canary})
+
+    assert canary not in caplog.text
+    # cache-key material is the hashed fingerprint, never the raw query
+    key = guards.get_cached.call_args_list[0].args[0]
+    assert key.startswith("search:")
+    assert canary not in key
+    assert canary not in str(guards.get_cached.call_args_list[0])

--- a/backend/tests/unit/workflow/test_web_search_node.py
+++ b/backend/tests/unit/workflow/test_web_search_node.py
@@ -247,7 +247,7 @@ async def test_advanced_content_falls_back_without_query_signal(guards):
 @pytest.mark.asyncio
 async def test_advanced_options_include_content_selection_marker(guards):
     await _make_node().process({"query": "q", "searchDepth": "advanced"})
-    assert guards.get_cached.call_args.args[1]["contentSelection"] == "relevance-v2"
+    assert guards.get_cached.call_args.args[1]["contentSelection"] == "relevance-v3"
 
     guards.get_cached.reset_mock()
     await _make_node().process({"query": "q"})

--- a/backend/tests/unit/workflow/test_web_search_node.py
+++ b/backend/tests/unit/workflow/test_web_search_node.py
@@ -5,9 +5,10 @@ caches, circuit breaker, rate limit); advanced mode page fetches within a size
 budget; and that the raw query never appears in logs or cache keys.
 """
 
+import asyncio
 import logging
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -39,6 +40,7 @@ def guards(monkeypatch):
     """Patch every Redis/cache/provider boundary in the node module with safe defaults."""
     mocks = SimpleNamespace(
         search_web=AsyncMock(return_value=_results()),
+        search_mwmbl=AsyncMock(return_value=_results(2)),
         get_cached=AsyncMock(return_value=None),
         store=AsyncMock(),
         get_negative=AsyncMock(return_value=None),
@@ -46,6 +48,8 @@ def guards(monkeypatch):
         check_tenant_rate=AsyncMock(return_value=True),
         store_negative=AsyncMock(),
         record_block_event=AsyncMock(),
+        mwmbl_circuit_is_open=AsyncMock(return_value=False),
+        record_mwmbl_failure=AsyncMock(),
         check_enabled=lambda: True,
         fetch_from_url=AsyncMock(return_value=_html_page()),
         extract_main_content=lambda html, url: ("A" * 5000, "<html/>"),
@@ -283,23 +287,38 @@ async def test_rate_limited_returns_failure_without_search(guards):
 
 
 @pytest.mark.asyncio
-async def test_circuit_open_returns_failure_without_search(guards):
+async def test_circuit_open_routes_to_mwmbl(guards):
     guards.circuit_is_open.return_value = True
     result = await _make_node().process({"query": "q"})
 
-    assert result["success"] is False
-    assert "throttling" in result["error"]
+    assert result["success"] is True
+    assert result["count"] == 2
+    assert result["warnings"][0] == web_search_node._FALLBACK_WARNING
     guards.search_web.assert_not_awaited()
+    guards.search_mwmbl.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_negative_cache_hit_returns_failure_without_search(guards):
+async def test_blocked_negative_cache_routes_to_mwmbl(guards):
     guards.get_negative.return_value = "blocked"
     result = await _make_node().process({"query": "q"})
 
-    assert result["success"] is False
-    assert "throttling" in result["error"]
+    assert result["success"] is True
+    assert result["count"] == 2
+    assert result["warnings"][0] == web_search_node._FALLBACK_WARNING
     guards.search_web.assert_not_awaited()
+    guards.search_mwmbl.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_timeout_negative_cache_returns_error_without_mwmbl(guards):
+    guards.get_negative.return_value = "timeout"
+    result = await _make_node().process({"query": "q"})
+
+    assert result["success"] is False
+    assert set(result) == _ENVELOPE_KEYS
+    guards.search_web.assert_not_awaited()
+    guards.search_mwmbl.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -313,16 +332,110 @@ async def test_positive_cache_hit_short_circuits(guards):
 
 
 @pytest.mark.asyncio
-async def test_websearcherror_maps_to_failure_and_records_block(guards):
+async def test_live_block_records_and_falls_back_to_mwmbl(guards):
     guards.search_web.side_effect = WebSearchError("blocked on all providers", category="blocked")
     result = await _make_node().process({"query": "q"})
 
-    assert result["success"] is False
-    assert result["error"] == "blocked on all providers"
-    assert set(result) == _ENVELOPE_KEYS
+    assert result["success"] is True
+    assert result["count"] == 2
+    assert result["warnings"][0] == web_search_node._FALLBACK_WARNING
+    assert _ENVELOPE_KEYS <= set(result)
     guards.store_negative.assert_awaited_once()
     assert guards.store_negative.call_args.args[1] == "blocked"
     guards.record_block_event.assert_awaited_once()
+    guards.search_mwmbl.assert_awaited_once()
+    guards.store.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_non_blocked_search_error_does_not_fall_back(guards):
+    guards.search_web.side_effect = WebSearchError("timed out", category="timeout")
+    result = await _make_node().process({"query": "q"})
+
+    assert result["success"] is False
+    assert result["error"] == "timed out"
+    guards.search_mwmbl.assert_not_awaited()
+    guards.record_block_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mwmbl_zero_results_is_success_with_warning(guards):
+    guards.circuit_is_open.return_value = True
+    guards.search_mwmbl.return_value = []
+    result = await _make_node().process({"query": "asdfqwerty"})
+
+    assert result["success"] is True
+    assert result["count"] == 0
+    assert result["results"] == []
+    assert result["text"] == 'No results found for: "asdfqwerty"'
+    assert result["warnings"] == [web_search_node._FALLBACK_WARNING]
+
+
+@pytest.mark.asyncio
+async def test_mwmbl_failure_returns_generic_error_envelope(guards):
+    guards.circuit_is_open.return_value = True
+    guards.search_mwmbl.side_effect = WebSearchError("mwmbl down", category="fallback")
+    result = await _make_node().process({"query": "q"})
+
+    assert result["success"] is False
+    assert result["error"] == "Web search is temporarily unavailable"
+    assert set(result) == _ENVELOPE_KEYS
+    guards.search_web.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_live_block_then_mwmbl_failure_still_records(guards):
+    guards.search_web.side_effect = WebSearchError("blocked", category="blocked")
+    guards.search_mwmbl.side_effect = WebSearchError("mwmbl down", category="fallback")
+    result = await _make_node().process({"query": "q"})
+
+    assert result["success"] is False
+    assert result["error"] == "Web search is temporarily unavailable"
+    guards.store_negative.assert_awaited_once()
+    guards.record_block_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_advanced_fallback_enriches_and_orders_warnings(guards):
+    guards.circuit_is_open.return_value = True
+    result = await _make_node().process({"query": "q", "searchDepth": "advanced"})
+
+    assert result["success"] is True
+    assert result["count"] == 2
+    assert result["enrichedCount"] <= 2
+    assert result["warnings"][0] == web_search_node._FALLBACK_WARNING
+
+
+@pytest.mark.asyncio
+async def test_fallback_passes_domains_and_max_results_to_mwmbl(guards):
+    guards.circuit_is_open.return_value = True
+    await _make_node().process(
+        {"query": "q", "maxResults": 1, "includeDomains": "example.com", "excludeDomains": "spam.com"}
+    )
+
+    kwargs = guards.search_mwmbl.call_args.kwargs
+    assert kwargs["max_results"] == 1
+    assert kwargs["include_domain"] == "example.com"
+    assert kwargs["exclude_domains"] == ["spam.com"]
+
+
+@pytest.mark.asyncio
+async def test_fallback_metric_outcomes(guards, monkeypatch):
+    recorder = Mock()  # record_web_search_event is synchronous
+    monkeypatch.setattr(web_search_node, "record_web_search_event", recorder)
+    guards.circuit_is_open.return_value = True
+
+    guards.search_mwmbl.return_value = _results(2)
+    await _make_node().process({"query": "q"})
+    assert recorder.call_args.args[0] == "fallback_ok"
+
+    guards.search_mwmbl.return_value = []
+    await _make_node().process({"query": "q"})
+    assert recorder.call_args.args[0] == "fallback_zero"
+
+    guards.search_mwmbl.side_effect = WebSearchError("x", category="fallback")
+    await _make_node().process({"query": "q"})
+    assert recorder.call_args.args[0] == "fallback_error"
 
 
 @pytest.mark.asyncio
@@ -349,16 +462,75 @@ async def test_log_hygiene_query_never_logged_or_used_as_key(guards, caplog):
     canary = "XYZZY-CANARY-QUERY"
 
     with caplog.at_level(logging.DEBUG):
-        # provider failure path
         guards.search_web.side_effect = WebSearchError("provider blocked", category="blocked")
         await _make_node().process({"query": canary})
-        # cache-backend failure path (node's own except)
         guards.get_cached.side_effect = RuntimeError("redis down")
         await _make_node().process({"query": canary})
 
     assert canary not in caplog.text
-    # cache-key material is the hashed fingerprint, never the raw query
     key = guards.get_cached.call_args_list[0].args[0]
     assert key.startswith("search:")
     assert canary not in key
     assert canary not in str(guards.get_cached.call_args_list[0])
+
+
+@pytest.mark.asyncio
+async def test_circuit_opening_midflight_stops_further_ddg_calls(guards, monkeypatch):
+    slot = asyncio.Semaphore(1)
+    monkeypatch.setattr(web_search_node, "acquire_global_slot", lambda: slot)
+    circuit = {"open": False}
+    guards.circuit_is_open.side_effect = lambda: circuit["open"]
+
+    def _open_circuit():
+        circuit["open"] = True
+
+    guards.record_block_event.side_effect = _open_circuit
+    guards.search_web.side_effect = WebSearchError("blocked", category="blocked")
+
+    results = await asyncio.gather(*[_make_node().process({"query": f"q{i}"}) for i in range(5)])
+
+    assert guards.search_web.call_count == 1
+    assert all(r["success"] and r["warnings"][0] == web_search_node._FALLBACK_WARNING for r in results)
+
+
+@pytest.mark.asyncio
+async def test_mwmbl_cooldown_skips_fallback(guards):
+    guards.circuit_is_open.return_value = True
+    guards.mwmbl_circuit_is_open.return_value = True
+    result = await _make_node().process({"query": "q"})
+
+    assert result["success"] is False
+    assert result["error"] == "Web search is temporarily unavailable"
+    guards.search_web.assert_not_awaited()
+    guards.search_mwmbl.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mwmbl_failure_records_cooldown(guards):
+    guards.circuit_is_open.return_value = True
+    guards.search_mwmbl.side_effect = WebSearchError("mwmbl down", category="fallback")
+    result = await _make_node().process({"query": "q"})
+
+    assert result["success"] is False
+    assert result["error"] == "Web search is temporarily unavailable"
+    guards.record_mwmbl_failure.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_mwmbl_cooldown_opening_midflight_stops_further_calls(guards, monkeypatch):
+    slot = asyncio.Semaphore(1)
+    monkeypatch.setattr(web_search_node, "acquire_global_slot", lambda: slot)
+    guards.circuit_is_open.return_value = True
+    cooldown = {"open": False}
+    guards.mwmbl_circuit_is_open.side_effect = lambda: cooldown["open"]
+
+    def _open_cooldown():
+        cooldown["open"] = True
+
+    guards.record_mwmbl_failure.side_effect = _open_cooldown
+    guards.search_mwmbl.side_effect = WebSearchError("mwmbl down", category="fallback")
+
+    results = await asyncio.gather(*[_make_node().process({"query": f"q{i}"}) for i in range(5)])
+
+    assert guards.search_mwmbl.call_count == 1
+    assert all(not r["success"] and r["error"] == "Web search is temporarily unavailable" for r in results)

--- a/frontend/src/helpers/nodeTypeLabel.ts
+++ b/frontend/src/helpers/nodeTypeLabel.ts
@@ -13,6 +13,7 @@ const NODE_TYPE_LABELS: Record<string, string> = {
   // Tools
   apiToolNode: "API Connector",
   webScraperNode: "Web Scraper",
+  webSearchNode: "Web Search",
   htmlToImageNode: "HTML to Image",
   openApiNode: "OpenAPI Explorer",
   knowledgeBaseNode: "Knowledge Query",

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/WebSearchDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/WebSearchDialog.tsx
@@ -161,8 +161,8 @@ export const WebSearchDialog: React.FC<
           </SelectContent>
         </Select>
         <div className="text-xs text-gray-500 break-words">
-          Advanced fetches page content from the top results within a total
-          budget.
+          Advanced fetches the most query-relevant page content from the top
+          results within a total budget.
         </div>
       </div>
 
@@ -192,7 +192,7 @@ export const WebSearchDialog: React.FC<
                 className="break-all w-full"
               />
               <div className="text-xs text-gray-500 break-words">
-                Restrict results to one domain (v1).
+                Restrict results to one domain.
               </div>
             </div>
 

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/WebSearchDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/WebSearchDialog.tsx
@@ -1,0 +1,274 @@
+import React, { useEffect, useState } from "react";
+import { WebSearchNodeData, WebSearchDepth } from "../types/nodes";
+import { Button } from "@/components/button";
+import { RichInput } from "@/components/richInput";
+import { Label } from "@/components/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/select";
+import { Save, ChevronDown, ChevronUp } from "lucide-react";
+import { NodeConfigPanel } from "../components/NodeConfigPanel";
+import { BaseNodeDialogProps } from "./base";
+import { DraggableInput } from "../components/custom/DraggableInput";
+
+// open the advanced section when any advanced option differs from its default
+const hasAdvancedOptions = (data: WebSearchNodeData): boolean =>
+  Boolean(data.includeDomains) ||
+  Boolean(data.excludeDomains) ||
+  (data.maxContentChars ?? 2000) !== 2000 ||
+  (data.maxTotalContentChars ?? 8000) !== 8000 ||
+  (data.maxAge ?? 600) !== 600;
+
+export const WebSearchDialog: React.FC<
+  BaseNodeDialogProps<WebSearchNodeData, WebSearchNodeData>
+> = (props) => {
+  const { isOpen, onClose, data, onUpdate } = props;
+
+  const [name, setName] = useState(data.name || "");
+  const [query, setQuery] = useState(data.query || "");
+  const [maxResults, setMaxResults] = useState<number>(data.maxResults ?? 5);
+  const [searchDepth, setSearchDepth] = useState<WebSearchDepth>(
+    data.searchDepth || "basic"
+  );
+  const [includeDomains, setIncludeDomains] = useState(
+    data.includeDomains || ""
+  );
+  const [excludeDomains, setExcludeDomains] = useState(
+    data.excludeDomains || ""
+  );
+  const [maxContentChars, setMaxContentChars] = useState<number>(
+    data.maxContentChars ?? 2000
+  );
+  const [maxTotalContentChars, setMaxTotalContentChars] = useState<number>(
+    data.maxTotalContentChars ?? 8000
+  );
+  const [maxAge, setMaxAge] = useState<number>(data.maxAge ?? 600);
+  const [showAdvanced, setShowAdvanced] = useState(hasAdvancedOptions(data));
+  useEffect(() => {
+    setName(data.name || "");
+    setQuery(data.query || "");
+    setMaxResults(data.maxResults ?? 5);
+    setSearchDepth(data.searchDepth || "basic");
+    setIncludeDomains(data.includeDomains || "");
+    setExcludeDomains(data.excludeDomains || "");
+    setMaxContentChars(data.maxContentChars ?? 2000);
+    setMaxTotalContentChars(data.maxTotalContentChars ?? 8000);
+    setMaxAge(data.maxAge ?? 600);
+    setShowAdvanced(hasAdvancedOptions(data));
+  }, [isOpen]);
+
+  const handleSave = () => {
+    onUpdate({
+      ...data,
+      name,
+      query,
+      maxResults,
+      searchDepth,
+      includeDomains,
+      excludeDomains,
+      maxContentChars,
+      maxTotalContentChars,
+      maxAge,
+    });
+    onClose();
+  };
+
+  return (
+    <NodeConfigPanel
+      footer={
+        <>
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave}>
+            <Save className="h-4 w-4 mr-2" />
+            Save Changes
+          </Button>
+        </>
+      }
+      {...props}
+      data={{
+        ...data,
+        name,
+        query,
+        maxResults,
+        searchDepth,
+        includeDomains,
+        excludeDomains,
+        maxContentChars,
+        maxTotalContentChars,
+        maxAge,
+      }}
+    >
+      <div className="space-y-2">
+        <Label htmlFor="name">Name</Label>
+        <RichInput
+          id="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Web Search"
+          className="break-all w-full"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="query">Query</Label>
+        <DraggableInput
+          id="query"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search the web for..."
+          className="break-all w-full"
+        />
+        <div className="text-xs text-gray-500 break-words">
+          Use {"{{field}}"} to define dynamic parameters
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="maxResults">Max Results</Label>
+        <RichInput
+          id="maxResults"
+          type="number"
+          value={String(maxResults)}
+          onChange={(e) =>
+            setMaxResults(Math.max(1, parseInt(e.target.value) || 1))
+          }
+          placeholder="5"
+          className="w-full"
+        />
+        <div className="text-xs text-gray-500 break-words">
+          Upper bound (up to 20); filtering may return fewer.
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="searchDepth">Search Depth</Label>
+        <Select
+          value={searchDepth}
+          onValueChange={(value) => setSearchDepth(value as WebSearchDepth)}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Select search depth" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="basic">Basic</SelectItem>
+            <SelectItem value="advanced">Advanced</SelectItem>
+          </SelectContent>
+        </Select>
+        <div className="text-xs text-gray-500 break-words">
+          Advanced fetches page content from the top results within a total
+          budget.
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <button
+          type="button"
+          className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700"
+          onClick={() => setShowAdvanced((v) => !v)}
+        >
+          {showAdvanced ? (
+            <ChevronUp className="h-3 w-3" />
+          ) : (
+            <ChevronDown className="h-3 w-3" />
+          )}
+          Advanced
+        </button>
+
+        {showAdvanced && (
+          <div className="space-y-4 pt-2">
+            <div className="space-y-2">
+              <Label htmlFor="includeDomains">Include Domain</Label>
+              <DraggableInput
+                id="includeDomains"
+                value={includeDomains}
+                onChange={(e) => setIncludeDomains(e.target.value)}
+                placeholder="example.com"
+                className="break-all w-full"
+              />
+              <div className="text-xs text-gray-500 break-words">
+                Restrict results to one domain (v1).
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="excludeDomains">Exclude Domains</Label>
+              <DraggableInput
+                id="excludeDomains"
+                value={excludeDomains}
+                onChange={(e) => setExcludeDomains(e.target.value)}
+                placeholder="reddit.com, pinterest.com"
+                className="break-all w-full"
+              />
+              <div className="text-xs text-gray-500 break-words">
+                Comma-separated, up to 10 domains.
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="maxContentChars">
+                Max Content Chars (per result)
+              </Label>
+              <RichInput
+                id="maxContentChars"
+                type="number"
+                value={String(maxContentChars)}
+                onChange={(e) =>
+                  setMaxContentChars(Math.max(0, parseInt(e.target.value) || 0))
+                }
+                placeholder="2000"
+                className="w-full"
+              />
+              <div className="text-xs text-gray-500 break-words">
+                Per-result content cap in advanced depth.
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="maxTotalContentChars">
+                Max Total Content Chars
+              </Label>
+              <RichInput
+                id="maxTotalContentChars"
+                type="number"
+                value={String(maxTotalContentChars)}
+                onChange={(e) =>
+                  setMaxTotalContentChars(
+                    Math.max(0, parseInt(e.target.value) || 0)
+                  )
+                }
+                placeholder="8000"
+                className="w-full"
+              />
+              <div className="text-xs text-gray-500 break-words">
+                Total enrichment budget across results in advanced depth.
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="maxAge">Cache Max Age (seconds)</Label>
+              <RichInput
+                id="maxAge"
+                type="number"
+                value={String(maxAge)}
+                onChange={(e) =>
+                  setMaxAge(Math.max(0, parseInt(e.target.value) || 0))
+                }
+                placeholder="600"
+                className="w-full"
+              />
+              <div className="text-xs text-gray-500 break-words">
+                Serve a cached result newer than this. 0 disables caching.
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </NodeConfigPanel>
+  );
+};

--- a/frontend/src/views/AIAgents/Workflows/nodeTypes/index.ts
+++ b/frontend/src/views/AIAgents/Workflows/nodeTypes/index.ts
@@ -3,6 +3,7 @@ import ChatInputNode from "./chat/chatInputNode";
 import LLMModelNode from "./llm/modelNode";
 import APIToolNode from "./tools/apiToolNode";
 import WebScraperNode from "./tools/webScraperNode";
+import WebSearchNode from "./tools/webSearchNode";
 import HtmlToImageNode from "./tools/htmlToImageNode";
 import OpenApiNode from "./tools/openApiNode";
 import AgentNode from "./llm/agentNode";
@@ -17,6 +18,7 @@ import {
 import {
   API_TOOL_NODE_DEFINITION,
   WEB_SCRAPER_NODE_DEFINITION,
+  WEB_SEARCH_NODE_DEFINITION,
   HTML_TO_IMAGE_NODE_DEFINITION,
   OPEN_API_NODE_DEFINITION,
   KNOWLEDGE_BASE_NODE_DEFINITION,
@@ -110,6 +112,7 @@ export const registerAllNodeTypes = () => {
   nodeRegistry.registerNodeType(MODEL_NODE_DEFINITION);
   nodeRegistry.registerNodeType(API_TOOL_NODE_DEFINITION);
   nodeRegistry.registerNodeType(WEB_SCRAPER_NODE_DEFINITION);
+  nodeRegistry.registerNodeType(WEB_SEARCH_NODE_DEFINITION);
   nodeRegistry.registerNodeType(HTML_TO_IMAGE_NODE_DEFINITION);
   nodeRegistry.registerNodeType(OPEN_API_NODE_DEFINITION);
 
@@ -182,6 +185,7 @@ export const getNodeTypes = () => {
     finalizeConversationNode: FinalizeConversationNode,
     apiToolNode: APIToolNode,
     webScraperNode: WebScraperNode,
+    webSearchNode: WebSearchNode,
     htmlToImageNode: HtmlToImageNode,
     openApiNode: OpenApiNode,
     agentNode: AgentNode,

--- a/frontend/src/views/AIAgents/Workflows/nodeTypes/tools/definitions.ts
+++ b/frontend/src/views/AIAgents/Workflows/nodeTypes/tools/definitions.ts
@@ -13,10 +13,12 @@ import {
   WorkflowExecutorNodeData,
   WebScraperNodeData,
   HtmlToImageNodeData,
+  WebSearchNodeData,
 } from "../../types/nodes";
 
 import APIToolNode from "./apiToolNode";
 import WebScraperNode from "./webScraperNode";
+import WebSearchNode from "./webSearchNode";
 import HtmlToImageNode from "./htmlToImageNode";
 import OpenApiNode from "./openApiNode";
 import KnowledgeBaseNode from "./knowledgeBaseNode";
@@ -29,6 +31,7 @@ import WorkflowExecutorNode from "./workflowExecutorNode";
 import {
   API_CONNECTOR_HELP_CONTENT,
   WEB_SCRAPER_HELP_CONTENT,
+  WEB_SEARCH_HELP_CONTENT,
   HTML_TO_IMAGE_HELP_CONTENT,
   KNOWLEDGE_QUERY_HELP_CONTENT,
   CREATE_WORKFLOW_SCHEDULE_HELP_CONTENT,
@@ -124,6 +127,53 @@ export const WEB_SCRAPER_NODE_DEFINITION: NodeTypeDefinition<WebScraperNodeData>
   createNode: (id, position, data) => ({
     id,
     type: "webScraperNode",
+    position,
+    data: {
+      ...data,
+    },
+  }),
+};
+
+export const WEB_SEARCH_NODE_DEFINITION: NodeTypeDefinition<WebSearchNodeData> = {
+  type: "webSearchNode",
+  label: "Web Search",
+  description:
+    "Searches the web (no API key) and returns ranked results with titles, URLs, and snippets, plus a short summary for the LLM. Optionally fetches full page text for the top results.",
+  shortDescription: "Search the web",
+  helpContent: WEB_SEARCH_HELP_CONTENT,
+  configSubtitle:
+    "Configure the query, result count, search depth, domain filters, content budgets and caching.",
+  category: "tools",
+  icon: "Search",
+  defaultData: {
+    name: "Web Search",
+    query: "",
+    maxResults: 5,
+    searchDepth: "basic",
+    includeDomains: "",
+    excludeDomains: "",
+    maxContentChars: 2000,
+    maxTotalContentChars: 8000,
+    maxAge: 600,
+    handlers: [
+      {
+        id: "input",
+        type: "target",
+        compatibility: "any",
+        position: "left",
+      },
+      {
+        id: "output",
+        type: "source",
+        compatibility: "any",
+        position: "right",
+      },
+    ],
+  } as WebSearchNodeData,
+  component: WebSearchNode as React.ComponentType<NodeProps<NodeData>>,
+  createNode: (id, position, data) => ({
+    id,
+    type: "webSearchNode",
     position,
     data: {
       ...data,

--- a/frontend/src/views/AIAgents/Workflows/nodeTypes/tools/definitions.ts
+++ b/frontend/src/views/AIAgents/Workflows/nodeTypes/tools/definitions.ts
@@ -138,7 +138,7 @@ export const WEB_SEARCH_NODE_DEFINITION: NodeTypeDefinition<WebSearchNodeData> =
   type: "webSearchNode",
   label: "Web Search",
   description:
-    "Searches the web (no API key) and returns ranked results with titles, URLs, and snippets, plus a short summary for the LLM. Optionally fetches full page text for the top results.",
+    "Searches the web and returns ranked results with titles, URLs, and snippets, plus a short summary for the LLM. Optionally fetches full page text for the top results.",
   shortDescription: "Search the web",
   helpContent: WEB_SEARCH_HELP_CONTENT,
   configSubtitle:

--- a/frontend/src/views/AIAgents/Workflows/nodeTypes/tools/helperDefinition.ts
+++ b/frontend/src/views/AIAgents/Workflows/nodeTypes/tools/helperDefinition.ts
@@ -98,7 +98,7 @@ export const WEB_SCRAPER_HELP_CONTENT: NodeHelpContent = {
 
 export const WEB_SEARCH_HELP_CONTENT: NodeHelpContent = {
   intro:
-    "The Web Search node searches the web without an API key and returns ranked results with titles, URLs, and snippets, plus a short summary for the LLM. Result page fetches block private networks, localhost, and cloud metadata hosts.",
+    "The Web Search node searches the web and returns ranked results with titles, URLs, and snippets, plus a short summary for the LLM. Result page fetches block private networks, localhost, and cloud metadata hosts.",
   sections: [
     {
       title: "Overview & Use Cases",
@@ -141,6 +141,7 @@ export const WEB_SEARCH_HELP_CONTENT: NodeHelpContent = {
         "Max Results is an upper bound — filtering may return fewer.",
         "Include Domain supports a single domain in this version.",
         "Advanced depth enriches only the top results within a total content budget and may fall back to snippets, setting partial.",
+        "If DuckDuckGo is temporarily unavailable, up to two results are served from the Mwmbl community index and flagged in the result warnings.",
       ],
     },
   ],

--- a/frontend/src/views/AIAgents/Workflows/nodeTypes/tools/helperDefinition.ts
+++ b/frontend/src/views/AIAgents/Workflows/nodeTypes/tools/helperDefinition.ts
@@ -96,6 +96,56 @@ export const WEB_SCRAPER_HELP_CONTENT: NodeHelpContent = {
   ],
 };
 
+export const WEB_SEARCH_HELP_CONTENT: NodeHelpContent = {
+  intro:
+    "The Web Search node searches the web without an API key and returns ranked results with titles, URLs, and snippets, plus a short summary for the LLM. Result page fetches block private networks, localhost, and cloud metadata hosts.",
+  sections: [
+    {
+      title: "Overview & Use Cases",
+      body: "Use the Web Search node when you need to:",
+      bullets: [
+        "Find current web results for a query inside a workflow",
+        "Feed ranked results and snippets to a downstream language model",
+        "Research within specific domains",
+        "Pull main-page content from top results in advanced depth",
+        "Replace a paid search API for simple lookups",
+      ],
+    },
+    {
+      title: "Configuring the node",
+      steps: [
+        "Click the settings icon in the node header.",
+        "Enter the Node Name.",
+        "Enter the Query (templatable with {{field}}).",
+        "Set Max Results (up to 20).",
+        "Choose the Search Depth (Basic snippets, or Advanced page content).",
+        "Optionally set Advanced options: domains, content budgets and caching.",
+        "Save the node configuration.",
+      ],
+    },
+    {
+      title: "Outputs",
+      body: "Downstream nodes read fields with {{source.field}}:",
+      bullets: [
+        "{{source.text}} — numbered, LLM-ready digest of the results",
+        "{{source.results}} — ranked array of {title, url, snippet, content, position, domain}",
+        "{{source.count}} — number of results returned",
+        "{{source.success}} — whether the search succeeded",
+        "{{source.enrichedCount}} — results whose content was fetched (advanced depth)",
+        "{{source.partial}} — true when some planned enrichment was skipped",
+      ],
+    },
+    {
+      title: "Notes",
+      bullets: [
+        "Max Results is an upper bound — filtering may return fewer.",
+        "Include Domain supports a single domain in this version.",
+        "Advanced depth enriches only the top results within a total content budget and may fall back to snippets, setting partial.",
+      ],
+    },
+  ],
+};
+
 export const HTML_TO_IMAGE_HELP_CONTENT: NodeHelpContent = {
   intro:
     "The HTML to Image node renders an HTML string in a headless browser and returns a hosted PNG image. It is useful for turning generated markup, templates or reports into shareable images. It runs without any external service and blocks private, loopback and metadata hosts.",

--- a/frontend/src/views/AIAgents/Workflows/nodeTypes/tools/helperDefinition.ts
+++ b/frontend/src/views/AIAgents/Workflows/nodeTypes/tools/helperDefinition.ts
@@ -107,7 +107,7 @@ export const WEB_SEARCH_HELP_CONTENT: NodeHelpContent = {
         "Find current web results for a query inside a workflow",
         "Feed ranked results and snippets to a downstream language model",
         "Research within specific domains",
-        "Pull main-page content from top results in advanced depth",
+        "Pull the most query-relevant page content from top results in advanced depth",
         "Replace a paid search API for simple lookups",
       ],
     },

--- a/frontend/src/views/AIAgents/Workflows/nodeTypes/tools/webSearchNode.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeTypes/tools/webSearchNode.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from "react";
+import { NodeProps } from "reactflow";
+import { WebSearchNodeData } from "../../types/nodes";
+import { getNodeColor } from "../../utils/nodeColors";
+import { WebSearchDialog } from "../../nodeDialogs/WebSearchDialog";
+import BaseNodeContainer from "../BaseNodeContainer";
+import { extractDynamicVariablesAsRecord } from "../../utils/helpers";
+import nodeRegistry from "../../registry/nodeRegistry";
+import { NodeContentRow } from "../nodeContent";
+
+export const WEB_SEARCH_NODE_TYPE = "webSearchNode";
+
+const WebSearchNode: React.FC<NodeProps<WebSearchNodeData>> = ({
+  id,
+  data,
+  selected,
+}) => {
+  const nodeDefinition = nodeRegistry.getNodeType(WEB_SEARCH_NODE_TYPE);
+  const color = getNodeColor(nodeDefinition.category);
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+
+  const onUpdate = (updatedData: WebSearchNodeData) => {
+    if (data.updateNodeData) {
+      const dataToUpdate: Partial<WebSearchNodeData> = {
+        ...data,
+        ...updatedData,
+      };
+
+      data.updateNodeData(id, dataToUpdate);
+    }
+  };
+
+  const nodeContent: NodeContentRow[] = [
+    { label: "Query", value: data.query },
+    { label: "Depth", value: data.searchDepth },
+    { label: "Max Results", value: String(data.maxResults) },
+    {
+      label: "Variables",
+      value: extractDynamicVariablesAsRecord(JSON.stringify(data)),
+      areDynamicVars: true,
+    },
+  ];
+
+  return (
+    <>
+      <BaseNodeContainer
+        id={id}
+        data={data}
+        selected={selected}
+        iconName={nodeDefinition.icon}
+        title={data.name || nodeDefinition.label}
+        subtitle={nodeDefinition.shortDescription}
+        color={color}
+        nodeType={WEB_SEARCH_NODE_TYPE}
+        nodeContent={nodeContent}
+        onSettings={() => setIsEditDialogOpen(true)}
+      />
+
+      <WebSearchDialog
+        isOpen={isEditDialogOpen}
+        onClose={() => setIsEditDialogOpen(false)}
+        data={data}
+        onUpdate={onUpdate}
+        nodeId={id}
+        nodeType={WEB_SEARCH_NODE_TYPE}
+      />
+    </>
+  );
+};
+
+export default WebSearchNode;

--- a/frontend/src/views/AIAgents/Workflows/types/nodes.ts
+++ b/frontend/src/views/AIAgents/Workflows/types/nodes.ts
@@ -208,6 +208,20 @@ export interface WebScraperNodeData extends BaseNodeData {
   maxAge: number;
 }
 
+// Web Search Node Data
+export type WebSearchDepth = "basic" | "advanced";
+
+export interface WebSearchNodeData extends BaseNodeData {
+  query: string;
+  maxResults: number;
+  searchDepth: WebSearchDepth;
+  includeDomains: string;
+  excludeDomains: string;
+  maxContentChars: number;
+  maxTotalContentChars: number;
+  maxAge: number;
+}
+
 // HTML to Image Node Data
 export type HtmlToImageCaptureMode = "fullPage" | "viewport";
 
@@ -600,7 +614,8 @@ export type NodeData =
   | STTNodeData
   | VoiceAgentNodeData
   | WebScraperNodeData
-  | HtmlToImageNodeData;
+  | HtmlToImageNodeData
+  | WebSearchNodeData;
 // Node type definition
 export interface NodeTypeDefinition<T extends NodeData> {
   type: string;


### PR DESCRIPTION
## Description

Adds a new Web Search workflow tool node in Agent Studio. Workflows can run a web search and get ranked results (title, URL, snippet) plus an LLM-ready digest. Optional Advanced depth fetches query-relevant page content from the top hits. Includes tenant-aware rate limiting, caching, and a Mwmbl fallback when DuckDuckGo blocks/throttles the request.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

- Add webSearchNode backend engine node with DDG HTML/Lite search, result normalization, and SSRF-safe URL handling
- Add operational guards: enable flag, per-tenant rate limit, single-flight, negative cache, and deployment-wide circuit breaker
- Support Basic vs Advanced search depth, with query-relevant content enrichment and content budgets
- Fall back to the Mwmbl community index (≤2 results + warning) when DDG is blocked; simplify circuit to open on first block for 15 minutes
- Add OpenTelemetry outcome/cache metrics for web search (ok, fallback_ok, etc.)
- Wire frontend node, dialog, registry, types, and help notes (query, max results, depth, domain filters, cache)
- Add unit tests for search utils, guards, content relevance, and the web search node 

## Testing

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] Multi-tenant considerations addressed (if applicable)

## Related Issues


Closes #

## Screenshots (if applicable)


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
