### PR TITLE
fix: conversation search-index migration without pg_trgm

### DIFF
--- a/backend/alembic/versions/00091_add_conversation_search_indexes.py
+++ b/backend/alembic/versions/00091_add_conversation_search_indexes.py
@@ -32,9 +32,38 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    # pg_trgm can be created inside the normal transaction; it enables the
-    # gin_trgm_ops operator class used by the topic/summary indexes below.
-    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    # Try to enable pg_trgm (needed by the gin_trgm_ops operator class used by
+    # the topic/summary indexes). In some environments the migration role lacks
+    # CREATE privilege on the database, so this can fail. We tolerate that and
+    # simply skip the trigram indexes rather than blocking the whole migration:
+    # the critical FK/ordering indexes below don't depend on pg_trgm.
+    bind = op.get_bind()
+
+    def _trgm_installed() -> bool:
+        return bool(
+            bind.exec_driver_sql(
+                "SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm'"
+            ).scalar()
+        )
+
+    trgm_available = _trgm_installed()
+    if not trgm_available:
+        # Attempt to create it inside a SAVEPOINT so a permission failure only
+        # rolls back this nested block and leaves the migration transaction
+        # usable (a raw failed statement would otherwise poison the whole txn).
+        try:
+            with bind.begin_nested():
+                op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+            trgm_available = _trgm_installed()
+        except Exception:
+            trgm_available = False
+    if not trgm_available:
+        print(
+            "WARNING: pg_trgm extension is not installed and could not be "
+            "created; skipping trigram indexes (ix_conversations_topic_trgm, "
+            "ix_conversation_analysis_summary_trgm). Install pg_trgm and "
+            "create these indexes manually to speed up ILIKE searches."
+        )
 
     # CREATE INDEX CONCURRENTLY must run outside a transaction.
     with op.get_context().autocommit_block():
@@ -48,20 +77,22 @@ def upgrade() -> None:
         )
 
         # (2) Trigram indexes so ILIKE '%term%' is index-backed.
-        op.execute(
-            """
-            CREATE INDEX CONCURRENTLY IF NOT EXISTS
-                ix_conversations_topic_trgm
-            ON conversations USING gin (topic gin_trgm_ops)
-            """
-        )
-        op.execute(
-            """
-            CREATE INDEX CONCURRENTLY IF NOT EXISTS
-                ix_conversation_analysis_summary_trgm
-            ON conversation_analysis USING gin (summary gin_trgm_ops)
-            """
-        )
+        #     Only buildable when pg_trgm is present.
+        if trgm_available:
+            op.execute(
+                """
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS
+                    ix_conversations_topic_trgm
+                ON conversations USING gin (topic gin_trgm_ops)
+                """
+            )
+            op.execute(
+                """
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS
+                    ix_conversation_analysis_summary_trgm
+                ON conversation_analysis USING gin (summary gin_trgm_ops)
+                """
+            )
 
         # (3) Support ORDER BY created_at DESC + pagination for live rows.
         op.execute(

--- a/backend/alembic/versions/00091_add_conversation_search_indexes.py
+++ b/backend/alembic/versions/00091_add_conversation_search_indexes.py
@@ -1,14 +1,18 @@
 """add indexes to speed up conversation search/filter
 
-Targets the slow conversation search queries (topic/summary ILIKE, correlated
-EXISTS on conversation_analysis, ORDER BY created_at DESC pagination).
+Targets the slow conversation search queries (correlated EXISTS on
+conversation_analysis, ORDER BY created_at DESC pagination).
 
 Adds:
 - b-tree index on conversation_analysis.conversation_id (FK had no index -> the
   correlated EXISTS subquery was doing a seq scan per conversation row)
-- pg_trgm GIN indexes on conversations.topic and conversation_analysis.summary so
-  leading-wildcard ILIKE '%x%' can use an index instead of a seq scan
 - partial b-tree on conversations.created_at DESC (live rows) for ORDER BY + LIMIT
+
+Note: topic/summary ILIKE '%x%' searches are intentionally NOT indexed here.
+A leading-wildcard ILIKE can only be index-backed via a pg_trgm GIN index, and
+creating that extension requires CREATE privilege on the database which is not
+available in all (e.g. managed prod) environments. Those searches continue to
+run as sequential scans.
 
 All indexes are built with CREATE INDEX CONCURRENTLY so no write locks are taken
 on prod tables. CONCURRENTLY cannot run inside a transaction, so we use an
@@ -32,39 +36,6 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    # Try to enable pg_trgm (needed by the gin_trgm_ops operator class used by
-    # the topic/summary indexes). In some environments the migration role lacks
-    # CREATE privilege on the database, so this can fail. We tolerate that and
-    # simply skip the trigram indexes rather than blocking the whole migration:
-    # the critical FK/ordering indexes below don't depend on pg_trgm.
-    bind = op.get_bind()
-
-    def _trgm_installed() -> bool:
-        return bool(
-            bind.exec_driver_sql(
-                "SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm'"
-            ).scalar()
-        )
-
-    trgm_available = _trgm_installed()
-    if not trgm_available:
-        # Attempt to create it inside a SAVEPOINT so a permission failure only
-        # rolls back this nested block and leaves the migration transaction
-        # usable (a raw failed statement would otherwise poison the whole txn).
-        try:
-            with bind.begin_nested():
-                op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
-            trgm_available = _trgm_installed()
-        except Exception:
-            trgm_available = False
-    if not trgm_available:
-        print(
-            "WARNING: pg_trgm extension is not installed and could not be "
-            "created; skipping trigram indexes (ix_conversations_topic_trgm, "
-            "ix_conversation_analysis_summary_trgm). Install pg_trgm and "
-            "create these indexes manually to speed up ILIKE searches."
-        )
-
     # CREATE INDEX CONCURRENTLY must run outside a transaction.
     with op.get_context().autocommit_block():
         # (1) Critical: index the FK column the correlated EXISTS subquery uses.
@@ -76,25 +47,7 @@ def upgrade() -> None:
             """
         )
 
-        # (2) Trigram indexes so ILIKE '%term%' is index-backed.
-        #     Only buildable when pg_trgm is present.
-        if trgm_available:
-            op.execute(
-                """
-                CREATE INDEX CONCURRENTLY IF NOT EXISTS
-                    ix_conversations_topic_trgm
-                ON conversations USING gin (topic gin_trgm_ops)
-                """
-            )
-            op.execute(
-                """
-                CREATE INDEX CONCURRENTLY IF NOT EXISTS
-                    ix_conversation_analysis_summary_trgm
-                ON conversation_analysis USING gin (summary gin_trgm_ops)
-                """
-            )
-
-        # (3) Support ORDER BY created_at DESC + pagination for live rows.
+        # (2) Support ORDER BY created_at DESC + pagination for live rows.
         op.execute(
             """
             CREATE INDEX CONCURRENTLY IF NOT EXISTS
@@ -112,12 +65,5 @@ def downgrade() -> None:
             "DROP INDEX CONCURRENTLY IF EXISTS ix_conversations_created_at_desc"
         )
         op.execute(
-            "DROP INDEX CONCURRENTLY IF EXISTS ix_conversation_analysis_summary_trgm"
-        )
-        op.execute(
-            "DROP INDEX CONCURRENTLY IF EXISTS ix_conversations_topic_trgm"
-        )
-        op.execute(
             "DROP INDEX CONCURRENTLY IF EXISTS ix_conversation_analysis_conversation_id"
         )
-    # Leave the pg_trgm extension in place; other objects may depend on it.


### PR DESCRIPTION
## Problem

Migration `00091_add_conversation_search_indexes.py` ran `CREATE EXTENSION IF NOT EXISTS pg_trgm` unconditionally. Where the migration role lacks `CREATE` privilege on the database (managed Postgres such as RDS/Cloud SQL, restricted prod/tenant roles), this fails and blocks the **entire** migration:

```
permission denied to create extension "pg_trgm"
```

## Change

Drop the pg_trgm extension and the two trigram GIN indexes entirely. Keep only the two extension-free B-tree indexes:

- `ix_conversation_analysis_conversation_id` — the critical FK index that removes the per-row seq scan on the correlated `EXISTS` subquery.
- `ix_conversations_created_at_desc` — partial index (live rows) for `ORDER BY created_at DESC` pagination.

Both build with `CREATE INDEX CONCURRENTLY` (no write locks) and need no extension, so the migration runs cleanly in every environment.

## Trade-off

`topic` / `summary` `ILIKE '%term%'` searches continue to run as sequential scans (a leading-wildcard match can only be index-backed via pg_trgm). If that becomes a bottleneck, options are enabling pg_trgm in prod, or switching to prefix search backed by a `text_pattern_ops` B-tree.