### PR TITLE
feat: add multi-phrase not_contains metric and make contains case-insensitive (casefold)

### DIFF
--- a/backend/app/services/test_suite.py
+++ b/backend/app/services/test_suite.py
@@ -293,6 +293,32 @@ def _build_grading_context(execution_trace: Any) -> Dict[str, Any]:
     }
 
 
+def _clean_forbidden_phrases(config: Dict[str, Any]) -> List[str]:
+    """Forbidden phrases from config: trimmed, de-duplicated (casefold), legacy ``text`` accepted.
+
+    Only a string or a list of strings is accepted; any other shape yields no phrases.
+    """
+    raw = config.get("phrases")
+    if raw is None:
+        raw = config.get("text")
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, list):
+        return []
+    phrases: List[str] = []
+    seen: set[str] = set()
+    for entry in raw:
+        if not isinstance(entry, str):
+            continue
+        cleaned = entry.strip()
+        key = cleaned.casefold()
+        if not cleaned or key in seen:
+            continue
+        seen.add(key)
+        phrases.append(cleaned)
+    return phrases
+
+
 class SimpleEvaluatorRegistry:
     """
     Lightweight evaluator registry inspired by OpenEvals.
@@ -309,6 +335,7 @@ class SimpleEvaluatorRegistry:
         self._evaluators = {
             "exact_match": self._exact_match,
             "contains": self._contains,
+            "not_contains": self._not_contains,
             "json_match": self._json_match,
             "field_equals": self._field_equals,
             "no_errors": self._no_errors,
@@ -403,12 +430,40 @@ class SimpleEvaluatorRegistry:
     ) -> Dict[str, Any]:
         actual = _normalize_text(outputs)
         expected = _normalize_text(reference_outputs)
-        passed = bool(actual and expected and expected in actual)
+        passed = bool(actual and expected and expected.casefold() in actual.casefold())
         return {
             "key": "contains",
             "score": passed,
             "passed": passed,
             "comment": None if passed else "Expected text not found in output.",
+        }
+
+    async def _not_contains(
+        self,
+        *,
+        inputs: Dict[str, Any],  # noqa: ARG002 - not used by this evaluator
+        outputs: Any,
+        reference_outputs: Any,  # noqa: ARG002 - forbidden phrases come from config
+        payload: Dict[str, Any],  # noqa: ARG002 - reserved for unified signature
+        config: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Pass when none of the configured forbidden phrases appear in the output."""
+        phrases = _clean_forbidden_phrases(config)
+        if not phrases:
+            return {
+                "key": "not_contains",
+                "score": False,
+                "passed": False,
+                "comment": "No forbidden phrases configured.",
+            }
+        actual = _normalize_text(outputs).casefold()
+        found = [phrase for phrase in phrases if phrase.casefold() in actual]
+        passed = not found
+        return {
+            "key": "not_contains",
+            "score": passed,
+            "passed": passed,
+            "comment": None if passed else f"Forbidden phrases found in output: {', '.join(found)}.",
         }
 
     async def _json_match(

--- a/backend/tests/unit/test_evaluators.py
+++ b/backend/tests/unit/test_evaluators.py
@@ -131,6 +131,187 @@ class TestTraceAwareEvaluators:
         assert metrics["contains"]["passed"] is True
 
 
+class TestContainsAndNotContains:
+    def setup_method(self):
+        self.registry = SimpleEvaluatorRegistry()
+
+    @pytest.mark.asyncio
+    async def test_contains_is_case_insensitive(self):
+        metrics = await self.registry.evaluate(
+            ["contains"],
+            inputs={},
+            outputs="We are OPEN 24/7 for support",
+            reference_outputs={"value": "open 24/7"},
+        )
+        assert metrics["contains"]["passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_not_contains_passes_when_forbidden_text_absent(self):
+        metrics = await self.registry.evaluate(
+            ["not_contains"],
+            inputs={},
+            outputs="Here is the information you asked for.",
+            reference_outputs=None,
+            technique_configs={"not_contains": {"text": "I cannot help"}},
+        )
+        assert metrics["not_contains"]["passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_not_contains_fails_when_forbidden_text_present(self):
+        metrics = await self.registry.evaluate(
+            ["not_contains"],
+            inputs={},
+            outputs="Sorry, I cannot help with that request.",
+            reference_outputs=None,
+            technique_configs={"not_contains": {"text": "I cannot help"}},
+        )
+        assert metrics["not_contains"]["passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_not_contains_is_case_insensitive(self):
+        metrics = await self.registry.evaluate(
+            ["not_contains"],
+            inputs={},
+            outputs="The password is SECRET123.",
+            reference_outputs=None,
+            technique_configs={"not_contains": {"text": "secret"}},
+        )
+        assert metrics["not_contains"]["passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_not_contains_fails_when_forbidden_text_missing(self):
+        metrics = await self.registry.evaluate(
+            ["not_contains"],
+            inputs={},
+            outputs="Any output at all.",
+            reference_outputs=None,
+            technique_configs={"not_contains": {"text": ""}},
+        )
+        assert metrics["not_contains"]["passed"] is False
+        assert metrics["not_contains"]["comment"] == "No forbidden phrases configured."
+
+    @pytest.mark.asyncio
+    async def test_not_contains_passes_on_empty_output(self):
+        metrics = await self.registry.evaluate(
+            ["not_contains"],
+            inputs={},
+            outputs="",
+            reference_outputs=None,
+            technique_configs={"not_contains": {"text": "forbidden"}},
+        )
+        assert metrics["not_contains"]["passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_not_contains_multiple_phrases_reports_matches(self):
+        metrics = await self.registry.evaluate(
+            ["not_contains"],
+            inputs={},
+            outputs="You could try Globex or initech instead.",
+            reference_outputs=None,
+            technique_configs={"not_contains": {"phrases": ["Acme", "Globex", "Initech"]}},
+        )
+        assert metrics["not_contains"]["passed"] is False
+        assert "Globex" in metrics["not_contains"]["comment"]
+        assert "Initech" in metrics["not_contains"]["comment"]
+        assert "Acme" not in metrics["not_contains"]["comment"]
+
+    @pytest.mark.asyncio
+    async def test_not_contains_passes_when_no_phrase_present(self):
+        metrics = await self.registry.evaluate(
+            ["not_contains"],
+            inputs={},
+            outputs="Our service lets you do everything from the app.",
+            reference_outputs=None,
+            technique_configs={"not_contains": {"phrases": ["Acme", "Globex"]}},
+        )
+        assert metrics["not_contains"]["passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_not_contains_casefold_matches_german_sharp_s(self):
+        metrics = await self.registry.evaluate(
+            ["not_contains"],
+            inputs={},
+            outputs="DIE STRASSE IST GESPERRT.",
+            reference_outputs=None,
+            technique_configs={"not_contains": {"phrases": ["straße"]}},
+        )
+        assert metrics["not_contains"]["passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_contains_casefold_matches_german_sharp_s(self):
+        metrics = await self.registry.evaluate(
+            ["contains"],
+            inputs={},
+            outputs="Die Straße ist offen.",
+            reference_outputs={"value": "STRASSE"},
+        )
+        assert metrics["contains"]["passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_not_contains_trims_and_dedupes_phrases(self):
+        metrics = await self.registry.evaluate(
+            ["not_contains"],
+            inputs={},
+            outputs="Nothing forbidden here.",
+            reference_outputs=None,
+            technique_configs={"not_contains": {"phrases": ["  Acme  ", "acme", "", "   "]}},
+        )
+        assert metrics["not_contains"]["passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_not_contains_empty_phrase_list_fails_with_config_message(self):
+        metrics = await self.registry.evaluate(
+            ["not_contains"],
+            inputs={},
+            outputs="Any output.",
+            reference_outputs=None,
+            technique_configs={"not_contains": {"phrases": ["", "   "]}},
+        )
+        assert metrics["not_contains"]["passed"] is False
+        assert metrics["not_contains"]["comment"] == "No forbidden phrases configured."
+
+    @pytest.mark.asyncio
+    async def test_not_contains_rejects_malformed_phrase_config(self):
+        for bad_phrases in (123, True, {"nested": "dict"}, [123, None, {}]):
+            metrics = await self.registry.evaluate(
+                ["not_contains"],
+                inputs={},
+                outputs="Any output.",
+                reference_outputs=None,
+                technique_configs={"not_contains": {"phrases": bad_phrases}},
+            )
+            assert metrics["not_contains"]["passed"] is False
+            assert metrics["not_contains"]["comment"] == "No forbidden phrases configured."
+
+    @pytest.mark.asyncio
+    async def test_not_contains_rejects_malformed_legacy_text(self):
+        metrics = await self.registry.evaluate(
+            ["not_contains"],
+            inputs={},
+            outputs="Any output.",
+            reference_outputs=None,
+            technique_configs={"not_contains": {"text": 123}},
+        )
+        assert metrics["not_contains"]["passed"] is False
+        assert metrics["not_contains"]["comment"] == "No forbidden phrases configured."
+
+    @pytest.mark.asyncio
+    async def test_contains_and_not_contains_coexist_with_independent_results(self):
+        # Same output graded by both: contains passes on the required phrase while
+        # not_contains fails on the forbidden one, so the case result reflects both.
+        metrics = await self.registry.evaluate(
+            ["contains", "not_contains"],
+            inputs={},
+            outputs="You can use our service, or try Acme instead.",
+            reference_outputs={"value": "our service"},
+            technique_configs={"not_contains": {"phrases": ["Acme"]}},
+        )
+        assert set(metrics) == {"contains", "not_contains"}
+        assert metrics["contains"]["passed"] is True
+        assert metrics["not_contains"]["passed"] is False
+        assert "Acme" in metrics["not_contains"]["comment"]
+
+
 # Synthetic trace fixture with generic placeholder values (not tied to any workflow).
 def _agent_trace(*, tool_name="lookup_tool", tool_args=None, tool_result="sample tool result", route="true", action_status="success"):
     return {

--- a/frontend/src/views/TestSuites/components/EvaluationWizard.tsx
+++ b/frontend/src/views/TestSuites/components/EvaluationWizard.tsx
@@ -38,6 +38,7 @@ const METRIC_GROUPS: { label: string; metrics: MetricDef[] }[] = [
     metrics: [
       { value: "exact_match", label: "Exact Match", description: "Output exactly equals the expected value" },
       { value: "contains", label: "Contains", description: "Output contains the expected text" },
+      { value: "not_contains", label: "Does Not Contain", description: "Output must not contain the specified text" },
       { value: "json_match", label: "JSON Match", description: "Output matches the expected JSON structure and values" },
     ],
   },
@@ -61,6 +62,7 @@ const METRIC_GROUPS: { label: string; metrics: MetricDef[] }[] = [
 ];
 
 const CONFIG_METRICS = [
+  "not_contains",
   "nli_eval",
   "provenance_eval",
   "tool_used",
@@ -151,6 +153,7 @@ export interface EvaluationWizardData {
   toolNode: string;
   toolResultNotEmpty: boolean;
   toolResultContains: string;
+  notContainsText: string;
   routeExpected: string;
   routeNode: string;
   actionNode: string;
@@ -247,6 +250,9 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
     return `Passes when ${agentPart} calls ${toolPart}${extras}.`;
   };
 
+  // Does Not Contain config
+  const [notContainsText, setNotContainsText] = useState(initialData?.notContainsText ?? "");
+
   // Route Taken config
   const [routeExpected, setRouteExpected] = useState(initialData?.routeExpected ?? "");
   const [routeNode, setRouteNode] = useState(initialData?.routeNode ?? "");
@@ -277,6 +283,7 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
 
   const isConfigureStepValid = (): boolean => {
     if (metrics.includes("llm_judge") && !judgeRubric.trim()) return false;
+    if (metrics.includes("not_contains") && !notContainsText.trim()) return false;
     if (metrics.includes("route_taken") && !routeExpected.trim()) return false;
     if (metrics.includes("action_taken") && !actionNode.trim() && !actionNodeType.trim()) return false;
     if (toolArgsInvalid || nliScoreInvalid || provScoreInvalid || judgeScoreInvalid) return false;
@@ -337,6 +344,7 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
         toolNode,
         toolResultNotEmpty,
         toolResultContains,
+        notContainsText,
         routeExpected,
         routeNode,
         actionNode,
@@ -383,6 +391,7 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
     setToolResultNotEmpty(false);
     setToolResultContains("");
     setToolAdvancedOpen(false);
+    setNotContainsText("");
     setRouteExpected("");
     setRouteNode("");
     setActionNode("");
@@ -782,6 +791,29 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
                     Rule
                   </div>
                   <p className="text-xs text-muted-foreground">{toolRuleSummary()}</p>
+                </div>
+              </div>
+            )}
+
+            {metrics.includes("not_contains") && (
+              <div className="border rounded-lg p-4 space-y-3">
+                <div className="text-sm font-semibold flex items-center gap-2">
+                  <span className="w-2 h-2 rounded-full bg-rose-500"></span>
+                  Does Not Contain Config
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Fails the run if any of these phrases appears in the output. One phrase
+                  per line. Matching is case-insensitive.
+                </p>
+                <div>
+                  <Label className="text-xs">Forbidden Phrases *</Label>
+                  <Textarea
+                    value={notContainsText}
+                    onChange={(e) => setNotContainsText(e.target.value)}
+                    placeholder={"e.g.\ncompetitor name\nsocial security number"}
+                    rows={3}
+                    className="mt-1"
+                  />
                 </div>
               </div>
             )}

--- a/frontend/src/views/TestSuites/helpers/evaluationForm.ts
+++ b/frontend/src/views/TestSuites/helpers/evaluationForm.ts
@@ -16,6 +16,28 @@ const parseJsonObject = (
   }
 };
 
+// One forbidden phrase per textarea line: trimmed, empties dropped, ASCII-case dedupe.
+// The backend re-dedupes with Unicode casefold, which is the authoritative pass.
+const splitForbiddenPhrases = (text: string): string[] => {
+  const phrases: string[] = [];
+  const seen = new Set<string>();
+  for (const line of text.split("\n")) {
+    const phrase = line.trim();
+    const key = phrase.toLowerCase();
+    if (!phrase || seen.has(key)) continue;
+    seen.add(key);
+    phrases.push(phrase);
+  }
+  return phrases;
+};
+
+// A stored not_contains config may hold the new phrases list or the legacy single text.
+const forbiddenPhrasesToText = (config: Record<string, unknown> | undefined): string => {
+  const phrases = config?.phrases;
+  if (Array.isArray(phrases)) return phrases.join("\n");
+  return (config?.text as string) ?? "";
+};
+
 // Parse the wizard's metadata textarea and fold in the "use memory" flag.
 export const wizardMetadata = (
   data: EvaluationWizardData,
@@ -33,6 +55,12 @@ export const buildTechniqueConfigs = (
   data: EvaluationWizardData,
 ): Record<string, Record<string, unknown>> => {
   const configs: Record<string, Record<string, unknown>> = {};
+
+  if (data.metrics.includes("not_contains")) {
+    configs.not_contains = {
+      phrases: splitForbiddenPhrases(data.notContainsText),
+    };
+  }
 
   if (data.metrics.includes("nli_eval")) {
     configs.nli_eval = {
@@ -111,6 +139,7 @@ export const getEditInitialData = (
   evaluation: TestEvaluationConfig,
   providers: LLMProviderMinimal[],
 ): Partial<EvaluationWizardData> => {
+  const notContainsCfg = evaluation.technique_configs?.["not_contains"] as Record<string, unknown> | undefined;
   const nliCfg = evaluation.technique_configs?.["nli_eval"] as Record<string, unknown> | undefined;
   const provCfg = evaluation.technique_configs?.["provenance_eval"] as Record<string, unknown> | undefined;
   const toolCfg = evaluation.technique_configs?.["tool_used"] as Record<string, unknown> | undefined;
@@ -147,6 +176,7 @@ export const getEditInitialData = (
     toolNode: (toolCfg?.node as string) ?? "",
     toolResultNotEmpty: Boolean(toolCfg?.result_not_empty),
     toolResultContains: (toolCfg?.result_contains as string) ?? "",
+    notContainsText: forbiddenPhrasesToText(notContainsCfg),
     routeExpected: (routeCfg?.expected as string) ?? "",
     routeNode: (routeCfg?.node as string) ?? "",
     actionNode: (actionCfg?.node as string) ?? "",

--- a/frontend/src/views/TestSuites/pages/EvaluationDetailPage.tsx
+++ b/frontend/src/views/TestSuites/pages/EvaluationDetailPage.tsx
@@ -54,6 +54,10 @@ const getMetricSourceLabel = (
     case "contains":
     case "json_match":
       return "Expected Output";
+    case "not_contains": {
+      const hasPhrases = Array.isArray(config?.phrases) ? (config.phrases as unknown[]).length > 0 : Boolean(config?.text);
+      return hasPhrases ? "Configured forbidden phrases" : "Forbidden phrases";
+    }
     case "field_equals":
       return config?.expected !== undefined ? "Configured expected value" : "Expected Output";
     case "nli_eval": {


### PR DESCRIPTION
## Description

- New not_contains metric: fails if any forbidden phrase appears in the output
- Multi-phrase support (one per line); result names which phrase matched
- Case-insensitive matching via casefold() for both metrics
- Backward compatible (accepts legacy text and new phrases); no migration

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
