### PR TITLE
feat:eval grouping

### DIFF
--- a/backend/app/api/v1/routes/test_evaluations.py
+++ b/backend/app/api/v1/routes/test_evaluations.py
@@ -83,6 +83,13 @@ async def update_evaluation(
     data: TestEvaluationUpdate,
     service: TestSuiteService = Injected(TestSuiteService),
 ):
+    """Refuses with 409 while the evaluation is queued/running — its config must
+    not change underneath an executing run."""
+    if await service.evaluation_has_active_run(evaluation_id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This evaluation is running. Wait for it to finish before editing.",
+        )
     return await service.update_evaluation(evaluation_id, data)
 
 
@@ -108,6 +115,13 @@ async def delete_evaluation(
     evaluation_id: UUID,
     service: TestSuiteService = Injected(TestSuiteService),
 ):
+    """Refuses with 409 while the evaluation is queued/running — deleting would
+    soft-delete a run the worker is still writing to."""
+    if await service.evaluation_has_active_run(evaluation_id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This evaluation is running. Wait for it to finish before deleting.",
+        )
     await service.delete_evaluation(evaluation_id)
 
 

--- a/backend/app/api/v1/routes/test_evaluations.py
+++ b/backend/app/api/v1/routes/test_evaluations.py
@@ -1,20 +1,40 @@
-from typing import List
-from uuid import UUID
+import logging
+from typing import List, Optional
+from uuid import UUID, uuid4
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi_injector import Injected
 
 from app.auth.dependencies import auth, permissions
 from app.core.permissions.constants import Permissions as P
+from app.core.tenant_scope import get_tenant_context
+from app.dependencies.dependency_injection import RedisString
+from app.dependencies.injector import injector
 from app.schemas.test_suite import (
+    PaginatedEvaluations,
+    StartedEvaluationRun,
     TestEvaluation,
     TestEvaluationCreate,
     TestEvaluationUpdate,
+    WorkflowEvaluationSummary,
 )
 from app.services.test_suite import TestSuiteService
+from app.tasks.test_suite_tasks import execute_test_suite_run_task
 
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# Safety-net TTL for the Run-all lock; released explicitly on completion.
+RUN_ALL_LOCK_TTL_SECONDS = 120
+
+# Release only if we still own the lock (token match), so an expired-and-reacquired
+# lock held by another request is never deleted by ours.
+_RELEASE_LOCK_LUA = (
+    "if redis.call('get', KEYS[1]) == ARGV[1] "
+    "then return redis.call('del', KEYS[1]) else return 0 end"
+)
 
 
 @router.get(
@@ -89,3 +109,95 @@ async def delete_evaluation(
     service: TestSuiteService = Injected(TestSuiteService),
 ):
     await service.delete_evaluation(evaluation_id)
+
+
+@router.post(
+    "/workflows/{workflow_id}/evaluations/run",
+    response_model=List[StartedEvaluationRun],
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(auth), Depends(permissions(P.Evaluation.RUN))],
+)
+async def run_workflow_evaluations(
+    workflow_id: UUID,
+    service: TestSuiteService = Injected(TestSuiteService),
+):
+    """
+    Queue a run for every evaluation that targets this workflow. Returns the
+    per-evaluation outcome immediately; execution is handled by background
+    workers. Evaluations that could not be queued are reported individually.
+
+    A Redis ``SET NX`` lock makes the "no active run?" check and the batch start
+    one atomic operation, so two concurrent requests cannot both start a batch.
+    Refuses with 409 while a batch is starting or the workflow already has
+    queued/running evaluations.
+    """
+    conflict = HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail="This workflow already has running evaluations.",
+    )
+    redis = injector.get(RedisString)
+    lock_key = f"tenant:{get_tenant_context()}:eval-run-all:{workflow_id}"
+    lock_token = uuid4().hex
+    acquired = await redis.set(
+        lock_key, lock_token, nx=True, ex=RUN_ALL_LOCK_TTL_SECONDS
+    )
+    if not acquired:
+        raise conflict
+
+    try:
+        if await service.workflow_has_active_run(workflow_id):
+            raise conflict
+
+        tenant = get_tenant_context()
+
+        def dispatch(run, input_metadata, technique_configs):
+            execute_test_suite_run_task.delay(
+                str(run.id),
+                tenant,
+                input_metadata,
+                technique_configs,
+            )
+
+        return await service.start_workflow_evaluations(workflow_id, dispatch)
+    finally:
+        # Compare-and-delete so we only release our own lock; never let a release
+        # error mask the actual response.
+        try:
+            await redis.eval(_RELEASE_LOCK_LUA, 1, lock_key, lock_token)
+        except Exception:
+            logger.warning("Failed to release Run-all lock %s", lock_key, exc_info=True)
+
+
+@router.get(
+    "/workflows/evaluation-summaries",
+    response_model=List[WorkflowEvaluationSummary],
+    dependencies=[Depends(auth), Depends(permissions(P.Evaluation.READ))],
+)
+async def list_workflow_evaluation_summaries(
+    service: TestSuiteService = Injected(TestSuiteService),
+):
+    """One row per workflow (and the unassigned bucket): count, health, running."""
+    return await service.get_workflow_evaluation_summaries()
+
+
+@router.get(
+    "/workflows/{workflow_id}/evaluations",
+    response_model=PaginatedEvaluations,
+    dependencies=[Depends(auth), Depends(permissions(P.Evaluation.READ))],
+)
+async def list_workflow_evaluations(
+    workflow_id: str,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    search: Optional[str] = Query(None),
+    service: TestSuiteService = Injected(TestSuiteService),
+):
+    """A page of one workflow's evaluations. Use ``unassigned`` for evals with no workflow."""
+    if workflow_id == "unassigned":
+        resolved: Optional[UUID] = None
+    else:
+        try:
+            resolved = UUID(workflow_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid workflow_id")
+    return await service.list_workflow_evaluations(resolved, page, page_size, search)

--- a/backend/app/repositories/test_suite.py
+++ b/backend/app/repositories/test_suite.py
@@ -1,8 +1,8 @@
-from typing import List
+from typing import List, Optional, Tuple
 from uuid import UUID
 
 from injector import inject
-from sqlalchemy import delete, exists, select, update
+from sqlalchemy import and_, delete, exists, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models.test_suite import (
@@ -110,4 +110,149 @@ class TestEvaluationRepository(DbRepository[TestEvaluationModel]):
         )
         result = await self.db.execute(stmt)
         return result.scalars().all()
+
+    def _workflow_condition(self, workflow_id: Optional[UUID]):
+        """Match evaluations by effective workflow: own ``workflow_id`` or, when
+        absent, their dataset's default. ``workflow_id=None`` = unassigned.
+
+        An evaluation is unassigned when it has no ``workflow_id`` and its suite
+        does not resolve to a live workflow — including evals whose suite was
+        soft-deleted. This mirrors ``count_by_effective_workflow`` (which coalesces
+        against the live suite), so the count and the list always agree.
+        """
+        evaluation = TestEvaluationModel
+        suite = TestSuiteModel
+        conditions = [evaluation.is_deleted == 0]
+        if workflow_id is None:
+            suites_with_workflow = select(suite.id).where(
+                suite.workflow_id.is_not(None), suite.is_deleted == 0
+            )
+            conditions.append(evaluation.workflow_id.is_(None))
+            conditions.append(
+                or_(
+                    evaluation.suite_id.is_(None),
+                    evaluation.suite_id.not_in(suites_with_workflow),
+                )
+            )
+        else:
+            workflow = str(workflow_id)
+            workflow_suites = select(suite.id).where(
+                suite.workflow_id == workflow, suite.is_deleted == 0
+            )
+            conditions.append(
+                or_(
+                    evaluation.workflow_id == workflow,
+                    and_(
+                        evaluation.workflow_id.is_(None),
+                        evaluation.suite_id.in_(workflow_suites),
+                    ),
+                )
+            )
+        return and_(*conditions)
+
+    def _search_condition(self, search: Optional[str]):
+        if not search or not search.strip():
+            return None
+        pattern = f"%{search.strip().lower()}%"
+        evaluation = TestEvaluationModel
+        return or_(
+            func.lower(evaluation.name).like(pattern),
+            func.lower(func.coalesce(evaluation.description, "")).like(pattern),
+        )
+
+    async def get_page_for_workflow(
+        self,
+        workflow_id: Optional[UUID],
+        offset: int,
+        limit: int,
+        search: Optional[str] = None,
+    ) -> List[TestEvaluationModel]:
+        stmt = select(TestEvaluationModel).where(self._workflow_condition(workflow_id))
+        search_condition = self._search_condition(search)
+        if search_condition is not None:
+            stmt = stmt.where(search_condition)
+        stmt = (
+            stmt.order_by(TestEvaluationModel.created_at.desc())
+            .offset(offset)
+            .limit(limit)
+        )
+        result = await self.db.execute(stmt)
+        return result.scalars().all()
+
+    async def count_for_workflow(
+        self, workflow_id: Optional[UUID], search: Optional[str] = None
+    ) -> int:
+        stmt = (
+            select(func.count())
+            .select_from(TestEvaluationModel)
+            .where(self._workflow_condition(workflow_id))
+        )
+        search_condition = self._search_condition(search)
+        if search_condition is not None:
+            stmt = stmt.where(search_condition)
+        result = await self.db.execute(stmt)
+        return int(result.scalar() or 0)
+
+    async def get_all_for_workflow(
+        self, workflow_id: Optional[UUID]
+    ) -> List[TestEvaluationModel]:
+        """Every evaluation for a workflow (no paging) — the Run all scope."""
+        stmt = (
+            select(TestEvaluationModel)
+            .where(self._workflow_condition(workflow_id))
+            .order_by(TestEvaluationModel.created_at.desc())
+        )
+        result = await self.db.execute(stmt)
+        return result.scalars().all()
+
+    async def count_by_effective_workflow(self) -> List[Tuple[Optional[UUID], int]]:
+        """(effective_workflow_id, count) per workflow; ``None`` = unassigned bucket."""
+        evaluation = TestEvaluationModel
+        suite = TestSuiteModel
+        effective = func.coalesce(evaluation.workflow_id, suite.workflow_id)
+        stmt = (
+            select(effective.label("workflow_id"), func.count().label("count"))
+            .select_from(evaluation)
+            .outerjoin(
+                suite,
+                and_(suite.id == evaluation.suite_id, suite.is_deleted == 0),
+            )
+            .where(evaluation.is_deleted == 0)
+            .group_by(effective)
+        )
+        result = await self.db.execute(stmt)
+        return [(row.workflow_id, int(row.count)) for row in result.all()]
+
+    async def get_latest_run_pointers(
+        self,
+    ) -> List[Tuple[Optional[UUID], List[str]]]:
+        """(effective_workflow_id, run_ids) for every live evaluation.
+
+        Used to compute per-workflow health: ``run_ids[0]`` is each evaluation's
+        latest run. Only the pointer lists are loaded here — not the runs.
+        """
+        evaluation = TestEvaluationModel
+        suite = TestSuiteModel
+        effective = func.coalesce(evaluation.workflow_id, suite.workflow_id)
+        stmt = (
+            select(effective.label("workflow_id"), evaluation.run_ids)
+            .select_from(evaluation)
+            .outerjoin(
+                suite,
+                and_(suite.id == evaluation.suite_id, suite.is_deleted == 0),
+            )
+            .where(evaluation.is_deleted == 0)
+        )
+        result = await self.db.execute(stmt)
+        return [(row.workflow_id, list(row.run_ids or [])) for row in result.all()]
+
+    async def get_run_pointers_for_workflow(
+        self, workflow_id: Optional[UUID]
+    ) -> List[List[str]]:
+        """``run_ids`` for every evaluation targeting one workflow (``None`` = unassigned)."""
+        stmt = select(TestEvaluationModel.run_ids).where(
+            self._workflow_condition(workflow_id)
+        )
+        result = await self.db.execute(stmt)
+        return [list(run_ids or []) for run_ids in result.scalars().all()]
 

--- a/backend/app/schemas/test_suite.py
+++ b/backend/app/schemas/test_suite.py
@@ -191,6 +191,20 @@ class BatchRunsRequest(BaseModel):
     )
 
 
+class StartedEvaluationRun(BaseModel):
+    """Outcome of starting one evaluation in a batch/workflow run.
+
+    ``run_id``/``suite_id`` are unset and ``error`` is populated when the
+    evaluation could not be queued (``status == "failed_to_start"``).
+    """
+
+    evaluation_id: UUID
+    run_id: Optional[UUID] = None
+    suite_id: Optional[UUID] = None
+    status: str
+    error: Optional[str] = None
+
+
 class TestEvaluationBase(BaseModel):
     name: str
     description: Optional[str] = None
@@ -226,4 +240,37 @@ class TestEvaluationInDB(TestEvaluationBase):
 
 class TestEvaluation(TestEvaluationInDB):
     pass
+
+
+class WorkflowEvaluationSummary(BaseModel):
+    """One overview row: a workflow (or the unassigned bucket) and its eval count.
+
+    ``health`` is the mean accuracy across the workflow's evaluations whose latest
+    run has finished, counting failed runs as 0; ``None`` when none have finished.
+    ``finished_count`` is how many evaluations contributed to ``health``.
+    ``any_running`` is true when any evaluation's latest run is queued or running.
+    """
+
+    workflow_id: Optional[UUID] = None
+    eval_count: int
+    health: Optional[float] = None
+    finished_count: int = 0
+    any_running: bool = False
+
+
+class PaginatedEvaluations(BaseModel):
+    """One page of a workflow's evaluations.
+
+    ``total`` is the count for the current search; ``total_unfiltered`` is the
+    workflow's full evaluation count (ignoring search), so the header can show
+    "N of M". ``any_running`` reflects the whole workflow (across all pages), not
+    just this page, so the client can block a duplicate "Run all".
+    """
+
+    items: List[TestEvaluationInDB] = Field(default_factory=list)
+    total: int
+    total_unfiltered: int
+    page: int
+    page_size: int
+    any_running: bool = False
 

--- a/backend/app/services/test_suite.py
+++ b/backend/app/services/test_suite.py
@@ -1,7 +1,7 @@
 import logging
 import json
-from typing import Any, Dict, Iterable, List
-from uuid import UUID
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from uuid import UUID, uuid4
 
 from injector import inject
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -30,6 +30,8 @@ from app.repositories.test_suite import (
 )
 from app.schemas.test_suite import (
     ImportCasesFromConversationRequest,
+    PaginatedEvaluations,
+    StartedEvaluationRun,
     TestCaseCreate,
     TestCaseInDB,
     TestCaseUpdate,
@@ -44,11 +46,11 @@ from app.schemas.test_suite import (
     TestSuiteCreate,
     TestSuiteUpdate,
     TestSuiteInDB,
+    WorkflowEvaluationSummary,
 )
 from app.schemas.workflow import WorkflowInDB
 from app.services.workflow import WorkflowService
 from app.core.tenant_scope import get_tenant_context
-from app.dependencies.injector import injector
 from app.modules.websockets.socket_connection_manager import SocketConnectionManager
 from app.services.realtime_notifications import emit_notification, notification_payload
 
@@ -1197,4 +1199,225 @@ class TestSuiteService:
             raise AppException(status_code=404, error_key=ErrorKey.NOT_FOUND)
         await self.run_repo.soft_delete_all_by_ids(list(row.run_ids or []))
         await self.evaluation_repo.soft_delete(row)
+
+    async def start_workflow_evaluations(
+        self,
+        workflow_id: UUID,
+        dispatch: Callable[
+            [TestRunInDB, Optional[Dict[str, Any]], Optional[Dict[str, Any]]], None
+        ],
+    ) -> List[StartedEvaluationRun]:
+        """Queue and dispatch a run for every evaluation targeting this workflow.
+
+        An evaluation targets the workflow either directly (``workflow_id``) or
+        through its dataset's default workflow. Each evaluation is created and
+        dispatched independently: one failure is reported as ``failed_to_start``
+        and does not prevent the rest from running.
+        """
+        targeted = await self._evaluations_for_workflow(workflow_id)
+
+        results: List[StartedEvaluationRun] = []
+        for ev in targeted:
+            try:
+                run = await self._start_evaluation_run(ev, dispatch)
+                results.append(
+                    StartedEvaluationRun(
+                        evaluation_id=ev.id,
+                        run_id=run.id,
+                        suite_id=run.suite_id,
+                        status=run.status,
+                    )
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to start evaluation %s for workflow %s", ev.id, workflow_id
+                )
+                results.append(
+                    StartedEvaluationRun(
+                        evaluation_id=ev.id,
+                        status="failed_to_start",
+                        error="Failed to start evaluation.",
+                    )
+                )
+        return results
+
+    async def _evaluations_for_workflow(
+        self, workflow_id: UUID
+    ) -> List[TestEvaluationModel]:
+        """The Run all scope: every evaluation for the workflow (DB-filtered)."""
+        return await self.evaluation_repo.get_all_for_workflow(workflow_id)
+
+    async def get_workflow_evaluation_summaries(
+        self,
+    ) -> List[WorkflowEvaluationSummary]:
+        """One row per workflow (and the unassigned bucket): count, health, running."""
+        count_rows = await self.evaluation_repo.count_by_effective_workflow()
+        pointers = await self.evaluation_repo.get_latest_run_pointers()
+        stats_by_workflow = await self._compute_workflow_stats(pointers)
+        summaries: List[WorkflowEvaluationSummary] = []
+        for workflow_id, count in count_rows:
+            health, finished, any_running = stats_by_workflow.get(
+                workflow_id, (None, 0, False)
+            )
+            summaries.append(
+                WorkflowEvaluationSummary(
+                    workflow_id=workflow_id,
+                    eval_count=count,
+                    health=health,
+                    finished_count=finished,
+                    any_running=any_running,
+                )
+            )
+        return summaries
+
+    async def _compute_workflow_stats(
+        self,
+        pointers: List[Tuple[Optional[UUID], List[str]]],
+    ) -> Dict[Optional[UUID], Tuple[Optional[float], int, bool]]:
+        """(health, finished_count, any_running) per workflow from latest runs.
+
+        Health is the mean accuracy over evaluations whose latest run has finished,
+        counting a failed run as 0. Queued/running runs set ``any_running`` and are
+        not scored. Only each evaluation's latest run (``run_ids[0]``) is fetched.
+        """
+        latest_run_to_workflow: Dict[str, Optional[UUID]] = {}
+        for workflow_id, run_ids in pointers:
+            if run_ids:
+                latest_run_to_workflow[run_ids[0]] = workflow_id
+        if not latest_run_to_workflow:
+            return {}
+
+        runs = await self.run_repo.get_by_ids(list(latest_run_to_workflow.keys()))
+        sums: Dict[Optional[UUID], float] = {}
+        counts: Dict[Optional[UUID], int] = {}
+        running: Dict[Optional[UUID], bool] = {}
+        for run in runs:
+            workflow_id = latest_run_to_workflow.get(str(run.id))
+            if run.status in ("queued", "running"):
+                running[workflow_id] = True
+                continue
+            if run.status == "failed":
+                sums[workflow_id] = sums.get(workflow_id, 0.0)
+                counts[workflow_id] = counts.get(workflow_id, 0) + 1
+                continue
+            if run.status == "completed":
+                accuracy = self._run_accuracy(run.summary_metrics)
+                if accuracy is None:
+                    continue
+                sums[workflow_id] = sums.get(workflow_id, 0.0) + accuracy
+                counts[workflow_id] = counts.get(workflow_id, 0) + 1
+
+        stats: Dict[Optional[UUID], Tuple[Optional[float], int, bool]] = {}
+        for workflow_id in set(counts) | set(running):
+            count = counts.get(workflow_id, 0)
+            health = sums[workflow_id] / count if count else None
+            stats[workflow_id] = (health, count, running.get(workflow_id, False))
+        return stats
+
+    async def workflow_has_active_run(self, workflow_id: Optional[UUID]) -> bool:
+        """True if any evaluation in the workflow has a queued/running latest run."""
+        pointer_lists = await self.evaluation_repo.get_run_pointers_for_workflow(
+            workflow_id
+        )
+        latest_run_ids = [run_ids[0] for run_ids in pointer_lists if run_ids]
+        if not latest_run_ids:
+            return False
+        runs = await self.run_repo.get_by_ids(latest_run_ids)
+        return any(run.status in ("queued", "running") for run in runs)
+
+    @staticmethod
+    def _run_accuracy(summary_metrics: Optional[Dict[str, Any]]) -> Optional[float]:
+        """Mean accuracy across a run's metrics, matching the per-row display."""
+        if not summary_metrics:
+            return None
+        accuracies = [
+            metric["accuracy"]
+            for metric in summary_metrics.values()
+            if isinstance(metric, dict)
+            and isinstance(metric.get("accuracy"), (int, float))
+            and not isinstance(metric.get("accuracy"), bool)
+        ]
+        if not accuracies:
+            return None
+        return sum(accuracies) / len(accuracies)
+
+    async def list_workflow_evaluations(
+        self,
+        workflow_id: Optional[UUID],
+        page: int,
+        page_size: int,
+        search: Optional[str] = None,
+    ) -> PaginatedEvaluations:
+        """One page of a workflow's evaluations (``workflow_id=None`` = unassigned).
+
+        Filtering, search and pagination run in the database, so only the
+        requested page is loaded.
+        """
+        page = max(page, 1)
+        page_size = max(1, min(page_size, 100))
+        offset = (page - 1) * page_size
+        rows = await self.evaluation_repo.get_page_for_workflow(
+            workflow_id, offset, page_size, search
+        )
+        total = await self.evaluation_repo.count_for_workflow(workflow_id, search)
+        total_unfiltered = (
+            total
+            if not (search and search.strip())
+            else await self.evaluation_repo.count_for_workflow(workflow_id, None)
+        )
+        any_running = await self.workflow_has_active_run(workflow_id)
+        return PaginatedEvaluations(
+            items=[
+                TestEvaluationInDB.model_validate(row, from_attributes=True)
+                for row in rows
+            ],
+            total=total,
+            total_unfiltered=total_unfiltered,
+            page=page,
+            page_size=page_size,
+            any_running=any_running,
+        )
+
+    async def _start_evaluation_run(
+        self,
+        ev: TestEvaluationModel,
+        dispatch: Callable[
+            [TestRunInDB, Optional[Dict[str, Any]], Optional[Dict[str, Any]]], None
+        ],
+    ) -> TestRunInDB:
+        """Create, record and dispatch a single evaluation run.
+
+        Create, attach and dispatch are treated as one unit: if attaching or
+        dispatching fails after the run is created, the run is marked ``failed``
+        so it is never left stranded in ``queued`` while the caller reports the
+        evaluation as failed to start.
+        """
+        input_metadata = dict(ev.input_metadata or {})
+        if input_metadata.get("use_memory"):
+            input_metadata["thread_id"] = str(uuid4())
+        data = TestRunCreate(
+            techniques=list(ev.techniques or []),
+            technique_configs=ev.technique_configs or None,
+            workflow_id=ev.workflow_id,
+            input_metadata=input_metadata or None,
+        )
+        run = await self.create_run(ev.suite_id, data)
+        try:
+            await self.append_run_to_evaluation(ev.id, str(run.id))
+            dispatch(run, input_metadata or None, ev.technique_configs or None)
+        except Exception:
+            await self._mark_run_failed_to_start(run.id)
+            raise
+        return run
+
+    async def _mark_run_failed_to_start(self, run_id: UUID) -> None:
+        """Flip a still-queued run to ``failed`` so it is not left dangling."""
+        try:
+            row = await self.run_repo.get_by_id(run_id)
+            if row and row.status == "queued":
+                row.status = "failed"
+                row.summary_metrics = {"error": "Failed to dispatch run"}
+                await self.run_repo.update(row)
+        except Exception:
+            logger.exception("Could not mark run %s as failed after start error", run_id)
 

--- a/backend/app/services/test_suite.py
+++ b/backend/app/services/test_suite.py
@@ -1314,6 +1314,17 @@ class TestSuiteService:
             stats[workflow_id] = (health, count, running.get(workflow_id, False))
         return stats
 
+    async def evaluation_has_active_run(self, evaluation_id: UUID) -> bool:
+        """True if this evaluation's latest run is queued or running.
+
+        Used to block edits and deletes while an evaluation is executing.
+        """
+        row = await self.evaluation_repo.get_by_id(evaluation_id)
+        if not row or not row.run_ids:
+            return False
+        runs = await self.run_repo.get_by_ids([row.run_ids[0]])
+        return any(run.status in ("queued", "running") for run in runs)
+
     async def workflow_has_active_run(self, workflow_id: Optional[UUID]) -> bool:
         """True if any evaluation in the workflow has a queued/running latest run."""
         pointer_lists = await self.evaluation_repo.get_run_pointers_for_workflow(

--- a/backend/tests/integration/test_workflow_evaluations_pagination_db.py
+++ b/backend/tests/integration/test_workflow_evaluations_pagination_db.py
@@ -1,0 +1,121 @@
+"""DB-backed proof that workflow-evaluation listing paginates and searches in SQL.
+
+Uses the unassigned bucket (``workflow_id=None``) so no ``workflows`` row is
+needed, and scopes every assertion by a unique name tag so pre-existing data
+cannot affect the result.
+"""
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config.settings import settings
+from app.db.models.test_suite import TestEvaluationModel, TestSuiteModel
+from app.repositories.test_suite import TestEvaluationRepository, TestSuiteRepository
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(settings.DATABASE_URL)
+    maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_pagination_and_search_run_in_the_database(db_session):
+    session = db_session
+    eval_repo = TestEvaluationRepository(session)
+    suite_repo = TestSuiteRepository(session)
+
+    prefix = f"zz_{uuid4().hex[:8]}_"
+    suite = await suite_repo.create(
+        TestSuiteModel(name=f"{prefix}suite", workflow_id=None)
+    )
+    created = []
+    try:
+        for i in range(25):
+            created.append(
+                await eval_repo.create(
+                    TestEvaluationModel(
+                        name=f"{prefix}eval_{i:02d}",
+                        suite_id=suite.id,
+                        workflow_id=None,
+                        techniques=[],
+                        run_ids=[],
+                    )
+                )
+            )
+
+        # Count scoped by our tag, so other data in the DB can't skew it.
+        assert await eval_repo.count_for_workflow(None, search=prefix) == 25
+
+        # The database returns only the requested page, not all 25 rows.
+        page1 = await eval_repo.get_page_for_workflow(None, 0, 20, search=prefix)
+        page2 = await eval_repo.get_page_for_workflow(None, 20, 20, search=prefix)
+        assert len(page1) == 20
+        assert len(page2) == 5
+        assert {e.id for e in page1}.isdisjoint({e.id for e in page2})
+
+        # Search narrows further, in SQL.
+        one = await eval_repo.get_page_for_workflow(None, 0, 50, search=f"{prefix}eval_07")
+        assert len(one) == 1 and one[0].name == f"{prefix}eval_07"
+        assert await eval_repo.count_for_workflow(None, search=f"{prefix}nope") == 0
+
+        # Run all scope (full, unpaginated) and the summary group-by — the paths
+        all_scope = await eval_repo.get_all_for_workflow(None)
+        assert {e.id for e in created} <= {e.id for e in all_scope}
+        summary = dict(await eval_repo.count_by_effective_workflow())
+        assert summary.get(None, 0) >= 25  # unassigned bucket includes ours
+    finally:
+        for evaluation in created:
+            await session.delete(evaluation)
+        await session.delete(suite)
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_eval_of_soft_deleted_suite_is_unassigned_consistently(db_session):
+    """An evaluation whose suite was soft-deleted must appear as unassigned in
+    BOTH the list and the count. Before the fix the list excluded it while
+    count_by_effective_workflow still bucketed it as unassigned.
+    """
+    session = db_session
+    eval_repo = TestEvaluationRepository(session)
+    suite_repo = TestSuiteRepository(session)
+
+    prefix = f"zz_{uuid4().hex[:8]}_"
+    suite = await suite_repo.create(
+        TestSuiteModel(name=f"{prefix}suite", workflow_id=None)
+    )
+    evaluation = await eval_repo.create(
+        TestEvaluationModel(
+            name=f"{prefix}orphan",
+            suite_id=suite.id,
+            workflow_id=None,
+            techniques=[],
+            run_ids=[],
+        )
+    )
+    try:
+        # Soft-delete the suite the evaluation points at.
+        suite.is_deleted = 1
+        await session.commit()
+
+        # The list (Run all / detail scope) now surfaces it as unassigned...
+        unassigned_ids = {e.id for e in await eval_repo.get_all_for_workflow(None)}
+        assert evaluation.id in unassigned_ids
+        page = await eval_repo.get_page_for_workflow(None, 0, 50, search=prefix)
+        assert {e.id for e in page} == {evaluation.id}
+        assert await eval_repo.count_for_workflow(None, search=prefix) == 1
+
+        # ...and the summary group-by agrees (unassigned bucket is non-empty).
+        summary = dict(await eval_repo.count_by_effective_workflow())
+        assert summary.get(None, 0) >= 1
+    finally:
+        await session.delete(evaluation)
+        await session.delete(suite)
+        await session.commit()

--- a/backend/tests/unit/test_run_all_lock_route.py
+++ b/backend/tests/unit/test_run_all_lock_route.py
@@ -1,0 +1,100 @@
+"""Route-level tests for the Run-all Redis lock: contention → 409, ownership-safe
+release (compare-and-delete with the token we acquired), and a release failure that
+must not mask a successful response."""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.v1.routes import test_evaluations as route_mod
+
+
+def _fake_redis(*, acquired: bool = True, release_error: bool = False):
+    redis = AsyncMock()
+    redis.set = AsyncMock(return_value=True if acquired else None)
+    if release_error:
+        redis.eval = AsyncMock(side_effect=RuntimeError("redis down"))
+    else:
+        redis.eval = AsyncMock(return_value=1)
+    return redis
+
+
+def _patch_injector(monkeypatch, redis):
+    fake_injector = MagicMock()
+    fake_injector.get.return_value = redis
+    monkeypatch.setattr(route_mod, "injector", fake_injector)
+
+
+def _service(*, active: bool = False, started=None):
+    service = AsyncMock()
+    service.workflow_has_active_run = AsyncMock(return_value=active)
+    service.start_workflow_evaluations = AsyncMock(return_value=started or [])
+    return service
+
+
+@pytest.mark.asyncio
+async def test_lock_contention_returns_409_without_starting(monkeypatch):
+    """If the lock is already held (SET NX fails), refuse and never start a batch
+    or touch the lock (nothing to release — we did not acquire it)."""
+    redis = _fake_redis(acquired=False)
+    _patch_injector(monkeypatch, redis)
+    service = _service()
+
+    with pytest.raises(HTTPException) as exc:
+        await route_mod.run_workflow_evaluations(uuid4(), service)
+
+    assert exc.value.status_code == 409
+    service.start_workflow_evaluations.assert_not_awaited()
+    redis.eval.assert_not_awaited()  # never acquired → never released
+
+
+@pytest.mark.asyncio
+async def test_already_running_returns_409_and_releases_own_lock(monkeypatch):
+    """Lock acquired but a batch is already running → 409, and we release using a
+    compare-and-delete against the exact token we set (ownership-safe)."""
+    redis = _fake_redis(acquired=True)
+    _patch_injector(monkeypatch, redis)
+    service = _service(active=True)
+
+    with pytest.raises(HTTPException) as exc:
+        await route_mod.run_workflow_evaluations(uuid4(), service)
+
+    assert exc.value.status_code == 409
+    service.start_workflow_evaluations.assert_not_awaited()
+
+    set_key, set_token = redis.set.await_args.args
+    redis.eval.assert_awaited_once()
+    script, numkeys, eval_key, eval_token = redis.eval.await_args.args
+    assert script == route_mod._RELEASE_LOCK_LUA
+    assert numkeys == 1
+    assert eval_key == set_key  # same lock key
+    assert eval_token == set_token  # release only our own token
+
+
+@pytest.mark.asyncio
+async def test_happy_path_starts_then_releases(monkeypatch):
+    redis = _fake_redis(acquired=True)
+    _patch_injector(monkeypatch, redis)
+    started = [SimpleNamespace(evaluation_id=uuid4())]
+    service = _service(active=False, started=started)
+
+    result = await route_mod.run_workflow_evaluations(uuid4(), service)
+
+    assert result is started
+    service.start_workflow_evaluations.assert_awaited_once()
+    redis.eval.assert_awaited_once()  # released after starting
+
+
+@pytest.mark.asyncio
+async def test_release_failure_does_not_mask_response(monkeypatch):
+    """A Redis error while releasing must be swallowed, not turned into a 500."""
+    redis = _fake_redis(acquired=True, release_error=True)
+    _patch_injector(monkeypatch, redis)
+    started = [SimpleNamespace(evaluation_id=uuid4())]
+    service = _service(active=False, started=started)
+
+    result = await route_mod.run_workflow_evaluations(uuid4(), service)
+
+    assert result is started  # successful start still returned despite release error

--- a/backend/tests/unit/test_workflow_evaluations_batch.py
+++ b/backend/tests/unit/test_workflow_evaluations_batch.py
@@ -1,0 +1,318 @@
+"""Unit tests for the workflow-batch evaluation runner: grouping, isolation, cleanup."""
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.services.test_suite import TestSuiteService as EvalService
+
+
+def _service() -> EvalService:
+    return EvalService(
+        suite_repo=AsyncMock(),
+        case_repo=AsyncMock(),
+        run_repo=AsyncMock(),
+        result_repo=AsyncMock(),
+        evaluation_repo=AsyncMock(),
+        workflow_service=AsyncMock(),
+        conversation_repo=AsyncMock(),
+    )
+
+
+def _eval(*, suite_id, workflow_id=None, eval_id=None):
+    return SimpleNamespace(
+        id=eval_id or uuid4(),
+        workflow_id=workflow_id,
+        suite_id=suite_id,
+        input_metadata=None,
+        techniques=["no_errors"],
+        technique_configs=None,
+    )
+
+
+def _full_eval(*, suite_id, workflow_id=None):
+    """A fake that satisfies TestEvaluationInDB.model_validate for list responses."""
+    now = datetime(2026, 1, 1)
+    return SimpleNamespace(
+        id=uuid4(),
+        name="eval",
+        description=None,
+        suite_id=suite_id,
+        workflow_id=workflow_id,
+        techniques=[],
+        technique_configs=None,
+        input_metadata=None,
+        run_ids=[],
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestEvaluationsForWorkflow:
+    @pytest.mark.asyncio
+    async def test_run_all_uses_full_db_scope(self):
+        """Run all delegates to the DB-filtered full scope (single source of truth).
+        The effective-workflow rule itself is exercised by the DB integration test."""
+        wf = uuid4()
+        rows = [_eval(suite_id=uuid4(), workflow_id=wf) for _ in range(3)]
+        service = _service()
+        service.evaluation_repo.get_all_for_workflow = AsyncMock(return_value=rows)
+
+        result = await service._evaluations_for_workflow(wf)
+
+        assert result == rows
+        service.evaluation_repo.get_all_for_workflow.assert_awaited_once_with(wf)
+
+
+class TestStartWorkflowEvaluations:
+    @pytest.mark.asyncio
+    async def test_one_failure_does_not_abort_the_rest(self):
+        suite = uuid4()
+        evals = [_eval(suite_id=suite, workflow_id=uuid4()) for _ in range(3)]
+        service = _service()
+        service._evaluations_for_workflow = AsyncMock(return_value=evals)
+
+        async def fake_start(ev, dispatch):
+            if ev is evals[1]:
+                raise RuntimeError("boom - secret internals")
+            return SimpleNamespace(id=uuid4(), suite_id=ev.suite_id, status="queued")
+
+        service._start_evaluation_run = fake_start
+
+        results = await service.start_workflow_evaluations(uuid4(), MagicMock())
+
+        assert len(results) == 3
+        failed = [r for r in results if r.status == "failed_to_start"]
+        started = [r for r in results if r.run_id is not None]
+        assert len(started) == 2
+        assert len(failed) == 1 and failed[0].evaluation_id == evals[1].id
+        # raw exception text must never reach the client
+        assert failed[0].error == "Failed to start evaluation."
+        assert "boom" not in (failed[0].error or "")
+
+
+class TestStartEvaluationRunOrphanCleanup:
+    @pytest.mark.asyncio
+    async def test_dispatch_failure_marks_run_failed_not_queued(self):
+        suite = uuid4()
+        ev = _eval(suite_id=suite, workflow_id=uuid4())
+        service = _service()
+
+        run = SimpleNamespace(id=uuid4(), suite_id=suite, status="queued")
+        service.create_run = AsyncMock(return_value=run)
+        service.append_run_to_evaluation = AsyncMock()
+
+        # the persisted row the cleanup path fetches and flips
+        row = SimpleNamespace(id=run.id, status="queued", summary_metrics=None)
+        service.run_repo.get_by_id = AsyncMock(return_value=row)
+        service.run_repo.update = AsyncMock()
+
+        def dispatch(_run, _meta, _configs):
+            raise RuntimeError("broker down")
+
+        with pytest.raises(RuntimeError):
+            await service._start_evaluation_run(ev, dispatch)
+
+        assert row.status == "failed"  # not left dangling in "queued"
+        assert row.summary_metrics == {"error": "Failed to dispatch run"}
+        service.run_repo.update.assert_awaited_once()
+
+
+class TestWorkflowEvaluationSummaries:
+    @pytest.mark.asyncio
+    async def test_maps_repo_rows_to_summaries(self):
+        """Service maps the DB group-by rows to summaries, incl. the unassigned bucket.
+        The group-by SQL itself is exercised by the DB integration test / smoke."""
+        wf_a, wf_b = uuid4(), uuid4()
+        service = _service()
+        service.evaluation_repo.count_by_effective_workflow = AsyncMock(
+            return_value=[(wf_a, 2), (wf_b, 1), (None, 3)]
+        )
+        service.evaluation_repo.get_latest_run_pointers = AsyncMock(return_value=[])
+        service.run_repo.get_by_ids = AsyncMock(return_value=[])
+
+        summaries = await service.get_workflow_evaluation_summaries()
+        by_key = {
+            (str(s.workflow_id) if s.workflow_id else None): s for s in summaries
+        }
+        assert by_key[str(wf_a)].eval_count == 2
+        assert by_key[str(wf_b)].eval_count == 1
+        assert by_key[None].eval_count == 3  # unassigned bucket preserved
+        # No runs anywhere → health is unknown, not 0, and nothing is running.
+        assert all(
+            s.health is None and s.finished_count == 0 and s.any_running is False
+            for s in summaries
+        )
+
+    @pytest.mark.asyncio
+    async def test_health_counts_failed_runs_as_zero(self):
+        """Health is the mean per-eval accuracy over evaluations whose latest run
+        has finished, counting a failed run as 0. Never-run evals are excluded."""
+        wf = uuid4()
+        service = _service()
+        service.evaluation_repo.count_by_effective_workflow = AsyncMock(
+            return_value=[(wf, 4)]
+        )
+        # Four evaluations: two completed, one failed, one never run.
+        service.evaluation_repo.get_latest_run_pointers = AsyncMock(
+            return_value=[
+                (wf, ["r1"]),
+                (wf, ["r2"]),
+                (wf, ["r3"]),
+                (wf, []),
+            ]
+        )
+        service.run_repo.get_by_ids = AsyncMock(
+            return_value=[
+                SimpleNamespace(
+                    id="r1",
+                    status="completed",
+                    summary_metrics={"a": {"accuracy": 1.0}, "b": {"accuracy": 0.5}},
+                ),
+                SimpleNamespace(
+                    id="r2",
+                    status="completed",
+                    summary_metrics={"a": {"accuracy": 0.5}},
+                ),
+                SimpleNamespace(
+                    id="r3", status="failed", summary_metrics={"error": "boom"}
+                ),
+            ]
+        )
+
+        summaries = await service.get_workflow_evaluation_summaries()
+        summary = next(s for s in summaries if s.workflow_id == wf)
+        assert summary.eval_count == 4
+        assert summary.finished_count == 3  # two completed + one failed
+        assert summary.any_running is False
+        # eval accuracies: 0.75, 0.5, failed→0.0 → mean (0.75+0.5+0.0)/3
+        assert summary.health == pytest.approx((0.75 + 0.5 + 0.0) / 3)
+
+        service.run_repo.get_by_ids.assert_awaited_once()
+        requested_ids = set(service.run_repo.get_by_ids.await_args.args[0])
+        assert requested_ids == {"r1", "r2", "r3"}  # empty pointer excluded
+
+    @pytest.mark.asyncio
+    async def test_running_run_sets_any_running_and_is_not_scored(self):
+        """A queued/running latest run flags any_running and does not affect health."""
+        wf = uuid4()
+        service = _service()
+        service.evaluation_repo.count_by_effective_workflow = AsyncMock(
+            return_value=[(wf, 2)]
+        )
+        service.evaluation_repo.get_latest_run_pointers = AsyncMock(
+            return_value=[(wf, ["r1"]), (wf, ["r2"])]
+        )
+        service.run_repo.get_by_ids = AsyncMock(
+            return_value=[
+                SimpleNamespace(
+                    id="r1",
+                    status="completed",
+                    summary_metrics={"a": {"accuracy": 1.0}},
+                ),
+                SimpleNamespace(id="r2", status="running", summary_metrics=None),
+            ]
+        )
+
+        summaries = await service.get_workflow_evaluation_summaries()
+        summary = next(s for s in summaries if s.workflow_id == wf)
+        assert summary.any_running is True
+        assert summary.finished_count == 1  # running run not counted
+        assert summary.health == pytest.approx(1.0)
+
+
+class TestWorkflowHasActiveRun:
+    @pytest.mark.asyncio
+    async def test_true_when_a_latest_run_is_active(self):
+        wf = uuid4()
+        service = _service()
+        service.evaluation_repo.get_run_pointers_for_workflow = AsyncMock(
+            return_value=[["r1"], ["r2"], []]
+        )
+        service.run_repo.get_by_ids = AsyncMock(
+            return_value=[
+                SimpleNamespace(id="r1", status="completed"),
+                SimpleNamespace(id="r2", status="queued"),
+            ]
+        )
+        assert await service.workflow_has_active_run(wf) is True
+        # Only latest-run ids are checked; the empty pointer is skipped.
+        assert set(service.run_repo.get_by_ids.await_args.args[0]) == {"r1", "r2"}
+
+    @pytest.mark.asyncio
+    async def test_false_when_no_active_run(self):
+        wf = uuid4()
+        service = _service()
+        service.evaluation_repo.get_run_pointers_for_workflow = AsyncMock(
+            return_value=[["r1"]]
+        )
+        service.run_repo.get_by_ids = AsyncMock(
+            return_value=[SimpleNamespace(id="r1", status="completed")]
+        )
+        assert await service.workflow_has_active_run(wf) is False
+
+    @pytest.mark.asyncio
+    async def test_false_when_no_runs_at_all(self):
+        service = _service()
+        service.evaluation_repo.get_run_pointers_for_workflow = AsyncMock(
+            return_value=[[], []]
+        )
+        service.run_repo.get_by_ids = AsyncMock(return_value=[])
+        assert await service.workflow_has_active_run(uuid4()) is False
+        service.run_repo.get_by_ids.assert_not_awaited()
+
+
+class TestListWorkflowEvaluations:
+    """Service-level: clamping, offset math, and search passthrough. The SQL
+    filtering/pagination/search itself is exercised against a real DB (smoke)."""
+
+    def _service_with_repo(self, page_rows, total):
+        service = _service()
+        service.evaluation_repo.get_page_for_workflow = AsyncMock(return_value=page_rows)
+        service.evaluation_repo.count_for_workflow = AsyncMock(return_value=total)
+        return service
+
+    @pytest.mark.asyncio
+    async def test_clamps_page_and_page_size(self):
+        wf = uuid4()
+        service = self._service_with_repo([], 0)
+
+        result = await service.list_workflow_evaluations(wf, page=0, page_size=999)
+
+        assert result.page == 1 and result.page_size == 100  # floor + cap
+        service.evaluation_repo.get_page_for_workflow.assert_awaited_once_with(
+            wf, 0, 100, None
+        )
+
+    @pytest.mark.asyncio
+    async def test_offset_and_search_are_forwarded(self):
+        wf = uuid4()
+        rows = [_full_eval(suite_id=uuid4(), workflow_id=wf) for _ in range(20)]
+        service = self._service_with_repo(rows, 55)
+
+        result = await service.list_workflow_evaluations(
+            wf, page=2, page_size=20, search="alpha"
+        )
+
+        assert result.total == 55 and result.page == 2 and len(result.items) == 20
+        assert result.total_unfiltered == 55
+        # page 2 of 20 -> offset 20, limit 20, search forwarded to the DB layer
+        service.evaluation_repo.get_page_for_workflow.assert_awaited_once_with(
+            wf, 20, 20, "alpha"
+        )
+        # Filtered count for the page, plus the unfiltered count for "N of M".
+        assert service.evaluation_repo.count_for_workflow.await_count == 2
+        service.evaluation_repo.count_for_workflow.assert_any_await(wf, "alpha")
+        service.evaluation_repo.count_for_workflow.assert_any_await(wf, None)
+
+    @pytest.mark.asyncio
+    async def test_unassigned_is_forwarded(self):
+        service = self._service_with_repo([], 0)
+
+        await service.list_workflow_evaluations(None, page=1, page_size=20)
+
+        service.evaluation_repo.get_page_for_workflow.assert_awaited_once_with(
+            None, 0, 20, None
+        )

--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -64,6 +64,7 @@ import DatasetsPage from "@/views/TestSuites/pages/DatasetsPage";
 import EvaluationsPage from "@/views/TestSuites/pages/EvaluationsPage";
 import DatasetDetailPage from "@/views/TestSuites/pages/DatasetDetailPage";
 import EvaluationDetailPage from "@/views/TestSuites/pages/EvaluationDetailPage";
+import WorkflowEvaluationsPage from "@/views/TestSuites/pages/WorkflowEvaluationsPage";
 import Privacy from "@/views/Privacy";
 import ServerStatusBanner from "@/components/ServerStatusBanner";
 import Onboarding from "@/views/Onboarding/pages/Onboarding";
@@ -515,6 +516,14 @@ export const RoutesProvider = () => {
               element: (
                 <ProtectedRoute requiredPermissions={["test:workflow"]}>
                   <EvaluationsPage />
+                </ProtectedRoute>
+              ),
+            },
+            {
+              path: "tests/evaluations/workflows/:workflowId",
+              element: (
+                <ProtectedRoute requiredPermissions={["test:workflow"]}>
+                  <WorkflowEvaluationsPage />
                 </ProtectedRoute>
               ),
             },

--- a/frontend/src/interfaces/testEvaluation.interface.ts
+++ b/frontend/src/interfaces/testEvaluation.interface.ts
@@ -12,3 +12,28 @@ export interface TestEvaluationConfig {
   updated_at: string;
 }
 
+export interface StartedEvaluationRun {
+  evaluation_id: string;
+  run_id?: string;
+  suite_id?: string;
+  status: string;
+  error?: string;
+}
+
+export interface WorkflowEvaluationSummary {
+  workflow_id: string | null;
+  eval_count: number;
+  health: number | null;
+  finished_count: number;
+  any_running: boolean;
+}
+
+export interface PaginatedEvaluations {
+  items: TestEvaluationConfig[];
+  total: number;
+  total_unfiltered: number;
+  page: number;
+  page_size: number;
+  any_running: boolean;
+}
+

--- a/frontend/src/services/testEvaluations.ts
+++ b/frontend/src/services/testEvaluations.ts
@@ -1,5 +1,16 @@
 import { apiRequest } from "@/config/api";
-import { TestEvaluationConfig } from "@/interfaces/testEvaluation.interface";
+import {
+  PaginatedEvaluations,
+  StartedEvaluationRun,
+  TestEvaluationConfig,
+  WorkflowEvaluationSummary,
+} from "@/interfaces/testEvaluation.interface";
+
+export type {
+  PaginatedEvaluations,
+  StartedEvaluationRun,
+  WorkflowEvaluationSummary,
+} from "@/interfaces/testEvaluation.interface";
 
 const BASE = "genagent/eval";
 
@@ -8,6 +19,8 @@ export type CreateTestEvaluationPayload = Omit<
   "id" | "run_ids" | "created_at" | "updated_at"
 >;
 
+// Kept as a compatibility wrapper for GET /evaluations until that endpoint is
+// formally deprecated, even though the UI no longer calls it directly.
 export const listTestEvaluations = () =>
   apiRequest<TestEvaluationConfig[]>("GET", `${BASE}/evaluations`);
 
@@ -41,3 +54,30 @@ export const appendRunToEvaluation = (evaluationId: string, runId: string) =>
     "POST",
     `${BASE}/evaluations/${evaluationId}/runs/${runId}`,
   );
+
+export const runWorkflowEvaluations = (workflowId: string) =>
+  apiRequest<StartedEvaluationRun[]>(
+    "POST",
+    `${BASE}/workflows/${workflowId}/evaluations/run`,
+  );
+
+export const getWorkflowEvaluationSummaries = () =>
+  apiRequest<WorkflowEvaluationSummary[]>(
+    "GET",
+    `${BASE}/workflows/evaluation-summaries`,
+  );
+
+export const getWorkflowEvaluationsPage = (
+  workflowId: string,
+  params: { page: number; pageSize: number; search?: string },
+) => {
+  const query = new URLSearchParams({
+    page: String(params.page),
+    page_size: String(params.pageSize),
+  });
+  if (params.search?.trim()) query.set("search", params.search.trim());
+  return apiRequest<PaginatedEvaluations>(
+    "GET",
+    `${BASE}/workflows/${workflowId}/evaluations?${query.toString()}`,
+  );
+};

--- a/frontend/src/views/TestSuites/components/EntityTitle.tsx
+++ b/frontend/src/views/TestSuites/components/EntityTitle.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+type EntityTitleLevel = "group" | "row";
+
+// Shared title scale so equivalent content looks equivalent across the section.
+// Hierarchy comes only from weight/size here — family, color, leading and
+// truncation stay identical. "row" (default) covers datasets, workflow groups
+// and evaluations, which intentionally share one style today; "group" is kept
+// as an extension point if a heavier grouping level is reintroduced later.
+const levelClasses: Record<EntityTitleLevel, string> = {
+  group: "text-base font-semibold",
+  row: "text-sm font-medium",
+};
+
+interface EntityTitleProps {
+  level?: EntityTitleLevel;
+  muted?: boolean;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export const EntityTitle: React.FC<EntityTitleProps> = ({
+  level = "row",
+  muted = false,
+  className,
+  children,
+}) => (
+  <span
+    className={cn(
+      "block min-w-0 truncate leading-tight",
+      levelClasses[level],
+      muted ? "text-gray-500" : "text-gray-900",
+      className,
+    )}
+  >
+    {children}
+  </span>
+);

--- a/frontend/src/views/TestSuites/components/EvaluationListRow.tsx
+++ b/frontend/src/views/TestSuites/components/EvaluationListRow.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { Loader2, Pencil, Play, Trash2 } from "lucide-react";
+import { Button } from "@/components/button";
+import { Badge } from "@/components/badge";
+import { Progress } from "@/components/progress";
+import { TestEvaluationConfig } from "@/interfaces/testEvaluation.interface";
+import { EntityTitle } from "./EntityTitle";
+import { accuracyColorClass } from "../helpers/evaluationMetrics";
+
+interface EvaluationListRowProps {
+  evaluation: TestEvaluationConfig;
+  avgAccuracy: number | null;
+  isRunning: boolean;
+  lastRunStatus?: string;
+  onOpen: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  onRun: (e: React.MouseEvent) => void;
+}
+
+export const EvaluationListRow: React.FC<EvaluationListRowProps> = ({
+  evaluation,
+  avgAccuracy,
+  isRunning,
+  lastRunStatus,
+  onOpen,
+  onEdit,
+  onDelete,
+  onRun,
+}) => (
+  <div className="w-full py-4 px-6 text-left hover:bg-gray-50 transition-colors">
+    <div className="flex items-center justify-between gap-4">
+      <button type="button" onClick={onOpen} className="flex-1 min-w-0 text-left">
+        <div className="flex items-center gap-2">
+          <EntityTitle>{evaluation.name}</EntityTitle>
+          <Badge variant="secondary" className="shrink-0 text-[10px] px-1.5">
+            EVAL
+          </Badge>
+        </div>
+        <p className="text-sm text-gray-500 mt-1 line-clamp-1">
+          {evaluation.description || "No description"}
+        </p>
+
+        {isRunning ? (
+          <div className="mt-2 flex items-center gap-1.5 text-xs font-medium text-blue-600">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            {lastRunStatus === "queued" ? "Queued" : "Running…"}
+          </div>
+        ) : lastRunStatus === "failed" ? (
+          <div className="mt-2 text-xs font-medium text-red-600">Last run failed</div>
+        ) : avgAccuracy !== null ? (
+          <div className="flex items-center gap-2 mt-2">
+            <Progress value={avgAccuracy * 100} className="h-2 w-32 bg-gray-100" />
+            <span className={`text-xs font-medium ${accuracyColorClass(avgAccuracy)}`}>
+              {Math.round(avgAccuracy * 100)}% accuracy
+            </span>
+            <span className="text-xs text-gray-400">
+              ({evaluation.run_ids.length} run{evaluation.run_ids.length !== 1 ? "s" : ""})
+            </span>
+          </div>
+        ) : (
+          <div className="mt-2 text-xs text-gray-400">Not run yet</div>
+        )}
+
+        <div className="flex flex-wrap items-center gap-1 mt-2">
+          <span className="text-xs text-gray-500 mr-1">Metrics:</span>
+          {evaluation.techniques.map((tech) => (
+            <Badge key={tech} variant="outline" className="text-[10px] px-1.5 py-0">
+              {tech}
+            </Badge>
+          ))}
+        </div>
+      </button>
+
+      <div className="flex items-center gap-1 shrink-0">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          aria-label="Edit evaluation"
+          onClick={onEdit}
+        >
+          <Pencil className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          aria-label="Delete evaluation"
+          onClick={onDelete}
+        >
+          <Trash2 className="h-4 w-4 text-red-500" />
+        </Button>
+        <Button size="sm" className="ml-1" disabled={isRunning} onClick={onRun}>
+          <Play className="h-3.5 w-3.5 mr-1" />
+          {isRunning ? "Running..." : "Run"}
+        </Button>
+      </div>
+    </div>
+  </div>
+);

--- a/frontend/src/views/TestSuites/components/EvaluationListRow.tsx
+++ b/frontend/src/views/TestSuites/components/EvaluationListRow.tsx
@@ -78,6 +78,8 @@ export const EvaluationListRow: React.FC<EvaluationListRowProps> = ({
           size="icon"
           className="h-8 w-8"
           aria-label="Edit evaluation"
+          disabled={isRunning}
+          title={isRunning ? "Can't edit while this evaluation is running" : "Edit evaluation"}
           onClick={onEdit}
         >
           <Pencil className="h-4 w-4" />
@@ -87,9 +89,11 @@ export const EvaluationListRow: React.FC<EvaluationListRowProps> = ({
           size="icon"
           className="h-8 w-8"
           aria-label="Delete evaluation"
+          disabled={isRunning}
+          title={isRunning ? "Can't delete while this evaluation is running" : "Delete evaluation"}
           onClick={onDelete}
         >
-          <Trash2 className="h-4 w-4 text-red-500" />
+          <Trash2 className={isRunning ? "h-4 w-4 text-gray-400" : "h-4 w-4 text-red-500"} />
         </Button>
         <Button size="sm" className="ml-1" disabled={isRunning} onClick={onRun}>
           <Play className="h-3.5 w-3.5 mr-1" />

--- a/frontend/src/views/TestSuites/helpers/evaluationForm.ts
+++ b/frontend/src/views/TestSuites/helpers/evaluationForm.ts
@@ -1,0 +1,160 @@
+import { EvaluationWizardData } from "../components/EvaluationWizard";
+import { TestEvaluationConfig } from "@/interfaces/testEvaluation.interface";
+import { LLMProviderMinimal } from "@/interfaces/llmProvider.interface";
+
+const parseJsonObject = (
+  text: string,
+): Record<string, unknown> | undefined => {
+  if (!text.trim()) return undefined;
+  try {
+    const parsed = JSON.parse(text);
+    const isPlainObject =
+      parsed && typeof parsed === "object" && !Array.isArray(parsed);
+    return isPlainObject ? (parsed as Record<string, unknown>) : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+// Parse the wizard's metadata textarea and fold in the "use memory" flag.
+export const wizardMetadata = (
+  data: EvaluationWizardData,
+): Record<string, unknown> | undefined => {
+  let metadata = parseJsonObject(data.inputMetadataText || "{}");
+  if (data.useMemory) {
+    metadata = { ...(metadata ?? {}), use_memory: true };
+  } else if (metadata) {
+    delete metadata["use_memory"];
+  }
+  return metadata;
+};
+
+export const buildTechniqueConfigs = (
+  data: EvaluationWizardData,
+): Record<string, Record<string, unknown>> => {
+  const configs: Record<string, Record<string, unknown>> = {};
+
+  if (data.metrics.includes("nli_eval")) {
+    configs.nli_eval = {
+      min_entail_score: Number(data.nliMinEntailScore || "0.5"),
+      fail_on_contradiction: data.nliFailOnContradiction,
+      ...(data.nliModelName.trim() ? { nli_model_name: data.nliModelName.trim() } : {}),
+    };
+  }
+
+  if (data.metrics.includes("provenance_eval")) {
+    const isLlmMode = data.provMode === "llm";
+    configs.provenance_eval = {
+      min_score: Number(data.provMinScore || "0.5"),
+      fail_on_violation: data.provFailOnViolation,
+      use_llm_judge: isLlmMode,
+      provenance_mode: data.provMode,
+      ...(isLlmMode && data.provLlmProviderId.trim()
+        ? { llm_provider_id: data.provLlmProviderId.trim() }
+        : {}),
+      ...(isLlmMode && data.provLlmJudgeSystemPromptSuffix.trim()
+        ? { llm_judge_system_prompt_suffix: data.provLlmJudgeSystemPromptSuffix.trim() }
+        : {}),
+      ...(!isLlmMode
+        ? {
+            embedding_type: data.provEmbeddingType,
+            embedding_model_name: data.provEmbeddingModelName.trim() || undefined,
+          }
+        : {}),
+    };
+  }
+
+  if (data.metrics.includes("tool_used")) {
+    // Advanced validation only applies when the tool must be called; drop it otherwise.
+    const includeAdvanced = data.toolShouldCall;
+    const expectedArgs = includeAdvanced ? parseJsonObject(data.toolExpectedArgsText) : undefined;
+    configs.tool_used = {
+      should_call: data.toolShouldCall,
+      ...(data.toolName.trim() ? { tool: data.toolName.trim() } : {}),
+      ...(data.toolNode.trim() ? { node: data.toolNode.trim() } : {}),
+      ...(expectedArgs ? { expected_args: expectedArgs } : {}),
+      ...(includeAdvanced && data.toolResultNotEmpty ? { result_not_empty: true } : {}),
+      ...(includeAdvanced && data.toolResultContains.trim()
+        ? { result_contains: data.toolResultContains.trim() }
+        : {}),
+    };
+  }
+
+  if (data.metrics.includes("route_taken")) {
+    configs.route_taken = {
+      expected: data.routeExpected.trim(),
+      ...(data.routeNode.trim() ? { node: data.routeNode.trim() } : {}),
+    };
+  }
+
+  if (data.metrics.includes("action_taken")) {
+    configs.action_taken = {
+      should_fire: data.actionShouldFire,
+      ...(data.actionNode.trim() ? { node: data.actionNode.trim() } : {}),
+      ...(data.actionNodeType.trim() ? { node_type: data.actionNodeType.trim() } : {}),
+    };
+  }
+
+  if (data.metrics.includes("llm_judge")) {
+    configs.llm_judge = {
+      rubric: data.judgeRubric.trim(),
+      min_score: Number(data.judgeMinScore || "0.5"),
+      ...(data.judgeProviderId.trim() ? { llm_provider_id: data.judgeProviderId.trim() } : {}),
+      ...(data.judgeSourceField.trim() ? { source_field: data.judgeSourceField.trim() } : {}),
+    };
+  }
+
+  return configs;
+};
+
+export const getEditInitialData = (
+  evaluation: TestEvaluationConfig,
+  providers: LLMProviderMinimal[],
+): Partial<EvaluationWizardData> => {
+  const nliCfg = evaluation.technique_configs?.["nli_eval"] as Record<string, unknown> | undefined;
+  const provCfg = evaluation.technique_configs?.["provenance_eval"] as Record<string, unknown> | undefined;
+  const toolCfg = evaluation.technique_configs?.["tool_used"] as Record<string, unknown> | undefined;
+  const routeCfg = evaluation.technique_configs?.["route_taken"] as Record<string, unknown> | undefined;
+  const actionCfg = evaluation.technique_configs?.["action_taken"] as Record<string, unknown> | undefined;
+  const judgeCfg = evaluation.technique_configs?.["llm_judge"] as Record<string, unknown> | undefined;
+  const metaWithoutMemory = evaluation.input_metadata
+    ? Object.fromEntries(Object.entries(evaluation.input_metadata).filter(([k]) => k !== "use_memory"))
+    : {};
+
+  return {
+    name: evaluation.name,
+    description: evaluation.description ?? "",
+    suiteId: evaluation.suite_id,
+    workflowId: evaluation.workflow_id ?? "none",
+    metrics: evaluation.techniques,
+    inputMetadataText: JSON.stringify(metaWithoutMemory, null, 2),
+    useMemory: Boolean(evaluation.input_metadata?.use_memory),
+    nliModelName: (nliCfg?.nli_model_name as string) ?? "cross-encoder/nli-deberta-v3-base",
+    nliMinEntailScore: String(nliCfg?.min_entail_score ?? "0.5"),
+    nliFailOnContradiction: Boolean(nliCfg?.fail_on_contradiction),
+    provMode: (provCfg?.provenance_mode as "embeddings" | "llm") ?? "embeddings",
+    provEmbeddingType: (provCfg?.embedding_type as "openai" | "huggingface" | "bedrock") ?? "huggingface",
+    provEmbeddingModelName: (provCfg?.embedding_model_name as string) ?? "all-MiniLM-L6-v2",
+    provMinScore: String(provCfg?.min_score ?? "0.5"),
+    provFailOnViolation: Boolean(provCfg?.fail_on_violation),
+    provLlmProviderId: (provCfg?.llm_provider_id as string) ?? providers[0]?.id ?? "",
+    provLlmJudgeSystemPromptSuffix: (provCfg?.llm_judge_system_prompt_suffix as string) ?? "",
+    toolName: (toolCfg?.tool as string) ?? "",
+    toolShouldCall: toolCfg?.should_call === undefined ? true : Boolean(toolCfg.should_call),
+    toolExpectedArgsText: toolCfg?.expected_args
+      ? JSON.stringify(toolCfg.expected_args, null, 2)
+      : "",
+    toolNode: (toolCfg?.node as string) ?? "",
+    toolResultNotEmpty: Boolean(toolCfg?.result_not_empty),
+    toolResultContains: (toolCfg?.result_contains as string) ?? "",
+    routeExpected: (routeCfg?.expected as string) ?? "",
+    routeNode: (routeCfg?.node as string) ?? "",
+    actionNode: (actionCfg?.node as string) ?? "",
+    actionNodeType: (actionCfg?.node_type as string) ?? "",
+    actionShouldFire: actionCfg?.should_fire === undefined ? true : Boolean(actionCfg.should_fire),
+    judgeRubric: (judgeCfg?.rubric as string) ?? "",
+    judgeMinScore: String(judgeCfg?.min_score ?? "0.5"),
+    judgeProviderId: (judgeCfg?.llm_provider_id as string) ?? providers[0]?.id ?? "",
+    judgeSourceField: (judgeCfg?.source_field as string) ?? "",
+  };
+};

--- a/frontend/src/views/TestSuites/helpers/evaluationMetrics.ts
+++ b/frontend/src/views/TestSuites/helpers/evaluationMetrics.ts
@@ -1,0 +1,5 @@
+export const accuracyColorClass = (accuracy: number): string => {
+  if (accuracy >= 0.9) return "text-green-600";
+  if (accuracy >= 0.7) return "text-amber-600";
+  return "text-red-600";
+};

--- a/frontend/src/views/TestSuites/pages/DatasetsPage.tsx
+++ b/frontend/src/views/TestSuites/pages/DatasetsPage.tsx
@@ -25,6 +25,7 @@ import {getWorkflowsMinimal} from "@/services/workflows";
 import type {WorkflowMinimal} from "@/interfaces/workflow.interface";
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue,} from "@/components/select";
 import {PageListSkeleton} from "@/components/skeletons";
+import {EntityTitle} from "../components/EntityTitle";
 
 const CONV_PAGE_SIZE = 20;
 
@@ -306,7 +307,7 @@ const DatasetsPage: React.FC = () => {
                       className="min-w-0 flex-1 text-left"
                     >
                       <div className="flex items-center gap-2">
-                        <div className="text-lg font-semibold truncate">{suite.name}</div>
+                        <EntityTitle>{suite.name}</EntityTitle>
                         <span className="inline-flex items-center rounded-md bg-gray-100 px-2 py-0.5 text-xs font-bold text-black shrink-0">
                           DATASET
                         </span>

--- a/frontend/src/views/TestSuites/pages/EvaluationsPage.tsx
+++ b/frontend/src/views/TestSuites/pages/EvaluationsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Activity, ChevronRight, Layers, ListChecks, Loader2, Play, Plus } from "lucide-react";
 import toast from "react-hot-toast";
 
@@ -28,6 +29,8 @@ import { buildTechniqueConfigs, wizardMetadata } from "../helpers/evaluationForm
 import { accuracyColorClass } from "../helpers/evaluationMetrics";
 
 const UNASSIGNED = "unassigned";
+const SUMMARIES_QUERY_KEY = ["workflow-evaluation-summaries"];
+const RUNNING_POLL_MS = 5000;
 
 interface WorkflowRow {
   key: string;
@@ -42,12 +45,12 @@ interface WorkflowRow {
 
 const EvaluationsPage: React.FC = () => {
   const navigate = useNavigate();
-  const [summaries, setSummaries] = useState<WorkflowEvaluationSummary[]>([]);
+  const queryClient = useQueryClient();
   const [workflows, setWorkflows] = useState<WorkflowMinimal[]>([]);
   const [suites, setSuites] = useState<TestSuite[]>([]);
   const [providers, setProviders] = useState<LLMProviderMinimal[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [hasError, setHasError] = useState(false);
+  const [isReferenceLoading, setIsReferenceLoading] = useState(true);
+  const [hasReferenceError, setHasReferenceError] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
@@ -55,27 +58,46 @@ const EvaluationsPage: React.FC = () => {
   // Synchronous guard against rapid double-clicks (state updates are async).
   const inFlightWorkflowIds = useRef<Set<string>>(new Set());
 
+  // Summaries carry the live health and running state. staleTime 0 makes
+  // react-query refetch them when the tab regains focus; the interval only runs
+  // while a batch is active and react-query pauses it in a hidden tab.
+  const {
+    data: summaries = [],
+    isPending: isSummariesLoading,
+    isError: hasSummariesError,
+    refetch: refetchSummaries,
+  } = useQuery({
+    queryKey: SUMMARIES_QUERY_KEY,
+    queryFn: async () => (await getWorkflowEvaluationSummaries()) ?? [],
+    staleTime: 0,
+    refetchInterval: (query) =>
+      (query.state.data ?? []).some((summary) => summary.any_running)
+        ? RUNNING_POLL_MS
+        : false,
+  });
+
+  const isLoading = isSummariesLoading || isReferenceLoading;
+  const hasError = hasSummariesError || hasReferenceError;
+
   useEffect(() => {
     let cancelled = false;
     const load = async () => {
-      setIsLoading(true);
-      setHasError(false);
+      setIsReferenceLoading(true);
+      setHasReferenceError(false);
       try {
-        const [summaryData, workflowData, suiteData, providersData] = await Promise.all([
-          getWorkflowEvaluationSummaries(),
+        const [workflowData, suiteData, providersData] = await Promise.all([
           getWorkflowsMinimal(),
           listTestSuites(),
           getLLMProvidersMinimal(),
         ]);
         if (cancelled) return;
-        setSummaries(summaryData ?? []);
         setWorkflows(workflowData ?? []);
         setSuites(suiteData ?? []);
         setProviders((providersData ?? []).filter((p) => p.is_active === 1));
       } catch {
-        if (!cancelled) setHasError(true);
+        if (!cancelled) setHasReferenceError(true);
       } finally {
-        if (!cancelled) setIsLoading(false);
+        if (!cancelled) setIsReferenceLoading(false);
       }
     };
     void load();
@@ -83,29 +105,6 @@ const EvaluationsPage: React.FC = () => {
       cancelled = true;
     };
   }, [reloadKey]);
-
-  // While any workflow is running, refresh summaries so health and the running
-  // state settle back once its batch finishes (no skeleton — silent refetch).
-  const hasRunningWorkflow = useMemo(() => summaries.some((s) => s.any_running), [summaries]);
-  useEffect(() => {
-    if (!hasRunningWorkflow) return;
-    let cancelled = false;
-    const poll = async () => {
-      if (cancelled) return;
-      try {
-        const data = await getWorkflowEvaluationSummaries();
-        if (!cancelled && data) setSummaries(data);
-      } catch {
-        // transient — keep polling
-      }
-      if (!cancelled) window.setTimeout(poll, 4000);
-    };
-    const timer = window.setTimeout(poll, 4000);
-    return () => {
-      cancelled = true;
-      window.clearTimeout(timer);
-    };
-  }, [hasRunningWorkflow]);
 
   const rows = useMemo<WorkflowRow[]>(() => {
     const nameFor = (workflowId: string | null): string => {
@@ -137,8 +136,8 @@ const EvaluationsPage: React.FC = () => {
   };
 
   const markWorkflowRunning = (workflowId: string) => {
-    setSummaries((prev) =>
-      prev.map((summary) =>
+    queryClient.setQueryData<WorkflowEvaluationSummary[]>(SUMMARIES_QUERY_KEY, (prev) =>
+      (prev ?? []).map((summary) =>
         summary.workflow_id === workflowId ? { ...summary, any_running: true } : summary,
       ),
     );
@@ -278,7 +277,13 @@ const EvaluationsPage: React.FC = () => {
         ) : hasError ? (
           <div className="py-16 text-center">
             <p className="text-sm text-gray-500 mb-3">Couldn't load evaluations.</p>
-            <Button variant="outline" onClick={() => setReloadKey((key) => key + 1)}>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setReloadKey((key) => key + 1);
+                void refetchSummaries();
+              }}
+            >
               Retry
             </Button>
           </div>

--- a/frontend/src/views/TestSuites/pages/EvaluationsPage.tsx
+++ b/frontend/src/views/TestSuites/pages/EvaluationsPage.tsx
@@ -1,335 +1,181 @@
-import React, {useEffect, useState} from "react";
-import {useNavigate} from "react-router-dom";
-import {PageLayout} from "@/components/PageLayout";
-import {PageHeader} from "@/components/PageHeader";
-import {getWorkflowsMinimal} from "@/services/workflows";
-import {getTestRun, getTestRunsBatch, listTestSuites, startTestRun} from "@/services/testSuites";
-import {WorkflowMinimal} from "@/interfaces/workflow.interface";
-import {TestRun, TestSuite} from "@/interfaces/testSuite.interface";
-import {Button} from "@/components/button";
-import {Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,} from "@/components/dialog";
-import {ListChecks, Pencil, Play, Plus, Trash2} from "lucide-react";
-import {
-  appendRunToEvaluation,
-  createTestEvaluation,
-  deleteTestEvaluation,
-  listTestEvaluations,
-  updateTestEvaluation,
-} from "@/services/testEvaluations";
-import {TestEvaluationConfig} from "@/interfaces/testEvaluation.interface";
-import {getLLMProvidersMinimal} from "@/services/llmProviders";
-import {LLMProviderMinimal} from "@/interfaces/llmProvider.interface";
-import {PageListSkeleton} from "@/components/skeletons";
-import {Progress} from "@/components/progress";
-import {Badge} from "@/components/badge";
-import {EvaluationWizard, EvaluationWizardData} from "../components/EvaluationWizard";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Activity, ChevronRight, Layers, ListChecks, Loader2, Play, Plus } from "lucide-react";
 import toast from "react-hot-toast";
 
-const parseJsonObject = (text: string): Record<string, unknown> | undefined => {
-  if (!text.trim()) return undefined;
-  try {
-    const parsed = JSON.parse(text);
-    const isPlainObject = parsed && typeof parsed === "object" && !Array.isArray(parsed);
-    return isPlainObject ? (parsed as Record<string, unknown>) : undefined;
-  } catch {
-    return undefined;
-  }
-};
+import { PageLayout } from "@/components/PageLayout";
+import { PageHeader } from "@/components/PageHeader";
+import { Button } from "@/components/button";
+import { Badge } from "@/components/badge";
+import { PageListSkeleton } from "@/components/skeletons";
+import { cn } from "@/lib/utils";
 
-const buildTechniqueConfigs = (
-  data: EvaluationWizardData
-): Record<string, Record<string, unknown>> => {
-  const configs: Record<string, Record<string, unknown>> = {};
+import { getWorkflowsMinimal } from "@/services/workflows";
+import { listTestSuites } from "@/services/testSuites";
+import { getLLMProvidersMinimal } from "@/services/llmProviders";
+import {
+  createTestEvaluation,
+  getWorkflowEvaluationSummaries,
+  runWorkflowEvaluations,
+  WorkflowEvaluationSummary,
+} from "@/services/testEvaluations";
+import { WorkflowMinimal } from "@/interfaces/workflow.interface";
+import { TestSuite } from "@/interfaces/testSuite.interface";
+import { LLMProviderMinimal } from "@/interfaces/llmProvider.interface";
+import { EvaluationWizard, EvaluationWizardData } from "../components/EvaluationWizard";
+import { EntityTitle } from "../components/EntityTitle";
+import { buildTechniqueConfigs, wizardMetadata } from "../helpers/evaluationForm";
+import { accuracyColorClass } from "../helpers/evaluationMetrics";
 
-  if (data.metrics.includes("nli_eval")) {
-    configs.nli_eval = {
-      min_entail_score: Number(data.nliMinEntailScore || "0.5"),
-      fail_on_contradiction: data.nliFailOnContradiction,
-      ...(data.nliModelName.trim() ? {nli_model_name: data.nliModelName.trim()} : {}),
-    };
-  }
+const UNASSIGNED = "unassigned";
 
-  if (data.metrics.includes("provenance_eval")) {
-    const isLlmMode = data.provMode === "llm";
-    configs.provenance_eval = {
-      min_score: Number(data.provMinScore || "0.5"),
-      fail_on_violation: data.provFailOnViolation,
-      use_llm_judge: isLlmMode,
-      provenance_mode: data.provMode,
-      ...(isLlmMode && data.provLlmProviderId.trim()
-        ? {llm_provider_id: data.provLlmProviderId.trim()}
-        : {}),
-      ...(isLlmMode && data.provLlmJudgeSystemPromptSuffix.trim()
-        ? {llm_judge_system_prompt_suffix: data.provLlmJudgeSystemPromptSuffix.trim()}
-        : {}),
-      ...(!isLlmMode
-        ? {
-            embedding_type: data.provEmbeddingType,
-            embedding_model_name: data.provEmbeddingModelName.trim() || undefined,
-          }
-        : {}),
-    };
-  }
-
-  if (data.metrics.includes("tool_used")) {
-    // Advanced validation only applies when the tool must be called; drop it otherwise.
-    const includeAdvanced = data.toolShouldCall;
-    const expectedArgs = includeAdvanced ? parseJsonObject(data.toolExpectedArgsText) : undefined;
-    configs.tool_used = {
-      should_call: data.toolShouldCall,
-      ...(data.toolName.trim() ? {tool: data.toolName.trim()} : {}),
-      ...(data.toolNode.trim() ? {node: data.toolNode.trim()} : {}),
-      ...(expectedArgs ? {expected_args: expectedArgs} : {}),
-      ...(includeAdvanced && data.toolResultNotEmpty ? {result_not_empty: true} : {}),
-      ...(includeAdvanced && data.toolResultContains.trim()
-        ? {result_contains: data.toolResultContains.trim()}
-        : {}),
-    };
-  }
-
-  if (data.metrics.includes("route_taken")) {
-    configs.route_taken = {
-      expected: data.routeExpected.trim(),
-      ...(data.routeNode.trim() ? {node: data.routeNode.trim()} : {}),
-    };
-  }
-
-  if (data.metrics.includes("action_taken")) {
-    configs.action_taken = {
-      should_fire: data.actionShouldFire,
-      ...(data.actionNode.trim() ? {node: data.actionNode.trim()} : {}),
-      ...(data.actionNodeType.trim() ? {node_type: data.actionNodeType.trim()} : {}),
-    };
-  }
-
-  if (data.metrics.includes("llm_judge")) {
-    configs.llm_judge = {
-      rubric: data.judgeRubric.trim(),
-      min_score: Number(data.judgeMinScore || "0.5"),
-      ...(data.judgeProviderId.trim() ? {llm_provider_id: data.judgeProviderId.trim()} : {}),
-      ...(data.judgeSourceField.trim() ? {source_field: data.judgeSourceField.trim()} : {}),
-    };
-  }
-
-  return configs;
-};
+interface WorkflowRow {
+  key: string;
+  workflowId: string | null;
+  name: string;
+  count: number;
+  health: number | null;
+  finishedCount: number;
+  anyRunning: boolean;
+  isUnassigned: boolean;
+}
 
 const EvaluationsPage: React.FC = () => {
   const navigate = useNavigate();
-  const [suites, setSuites] = useState<TestSuite[]>([]);
+  const [summaries, setSummaries] = useState<WorkflowEvaluationSummary[]>([]);
   const [workflows, setWorkflows] = useState<WorkflowMinimal[]>([]);
+  const [suites, setSuites] = useState<TestSuite[]>([]);
   const [providers, setProviders] = useState<LLMProviderMinimal[]>([]);
-  const [evaluations, setEvaluations] = useState<TestEvaluationConfig[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [runningEvalIds, setRunningEvalIds] = useState<Set<string>>(new Set());
-  const [lastRunsByEvaluationId, setLastRunsByEvaluationId] = useState<
-    Record<string, TestRun | null>
-  >({});
-  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
-  const [editingEvaluation, setEditingEvaluation] = useState<TestEvaluationConfig | null>(null);
-  const [deletingEvaluationId, setDeletingEvaluationId] = useState<string | null>(null);
+  const [hasError, setHasError] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [runningWorkflowIds, setRunningWorkflowIds] = useState<Set<string>>(new Set());
+  // Synchronous guard against rapid double-clicks (state updates are async).
+  const inFlightWorkflowIds = useRef<Set<string>>(new Set());
 
   useEffect(() => {
+    let cancelled = false;
     const load = async () => {
       setIsLoading(true);
+      setHasError(false);
       try {
-        const [suiteData, workflowData, providersData, evaluationData] = await Promise.all([
-          listTestSuites(),
+        const [summaryData, workflowData, suiteData, providersData] = await Promise.all([
+          getWorkflowEvaluationSummaries(),
           getWorkflowsMinimal(),
+          listTestSuites(),
           getLLMProvidersMinimal(),
-          listTestEvaluations(),
         ]);
-        setSuites(suiteData ?? []);
+        if (cancelled) return;
+        setSummaries(summaryData ?? []);
         setWorkflows(workflowData ?? []);
-        const activeProviders = (providersData ?? []).filter((p) => p.is_active === 1);
-        setProviders(activeProviders);
-        setEvaluations(evaluationData ?? []);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    load();
-  }, []);
-
-  useEffect(() => {
-    const loadLastRuns = async () => {
-      if (!evaluations.length) {
-        setLastRunsByEvaluationId({});
-        return;
-      }
-      const runIdToEvalId: Record<string, string> = {};
-      evaluations.forEach((evaluation) => {
-        const evalId = evaluation.id;
-        const lastRunId = evaluation.run_ids?.[0];
-        if (evalId && lastRunId) {
-          runIdToEvalId[lastRunId] = evalId;
-        }
-      });
-      const runIds = Object.keys(runIdToEvalId);
-      if (!runIds.length) {
-        setLastRunsByEvaluationId({});
-        return;
-      }
-      try {
-        const runs = await getTestRunsBatch(runIds);
-        const mapping: Record<string, TestRun | null> = {};
-        (runs ?? []).forEach((run) => {
-          const evalId = run.id ? runIdToEvalId[run.id] : undefined;
-          if (evalId) mapping[evalId] = run;
-        });
-        // Fill nulls for evaluations whose run wasn't returned
-        evaluations.forEach((evaluation) => {
-          if (evaluation.id && !(evaluation.id in mapping)) {
-            mapping[evaluation.id] = null;
-          }
-        });
-        setLastRunsByEvaluationId(mapping);
+        setSuites(suiteData ?? []);
+        setProviders((providersData ?? []).filter((p) => p.is_active === 1));
       } catch {
-        setLastRunsByEvaluationId({});
+        if (!cancelled) setHasError(true);
+      } finally {
+        if (!cancelled) setIsLoading(false);
       }
     };
-    void loadLastRuns();
-  }, [evaluations]);
-
-  const handleDeleteEvaluation = async (id: string) => {
-    await deleteTestEvaluation(id);
-    setEvaluations((prev) => prev.filter((e) => e.id !== id));
-    setDeletingEvaluationId(null);
-  };
-
-  const getEditInitialData = (evaluation: TestEvaluationConfig): Partial<EvaluationWizardData> => {
-    const nliCfg = evaluation.technique_configs?.["nli_eval"] as Record<string, unknown> | undefined;
-    const provCfg = evaluation.technique_configs?.["provenance_eval"] as Record<string, unknown> | undefined;
-    const toolCfg = evaluation.technique_configs?.["tool_used"] as Record<string, unknown> | undefined;
-    const routeCfg = evaluation.technique_configs?.["route_taken"] as Record<string, unknown> | undefined;
-    const actionCfg = evaluation.technique_configs?.["action_taken"] as Record<string, unknown> | undefined;
-    const judgeCfg = evaluation.technique_configs?.["llm_judge"] as Record<string, unknown> | undefined;
-    const metaWithoutMemory = evaluation.input_metadata
-      ? Object.fromEntries(Object.entries(evaluation.input_metadata).filter(([k]) => k !== "use_memory"))
-      : {};
-
-    return {
-      name: evaluation.name,
-      description: evaluation.description ?? "",
-      suiteId: evaluation.suite_id,
-      workflowId: evaluation.workflow_id ?? "none",
-      metrics: evaluation.techniques,
-      inputMetadataText: JSON.stringify(metaWithoutMemory, null, 2),
-      useMemory: Boolean(evaluation.input_metadata?.use_memory),
-      nliModelName: (nliCfg?.nli_model_name as string) ?? "cross-encoder/nli-deberta-v3-base",
-      nliMinEntailScore: String(nliCfg?.min_entail_score ?? "0.5"),
-      nliFailOnContradiction: Boolean(nliCfg?.fail_on_contradiction),
-      provMode: (provCfg?.provenance_mode as "embeddings" | "llm") ?? "embeddings",
-      provEmbeddingType: (provCfg?.embedding_type as "openai" | "huggingface" | "bedrock") ?? "huggingface",
-      provEmbeddingModelName: (provCfg?.embedding_model_name as string) ?? "all-MiniLM-L6-v2",
-      provMinScore: String(provCfg?.min_score ?? "0.5"),
-      provFailOnViolation: Boolean(provCfg?.fail_on_violation),
-      provLlmProviderId: (provCfg?.llm_provider_id as string) ?? providers[0]?.id ?? "",
-      provLlmJudgeSystemPromptSuffix: (provCfg?.llm_judge_system_prompt_suffix as string) ?? "",
-      toolName: (toolCfg?.tool as string) ?? "",
-      toolShouldCall: toolCfg?.should_call === undefined ? true : Boolean(toolCfg.should_call),
-      toolExpectedArgsText: toolCfg?.expected_args
-        ? JSON.stringify(toolCfg.expected_args, null, 2)
-        : "",
-      toolNode: (toolCfg?.node as string) ?? "",
-      toolResultNotEmpty: Boolean(toolCfg?.result_not_empty),
-      toolResultContains: (toolCfg?.result_contains as string) ?? "",
-      routeExpected: (routeCfg?.expected as string) ?? "",
-      routeNode: (routeCfg?.node as string) ?? "",
-      actionNode: (actionCfg?.node as string) ?? "",
-      actionNodeType: (actionCfg?.node_type as string) ?? "",
-      actionShouldFire: actionCfg?.should_fire === undefined ? true : Boolean(actionCfg.should_fire),
-      judgeRubric: (judgeCfg?.rubric as string) ?? "",
-      judgeMinScore: String(judgeCfg?.min_score ?? "0.5"),
-      judgeProviderId: (judgeCfg?.llm_provider_id as string) ?? providers[0]?.id ?? "",
-      judgeSourceField: (judgeCfg?.source_field as string) ?? "",
+    void load();
+    return () => {
+      cancelled = true;
     };
-  };
+  }, [reloadKey]);
 
-  const handleEditWizardSubmit = async (data: EvaluationWizardData) => {
-    if (!editingEvaluation?.id) return;
-
-    let parsedMetadata: Record<string, unknown> | undefined;
-    try {
-      const parsed = JSON.parse(data.inputMetadataText || "{}");
-      parsedMetadata = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : undefined;
-    } catch {
-      parsedMetadata = undefined;
-    }
-    if (data.useMemory) {
-      parsedMetadata = { ...(parsedMetadata ?? {}), use_memory: true };
-    } else if (parsedMetadata) {
-      delete parsedMetadata["use_memory"];
-    }
-
-    const updated = await updateTestEvaluation(editingEvaluation.id, {
-      name: data.name.trim(),
-      description: data.description.trim() || undefined,
-      suite_id: data.suiteId,
-      workflow_id: data.workflowId === "none" ? undefined : data.workflowId,
-      techniques: data.metrics,
-      technique_configs: buildTechniqueConfigs(data),
-      input_metadata: parsedMetadata,
-    });
-
-    if (!updated) return;
-    setEvaluations((prev) => prev.map((e) => (e.id === updated.id ? updated : e)));
-    setEditingEvaluation(null);
-    toast.success("Evaluation updated successfully");
-  };
-
-  const handleQuickRun = async (evaluation: TestEvaluationConfig, e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (!evaluation.id) return;
-
-    setRunningEvalIds((prev) => new Set(prev).add(evaluation.id));
-    try {
-      let runMetadata = evaluation.input_metadata ?? undefined;
-      if (runMetadata?.use_memory) {
-        runMetadata = { ...runMetadata, thread_id: crypto.randomUUID() };
+  // While any workflow is running, refresh summaries so health and the running
+  // state settle back once its batch finishes (no skeleton — silent refetch).
+  const hasRunningWorkflow = useMemo(() => summaries.some((s) => s.any_running), [summaries]);
+  useEffect(() => {
+    if (!hasRunningWorkflow) return;
+    let cancelled = false;
+    const poll = async () => {
+      if (cancelled) return;
+      try {
+        const data = await getWorkflowEvaluationSummaries();
+        if (!cancelled && data) setSummaries(data);
+      } catch {
+        // transient — keep polling
       }
-      const created = await startTestRun(evaluation.suite_id, {
-        techniques: evaluation.techniques,
-        technique_configs: evaluation.technique_configs,
-        workflow_id: evaluation.workflow_id,
-        input_metadata: runMetadata,
+      if (!cancelled) window.setTimeout(poll, 4000);
+    };
+    const timer = window.setTimeout(poll, 4000);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [hasRunningWorkflow]);
+
+  const rows = useMemo<WorkflowRow[]>(() => {
+    const nameFor = (workflowId: string | null): string => {
+      if (workflowId === null) return "Unassigned evaluations";
+      return workflows.find((w) => w.id === workflowId)?.name ?? "Unknown workflow";
+    };
+    const query = searchQuery.trim().toLowerCase();
+    return summaries
+      .map((summary) => ({
+        key: summary.workflow_id ?? UNASSIGNED,
+        workflowId: summary.workflow_id,
+        name: nameFor(summary.workflow_id),
+        count: summary.eval_count,
+        health: summary.health,
+        finishedCount: summary.finished_count,
+        anyRunning: summary.any_running,
+        isUnassigned: summary.workflow_id === null,
+      }))
+      .filter((row) => !query || row.name.toLowerCase().includes(query))
+      .sort((a, b) => {
+        if (a.isUnassigned) return 1;
+        if (b.isUnassigned) return -1;
+        return a.name.localeCompare(b.name);
       });
-      if (created?.id) {
-        await appendRunToEvaluation(evaluation.id, created.id);
-        // Update the last run for this evaluation
-        setLastRunsByEvaluationId((prev) => ({ ...prev, [evaluation.id]: created }));
-        toast.success("Evaluation started successfully");
-        navigate(`/tests/evaluations/${evaluation.id}`);
+  }, [summaries, workflows, searchQuery]);
+
+  const openWorkflow = (row: WorkflowRow) => {
+    navigate(`/tests/evaluations/workflows/${row.workflowId ?? UNASSIGNED}`);
+  };
+
+  const markWorkflowRunning = (workflowId: string) => {
+    setSummaries((prev) =>
+      prev.map((summary) =>
+        summary.workflow_id === workflowId ? { ...summary, any_running: true } : summary,
+      ),
+    );
+  };
+
+  const handleRunAll = async (workflowId: string) => {
+    if (inFlightWorkflowIds.current.has(workflowId)) return;
+    inFlightWorkflowIds.current.add(workflowId);
+    setRunningWorkflowIds((prev) => new Set(prev).add(workflowId));
+    try {
+      const started = await runWorkflowEvaluations(workflowId);
+      const startedCount = (started ?? []).filter((s) => s.run_id).length;
+      if (!startedCount) {
+        toast.error("No evaluations could be started for this workflow");
+      } else {
+        toast.success(`Started ${startedCount} evaluation${startedCount !== 1 ? "s" : ""}`);
+        markWorkflowRunning(workflowId);
       }
-    } catch (err) {
-      toast.error("Failed to start evaluation");
+    } catch (error) {
+      const status = (error as { response?: { status?: number } })?.response?.status;
+      if (status === 409) {
+        toast.error("This workflow already has running evaluations");
+        markWorkflowRunning(workflowId);
+      } else {
+        toast.error("Failed to start evaluations for this workflow");
+      }
     } finally {
-      setRunningEvalIds((prev) => {
+      inFlightWorkflowIds.current.delete(workflowId);
+      setRunningWorkflowIds((prev) => {
         const next = new Set(prev);
-        next.delete(evaluation.id);
+        next.delete(workflowId);
         return next;
       });
     }
   };
 
-  const handleWizardSubmit = async (data: EvaluationWizardData) => {
-    let parsedMetadata: Record<string, unknown> | undefined;
-    try {
-      const parsed = JSON.parse(data.inputMetadataText || "{}");
-      parsedMetadata =
-        parsed && typeof parsed === "object"
-          ? (parsed as Record<string, unknown>)
-          : undefined;
-    } catch {
-      parsedMetadata = undefined;
-    }
-    if (data.useMemory) {
-      parsedMetadata = { ...(parsedMetadata ?? {}), use_memory: true };
-    } else if (parsedMetadata) {
-      delete parsedMetadata["use_memory"];
-    }
-
+  const handleCreate = async (data: EvaluationWizardData) => {
     const created = await createTestEvaluation({
       name: data.name.trim(),
       description: data.description.trim() || undefined,
@@ -337,47 +183,91 @@ const EvaluationsPage: React.FC = () => {
       workflow_id: data.workflowId === "none" ? undefined : data.workflowId,
       techniques: data.metrics,
       technique_configs: buildTechniqueConfigs(data),
-      input_metadata: parsedMetadata,
+      input_metadata: wizardMetadata(data),
     });
     if (!created) return;
     setIsCreateDialogOpen(false);
     navigate(`/tests/evaluations/${created.id}`);
   };
 
-  const getAverageAccuracy = (evaluation: TestEvaluationConfig): number | null => {
-    if (!evaluation.id) return null;
-    const lastRun = lastRunsByEvaluationId[evaluation.id];
-    if (!lastRun?.summary_metrics) return null;
-
-    const metrics = lastRun.summary_metrics as Record<
-      string,
-      { accuracy?: number; avg_score?: number; cases?: number }
-    >;
-    const accuracies = Object.values(metrics)
-      .map((m) => m.accuracy)
-      .filter((a): a is number => typeof a === "number");
-
-    if (accuracies.length === 0) return null;
-    return accuracies.reduce((sum, a) => sum + a, 0) / accuracies.length;
-  };
-
-  const filteredEvaluations = evaluations.filter((evaluation) => {
-    const query = searchQuery.trim().toLowerCase();
-    if (!query) return true;
+  const renderRow = (row: WorkflowRow) => {
+    const isPending = row.workflowId ? runningWorkflowIds.has(row.workflowId) : false;
+    const isRunning = isPending || row.anyRunning;
+    const healthTooltip = row.anyRunning
+      ? row.health !== null
+        ? "Evaluations running; health shown is from the previous completed runs."
+        : "Evaluations are running…"
+      : row.health !== null
+        ? `Health from ${row.finishedCount} of ${row.count} evaluation${
+            row.count !== 1 ? "s" : ""
+          } (failed runs count as 0%)`
+        : "No evaluations scored yet";
     return (
-      evaluation.name.toLowerCase().includes(query) ||
-      (evaluation.description ?? "").toLowerCase().includes(query)
+      <tr
+        key={row.key}
+        onClick={() => openWorkflow(row)}
+        className="hover:bg-gray-50 transition-colors cursor-pointer"
+      >
+        <td className="px-6 py-4">
+          <div className="flex items-center gap-2 min-w-0">
+            <Layers className="h-4 w-4 text-gray-400 shrink-0" />
+            <EntityTitle muted={row.isUnassigned}>{row.name}</EntityTitle>
+          </div>
+        </td>
+        <td className="px-6 py-4">
+          <div className="flex items-center gap-1.5" title={healthTooltip}>
+            {row.anyRunning ? (
+              <Loader2 className="h-3.5 w-3.5 text-blue-600 animate-spin" />
+            ) : (
+              <Activity className="h-3.5 w-3.5 text-gray-400" />
+            )}
+            {row.health !== null ? (
+              <span className={cn("font-medium", accuracyColorClass(row.health))}>
+                {Math.round(row.health * 100)}%
+              </span>
+            ) : row.anyRunning ? (
+              <span className="text-blue-600">Running…</span>
+            ) : (
+              <span className="text-gray-400">No scores yet</span>
+            )}
+          </div>
+        </td>
+        <td className="px-6 py-4">
+          <Badge variant="secondary">
+            {row.count} eval{row.count !== 1 ? "s" : ""}
+          </Badge>
+        </td>
+        <td className="px-6 py-4" onClick={(e) => e.stopPropagation()}>
+          <div className="flex items-center justify-end gap-2">
+            {!row.isUnassigned && row.count > 0 && row.workflowId && (
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={isRunning}
+                onClick={() => handleRunAll(row.workflowId as string)}
+              >
+                <Play className="h-3.5 w-3.5 mr-1" />
+                {isRunning ? "Running..." : "Run all"}
+              </Button>
+            )}
+            <Button variant="ghost" size="sm" onClick={() => openWorkflow(row)}>
+              Open
+              <ChevronRight className="h-4 w-4 ml-1" />
+            </Button>
+          </div>
+        </td>
+      </tr>
     );
-  });
+  };
 
   return (
     <PageLayout>
       <PageHeader
         title="Evaluations"
-        subtitle="Create and execute evaluations by linking dataset, workflow, metadata, and metrics."
+        subtitle="Grouped by workflow. Open a workflow to view and run its evaluations."
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
-        searchPlaceholder="Search evaluations..."
+        searchPlaceholder="Search workflows..."
         actionButtonText="New Evaluation"
         onActionClick={() => setIsCreateDialogOpen(true)}
       />
@@ -385,7 +275,14 @@ const EvaluationsPage: React.FC = () => {
       <div className="rounded-lg border bg-white overflow-hidden">
         {isLoading ? (
           <PageListSkeleton variant="evaluation" bordered={false} />
-        ) : filteredEvaluations.length === 0 ? (
+        ) : hasError ? (
+          <div className="py-16 text-center">
+            <p className="text-sm text-gray-500 mb-3">Couldn't load evaluations.</p>
+            <Button variant="outline" onClick={() => setReloadKey((key) => key + 1)}>
+              Retry
+            </Button>
+          </div>
+        ) : rows.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-16 gap-4 text-center">
             <div className="rounded-full bg-gray-100 p-4">
               <ListChecks className="h-12 w-12 text-gray-400" />
@@ -393,7 +290,7 @@ const EvaluationsPage: React.FC = () => {
             <h3 className="font-medium text-lg">No evaluations yet</h3>
             <p className="text-sm text-gray-500 max-w-sm">
               {searchQuery
-                ? "No evaluations match your search. Try adjusting your query."
+                ? "No workflows match your search."
                 : "Evaluations help you test your AI agents against golden datasets. Create your first evaluation to get started."}
             </p>
             {!searchQuery && (
@@ -404,148 +301,26 @@ const EvaluationsPage: React.FC = () => {
             )}
           </div>
         ) : (
-          <div className="divide-y divide-gray-100">
-            {filteredEvaluations.map((evaluation) => {
-              const avgAccuracy = getAverageAccuracy(evaluation);
-              const isRunning = evaluation.id ? runningEvalIds.has(evaluation.id) : false;
-
-              return (
-                <div
-                  key={evaluation.id}
-                  className="w-full py-4 px-6 text-left hover:bg-gray-50 transition-colors"
-                >
-                  <div className="flex items-center justify-between gap-4">
-                    <button
-                      type="button"
-                      onClick={() => navigate(`/tests/evaluations/${evaluation.id}`)}
-                      className="flex-1 min-w-0 text-left"
-                    >
-                      <div className="flex items-center gap-2">
-                        <div className="text-lg font-semibold truncate">
-                          {evaluation.name}
-                        </div>
-                        <Badge variant="secondary" className="shrink-0 text-[10px] px-1.5">
-                          EVAL
-                        </Badge>
-                      </div>
-                      <p className="text-sm text-gray-500 mt-1 line-clamp-1">
-                        {evaluation.description || "No description"}
-                      </p>
-
-                      {/* Accuracy progress bar */}
-                      {avgAccuracy !== null && (
-                        <div className="flex items-center gap-2 mt-2">
-                          <Progress
-                            value={avgAccuracy * 100}
-                            className="h-2 w-32 bg-gray-100"
-                          />
-                          <span
-                            className={`text-xs font-medium ${
-                              avgAccuracy >= 0.9
-                                ? "text-green-600"
-                                : avgAccuracy >= 0.7
-                                ? "text-amber-600"
-                                : "text-red-600"
-                            }`}
-                          >
-                            {Math.round(avgAccuracy * 100)}% accuracy
-                          </span>
-                          <span className="text-xs text-gray-400">
-                            ({evaluation.run_ids.length} run{evaluation.run_ids.length !== 1 ? "s" : ""})
-                          </span>
-                        </div>
-                      )}
-
-                      {/* Metrics badges */}
-                      <div className="flex flex-wrap items-center gap-1 mt-2">
-                        <span className="text-xs text-gray-500 mr-1">Metrics:</span>
-                        {evaluation.techniques.map((tech) => (
-                          <Badge key={tech} variant="outline" className="text-[10px] px-1.5 py-0">
-                            {tech}
-                          </Badge>
-                        ))}
-                      </div>
-                    </button>
-
-                    <div className="flex items-center gap-1 shrink-0">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8"
-                        aria-label="Edit evaluation"
-                        onClick={() => setEditingEvaluation(evaluation)}
-                      >
-                        <Pencil className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8"
-                        aria-label="Delete evaluation"
-                        onClick={() => setDeletingEvaluationId(evaluation.id ?? null)}
-                      >
-                        <Trash2 className="h-4 w-4 text-red-500" />
-                      </Button>
-                      <Button
-                        size="sm"
-                        className="ml-1"
-                        disabled={isRunning}
-                        onClick={(e) => handleQuickRun(evaluation, e)}
-                      >
-                        <Play className="h-3.5 w-3.5 mr-1" />
-                        {isRunning ? "Running..." : "Run"}
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-gray-50 text-left text-xs font-medium uppercase tracking-wide text-gray-500">
+                  <th className="px-6 py-3 font-medium">Workflow</th>
+                  <th className="px-6 py-3 font-medium">Health</th>
+                  <th className="px-6 py-3 font-medium">Evaluations</th>
+                  <th className="px-6 py-3 font-medium text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">{rows.map(renderRow)}</tbody>
+            </table>
           </div>
         )}
       </div>
 
-      {/* Edit Wizard */}
-      {editingEvaluation && (
-        <EvaluationWizard
-          isOpen={!!editingEvaluation}
-          onOpenChange={(open) => { if (!open) setEditingEvaluation(null); }}
-          onSubmit={handleEditWizardSubmit}
-          suites={suites}
-          workflows={workflows}
-          providers={providers}
-          mode="edit"
-          initialData={getEditInitialData(editingEvaluation)}
-        />
-      )}
-
-      {/* Delete Confirmation Dialog */}
-      <Dialog open={!!deletingEvaluationId} onOpenChange={(open) => { if (!open) setDeletingEvaluationId(null); }}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>Delete Evaluation</DialogTitle>
-          </DialogHeader>
-          <p className="text-sm text-gray-600">
-            Are you sure you want to delete this evaluation? This will also permanently delete all
-            associated runs and their results. This action cannot be undone.
-          </p>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setDeletingEvaluationId(null)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={() => deletingEvaluationId && handleDeleteEvaluation(deletingEvaluationId)}
-            >
-              Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
       <EvaluationWizard
         isOpen={isCreateDialogOpen}
         onOpenChange={setIsCreateDialogOpen}
-        onSubmit={handleWizardSubmit}
+        onSubmit={handleCreate}
         suites={suites}
         workflows={workflows}
         providers={providers}
@@ -556,4 +331,3 @@ const EvaluationsPage: React.FC = () => {
 };
 
 export default EvaluationsPage;
-

--- a/frontend/src/views/TestSuites/pages/WorkflowEvaluationsPage.tsx
+++ b/frontend/src/views/TestSuites/pages/WorkflowEvaluationsPage.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, ListChecks, Loader2, Play, Plus, Search } from "lucide-react";
 import toast from "react-hot-toast";
 
@@ -23,7 +24,6 @@ import {
   appendRunToEvaluation,
   deleteTestEvaluation,
   getWorkflowEvaluationsPage,
-  PaginatedEvaluations,
   runWorkflowEvaluations,
   updateTestEvaluation,
 } from "@/services/testEvaluations";
@@ -37,6 +37,7 @@ import { buildTechniqueConfigs, getEditInitialData, wizardMetadata } from "../he
 
 const PAGE_SIZE = 20;
 const UNASSIGNED = "unassigned";
+const RUNNING_POLL_MS = 5000;
 
 const WorkflowEvaluationsPage: React.FC = () => {
   const navigate = useNavigate();
@@ -47,13 +48,9 @@ const WorkflowEvaluationsPage: React.FC = () => {
   const [suites, setSuites] = useState<TestSuite[]>([]);
   const [providers, setProviders] = useState<LLMProviderMinimal[]>([]);
 
-  const [pageData, setPageData] = useState<PaginatedEvaluations | null>(null);
   const [page, setPage] = useState(1);
   const [searchInput, setSearchInput] = useState("");
   const [search, setSearch] = useState("");
-  const [isLoading, setIsLoading] = useState(true);
-  const [hasError, setHasError] = useState(false);
-  const [reloadKey, setReloadKey] = useState(0);
 
   const [lastRunsByEvaluationId, setLastRunsByEvaluationId] = useState<
     Record<string, TestRun | null>
@@ -98,6 +95,28 @@ const WorkflowEvaluationsPage: React.FC = () => {
   const [editingEvaluation, setEditingEvaluation] = useState<TestEvaluationConfig | null>(null);
   const [deletingEvaluationId, setDeletingEvaluationId] = useState<string | null>(null);
 
+  // staleTime 0 makes react-query refetch this when the tab regains focus. The
+  // interval is the page's only poll: it runs when a batch is active that this
+  // session isn't already tracking, and react-query pauses it in a hidden tab.
+  const {
+    data: pageData = null,
+    dataUpdatedAt,
+    isPending: isLoading,
+    isError: hasError,
+    refetch: refetchPage,
+  } = useQuery({
+    queryKey: ["workflow-evaluations", workflowId, page, search],
+    queryFn: async () =>
+      (await getWorkflowEvaluationsPage(workflowId, {
+        page,
+        pageSize: PAGE_SIZE,
+        search,
+      })) ?? null,
+    staleTime: 0,
+    refetchInterval: (query) =>
+      query.state.data?.any_running && !isWorkflowRunning ? RUNNING_POLL_MS : false,
+  });
+
   const evaluations = pageData?.items ?? [];
   const total = pageData?.total ?? 0;
   const totalUnfiltered = pageData?.total_unfiltered ?? 0;
@@ -128,30 +147,6 @@ const WorkflowEvaluationsPage: React.FC = () => {
     return () => window.clearTimeout(timer);
   }, [searchInput]);
 
-  useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
-      setIsLoading(true);
-      setHasError(false);
-      try {
-        const data = await getWorkflowEvaluationsPage(workflowId, {
-          page,
-          pageSize: PAGE_SIZE,
-          search,
-        });
-        if (!cancelled) setPageData(data ?? null);
-      } catch {
-        if (!cancelled) setHasError(true);
-      } finally {
-        if (!cancelled) setIsLoading(false);
-      }
-    };
-    void load();
-    return () => {
-      cancelled = true;
-    };
-  }, [workflowId, page, search, reloadKey]);
-
   // Load the latest run for each evaluation on the page.
   useEffect(() => {
     const loadLastRuns = async () => {
@@ -179,82 +174,10 @@ const WorkflowEvaluationsPage: React.FC = () => {
       }
     };
     void loadLastRuns();
-  }, [pageData]);
-
-  // Keep in-flight runs fresh so "Running" clears after they finish (even post-refresh).
-  const activeRunIds = useMemo(
-    () =>
-      Object.values(lastRunsByEvaluationId)
-        .filter(
-          (run): run is TestRun =>
-            !!run && (run.status === "queued" || run.status === "running"),
-        )
-        .map((run) => run.id)
-        .sort()
-        .join(","),
-    [lastRunsByEvaluationId],
-  );
-  useEffect(() => {
-    if (!activeRunIds) return;
-    const runIds = activeRunIds.split(",");
-    let cancelled = false;
-    const poll = async () => {
-      if (cancelled) return;
-      try {
-        const runs = await getTestRunsBatch(runIds);
-        setLastRunsByEvaluationId((prev) => {
-          const runIdToEvalId: Record<string, string> = {};
-          Object.entries(prev).forEach(([evalId, run]) => {
-            if (run?.id) runIdToEvalId[run.id] = evalId;
-          });
-          let changed = false;
-          const next = { ...prev };
-          (runs ?? []).forEach((run) => {
-            const evalId = run?.id ? runIdToEvalId[run.id] : undefined;
-            if (evalId && next[evalId]?.status !== run.status) {
-              next[evalId] = run;
-              changed = true;
-            }
-          });
-          return changed ? next : prev;
-        });
-      } catch {
-        // transient — keep polling
-      }
-      if (!cancelled) window.setTimeout(poll, 3000);
-    };
-    const timer = window.setTimeout(poll, 3000);
-    return () => {
-      cancelled = true;
-      window.clearTimeout(timer);
-    };
-  }, [activeRunIds]);
-
-  // A batch may be running from another page/tab. While any_running is set,
-  // silently refetch so the workflow-level "Running" state clears when it ends.
-  useEffect(() => {
-    if (!pageData?.any_running) return;
-    let cancelled = false;
-    const poll = async () => {
-      if (cancelled) return;
-      try {
-        const data = await getWorkflowEvaluationsPage(workflowId, {
-          page,
-          pageSize: PAGE_SIZE,
-          search,
-        });
-        if (!cancelled && data) setPageData(data);
-      } catch {
-        // transient — keep polling
-      }
-      if (!cancelled) window.setTimeout(poll, 4000);
-    };
-    const timer = window.setTimeout(poll, 4000);
-    return () => {
-      cancelled = true;
-      window.clearTimeout(timer);
-    };
-  }, [pageData?.any_running, workflowId, page, search]);
+    // Keyed on dataUpdatedAt, not pageData: react-query's structural sharing keeps
+    // the same object reference when a poll returns identical rows, but run status
+    // lives in test_runs — so it must refresh on every fetch, not only on change.
+  }, [dataUpdatedAt]);
 
   const isEvaluationRunning = (evaluation: TestEvaluationConfig): boolean => {
     if (evaluation.id && runningEvalIds.has(evaluation.id)) return true;
@@ -292,6 +215,7 @@ const WorkflowEvaluationsPage: React.FC = () => {
         await appendRunToEvaluation(evaluation.id, created.id);
         setLastRunsByEvaluationId((prev) => ({ ...prev, [evaluation.id as string]: created }));
         toast.success("Evaluation started");
+        void refetchPage(); // any_running turns on, which starts the status poll
       }
     } catch {
       toast.error("Failed to start evaluation");
@@ -317,6 +241,7 @@ const WorkflowEvaluationsPage: React.FC = () => {
       if (isStale()) return; // don't touch another workflow's guard/progress
       isRunAllInFlight.current = false;
       setIsWorkflowRunning(false);
+      void refetchPage(); // settle any_running/health once the batch ends
     };
 
     try {
@@ -347,6 +272,11 @@ const WorkflowEvaluationsPage: React.FC = () => {
       const maxPollErrors = 5;
       const poll = async () => {
         if (isStale()) return;
+        // Don't poll a hidden tab; pick back up on the next tick.
+        if (document.visibilityState !== "visible") {
+          runAllPollTimer.current = window.setTimeout(poll, RUNNING_POLL_MS);
+          return;
+        }
         try {
           const runs = await getTestRunsBatch(runIds);
           consecutivePollErrors = 0;
@@ -373,7 +303,7 @@ const WorkflowEvaluationsPage: React.FC = () => {
             return;
           }
         }
-        if (!isStale()) runAllPollTimer.current = window.setTimeout(poll, 3000);
+        if (!isStale()) runAllPollTimer.current = window.setTimeout(poll, RUNNING_POLL_MS);
       };
       runAllPollTimer.current = window.setTimeout(poll, 2000);
     } catch (error) {
@@ -381,7 +311,7 @@ const WorkflowEvaluationsPage: React.FC = () => {
       const status = (error as { response?: { status?: number } })?.response?.status;
       if (status === 409) {
         toast.error("This workflow already has running evaluations");
-        setReloadKey((key) => key + 1); // refetch so any_running blocks the button
+        void refetchPage(); // refetch so any_running blocks the button
       } else {
         toast.error("Failed to start evaluations");
       }
@@ -389,31 +319,57 @@ const WorkflowEvaluationsPage: React.FC = () => {
     }
   };
 
+  // The backend refuses (409) if the evaluation started running since the page
+  // loaded, so a stale UI can't edit or delete a run in flight.
+  const isRunningConflict = (error: unknown): boolean =>
+    (error as { response?: { status?: number } })?.response?.status === 409;
+
   const handleEditSubmit = async (data: EvaluationWizardData) => {
     if (!editingEvaluation?.id) return;
-    const updated = await updateTestEvaluation(editingEvaluation.id, {
-      name: data.name.trim(),
-      description: data.description.trim() || undefined,
-      suite_id: data.suiteId,
-      workflow_id: data.workflowId === "none" ? undefined : data.workflowId,
-      techniques: data.metrics,
-      technique_configs: buildTechniqueConfigs(data),
-      input_metadata: wizardMetadata(data),
-    });
-    if (!updated) return;
-    setEditingEvaluation(null);
-    toast.success("Evaluation updated");
-    setReloadKey((key) => key + 1); // its workflow may have changed — refetch the page
+    try {
+      const updated = await updateTestEvaluation(editingEvaluation.id, {
+        name: data.name.trim(),
+        description: data.description.trim() || undefined,
+        suite_id: data.suiteId,
+        workflow_id: data.workflowId === "none" ? undefined : data.workflowId,
+        techniques: data.metrics,
+        technique_configs: buildTechniqueConfigs(data),
+        input_metadata: wizardMetadata(data),
+      });
+      if (!updated) return;
+      setEditingEvaluation(null);
+      toast.success("Evaluation updated");
+      void refetchPage(); // its workflow may have changed — refetch the page
+    } catch (error) {
+      if (isRunningConflict(error)) {
+        toast.error("This evaluation is running. Wait for it to finish before editing.");
+        setEditingEvaluation(null);
+        void refetchPage();
+      } else {
+        toast.error("Failed to update evaluation");
+      }
+    }
   };
 
   const handleDelete = async (id: string) => {
-    await deleteTestEvaluation(id);
+    try {
+      await deleteTestEvaluation(id);
+    } catch (error) {
+      setDeletingEvaluationId(null);
+      if (isRunningConflict(error)) {
+        toast.error("This evaluation is running. Wait for it to finish before deleting.");
+        void refetchPage();
+      } else {
+        toast.error("Failed to delete evaluation");
+      }
+      return;
+    }
     setDeletingEvaluationId(null);
     toast.success("Evaluation deleted");
     if (evaluations.length === 1 && page > 1) {
       setPage((current) => current - 1);
     } else {
-      setReloadKey((key) => key + 1);
+      void refetchPage();
     }
   };
 
@@ -484,7 +440,7 @@ const WorkflowEvaluationsPage: React.FC = () => {
         ) : hasError ? (
           <div className="py-16 text-center">
             <p className="text-sm text-gray-500 mb-3">Couldn't load evaluations.</p>
-            <Button variant="outline" onClick={() => setReloadKey((key) => key + 1)}>
+            <Button variant="outline" onClick={() => void refetchPage()}>
               Retry
             </Button>
           </div>

--- a/frontend/src/views/TestSuites/pages/WorkflowEvaluationsPage.tsx
+++ b/frontend/src/views/TestSuites/pages/WorkflowEvaluationsPage.tsx
@@ -1,0 +1,585 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { ArrowLeft, ListChecks, Loader2, Play, Plus, Search } from "lucide-react";
+import toast from "react-hot-toast";
+
+import { PageLayout } from "@/components/PageLayout";
+import { Button } from "@/components/button";
+import { Badge } from "@/components/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/dialog";
+import { PaginationBar } from "@/components/PaginationBar";
+import { PageListSkeleton } from "@/components/skeletons";
+
+import { getWorkflowsMinimal } from "@/services/workflows";
+import { getTestRunsBatch, listTestSuites, startTestRun } from "@/services/testSuites";
+import { getLLMProvidersMinimal } from "@/services/llmProviders";
+import {
+  appendRunToEvaluation,
+  deleteTestEvaluation,
+  getWorkflowEvaluationsPage,
+  PaginatedEvaluations,
+  runWorkflowEvaluations,
+  updateTestEvaluation,
+} from "@/services/testEvaluations";
+import { TestEvaluationConfig } from "@/interfaces/testEvaluation.interface";
+import { WorkflowMinimal } from "@/interfaces/workflow.interface";
+import { TestRun, TestSuite } from "@/interfaces/testSuite.interface";
+import { LLMProviderMinimal } from "@/interfaces/llmProvider.interface";
+import { EvaluationWizard, EvaluationWizardData } from "../components/EvaluationWizard";
+import { EvaluationListRow } from "../components/EvaluationListRow";
+import { buildTechniqueConfigs, getEditInitialData, wizardMetadata } from "../helpers/evaluationForm";
+
+const PAGE_SIZE = 20;
+const UNASSIGNED = "unassigned";
+
+const WorkflowEvaluationsPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { workflowId = "" } = useParams();
+  const isUnassigned = workflowId === UNASSIGNED;
+
+  const [workflows, setWorkflows] = useState<WorkflowMinimal[]>([]);
+  const [suites, setSuites] = useState<TestSuite[]>([]);
+  const [providers, setProviders] = useState<LLMProviderMinimal[]>([]);
+
+  const [pageData, setPageData] = useState<PaginatedEvaluations | null>(null);
+  const [page, setPage] = useState(1);
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const [lastRunsByEvaluationId, setLastRunsByEvaluationId] = useState<
+    Record<string, TestRun | null>
+  >({});
+  const [runningEvalIds, setRunningEvalIds] = useState<Set<string>>(new Set());
+  const [isWorkflowRunning, setIsWorkflowRunning] = useState(false);
+  const [workflowProgress, setWorkflowProgress] = useState<{ done: number; total: number } | null>(
+    null,
+  );
+  // Synchronous guard against a rapid double-click (state updates are async).
+  const isRunAllInFlight = useRef(false);
+  const runAllPollTimer = useRef<number | null>(null);
+  // Bumped whenever the Run-all poll must be abandoned (unmount or workflow switch)
+  // so an in-flight poll from a previous context can't apply to the current one.
+  const runAllEpoch = useRef(0);
+  const isMounted = useRef(true);
+
+  // Set true on setup so React Strict Mode's setup/cleanup/setup cycle leaves it true.
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  // React Router reuses this component across workflows, so when the id changes
+  // abandon the previous workflow's Run-all poll and reset its guard/progress —
+  // otherwise workflow A's poll could land on workflow B's page.
+  useEffect(() => {
+    return () => {
+      runAllEpoch.current += 1;
+      if (runAllPollTimer.current) {
+        window.clearTimeout(runAllPollTimer.current);
+        runAllPollTimer.current = null;
+      }
+      isRunAllInFlight.current = false;
+      setIsWorkflowRunning(false);
+      setWorkflowProgress(null);
+    };
+  }, [workflowId]);
+
+  const [editingEvaluation, setEditingEvaluation] = useState<TestEvaluationConfig | null>(null);
+  const [deletingEvaluationId, setDeletingEvaluationId] = useState<string | null>(null);
+
+  const evaluations = pageData?.items ?? [];
+  const total = pageData?.total ?? 0;
+  const totalUnfiltered = pageData?.total_unfiltered ?? 0;
+  const workflowName = isUnassigned
+    ? "Unassigned evaluations"
+    : workflows.find((w) => w.id === workflowId)?.name ?? "Workflow";
+
+  useEffect(() => {
+    const load = async () => {
+      const [workflowData, suiteData, providersData] = await Promise.all([
+        getWorkflowsMinimal(),
+        listTestSuites(),
+        getLLMProvidersMinimal(),
+      ]);
+      setWorkflows(workflowData ?? []);
+      setSuites(suiteData ?? []);
+      setProviders((providersData ?? []).filter((p) => p.is_active === 1));
+    };
+    void load();
+  }, []);
+
+  // Debounce the search box and reset to the first page when it changes.
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setSearch(searchInput);
+      setPage(1);
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [searchInput]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setIsLoading(true);
+      setHasError(false);
+      try {
+        const data = await getWorkflowEvaluationsPage(workflowId, {
+          page,
+          pageSize: PAGE_SIZE,
+          search,
+        });
+        if (!cancelled) setPageData(data ?? null);
+      } catch {
+        if (!cancelled) setHasError(true);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [workflowId, page, search, reloadKey]);
+
+  // Load the latest run for each evaluation on the page.
+  useEffect(() => {
+    const loadLastRuns = async () => {
+      const items = pageData?.items ?? [];
+      const runIdToEvalId: Record<string, string> = {};
+      items.forEach((evaluation) => {
+        const lastRunId = evaluation.run_ids?.[0];
+        if (evaluation.id && lastRunId) runIdToEvalId[lastRunId] = evaluation.id;
+      });
+      const runIds = Object.keys(runIdToEvalId);
+      if (!runIds.length) {
+        setLastRunsByEvaluationId({});
+        return;
+      }
+      try {
+        const runs = await getTestRunsBatch(runIds);
+        const mapping: Record<string, TestRun | null> = {};
+        (runs ?? []).forEach((run) => {
+          const evalId = run.id ? runIdToEvalId[run.id] : undefined;
+          if (evalId) mapping[evalId] = run;
+        });
+        setLastRunsByEvaluationId(mapping);
+      } catch {
+        setLastRunsByEvaluationId({});
+      }
+    };
+    void loadLastRuns();
+  }, [pageData]);
+
+  // Keep in-flight runs fresh so "Running" clears after they finish (even post-refresh).
+  const activeRunIds = useMemo(
+    () =>
+      Object.values(lastRunsByEvaluationId)
+        .filter(
+          (run): run is TestRun =>
+            !!run && (run.status === "queued" || run.status === "running"),
+        )
+        .map((run) => run.id)
+        .sort()
+        .join(","),
+    [lastRunsByEvaluationId],
+  );
+  useEffect(() => {
+    if (!activeRunIds) return;
+    const runIds = activeRunIds.split(",");
+    let cancelled = false;
+    const poll = async () => {
+      if (cancelled) return;
+      try {
+        const runs = await getTestRunsBatch(runIds);
+        setLastRunsByEvaluationId((prev) => {
+          const runIdToEvalId: Record<string, string> = {};
+          Object.entries(prev).forEach(([evalId, run]) => {
+            if (run?.id) runIdToEvalId[run.id] = evalId;
+          });
+          let changed = false;
+          const next = { ...prev };
+          (runs ?? []).forEach((run) => {
+            const evalId = run?.id ? runIdToEvalId[run.id] : undefined;
+            if (evalId && next[evalId]?.status !== run.status) {
+              next[evalId] = run;
+              changed = true;
+            }
+          });
+          return changed ? next : prev;
+        });
+      } catch {
+        // transient — keep polling
+      }
+      if (!cancelled) window.setTimeout(poll, 3000);
+    };
+    const timer = window.setTimeout(poll, 3000);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [activeRunIds]);
+
+  // A batch may be running from another page/tab. While any_running is set,
+  // silently refetch so the workflow-level "Running" state clears when it ends.
+  useEffect(() => {
+    if (!pageData?.any_running) return;
+    let cancelled = false;
+    const poll = async () => {
+      if (cancelled) return;
+      try {
+        const data = await getWorkflowEvaluationsPage(workflowId, {
+          page,
+          pageSize: PAGE_SIZE,
+          search,
+        });
+        if (!cancelled && data) setPageData(data);
+      } catch {
+        // transient — keep polling
+      }
+      if (!cancelled) window.setTimeout(poll, 4000);
+    };
+    const timer = window.setTimeout(poll, 4000);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [pageData?.any_running, workflowId, page, search]);
+
+  const isEvaluationRunning = (evaluation: TestEvaluationConfig): boolean => {
+    if (evaluation.id && runningEvalIds.has(evaluation.id)) return true;
+    const lastRun = evaluation.id ? lastRunsByEvaluationId[evaluation.id] : null;
+    return lastRun?.status === "queued" || lastRun?.status === "running";
+  };
+
+  const getAverageAccuracy = (evaluation: TestEvaluationConfig): number | null => {
+    const lastRun = evaluation.id ? lastRunsByEvaluationId[evaluation.id] : null;
+    if (!lastRun?.summary_metrics) return null;
+    const metrics = lastRun.summary_metrics as Record<string, { accuracy?: number }>;
+    const accuracies = Object.values(metrics)
+      .map((m) => m.accuracy)
+      .filter((a): a is number => typeof a === "number");
+    if (!accuracies.length) return null;
+    return accuracies.reduce((sum, a) => sum + a, 0) / accuracies.length;
+  };
+
+  const handleQuickRun = async (evaluation: TestEvaluationConfig, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!evaluation.id || isEvaluationRunning(evaluation)) return;
+    setRunningEvalIds((prev) => new Set(prev).add(evaluation.id));
+    try {
+      let runMetadata = evaluation.input_metadata ?? undefined;
+      if (runMetadata?.use_memory) {
+        runMetadata = { ...runMetadata, thread_id: crypto.randomUUID() };
+      }
+      const created = await startTestRun(evaluation.suite_id, {
+        techniques: evaluation.techniques,
+        technique_configs: evaluation.technique_configs,
+        workflow_id: evaluation.workflow_id,
+        input_metadata: runMetadata,
+      });
+      if (created?.id) {
+        await appendRunToEvaluation(evaluation.id, created.id);
+        setLastRunsByEvaluationId((prev) => ({ ...prev, [evaluation.id as string]: created }));
+        toast.success("Evaluation started");
+      }
+    } catch {
+      toast.error("Failed to start evaluation");
+    } finally {
+      setRunningEvalIds((prev) => {
+        const next = new Set(prev);
+        if (evaluation.id) next.delete(evaluation.id);
+        return next;
+      });
+    }
+  };
+
+  const handleRunAll = async () => {
+    if (isUnassigned || isRunAllInFlight.current || isWorkflowRunning || pageData?.any_running) {
+      return;
+    }
+    isRunAllInFlight.current = true;
+    const epoch = runAllEpoch.current; // invalidated if the workflow changes
+    setIsWorkflowRunning(true);
+    setWorkflowProgress(null); // real total is known only once runs are started
+    const isStale = () => !isMounted.current || epoch !== runAllEpoch.current;
+    const finish = () => {
+      if (isStale()) return; // don't touch another workflow's guard/progress
+      isRunAllInFlight.current = false;
+      setIsWorkflowRunning(false);
+    };
+
+    try {
+      const started = await runWorkflowEvaluations(workflowId);
+      if (isStale()) return; // navigated away before the POST resolved
+      const startedRuns = (started ?? []).filter(
+        (s): s is typeof s & { run_id: string } => Boolean(s.run_id),
+      );
+      const failedCount = (started ?? []).length - startedRuns.length;
+      if (!startedRuns.length) {
+        toast.error("No evaluations could be started");
+        finish();
+        return;
+      }
+      if (failedCount > 0) {
+        toast.error(`${failedCount} evaluation${failedCount !== 1 ? "s" : ""} failed to start`);
+      }
+      const runIdToEvalId: Record<string, string> = {};
+      startedRuns.forEach((s) => {
+        runIdToEvalId[s.run_id] = s.evaluation_id;
+      });
+      const runIds = startedRuns.map((s) => s.run_id);
+      // Run all starts every evaluation in the workflow, not just the filtered page.
+      setWorkflowProgress({ done: 0, total: runIds.length });
+      toast.success(`Started ${runIds.length} evaluation${runIds.length !== 1 ? "s" : ""}`);
+
+      let consecutivePollErrors = 0;
+      const maxPollErrors = 5;
+      const poll = async () => {
+        if (isStale()) return;
+        try {
+          const runs = await getTestRunsBatch(runIds);
+          consecutivePollErrors = 0;
+          const updates: Record<string, TestRun> = {};
+          let done = 0;
+          (runs ?? []).forEach((run) => {
+            if (!run?.id) return;
+            const evalId = runIdToEvalId[run.id];
+            if (evalId) updates[evalId] = run;
+            if (run.status === "completed" || run.status === "failed") done += 1;
+          });
+          if (isStale()) return;
+          setLastRunsByEvaluationId((prev) => ({ ...prev, ...updates }));
+          setWorkflowProgress({ done, total: runIds.length });
+          if (done >= runIds.length) {
+            finish();
+            return;
+          }
+        } catch {
+          consecutivePollErrors += 1;
+          if (consecutivePollErrors >= maxPollErrors) {
+            toast.error("Lost track of running evaluations. Refresh to see their status.");
+            finish();
+            return;
+          }
+        }
+        if (!isStale()) runAllPollTimer.current = window.setTimeout(poll, 3000);
+      };
+      runAllPollTimer.current = window.setTimeout(poll, 2000);
+    } catch (error) {
+      if (isStale()) return; // navigated away before the POST rejected
+      const status = (error as { response?: { status?: number } })?.response?.status;
+      if (status === 409) {
+        toast.error("This workflow already has running evaluations");
+        setReloadKey((key) => key + 1); // refetch so any_running blocks the button
+      } else {
+        toast.error("Failed to start evaluations");
+      }
+      finish();
+    }
+  };
+
+  const handleEditSubmit = async (data: EvaluationWizardData) => {
+    if (!editingEvaluation?.id) return;
+    const updated = await updateTestEvaluation(editingEvaluation.id, {
+      name: data.name.trim(),
+      description: data.description.trim() || undefined,
+      suite_id: data.suiteId,
+      workflow_id: data.workflowId === "none" ? undefined : data.workflowId,
+      techniques: data.metrics,
+      technique_configs: buildTechniqueConfigs(data),
+      input_metadata: wizardMetadata(data),
+    });
+    if (!updated) return;
+    setEditingEvaluation(null);
+    toast.success("Evaluation updated");
+    setReloadKey((key) => key + 1); // its workflow may have changed — refetch the page
+  };
+
+  const handleDelete = async (id: string) => {
+    await deleteTestEvaluation(id);
+    setDeletingEvaluationId(null);
+    toast.success("Evaluation deleted");
+    if (evaluations.length === 1 && page > 1) {
+      setPage((current) => current - 1);
+    } else {
+      setReloadKey((key) => key + 1);
+    }
+  };
+
+  return (
+    <PageLayout>
+      <div className="mb-6">
+        <button
+          type="button"
+          onClick={() => navigate("/tests/evaluations")}
+          className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 mb-2"
+        >
+          <ArrowLeft className="h-4 w-4" /> All workflows
+        </button>
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-2 min-w-0">
+            <h1 className="text-2xl font-semibold truncate">{workflowName}</h1>
+            <Badge variant="secondary" className="shrink-0">
+              {search
+                ? `Showing ${total} of ${totalUnfiltered}`
+                : `${total} evaluation${total !== 1 ? "s" : ""}`}
+            </Badge>
+          </div>
+          {!isUnassigned && (
+            <Button
+              variant="outline"
+              disabled={isWorkflowRunning || Boolean(pageData?.any_running)}
+              onClick={handleRunAll}
+            >
+              {isWorkflowRunning && workflowProgress ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                  {workflowProgress.done}/{workflowProgress.total}
+                </>
+              ) : isWorkflowRunning ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                  Starting…
+                </>
+              ) : pageData?.any_running ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                  Running…
+                </>
+              ) : (
+                <>
+                  <Play className="h-3.5 w-3.5 mr-1" />
+                  Run all
+                </>
+              )}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="relative mb-4 max-w-sm">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+        <input
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          placeholder="Search evaluations..."
+          className="w-full pl-9 pr-3 py-2 rounded-lg border text-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
+        />
+      </div>
+
+      <div className="rounded-lg border bg-white overflow-hidden">
+        {isLoading ? (
+          <PageListSkeleton variant="evaluation" bordered={false} />
+        ) : hasError ? (
+          <div className="py-16 text-center">
+            <p className="text-sm text-gray-500 mb-3">Couldn't load evaluations.</p>
+            <Button variant="outline" onClick={() => setReloadKey((key) => key + 1)}>
+              Retry
+            </Button>
+          </div>
+        ) : evaluations.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 gap-3 text-center">
+            <div className="rounded-full bg-gray-100 p-4">
+              <ListChecks className="h-10 w-10 text-gray-400" />
+            </div>
+            <p className="text-sm text-gray-500 max-w-sm">
+              {search
+                ? "No evaluations match your search."
+                : "This workflow has no evaluations yet."}
+            </p>
+            {!search && (
+              <Button onClick={() => navigate("/tests/evaluations")}>
+                <Plus className="h-4 w-4 mr-2" /> Create one from the overview
+              </Button>
+            )}
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-100">
+            {evaluations.map((evaluation) => (
+              <EvaluationListRow
+                key={evaluation.id}
+                evaluation={evaluation}
+                avgAccuracy={getAverageAccuracy(evaluation)}
+                isRunning={isEvaluationRunning(evaluation)}
+                lastRunStatus={
+                  evaluation.id ? lastRunsByEvaluationId[evaluation.id]?.status : undefined
+                }
+                onOpen={() => navigate(`/tests/evaluations/${evaluation.id}`)}
+                onEdit={() => setEditingEvaluation(evaluation)}
+                onDelete={() => setDeletingEvaluationId(evaluation.id ?? null)}
+                onRun={(e) => handleQuickRun(evaluation, e)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {!isLoading && !hasError && total > PAGE_SIZE && (
+        <PaginationBar
+          total={total}
+          currentPage={page}
+          pageSize={PAGE_SIZE}
+          pageItemCount={evaluations.length}
+          onPageChange={setPage}
+          className="mt-4"
+        />
+      )}
+
+      {editingEvaluation && (
+        <EvaluationWizard
+          isOpen={!!editingEvaluation}
+          onOpenChange={(open) => {
+            if (!open) setEditingEvaluation(null);
+          }}
+          onSubmit={handleEditSubmit}
+          suites={suites}
+          workflows={workflows}
+          providers={providers}
+          mode="edit"
+          initialData={getEditInitialData(editingEvaluation, providers)}
+        />
+      )}
+
+      <Dialog
+        open={!!deletingEvaluationId}
+        onOpenChange={(open) => {
+          if (!open) setDeletingEvaluationId(null);
+        }}
+      >
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete Evaluation</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-gray-600">
+            Are you sure you want to delete this evaluation? This will also permanently delete all
+            associated runs and their results. This action cannot be undone.
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeletingEvaluationId(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => deletingEvaluationId && handleDelete(deletingEvaluationId)}
+            >
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </PageLayout>
+  );
+};
+
+export default WorkflowEvaluationsPage;


### PR DESCRIPTION
## Description

Groups evaluations by workflow, adds per-workflow health, and makes Run-all safe against duplicate batches.

- **Overview**: table grouped by workflow (name, health %, eval count, Run all); DB-level pagination + search on the per-workflow detail page.
- **Health**: per-workflow score (failed runs count as 0%) + live running state that clears itself via polling.
- **Run-all safety**: atomic Redis `SET NX` lock (unique token + compare-and-delete release) + synchronous UI double-click guard + navigation-safe, epoch-guarded polling — no duplicate runs.
- **Consistency**: unified effective-workflow rule (incl. soft-deleted suites) across count/list; shared `EntityTitle` so list-row titles match across Datasets + Evaluations.
- **Backend**: workflow-eval routes consolidated into `test_evaluations.py`.
- **Tests**: unit + route-lock + DB-integration coverage

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [x] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
