### PR TITLE
fix: duplicate conversation analysis

### DIFF
--- a/backend/alembic/versions/00094_unique_conversation_analysis_conversation_id.py
+++ b/backend/alembic/versions/00094_unique_conversation_analysis_conversation_id.py
@@ -1,0 +1,72 @@
+"""unique_conversation_analysis_conversation_id
+
+Enforce one analysis row per conversation.
+
+A conversation could previously accumulate multiple ``conversation_analysis``
+rows because every write went through a plain INSERT with no DB uniqueness
+(migration 00091 added only a *non-unique* index on ``conversation_id``). This
+migration:
+  1. de-duplicates existing rows, keeping the most recent analysis per
+     conversation (by ``created_at``, then ``id``),
+  2. drops the now-superseded non-unique index, and
+  3. adds a UNIQUE constraint on ``conversation_id`` so re-analysis can only
+     replace the existing row, never add another.
+
+Revision ID: 3900c6b0aaeb
+Revises: 21f612ab93ba
+Create Date: 2026-07-21 13:59:24.226385
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '3900c6b0aaeb'
+down_revision: Union[str, None] = '21f612ab93ba'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+UNIQUE_CONSTRAINT = "uq_conversation_analysis_conversation_id"
+NON_UNIQUE_INDEX = "ix_conversation_analysis_conversation_id"
+
+
+def upgrade() -> None:
+    # (1) Collapse duplicate analysis rows to one per conversation, keeping the
+    #     most recent. Without this the UNIQUE constraint below would fail.
+    op.execute(
+        """
+        DELETE FROM conversation_analysis ca
+        USING (
+            SELECT id,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY conversation_id
+                       ORDER BY created_at DESC NULLS LAST, id DESC
+                   ) AS rn
+            FROM conversation_analysis
+        ) dups
+        WHERE ca.id = dups.id
+          AND dups.rn > 1
+        """
+    )
+
+    # (2) The non-unique index is superseded by the unique constraint's index.
+    op.execute(f"DROP INDEX IF EXISTS {NON_UNIQUE_INDEX}")
+
+    # (3) Enforce the one-analysis-per-conversation invariant at the DB level.
+    op.create_unique_constraint(
+        UNIQUE_CONSTRAINT, "conversation_analysis", ["conversation_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        UNIQUE_CONSTRAINT, "conversation_analysis", type_="unique"
+    )
+    # Recreate the plain b-tree index that migration 00091 relied on.
+    op.execute(
+        f"""
+        CREATE INDEX IF NOT EXISTS {NON_UNIQUE_INDEX}
+        ON conversation_analysis (conversation_id)
+        """
+    )

--- a/backend/alembic/versions/00094_unique_conversation_analysis_conversation_id.py
+++ b/backend/alembic/versions/00094_unique_conversation_analysis_conversation_id.py
@@ -22,7 +22,7 @@ from typing import Sequence, Union
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = '3900c6b0aaeb'
+revision: str = '322883fb3a4d'
 down_revision: Union[str, None] = '21f612ab93ba'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/app/api/v1/routes/zendesk.py
+++ b/backend/app/api/v1/routes/zendesk.py
@@ -11,7 +11,10 @@ from app.auth.dependencies import auth
 from app.core.config.settings import settings
 from app.repositories.conversations import ConversationRepository
 from app.repositories.conversation_analysis import ConversationAnalysisRepository
+from app.repositories.operator_statistics import OperatorStatisticsRepository
 from app.modules.integration.zendesk import ZendeskConnector
+from app.services.conversation_analysis import ConversationAnalysisService
+from app.services.operator_statistics import OperatorStatisticsService
 from app.services.zendesk import analyze_ticket_for_db
 from app.tasks.zendesk_tasks import analyze_zendesk_tickets_async
 
@@ -109,8 +112,24 @@ async def zendesk_ticket_closed(
 
     analysis_payload = ConversationAnalysisCreate(**analysis_dict)
 
-    conv_anal_repo = ConversationAnalysisRepository(db)
-    new_analysis = await conv_anal_repo.save_conversation_analysis(analysis_payload)
+    analysis_service = ConversationAnalysisService(ConversationAnalysisRepository(db))
+    operator_statistics_service = OperatorStatisticsService(
+        OperatorStatisticsRepository(db)
+    )
+
+    # Snapshot any existing analysis before the upsert so a replace adjusts the
+    # operator's running statistics in place instead of double-counting.
+    previous_analysis = await analysis_service.get_by_conversation_id(conversation.id)
+    new_analysis = await analysis_service.save_conversation_analysis(analysis_payload)
+
+    # Fold this analysis into the operator's statistics. The direct webhook insert
+    # previously skipped this (unlike the finalize path), leaving stats out of sync.
+    await operator_statistics_service.update_from_analysis(
+        new_analysis,
+        conversation.operator_id,
+        conversation.duration or 0,
+        previous_analysis=previous_analysis,
+    )
 
     logger.info(
         f"✔ Saved ConversationAnalysis id={new_analysis.id} for conversation={conversation.id}"

--- a/backend/app/db/models/conversation.py
+++ b/backend/app/db/models/conversation.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     PrimaryKeyConstraint,
     String,
     Text,
+    UniqueConstraint,
     inspect as sa_inspect,
     text,
 )
@@ -31,6 +32,9 @@ class ConversationAnalysisModel(Base):
             ["conversation_id"], ["conversations.id"], name="conversation_id_fk"
         ),
         PrimaryKeyConstraint("id", name="conversation_analysis_pkey"),
+        UniqueConstraint(
+            "conversation_id", name="uq_conversation_analysis_conversation_id"
+        ),
     )
 
     conversation_id: Mapped[UUID] = mapped_column(UUID)

--- a/backend/app/repositories/conversation_analysis.py
+++ b/backend/app/repositories/conversation_analysis.py
@@ -14,8 +14,10 @@ class ConversationAnalysisRepository(DbRepository[ConversationAnalysisModel]):
         super().__init__(ConversationAnalysisModel, db)
 
     async def save_conversation_analysis(self, analysis_data: ConversationAnalysisCreate) -> ConversationAnalysisModel:
-        new_analysis = ConversationAnalysisModel(
-                conversation_id=analysis_data.conversation_id,
+        # Upsert by conversation_id: a conversation must have at most one analysis row.
+        # Re-analysis (finalize/backfill races, Zendesk re-close, etc.) must REPLACE the
+        # existing row in place rather than insert a duplicate.
+        fields = dict(
                 topic=analysis_data.topic,
                 summary=analysis_data.summary,
                 positive_sentiment=analysis_data.positive_sentiment,
@@ -30,10 +32,23 @@ class ConversationAnalysisRepository(DbRepository[ConversationAnalysisModel]):
                 response_time=analysis_data.response_time,
                 quality_of_service=analysis_data.quality_of_service,
                 )
-        self.db.add(new_analysis)
+
+        existing = await self.get_by_conversation_id(analysis_data.conversation_id)
+        if existing is not None:
+            # Update in place, preserving the same id (and any FK references to it).
+            for key, value in fields.items():
+                setattr(existing, key, value)
+            analysis = existing
+        else:
+            analysis = ConversationAnalysisModel(
+                    conversation_id=analysis_data.conversation_id,
+                    **fields,
+                    )
+            self.db.add(analysis)
+
         await self.db.commit()
-        await self.db.refresh(new_analysis)
-        return new_analysis
+        await self.db.refresh(analysis)
+        return analysis
 
     async def get_by_conversation_id(self, conversation_id: UUID) -> Optional[ConversationAnalysisModel]:
         query = select(ConversationAnalysisModel).where(ConversationAnalysisModel.conversation_id == conversation_id)

--- a/backend/app/repositories/conversations.py
+++ b/backend/app/repositories/conversations.py
@@ -2,7 +2,7 @@ import datetime
 from typing import List, Optional, Sequence, Tuple
 from uuid import UUID
 from injector import inject
-from sqlalchemy import asc, cast, desc, func, and_, or_, nulls_last, String, update
+from sqlalchemy import asc, cast, desc, distinct, func, and_, or_, nulls_last, String, update
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -478,7 +478,10 @@ class ConversationRepository(DbRepository[ConversationModel]):
         query = add_pagination(conversation_filter, query)
 
         result = await self.db.execute(query)
-        return result.scalars().all()
+        # The analysis outerjoin (needs_join branch) can emit one row per
+        # (conversation, analysis) pair when a conversation has more than one
+        # analysis row, so collapse duplicate ConversationModel identities.
+        return result.unique().scalars().all()
 
     @staticmethod
     def _sentiment_predicate(conversation_filter: ConversationFilter):
@@ -534,7 +537,9 @@ class ConversationRepository(DbRepository[ConversationModel]):
         """
         Return the total count of conversations matching ALL active filters.
         """
-        query = select(func.count(ConversationModel.id))
+        # Count distinct conversations: the analysis outerjoin below can repeat
+        # a conversation once per analysis row, which would inflate the total.
+        query = select(func.count(distinct(ConversationModel.id)))
         query = self._apply_base_filters(query, conversation_filter)
 
         group_clause = self._get_conversation_group_clause()

--- a/backend/app/services/conversation_analysis.py
+++ b/backend/app/services/conversation_analysis.py
@@ -6,7 +6,11 @@ from fastapi_injector import Injected
 from injector import inject
 
 from app.repositories.conversation_analysis import ConversationAnalysisRepository
-from app.schemas.conversation_analysis import AnalysisResult, ConversationAnalysisCreate
+from app.schemas.conversation_analysis import (
+    AnalysisResult,
+    ConversationAnalysisCreate,
+    ConversationAnalysisRead,
+)
 
 
 def _truncate(text: Optional[str], max_length: int = 255) -> str:
@@ -24,6 +28,19 @@ class ConversationAnalysisService:
     async def save_conversation_analysis(self, conversation: ConversationAnalysisCreate):
         model = await self.repository.save_conversation_analysis(conversation)
         return model
+
+    async def get_by_conversation_id(
+        self, conversation_id: UUID
+    ) -> Optional[ConversationAnalysisRead]:
+        """Return a detached snapshot of the current analysis (or None).
+
+        Callers use this to capture the pre-existing values before an upsert so
+        operator statistics can be adjusted instead of double-counted on replace.
+        """
+        model = await self.repository.get_by_conversation_id(conversation_id)
+        if model is None:
+            return None
+        return ConversationAnalysisRead.model_validate(model)
 
 
     async def create_conversation_analysis(self, gpt_analysis: AnalysisResult, llm_analyst_id: UUID,

--- a/backend/app/services/conversations.py
+++ b/backend/app/services/conversations.py
@@ -364,13 +364,18 @@ class ConversationService:
         # Get messages for analysis
         gpt_analysis = await self._analyze_transcript(conversation_id, resolved_analyst_id)
 
+        # Snapshot any pre-existing analysis so a replace (e.g. a concurrent backfill
+        # already created one) adjusts operator stats instead of double-counting.
+        previous_analysis = await self.conversation_analysis_service.get_by_conversation_id(
+                saved_conversation.id)
+
         conversation_analysis = (
             await self.conversation_analysis_service.create_conversation_analysis(gpt_analysis, resolved_analyst_id,
                     saved_conversation.id))
 
         # Update operator statistics
         await self.operator_statistics_service.update_from_analysis(conversation_analysis, conversation.operator_id,
-                saved_conversation.duration)
+                saved_conversation.duration, previous_analysis=previous_analysis)
 
         # Store in Zendesk if enabled
         store_in_zendesk = (os.getenv("STORE_CONVERSATIONS_IN_ZENDESK", "false").lower() == "true")
@@ -456,11 +461,15 @@ class ConversationService:
             raise AppException(ErrorKey.CONVERSATION_NOT_FOUND)
 
         gpt_analysis = await self._analyze_transcript(conversation_id, llm_analyst_id)
+        # Snapshot any pre-existing analysis so re-analysis replaces the row and adjusts
+        # operator stats in place rather than counting the conversation twice.
+        previous_analysis = await self.conversation_analysis_service.get_by_conversation_id(
+                conversation_id)
         conversation_analysis = (
             await self.conversation_analysis_service.create_conversation_analysis(gpt_analysis, llm_analyst_id,
                     conversation_id))
         await self.operator_statistics_service.update_from_analysis(conversation_analysis, conversation.operator_id,
-                conversation.duration)
+                conversation.duration, previous_analysis=previous_analysis)
 
 
     async def store_zendesk_analysis(self, saved_conversation: ConversationModel,

--- a/backend/app/services/operator_statistics.py
+++ b/backend/app/services/operator_statistics.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from uuid import UUID
 from fastapi import Depends
 from injector import inject
@@ -33,7 +34,18 @@ class OperatorStatisticsService:
     async def update_from_analysis(self,
                                    conversation_analysis: ConversationAnalysisRead,
                                    operator_id: UUID,
-                                   conversation_duration: int):
+                                   conversation_duration: int,
+                                   previous_analysis: Optional[ConversationAnalysisRead] = None):
+        """Fold a conversation's analysis into the operator's running averages.
+
+        Fresh analysis (``previous_analysis is None``): count this as a new call —
+        increment ``call_count``, add ``conversation_duration``, and fold the metrics
+        into the averages.
+
+        Replacement (``previous_analysis`` supplied): the conversation was already
+        counted, so keep ``call_count`` and ``total_duration`` fixed and only swap the
+        old metric contribution for the new one in each average.
+        """
 
         # Update operator_statistics
         existing_stats = await self.get_by_operator_id(operator_id)
@@ -41,48 +53,40 @@ class OperatorStatisticsService:
             existing_stats = await self.create(
                 operator_id=operator_id)
 
-        new_call_count = existing_stats.call_count + 1
-        # Running average calculation (integer division for now, or float if needed)
-        updated_avg_positive = (
-                (existing_stats.avg_positive_sentiment * existing_stats.call_count + conversation_analysis.positive_sentiment)
-                / new_call_count
+        # A replacement can only adjust averages that already include the prior call.
+        is_replacement = previous_analysis is not None and existing_stats.call_count > 0
 
-        )
-        updated_avg_negative = (
-                (existing_stats.avg_negative_sentiment * existing_stats.call_count + conversation_analysis.negative_sentiment)
-                / new_call_count
+        if is_replacement:
+            count = existing_stats.call_count
+            new_call_count = count
+            updated_total_duration = existing_stats.total_duration
 
-        )
-        updated_avg_neutral = (
-                (existing_stats.avg_neutral_sentiment * existing_stats.call_count + conversation_analysis.neutral_sentiment)
-                / new_call_count
+            def swap(current_avg, attr):
+                # Remove the previous analysis's contribution, add the new one.
+                new_sum = (current_avg * count
+                           - getattr(previous_analysis, attr)
+                           + getattr(conversation_analysis, attr))
+                return new_sum / count
+        else:
+            count = existing_stats.call_count
+            new_call_count = count + 1
+            updated_total_duration = existing_stats.total_duration + conversation_duration
 
-        )
-        updated_avg_response_time = (
-                (existing_stats.avg_response_time * existing_stats.call_count + conversation_analysis.response_time)
-                / new_call_count
+            def swap(current_avg, attr):
+                # Fold the new analysis in as an additional call.
+                new_sum = current_avg * count + getattr(conversation_analysis, attr)
+                return new_sum / new_call_count
 
-        )
-        updated_avg_resolution_rate = (
-                (existing_stats.avg_resolution_rate * existing_stats.call_count + conversation_analysis.resolution_rate)
-                / new_call_count
+        updated_avg_positive = swap(existing_stats.avg_positive_sentiment, "positive_sentiment")
+        updated_avg_negative = swap(existing_stats.avg_negative_sentiment, "negative_sentiment")
+        updated_avg_neutral = swap(existing_stats.avg_neutral_sentiment, "neutral_sentiment")
+        updated_avg_response_time = swap(existing_stats.avg_response_time, "response_time")
+        updated_avg_resolution_rate = swap(existing_stats.avg_resolution_rate, "resolution_rate")
+        updated_avg_customer_satisfaction = swap(existing_stats.avg_customer_satisfaction, "customer_satisfaction")
+        updated_avg_quality_of_service = swap(existing_stats.avg_quality_of_service, "quality_of_service")
 
-        )
-        updated_avg_customer_satisfaction = (
-                (
-                        existing_stats.avg_customer_satisfaction * existing_stats.call_count + conversation_analysis.customer_satisfaction)
-                / new_call_count
-
-        )
-        updated_avg_quality_of_service = (
-                (
-                        existing_stats.avg_quality_of_service * existing_stats.call_count + conversation_analysis.quality_of_service)
-                / new_call_count
-
-        )
         updated_avg_score = calculate_rating_score(positive_percentage=updated_avg_positive,
                                            negative_percentage=updated_avg_negative, neutral_percentage=updated_avg_neutral,)
-        updated_total_duration = existing_stats.total_duration + conversation_duration
 
         await self.update(
                 operator_id=operator_id,

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -17595,6 +17595,7 @@
           "Test Evaluations"
         ],
         "summary": "Update Evaluation",
+        "description": "Refuses with 409 while the evaluation is queued/running \u2014 its config must\nnot change underneath an executing run.",
         "operationId": "update_evaluation_api_genagent_eval_evaluations__evaluation_id__patch",
         "security": [
           {
@@ -17655,6 +17656,7 @@
           "Test Evaluations"
         ],
         "summary": "Delete Evaluation",
+        "description": "Refuses with 409 while the evaluation is queued/running \u2014 deleting would\nsoft-delete a run the worker is still writing to.",
         "operationId": "delete_evaluation_api_genagent_eval_evaluations__evaluation_id__delete",
         "security": [
           {
@@ -17738,6 +17740,189 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TestEvaluation"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/genagent/eval/workflows/{workflow_id}/evaluations/run": {
+      "post": {
+        "tags": [
+          "v1",
+          "Test Evaluations"
+        ],
+        "summary": "Run Workflow Evaluations",
+        "description": "Queue a run for every evaluation that targets this workflow. Returns the\nper-evaluation outcome immediately; execution is handled by background\nworkers. Evaluations that could not be queued are reported individually.\n\nA Redis ``SET NX`` lock makes the \"no active run?\" check and the batch start\none atomic operation, so two concurrent requests cannot both start a batch.\nRefuses with 409 while a batch is starting or the workflow already has\nqueued/running evaluations.",
+        "operationId": "run_workflow_evaluations_api_genagent_eval_workflows__workflow_id__evaluations_run_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workflow_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workflow Id"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/StartedEvaluationRun"
+                  },
+                  "title": "Response Run Workflow Evaluations Api Genagent Eval Workflows  Workflow Id  Evaluations Run Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/genagent/eval/workflows/evaluation-summaries": {
+      "get": {
+        "tags": [
+          "v1",
+          "Test Evaluations"
+        ],
+        "summary": "List Workflow Evaluation Summaries",
+        "description": "One row per workflow (and the unassigned bucket): count, health, running.",
+        "operationId": "list_workflow_evaluation_summaries_api_genagent_eval_workflows_evaluation_summaries_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/WorkflowEvaluationSummary"
+                  },
+                  "type": "array",
+                  "title": "Response List Workflow Evaluation Summaries Api Genagent Eval Workflows Evaluation Summaries Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/genagent/eval/workflows/{workflow_id}/evaluations": {
+      "get": {
+        "tags": [
+          "v1",
+          "Test Evaluations"
+        ],
+        "summary": "List Workflow Evaluations",
+        "description": "A page of one workflow's evaluations. Use ``unassigned`` for evals with no workflow.",
+        "operationId": "list_workflow_evaluations_api_genagent_eval_workflows__workflow_id__evaluations_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workflow_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workflow Id"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Page Size"
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedEvaluations"
                 }
               }
             }
@@ -35586,6 +35771,47 @@
         "title": "OperatorStatisticsRead",
         "description": "Used for returning OperatorRead Statistics"
       },
+      "PaginatedEvaluations": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TestEvaluationInDB"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "total_unfiltered": {
+            "type": "integer",
+            "title": "Total Unfiltered"
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page"
+          },
+          "page_size": {
+            "type": "integer",
+            "title": "Page Size"
+          },
+          "any_running": {
+            "type": "boolean",
+            "title": "Any Running",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "total",
+          "total_unfiltered",
+          "page",
+          "page_size"
+        ],
+        "title": "PaginatedEvaluations",
+        "description": "One page of a workflow's evaluations.\n\n``total`` is the count for the current search; ``total_unfiltered`` is the\nworkflow's full evaluation count (ignoring search), so the header can show\n\"N of M\". ``any_running`` reflects the whole workflow (across all pages), not\njust this page, so the client can block a duplicate \"Run all\"."
+      },
       "PaginatedResponse_AgentListItem_": {
         "properties": {
           "items": {
@@ -36978,6 +37204,61 @@
         ],
         "title": "SortField"
       },
+      "StartedEvaluationRun": {
+        "properties": {
+          "evaluation_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Evaluation Id"
+          },
+          "run_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Id"
+          },
+          "suite_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suite Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "evaluation_id",
+          "status"
+        ],
+        "title": "StartedEvaluationRun",
+        "description": "Outcome of starting one evaluation in a batch/workflow run.\n\n``run_id``/``suite_id`` are unset and ``error`` is populated when the\nevaluation could not be queued (``status == \"failed_to_start\"``)."
+      },
       "SupportTicketCommentCreate": {
         "properties": {
           "body": {
@@ -38036,6 +38317,104 @@
           "suite_id"
         ],
         "title": "TestEvaluationCreate"
+      },
+      "TestEvaluationInDB": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "suite_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Suite Id"
+          },
+          "workflow_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workflow Id"
+          },
+          "techniques": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Techniques"
+          },
+          "technique_configs": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Technique Configs"
+          },
+          "input_metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input Metadata"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "run_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Run Ids"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "suite_id",
+          "id",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "TestEvaluationInDB"
       },
       "TestEvaluationUpdate": {
         "properties": {
@@ -40251,6 +40630,53 @@
           "version"
         ],
         "title": "WorkflowCreate"
+      },
+      "WorkflowEvaluationSummary": {
+        "properties": {
+          "workflow_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workflow Id"
+          },
+          "eval_count": {
+            "type": "integer",
+            "title": "Eval Count"
+          },
+          "health": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Health"
+          },
+          "finished_count": {
+            "type": "integer",
+            "title": "Finished Count",
+            "default": 0
+          },
+          "any_running": {
+            "type": "boolean",
+            "title": "Any Running",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "eval_count"
+        ],
+        "title": "WorkflowEvaluationSummary",
+        "description": "One overview row: a workflow (or the unassigned bucket) and its eval count.\n\n``health`` is the mean accuracy across the workflow's evaluations whose latest\nrun has finished, counting failed runs as 0; ``None`` when none have finished.\n``finished_count`` is how many evaluations contributed to ``health``.\n``any_running`` is true when any evaluation's latest run is queued or running."
       },
       "WorkflowMinimal": {
         "properties": {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2717,11 +2717,6 @@ lovable-tagger@^1.1.3:
     esbuild "^0.25.0"
     tailwindcss "^3.4.17"
 
-lucide-react@^0.462.0:
-  version "0.462.0"
-  resolved "https://registry.npmjs.org/lucide-react/-/lucide-react-0.462.0.tgz"
-  integrity sha512-NTL7EbAao9IFtuSivSZgrAh4fZd09Lr+6MTkqIxuHaH2nnYiYIzXPo06cOxHg9wKLdj6LL8TByG4qpePqwgx/g==
-
 lucide-react@^0.511.0:
   version "0.511.0"
   resolved "https://registry.npmjs.org/lucide-react/-/lucide-react-0.511.0.tgz"
@@ -3635,7 +3630,7 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-"react@^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.14.0 || 17.x || 18.x || 19.x", "react@^16.3 || ^17.0 || ^18.0 || ^19.0", "react@^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc", "react@^16.8 || ^17 || ^18", "react@^16.8 || ^17.0 || ^18.0", "react@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react@^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.8.0 || ^17 || ^18 || ^19", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^18 || ^19", "react@^18 || ^19 || ^19.0.0-rc", react@^18.3.1, react@>=16, react@>=16.6.0, react@>=16.8, react@>=16.8.0, react@>=17, react@>=18:
+"react@^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.14.0 || 17.x || 18.x || 19.x", "react@^16.3 || ^17.0 || ^18.0 || ^19.0", "react@^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8 || ^17 || ^18", "react@^16.8 || ^17.0 || ^18.0", "react@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react@^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.8.0 || ^17 || ^18 || ^19", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^18 || ^19", "react@^18 || ^19 || ^19.0.0-rc", react@^18.3.1, react@>=16, react@>=16.6.0, react@>=16.8, react@>=16.8.0, react@>=17, react@>=18:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react/-/react-18.3.1.tgz"
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==


### PR DESCRIPTION
## Description

- update previous conversation analysis to avoid duplication
- update operator statistics when performing new analysis
- select unique conversations when using conversation analysis attributes as filter

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release