### PR TITLE
enhancement: stop sidebar remounting on navigation

### DIFF
--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, Navigate } from "react-router-dom";
 import { Outlet, RouterProvider } from "react-router-dom";
 import { createContext, useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import ProtectedRoute from "@/layout/ProtectedRoute";
+import AppLayout from "@/layout/AppLayout";
 import { Register } from "@/views/Register";
 import { ChangePassword, Login, LoginSsoCallback } from "@/views/Login";
 import Index from "@/views/Index";
@@ -146,6 +147,9 @@ export const RoutesProvider = () => {
           element: <ProtectedLayout />,
           children: [
             { path: "", element: <Navigate to="/dashboard" replace /> },
+            {
+              element: <AppLayout />,
+              children: [
             { path: "dashboard", element: <Index /> },
             {
               path: "transcripts",
@@ -570,6 +574,8 @@ export const RoutesProvider = () => {
                   <MCPServersPage />
                 </ProtectedRoute>
               ),
+            },
+              ],
             },
 
             { path: "change-password", element: <ChangePassword /> },

--- a/frontend/src/components/PageLayout.tsx
+++ b/frontend/src/components/PageLayout.tsx
@@ -1,6 +1,4 @@
 import { ReactNode } from "react";
-import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
-import { AppSidebar } from "@/layout/app-sidebar";
 
 interface PageLayoutProps {
   children: ReactNode;
@@ -8,18 +6,8 @@ interface PageLayoutProps {
 
 export function PageLayout({ children }: PageLayoutProps) {
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full overflow-x-hidden">
-        <AppSidebar />
-        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
-          <div className="flex-1 p-4 sm:p-6 lg:p-8">
-            <div className="max-w-7xl mx-auto w-full space-y-6">
-              {children}
-            </div>
-          </div>
-        </main>
-      </div>
-    </SidebarProvider>
+    <div className="flex-1 p-4 sm:p-6 lg:p-8">
+      <div className="max-w-7xl mx-auto w-full space-y-6">{children}</div>
+    </div>
   );
 }

--- a/frontend/src/layout/AppLayout.tsx
+++ b/frontend/src/layout/AppLayout.tsx
@@ -1,0 +1,17 @@
+import { Outlet } from "react-router-dom";
+import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
+import { AppSidebar } from "@/layout/app-sidebar";
+
+export default function AppLayout() {
+  return (
+    <SidebarProvider>
+      <div className="min-h-screen flex w-full overflow-x-hidden">
+        <AppSidebar />
+        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
+          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
+          <Outlet />
+        </main>
+      </div>
+    </SidebarProvider>
+  );
+}

--- a/frontend/src/layout/app-sidebar.tsx
+++ b/frontend/src/layout/app-sidebar.tsx
@@ -801,7 +801,7 @@ export function AppSidebar() {
         </div>
 
         {/* Scrollable nav */}
-        <nav className="flex-1 overflow-y-auto px-3 pb-2">
+        <nav className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pb-2">
           {filteredGroups.map((group, gIdx) => (
             <SidebarGroup key={group.label} className="p-0">
               <div

--- a/frontend/src/views/AIAgents/Index.tsx
+++ b/frontend/src/views/AIAgents/Index.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 import Dashboard from './components/Dashboard';
 import Chat from './components/Chat';
-import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
-import { AppSidebar } from "@/layout/app-sidebar";
 import { useIsMobile } from "@/hooks/useMobile";
 import ChatAsCustomer from "@/views/AIAgents/components/Customer/ChatAsCustomer"; 
 import SecurityPage from "@/views/AIAgents/components/Customer/SecurityPage";
@@ -15,27 +13,19 @@ const AIAgentsView: React.FC = () => {
   const isMobile = useIsMobile();
   
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full overflow-x-hidden">
-        <AppSidebar />
-        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
-          <div className="flex-1">
-              <Routes>
-                <Route path="/" element={<Dashboard />} />
-                {/* <Route path="/tools" element={<Tools />} /> */}
+    <div className="flex-1">
+      <Routes>
+        <Route path="/" element={<Dashboard />} />
+        {/* <Route path="/tools" element={<Tools />} /> */}
 
-                <Route path="chat/:agentId/:threadId" element={<Chat />} />
-                <Route path="new" element={<AgentStudioPage />} />
-                <Route path="workflow/:agentId" element={<AgentStudioPage />} />
-                <Route path="integration/:agentId" element={<ChatAsCustomer />} />
-                <Route path="security/:agentId" element={<SecurityPage />} />
-                <Route path="scheduling/:agentId" element={<SchedulingPage />} />
-              </Routes>
-          </div>
-        </main>
-      </div>
-    </SidebarProvider>
+        <Route path="chat/:agentId/:threadId" element={<Chat />} />
+        <Route path="new" element={<AgentStudioPage />} />
+        <Route path="workflow/:agentId" element={<AgentStudioPage />} />
+        <Route path="integration/:agentId" element={<ChatAsCustomer />} />
+        <Route path="security/:agentId" element={<SecurityPage />} />
+        <Route path="scheduling/:agentId" element={<SchedulingPage />} />
+      </Routes>
+    </div>
   );
 };
 

--- a/frontend/src/views/AIAgents/components/Customer/SecurityPage.tsx
+++ b/frontend/src/views/AIAgents/components/Customer/SecurityPage.tsx
@@ -1,8 +1,7 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { Button } from "@/components/button";
 import { ArrowLeft } from "lucide-react";
-import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
-import { AppSidebar } from "@/layout/app-sidebar";
+import { SidebarTrigger } from "@/components/sidebar";
 import { useIsMobile } from "@/hooks/useMobile";
 import SecurityPanel from "@/views/AIAgents/components/Customer/SecurityPanel";
 

--- a/frontend/src/views/Analytics/pages/AgentPerformancePage.tsx
+++ b/frontend/src/views/Analytics/pages/AgentPerformancePage.tsx
@@ -3,8 +3,6 @@ import { subDays } from "date-fns";
 import { toExpandedUTCDateRange } from "@/helpers/analyticsParams";
 import { Settings2, TrendingDown, ShieldCheck, ThumbsUp, ThumbsDown } from "lucide-react";
 import { DateRange } from "react-day-picker";
-import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
-import { AppSidebar } from "@/layout/app-sidebar";
 import {
   Select,
   SelectContent,
@@ -360,11 +358,7 @@ const AgentPerformancePage = () => {
   const canExport = !loading && exportRowCount > 0;
 
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full overflow-x-hidden">
-        <AppSidebar />
-        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
+    <>
           <div className="flex-1 p-4 sm:p-6 lg:p-8">
             <div className="max-w-7xl mx-auto space-y-6">
 
@@ -544,8 +538,6 @@ const AgentPerformancePage = () => {
 
             </div>
           </div>
-        </main>
-      </div>
 
       {selectedItem && (
         <AgentNodeBreakdownDialog
@@ -558,7 +550,7 @@ const AgentPerformancePage = () => {
           toDate={toExpandedUTCDateRange(dateRange).to_date}
         />
       )}
-    </SidebarProvider>
+    </>
   );
 };
 

--- a/frontend/src/views/Analytics/pages/Analytics.tsx
+++ b/frontend/src/views/Analytics/pages/Analytics.tsx
@@ -1,7 +1,5 @@
 import { subDays } from "date-fns";
 import { usePersistedDateRange, COMPARE_DATE_RANGE_STORAGE_KEY } from "@/hooks/usePersistedDateRange";
-import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
-import { AppSidebar } from "@/layout/app-sidebar";
 import { AnalyticsMetricsSection } from "../components/AnalyticsMetricsSection";
 import { AnalyticsFilters } from "../components/AnalyticsFilters";
 import { AnalyticsPageHeader } from "../components/AnalyticsPageHeader";
@@ -38,11 +36,7 @@ const AnalyticsPage = () => {
   );
 
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full overflow-x-hidden">
-        <AppSidebar />
-        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
+    <>
           <div className="flex-1 p-4 sm:p-6 lg:p-8">
             <div className="max-w-7xl mx-auto">
               <AnalyticsPageHeader
@@ -88,9 +82,7 @@ const AnalyticsPage = () => {
               )}
             </div>
           </div>
-        </main>
-      </div>
-    </SidebarProvider>
+    </>
   );
 };
 

--- a/frontend/src/views/Analytics/pages/NodeAnalyticsPage.tsx
+++ b/frontend/src/views/Analytics/pages/NodeAnalyticsPage.tsx
@@ -3,8 +3,6 @@ import { subDays } from "date-fns";
 import { toExpandedUTCDateRange } from "@/helpers/analyticsParams";
 import { cn } from "@/helpers/utils";
 import { DateRange } from "react-day-picker";
-import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
-import { AppSidebar } from "@/layout/app-sidebar";
 import {
   Select,
   SelectContent,
@@ -194,11 +192,7 @@ const NodeAnalyticsPage = () => {
   const canExport = !loading && agentBreakdown.length > 0;
 
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full overflow-x-hidden">
-        <AppSidebar />
-        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
+    <>
           <div className="flex-1 p-4 sm:p-6 lg:p-8">
             <div className="max-w-7xl mx-auto space-y-6">
 
@@ -261,9 +255,7 @@ const NodeAnalyticsPage = () => {
 
             </div>
           </div>
-        </main>
-      </div>
-    </SidebarProvider>
+    </>
   );
 };
 

--- a/frontend/src/views/AuditLogs/pages/AuditLogs.tsx
+++ b/frontend/src/views/AuditLogs/pages/AuditLogs.tsx
@@ -1,7 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { fetchAuditLogs, fetchUsers } from "@/services/auditLogs";
-import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
-import { AppSidebar } from "@/layout/app-sidebar";
 import { AuditLogCard } from "@/views/AuditLogs/components/AuditLogCard";
 import { AuditLogDetailsDialog } from "@/views/AuditLogs/components/AuditLogDetailsDialog";
 import { useIsMobile } from "@/hooks/useMobile";
@@ -138,11 +136,7 @@ export default function AuditLogs() {
   };
 
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full overflow-x-hidden">
-        <AppSidebar />
-        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
+    <>
           <div className="flex-1 p-4 sm:p-6 lg:p-8">
             <div className="max-w-2xl xl:max-w-7xl mx-auto space-y-6">
               <div className="flex justify-between items-start">
@@ -286,8 +280,6 @@ export default function AuditLogs() {
 
             </div>
           </div>
-        </main>
-      </div>
 
       <AuditLogDetailsDialog
         isOpen={isDialogOpen}
@@ -295,6 +287,6 @@ export default function AuditLogs() {
         auditLogId={selectedAuditLogId}
         users={users}
       />
-    </SidebarProvider>
+    </>
   );
 }

--- a/frontend/src/views/Index.tsx
+++ b/frontend/src/views/Index.tsx
@@ -1,5 +1,3 @@
-import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
-import { AppSidebar } from "@/layout/app-sidebar";
 import { DateRangePicker } from "@/components/date-range-picker";
 import { subDays, differenceInCalendarDays } from "date-fns";
 import { usePersistedDateRange } from "@/hooks/usePersistedDateRange";
@@ -19,11 +17,7 @@ const Index = () => {
   })();
 
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full overflow-x-hidden">
-        <AppSidebar />
-        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
+    <>
           <div className="flex-1 p-4 sm:p-6 lg:p-8">
             <div className="max-w-7xl mx-auto w-full">
               <header className="mb-6 sm:mb-8">
@@ -46,9 +40,7 @@ const Index = () => {
               <ActiveConversations />
             </div>
           </div>
-        </main>
-      </div>
-    </SidebarProvider>
+    </>
   );
 };
 

--- a/frontend/src/views/KnowledgeBase/pages/KnowledgeBase.tsx
+++ b/frontend/src/views/KnowledgeBase/pages/KnowledgeBase.tsx
@@ -1,26 +1,18 @@
 import React from 'react';
 import KnowledgeBaseManager from '../components/KnowledgeBaseManager';
-import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
-import { AppSidebar } from "@/layout/app-sidebar";
 import { useIsMobile } from "@/hooks/useMobile";
 
 const KnowledgeBase: React.FC = () => {
   const isMobile = useIsMobile();
-  
+
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full overflow-x-hidden">
-        <AppSidebar />
-        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
-          <div className="flex-1 p-4 sm:p-6 lg:p-8">
-            <div className="max-w-7xl mx-auto">
-              <KnowledgeBaseManager />
-            </div>
-          </div>
-        </main>
+    <>
+      <div className="flex-1 p-4 sm:p-6 lg:p-8">
+        <div className="max-w-7xl mx-auto">
+          <KnowledgeBaseManager />
+        </div>
       </div>
-    </SidebarProvider>
+    </>
   );
 };
 

--- a/frontend/src/views/KnowledgeBase/pages/KnowledgeBaseForm.tsx
+++ b/frontend/src/views/KnowledgeBase/pages/KnowledgeBaseForm.tsx
@@ -44,8 +44,6 @@ import DynamicRagConfigSection from '../components/DynamicRagConfigSection';
 import { DataSourceDialog } from '@/views/DataSources/components/DataSourceDialog';
 import { isEqual } from 'lodash';
 import { KnowledgeItem, UrlHeaderRow, UploadResult, FileItem } from '../types/knowledgeBase';
-import { SidebarProvider, SidebarTrigger } from '@/components/sidebar';
-import { AppSidebar } from '@/layout/app-sidebar';
 import { useIsMobile } from '@/hooks/useMobile';
 import { Progress } from '@/components/progress';
 
@@ -635,26 +633,16 @@ const KnowledgeBaseForm: React.FC = () => {
 
   if (loading && isEditMode && !editingItem) {
     return (
-      <SidebarProvider>
-        <div className="min-h-screen flex w-full overflow-x-hidden">
-          <AppSidebar />
-          <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative">
-            <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
-            <div className="flex-1 flex items-center justify-center">
-              <div className="text-sm text-gray-500">Loading...</div>
-            </div>
-          </main>
+      <>
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-sm text-gray-500">Loading...</div>
         </div>
-      </SidebarProvider>
+      </>
     );
   }
 
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full overflow-x-hidden">
-        <AppSidebar />
-        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
+    <>
           <div className="flex-1 p-4 sm:p-6 lg:p-8">
             <div className="max-w-7xl mx-auto space-y-8">
               <div className="flex items-center">
@@ -1431,8 +1419,6 @@ const KnowledgeBaseForm: React.FC = () => {
               </form>
             </div>
           </div>
-        </main>
-      </div>
 
       {isDataSourceDialogOpen && (
         <DataSourceDialog
@@ -1454,7 +1440,7 @@ const KnowledgeBaseForm: React.FC = () => {
         description="You have unsaved changes. Save first and then trigger sync?"
         primaryButtonText="Save & Sync"
       />
-    </SidebarProvider>
+    </>
   );
 };
 

--- a/frontend/src/views/MLModels/components/MLModelDetail.tsx
+++ b/frontend/src/views/MLModels/components/MLModelDetail.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { toast } from "react-hot-toast";
-import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
-import { AppSidebar } from "@/layout/app-sidebar";
 import { useIsMobile } from "@/hooks/useMobile";
 import { Button } from "@/components/button";
 import { Input } from "@/components/ui/input";
@@ -359,53 +357,37 @@ const MLModelDetail: React.FC = () => {
 
   if (loading) {
     return (
-      <SidebarProvider>
-        <div className="min-h-screen flex w-full overflow-x-hidden">
-          <AppSidebar />
-          <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-            <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
-            <div className="flex-1 p-4 sm:p-6 lg:p-8">
-              <div className="max-w-7xl mx-auto">
-                <div className="flex justify-center items-center py-12">
-                  <div className="text-sm text-gray-500">Loading model details...</div>
-                </div>
-              </div>
+      <>
+        <div className="flex-1 p-4 sm:p-6 lg:p-8">
+          <div className="max-w-7xl mx-auto">
+            <div className="flex justify-center items-center py-12">
+              <div className="text-sm text-gray-500">Loading model details...</div>
             </div>
-          </main>
+          </div>
         </div>
-      </SidebarProvider>
+      </>
     );
   }
 
   if (!model) {
     return (
-      <SidebarProvider>
-        <div className="min-h-screen flex w-full overflow-x-hidden">
-          <AppSidebar />
-          <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-            <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
-            <div className="flex-1 p-4 sm:p-6 lg:p-8">
-              <div className="max-w-7xl mx-auto">
-                <div className="flex flex-col items-center justify-center py-12 gap-4">
-                  <AlertCircle className="h-12 w-12 text-gray-400" />
-                  <h3 className="font-medium text-lg">Model not found</h3>
-                  <Button onClick={() => navigate("/ml-models")}>Back to ML Models</Button>
-                </div>
-              </div>
+      <>
+        <div className="flex-1 p-4 sm:p-6 lg:p-8">
+          <div className="max-w-7xl mx-auto">
+            <div className="flex flex-col items-center justify-center py-12 gap-4">
+              <AlertCircle className="h-12 w-12 text-gray-400" />
+              <h3 className="font-medium text-lg">Model not found</h3>
+              <Button onClick={() => navigate("/ml-models")}>Back to ML Models</Button>
             </div>
-          </main>
+          </div>
         </div>
-      </SidebarProvider>
+      </>
     );
   }
 
 
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full overflow-x-hidden">
-        <AppSidebar />
-        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
+    <>
           <div className="flex-1 p-4 sm:p-6 lg:p-8">
             <div className="max-w-7xl mx-auto">
               <div className="space-y-6">
@@ -863,9 +845,7 @@ const MLModelDetail: React.FC = () => {
               </div>
             </div>
           </div>
-        </main>
-      </div>
-    </SidebarProvider>
+    </>
   );
 };
 

--- a/frontend/src/views/MLModels/pages/MLModels.tsx
+++ b/frontend/src/views/MLModels/pages/MLModels.tsx
@@ -1,26 +1,18 @@
 import React from 'react';
 import MLModelsManager from '../components/MLModelsManager';
-import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
-import { AppSidebar } from "@/layout/app-sidebar";
 import { useIsMobile } from "@/hooks/useMobile";
 
 const MLModels: React.FC = () => {
   const isMobile = useIsMobile();
-  
+
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full overflow-x-hidden">
-        <AppSidebar />
-        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
-          <div className="flex-1 p-4 sm:p-6 lg:p-8">
-            <div className="max-w-7xl mx-auto">
-              <MLModelsManager />
-            </div>
-          </div>
-        </main>
+    <>
+      <div className="flex-1 p-4 sm:p-6 lg:p-8">
+        <div className="max-w-7xl mx-auto">
+          <MLModelsManager />
+        </div>
       </div>
-    </SidebarProvider>
+    </>
   );
 };
 

--- a/frontend/src/views/Notifications/pages/NotificationsPage.tsx
+++ b/frontend/src/views/Notifications/pages/NotificationsPage.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
-import { SidebarProvider, SidebarTrigger } from "@/components/sidebar"
-import { AppSidebar } from "@/layout/app-sidebar"
 import { useIsMobile } from "@/hooks/useMobile"
 import { Button } from "@/components/button"
 import { Card } from "@/components/card"
@@ -130,11 +128,7 @@ const NotificationsPage = () => {
   ])
 
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full overflow-x-hidden">
-        <AppSidebar />
-        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
+    <>
           <div className="flex-1 p-4 sm:p-6 lg:p-8">
             <div className="max-w-7xl mx-auto w-full">
             <div className="flex items-center justify-between mb-8">
@@ -286,9 +280,7 @@ const NotificationsPage = () => {
             </Tabs>
             </div>
           </div>
-        </main>
-      </div>
-    </SidebarProvider>
+    </>
   )
 }
 

--- a/frontend/src/views/Operators/pages/Operator.tsx
+++ b/frontend/src/views/Operators/pages/Operator.tsx
@@ -1,5 +1,3 @@
-import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
-import { AppSidebar } from "@/layout/app-sidebar";
 import { OperatorsCard } from "@/views/Operators/components/OperatorCard";
 import { useIsMobile } from "@/hooks/useMobile";
 import { Plus } from "lucide-react";
@@ -51,11 +49,7 @@ export default function Operators() {
 
 
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full overflow-x-hidden">
-        <AppSidebar />
-        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
+    <>
           <div className="flex-1 p-4 sm:p-6 lg:p-8">
             <div className="max-w-7xl mx-auto space-y-6 w-full">
               <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:flex-wrap">
@@ -84,8 +78,6 @@ export default function Operators() {
 
             </div>
           </div>
-        </main>
-      </div>
 
       <CreateOperator
         isOpen={isDialogOpen}
@@ -99,6 +91,6 @@ export default function Operators() {
         credentials={newOperatorCredentials}
       />
 
-    </SidebarProvider>
+    </>
   );
 }

--- a/frontend/src/views/Settings/pages/Settings.tsx
+++ b/frontend/src/views/Settings/pages/Settings.tsx
@@ -1,5 +1,3 @@
-import { SidebarProvider, SidebarTrigger } from '@/components/sidebar';
-import { AppSidebar } from '@/layout/app-sidebar';
 import { Card } from '@/components/card';
 import { Button } from '@/components/button';
 import { useIsMobile } from '@/hooks/useMobile';
@@ -74,11 +72,7 @@ const SettingsPage = () => {
   }, [userProfile]);
 
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full overflow-x-hidden">
-        <AppSidebar />
-        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
+    <>
           <div className="flex-1 p-4 sm:p-6 lg:p-8">
             <div className="max-w-7xl mx-auto">
               <header className="mb-8">
@@ -202,9 +196,7 @@ const SettingsPage = () => {
               </p>
             </div>
           </footer>
-        </main>
-      </div>
-    </SidebarProvider>
+    </>
   );
 };
 

--- a/frontend/src/views/Tools/pages/CreateTool.tsx
+++ b/frontend/src/views/Tools/pages/CreateTool.tsx
@@ -1,6 +1,4 @@
 import { useState, useEffect } from "react";
-import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
-import { AppSidebar } from "@/layout/app-sidebar";
 import { useIsMobile } from "@/hooks/useMobile";
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "react-hot-toast";
@@ -307,23 +305,14 @@ export default function CreateTool() {
 
   if (loading) {
     return (
-      <SidebarProvider>
-        <div className="min-h-screen flex w-full overflow-x-hidden">
-          <AppSidebar />
-          <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200 items-center justify-center">
+      <>
             <CirclePlay className="animate-spin w-12 h-12" />
-          </main>
-        </div>
-      </SidebarProvider>
+      </>
     );
   }
 
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full overflow-x-hidden">
-        <AppSidebar />
-        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
+    <>
           <div className="flex-1 p-4 sm:p-6 lg:p-8">
             <div className="max-w-[1140px] mx-auto">
             <PageHeader
@@ -407,8 +396,6 @@ export default function CreateTool() {
             </Card>
             </div>
           </div>
-        </main>
-      </div>
-    </SidebarProvider>
+    </>
   );
 }

--- a/frontend/src/views/Tools/pages/Tools.tsx
+++ b/frontend/src/views/Tools/pages/Tools.tsx
@@ -1,6 +1,4 @@
 import { useState, useEffect, useMemo } from "react";
-import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
-import { AppSidebar } from "@/layout/app-sidebar";
 import { ToolCard } from "../components/ToolsCard";
 import { useIsMobile } from "@/hooks/useMobile";
 import { Plus, Loader2 } from "lucide-react";
@@ -82,11 +80,7 @@ export default function Tools() {
   }, [tools, searchQuery, filterType]);
 
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full overflow-x-hidden">
-        <AppSidebar />
-        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
+    <>
           <div className="flex-1 p-4 sm:p-6 lg:p-8">
             <div className="max-w-7xl mx-auto space-y-6">
             <header className="flex justify-between items-center">
@@ -146,8 +140,6 @@ export default function Tools() {
             )}
             </div>
           </div>
-        </main>
-      </div>
-    </SidebarProvider>
+    </>
   );
 }

--- a/frontend/src/views/Transcripts/pages/Transcripts.tsx
+++ b/frontend/src/views/Transcripts/pages/Transcripts.tsx
@@ -1,6 +1,4 @@
-import { SidebarProvider, SidebarTrigger } from "@/components/sidebar";
 import { METRIC_COLORS } from "@/constants/chartColors";
-import { AppSidebar } from "@/layout/app-sidebar";
 import {
   MessageSquare,
   PlayCircle,
@@ -584,11 +582,7 @@ const Transcripts = () => {
   };
 
   return (
-    <SidebarProvider>
-      <div className="min-h-screen flex w-full overflow-x-hidden">
-        <AppSidebar />
-        <main className="flex-1 flex flex-col bg-zinc-100 min-w-0 relative peer-data-[state=expanded]:md:ml-[calc(var(--sidebar-width)-2px)] peer-data-[state=collapsed]:md:ml-0 transition-[margin] duration-200">
-          <SidebarTrigger className="fixed top-6 z-10 h-8 w-8 bg-white/50 backdrop-blur-sm hover:bg-white/70 rounded-full shadow-md transition-[left] duration-200" />
+    <>
           <div className="flex-1 p-4 sm:p-6 lg:p-8">
             <div className="max-w-7xl mx-auto space-y-4 w-full">
               {/* Top row: Title/Upload | Agent, Date Range, Search */}
@@ -1162,8 +1156,6 @@ const Transcripts = () => {
               />
             </div>
           </div>
-        </main>
-      </div>
       <UploadMediaDialog
         isOpen={isUploadDialogOpen}
         onOpenChange={setIsUploadDialogOpen}
@@ -1188,7 +1180,7 @@ const Transcripts = () => {
           }
         />
       )}
-    </SidebarProvider>
+    </>
   );
 };
 


### PR DESCRIPTION
## Description

Move the sidebar into a shared layout so it stays put across page changes instead of rebuilding each time. This stops the nav from jumping to the top and flashing when you switch tabs.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [X] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
