### PR TITLE
fix: truncate LLM analyst prompts with hover tooltip

### DIFF
--- a/frontend/src/views/LlmAnalyst/components/LLMAnalystCard.tsx
+++ b/frontend/src/views/LlmAnalyst/components/LLMAnalystCard.tsx
@@ -1,9 +1,15 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { DataTable, Column } from "@/components/ui/data-table";
 import { LIST_PAGE_SIZE } from "@/constants/pagination";
 import { ActionButtons } from "@/components/ActionButtons";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Badge } from "@/components/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  TooltipProvider,
+} from "@/components/RadixTooltip";
 import { LLMAnalyst } from "@/interfaces/llmAnalyst.interface";
 import { toast } from "react-hot-toast";
 
@@ -13,6 +19,37 @@ interface LLMAnalystCardProps {
   loading?: boolean;
   onEdit: (analyst: LLMAnalyst) => void;
   onDelete: (id: string) => Promise<void>;
+}
+
+// Reveals the full prompt on hover only when the cell text is truncated
+function PromptCell({ prompt }: { prompt: string }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const measure = () => setIsTruncated(el.scrollWidth > el.clientWidth);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [prompt]);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span ref={ref} className="block truncate">
+          {prompt}
+        </span>
+      </TooltipTrigger>
+      {isTruncated && (
+        <TooltipContent className="max-w-md whitespace-pre-wrap break-words">
+          {prompt}
+        </TooltipContent>
+      )}
+    </Tooltip>
+  );
 }
 
 export function LLMAnalystCard({
@@ -74,7 +111,9 @@ export function LLMAnalystCard({
     {
       header: "Prompt",
       key: "prompt",
-      cell: (analyst) => <span className="line-clamp-2">{analyst.prompt}</span>,
+      headerClassName: "w-[360px]",
+      className: "max-w-[360px]",
+      cell: (analyst) => <PromptCell prompt={analyst.prompt} />,
     },
     {
       header: "Status",
@@ -102,15 +141,17 @@ export function LLMAnalystCard({
 
   return (
     <>
-      <DataTable
-        data={filtered}
-        columns={columns}
-        loading={loading}
-        searchQuery={searchQuery}
-        pageSize={LIST_PAGE_SIZE}
-        emptyMessage="No LLM Analysts found"
-        notFoundMessage="No LLM Analysts found matching your search"
-      />
+      <TooltipProvider delayDuration={200}>
+        <DataTable
+          data={filtered}
+          columns={columns}
+          loading={loading}
+          searchQuery={searchQuery}
+          pageSize={LIST_PAGE_SIZE}
+          emptyMessage="No LLM Analysts found"
+          notFoundMessage="No LLM Analysts found matching your search"
+        />
+      </TooltipProvider>
 
       <ConfirmDialog
         isOpen={isDeleteDialogOpen}


### PR DESCRIPTION
## Description

Fixes the Prompt column on the LLM Analysts list so long prompts truncate with a visible ellipsis and the full text is available on hover.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

- Constrained the Prompt column width and switched rendering to single-line truncate with ellipsis.
- Added a hover tooltip that shows the full prompt only when the cell text is actually truncated.
- Wrapped the analysts table in TooltipProvider for consistent tooltip behavior.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues


Closes #

## Screenshots (if applicable)


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
