### PR TITLE
feat: tool usage rule builder

### DIFF
--- a/backend/alembic/versions/00101_add_test_tool_rule_results.py
+++ b/backend/alembic/versions/00101_add_test_tool_rule_results.py
@@ -1,0 +1,51 @@
+"""add test_tool_rule_results table
+
+Canonical per-rule outcomes for Tool Usage evaluation. Turn-scoped rules store
+case_id; conversation-scoped rules store source_conversation_id. ``details`` holds
+a snapshot of the evaluated rule so results stay readable after config changes.
+
+Revision ID: b7c2e9d14a83
+Revises: a3f9c1d7e204
+Create Date: 2026-07-24 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c2e9d14a83"
+down_revision: Union[str, None] = "a3f9c1d7e204"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "test_tool_rule_results",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("run_id", sa.UUID(), nullable=False),
+        sa.Column("rule_id", sa.String(length=128), nullable=False),
+        sa.Column("scope", sa.String(length=32), nullable=False),
+        sa.Column("case_id", sa.UUID(), nullable=True),
+        sa.Column("source_conversation_id", sa.UUID(), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("score", sa.Float(), nullable=True),
+        sa.Column("details", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("created_by", sa.UUID(), nullable=True),
+        sa.Column("updated_by", sa.UUID(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=True),
+        sa.Column("is_deleted", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.ForeignKeyConstraint(["run_id"], ["test_runs.id"]),
+        sa.ForeignKeyConstraint(["case_id"], ["test_cases.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_test_tool_rule_results_run", "test_tool_rule_results", ["run_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_test_tool_rule_results_run", table_name="test_tool_rule_results")
+    op.drop_table("test_tool_rule_results")

--- a/backend/app/api/v1/routes/test_evaluations.py
+++ b/backend/app/api/v1/routes/test_evaluations.py
@@ -11,6 +11,7 @@ from app.core.tenant_scope import get_tenant_context
 from app.dependencies.dependency_injection import RedisString
 from app.dependencies.injector import injector
 from app.schemas.test_suite import (
+    EvaluationToolCatalog,
     PaginatedEvaluations,
     StartedEvaluationRun,
     TestEvaluation,
@@ -35,6 +36,19 @@ _RELEASE_LOCK_LUA = (
     "if redis.call('get', KEYS[1]) == ARGV[1] "
     "then return redis.call('del', KEYS[1]) else return 0 end"
 )
+
+
+@router.get(
+    "/workflows/{workflow_id}/evaluation-tool-catalog",
+    response_model=EvaluationToolCatalog,
+    dependencies=[Depends(auth), Depends(permissions(P.Evaluation.READ))],
+)
+async def get_evaluation_tool_catalog(
+    workflow_id: UUID,
+    service: TestSuiteService = Injected(TestSuiteService),
+):
+    """Agents and their tools for a workflow, so the rule builder never needs free text."""
+    return await service.get_evaluation_tool_catalog(workflow_id)
 
 
 @router.get(

--- a/backend/app/api/v1/routes/test_runs.py
+++ b/backend/app/api/v1/routes/test_runs.py
@@ -12,6 +12,7 @@ from app.schemas.test_suite import (
     TestResult,
     TestRun,
     TestRunCreate,
+    TestToolRuleResult,
 )
 from app.services.test_suite import TestSuiteService
 from app.tasks.test_suite_tasks import execute_test_suite_run_task
@@ -94,3 +95,16 @@ async def list_results_for_run(
     service: TestSuiteService = Injected(TestSuiteService),
 ):
     return await service.list_results_for_run(run_id)
+
+
+@router.get(
+    "/runs/{run_id}/tool-rule-results",
+    response_model=List[TestToolRuleResult],
+    dependencies=[Depends(auth), Depends(permissions(P.Evaluation.READ))],
+)
+async def list_tool_rule_results_for_run(
+    run_id: UUID,
+    service: TestSuiteService = Injected(TestSuiteService),
+):
+    """Per-rule Tool Usage outcomes for a run (turn- and conversation-scoped)."""
+    return await service.list_tool_rule_results_for_run(run_id)

--- a/backend/app/core/exceptions/error_messages.py
+++ b/backend/app/core/exceptions/error_messages.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 
 class ErrorKey(Enum):
     INTERNAL_ERROR = "error_500"
+    TOOL_USAGE_CONFIG_INVALID = "tool_usage_config_invalid"
     NOT_FOUND = "not_found"
     AUDIT_LOG_NOT_FOUND = "audit_log_not_found"
     SENTIMENT_OBJECT_STRUCTURE = "sentiment_object_structure"
@@ -175,6 +176,7 @@ class ErrorKey(Enum):
 ERROR_MESSAGES = {
     "en": {
         ErrorKey.INTERNAL_ERROR: "An internal server error occurred. Please try again later.",
+        ErrorKey.TOOL_USAGE_CONFIG_INVALID: "The tool usage configuration could not be resolved to canonical tool ids.",
         ErrorKey.NOT_FOUND: "The requested resource was not found.",
         ErrorKey.AUDIT_LOG_NOT_FOUND: "The requested log was not found.",
         ErrorKey.SENTIMENT_OBJECT_STRUCTURE: "Sentiment object must have 'positive', 'neutral', and 'negative' fields.",

--- a/backend/app/db/models/test_suite.py
+++ b/backend/app/db/models/test_suite.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 from uuid import UUID
 
-from sqlalchemy import ForeignKey, Index, String, Text
+from sqlalchemy import Float, ForeignKey, Index, String, Text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -177,4 +177,37 @@ class TestResultModel(Base):
 
     run = relationship("TestRunModel", back_populates="results")
     case = relationship("TestCaseModel", back_populates="results")
+
+
+class TestToolRuleResultModel(Base):
+    """Canonical per-rule outcome for Tool Usage evaluation.
+
+    One row per rule per scope unit: a specific/every-turn rule stores case_id; a
+    conversation rule stores source_conversation_id. ``details`` snapshots the
+    evaluated rule so historical results stay readable after config changes.
+    """
+
+    __tablename__ = "test_tool_rule_results"
+    __table_args__ = (
+        Index("ix_test_tool_rule_results_run", "run_id"),
+    )
+
+    run_id: Mapped[UUID] = mapped_column(ForeignKey("test_runs.id"), nullable=False)
+    rule_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    scope: Mapped[str] = mapped_column(String(32), nullable=False)
+
+    # Turn-scoped rules point at a case; conversation-scoped rules at a conversation.
+    case_id: Mapped[Optional[UUID]] = mapped_column(
+        ForeignKey("test_cases.id"), nullable=True
+    )
+    source_conversation_id: Mapped[Optional[UUID]] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+
+    # passed | failed | not_evaluated
+    status: Mapped[str] = mapped_column(String(32), nullable=False)
+    score: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+
+    # Snapshot of the evaluated rule + observed/missing/forbidden tools.
+    details: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
 

--- a/backend/app/modules/workflow/agents/base_tool.py
+++ b/backend/app/modules/workflow/agents/base_tool.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+import weakref
 from typing import Any, Callable, Protocol
 
 logger = logging.getLogger(__name__)
@@ -39,7 +40,7 @@ class Tool(Protocol):
 
 class BaseTool(Tool):
     """Base class for tools"""
-    def __init__(self, node_id: str, name: str, description: str, parameters: dict, function: Callable, return_direct: bool = False):
+    def __init__(self, node_id: str, name: str, description: str, parameters: dict, function: Callable, return_direct: bool = False, agent_id: str = None, state: Any = None):
         self.node_id = node_id
         self.name = to_snake_case(name)
         self.description = description
@@ -47,6 +48,27 @@ class BaseTool(Tool):
         self.parameters = filtered_params
         self.function = function
         self.return_direct = return_direct
+        # Owning agent node and workflow state, bound when the tool is attached to
+        # an agent, so each call can be recorded for evaluation.
+        self.agent_id = agent_id
+        self.state = state
+
+    @property
+    def state(self) -> Any:
+        """The owning WorkflowState, held weakly so a tool never creates a
+        reference cycle back into the state it is serialized inside."""
+        return self._state_ref() if self._state_ref is not None else None
+
+    @state.setter
+    def state(self, value: Any) -> None:
+        if value is None:
+            self._state_ref = None
+            return
+        try:
+            self._state_ref = weakref.ref(value)
+        except TypeError:
+            # Non-weak-referenceable (e.g. a test double): keep a plain reference.
+            self._state_ref = lambda v=value: v
 
     async def invoke(self, **kwargs) -> Any:
         """Execute the tool with the given arguments.
@@ -61,17 +83,41 @@ class BaseTool(Tool):
         # Imported lazily to avoid any import-time coupling with the engine package.
         from app.modules.workflow.engine.node_result import is_node_failure
 
-        result = self.function({"parameters": kwargs})
-        if inspect.isawaitable(result):
-            result = await result
+        try:
+            result = self.function({"parameters": kwargs})
+            if inspect.isawaitable(result):
+                result = await result
+        except Exception as exc:
+            self._record_event(kwargs, None, status="failed", error=str(exc))
+            raise
 
         failure = is_node_failure(result)
         if failure is not None:
             reason = failure.get("error") or "the tool did not complete its action"
             logger.warning("Tool '%s' (node %s) failed: %s", self.name, self.node_id, reason)
+            self._record_event(kwargs, result, status="failed", error=reason)
             return (
                 f"ERROR: the '{self.name}' tool did not complete successfully and no "
                 f"action was taken. Reason: {reason}. Do not tell the user this "
                 f"succeeded — report that it could not be completed."
             )
+        self._record_event(kwargs, result, status="succeeded", error=None)
         return result
+
+    def _record_event(self, arguments: dict, result: Any, *, status: str, error: str = None) -> None:
+        """Record this call on the workflow state; never let telemetry break execution."""
+        state = self.state
+        if state is None or not hasattr(state, "add_tool_event"):
+            return
+        try:
+            state.add_tool_event(
+                agent_id=self.agent_id,
+                tool_id=self.node_id,
+                tool_name=self.name,
+                arguments=arguments,
+                result=result,
+                status=status,
+                error=error,
+            )
+        except Exception:
+            logger.debug("Failed to record tool event for '%s'", self.name, exc_info=True)

--- a/backend/app/modules/workflow/engine/base_node.py
+++ b/backend/app/modules/workflow/engine/base_node.py
@@ -285,8 +285,11 @@ class BaseNode(ABC):
                 if node:
                     # Check if node exposes multiple tools (e.g., MCP node)
                     if hasattr(node, "get_tools") and callable(getattr(node, "get_tools")):
-                        # Node exposes multiple tools
+                        # Node exposes multiple tools (e.g. MCP)
                         tools = node.get_tools()
+                        for t in tools:
+                            t.agent_id = self.node_id
+                            t.state = self.get_state()
                         connected_nodes.extend(tools)
                         logger.debug("Added %d tools from node %s", len(tools), source_node_id)
                     else:
@@ -298,6 +301,8 @@ class BaseNode(ABC):
                             parameters=node.get_input_schema(),
                             return_direct=node.get_node_data().get("returnDirect", False),
                             function=node.execute,
+                            agent_id=self.node_id,
+                            state=self.get_state(),
                         )
 
                         connected_nodes.append(tool)

--- a/backend/app/modules/workflow/engine/nodes/ml/ml_utils.py
+++ b/backend/app/modules/workflow/engine/nodes/ml/ml_utils.py
@@ -19,12 +19,22 @@ from app.core.project_path import DATA_VOLUME
 
 logger = logging.getLogger(__name__)
 
+# Backstops so the recursive walk can never wedge the worker: a cap on nesting
+# depth, and a cap on total nodes visited (size). Cycles are caught separately.
+_MAX_SANITIZE_DEPTH = 200
+_MAX_SANITIZE_NODES = 1_000_000
 
-def sanitize_for_json(obj: Any) -> Any:
+
+def sanitize_for_json(obj: Any, _seen: set | None = None, _depth: int = 0, _budget: list | None = None) -> Any:
     """
     Recursively sanitize data to make it JSON-compliant.
     Converts inf, -inf, and nan float values to None or string representations.
     Also handles custom objects by converting them to strings or dictionaries.
+
+    Guards against reference cycles (an object reachable from itself, e.g. a tool
+    holding a back-reference to the workflow state it lives in), pathological
+    depth, and unbounded size — any of which would otherwise recurse forever or
+    stall the worker. ``_seen``/``_depth``/``_budget`` are internal.
 
     Args:
         obj: Any object to sanitize
@@ -32,13 +42,23 @@ def sanitize_for_json(obj: Any) -> Any:
     Returns:
         JSON-compliant version of the object
     """
+    if _seen is None:
+        _seen = set()
+    if _budget is None:
+        _budget = [_MAX_SANITIZE_NODES]
+    if _depth > _MAX_SANITIZE_DEPTH:
+        return f"<max-depth:{type(obj).__name__}>"
+    _budget[0] -= 1
+    if _budget[0] < 0:
+        return "<truncated:size>"
+
     # Handle numpy types (pandas uses numpy internally)
     try:
         import numpy as np
         if isinstance(obj, (np.floating, np.integer)):
             obj = float(obj) if isinstance(obj, np.floating) else int(obj)
         elif isinstance(obj, np.ndarray):
-            return sanitize_for_json(obj.tolist())
+            return sanitize_for_json(obj.tolist(), _seen, _depth + 1, _budget)
     except ImportError:
         pass  # numpy not available, skip
 
@@ -50,12 +70,26 @@ def sanitize_for_json(obj: Any) -> Any:
             return None
         return obj
     elif isinstance(obj, dict):
-        return {key: sanitize_for_json(value) for key, value in obj.items()}
+        obj_id = id(obj)
+        if obj_id in _seen:
+            return "<cycle>"
+        _seen.add(obj_id)
+        try:
+            return {key: sanitize_for_json(value, _seen, _depth + 1, _budget) for key, value in obj.items()}
+        finally:
+            _seen.discard(obj_id)
     elif isinstance(obj, list):
-        return [sanitize_for_json(item) for item in obj]
+        obj_id = id(obj)
+        if obj_id in _seen:
+            return "<cycle>"
+        _seen.add(obj_id)
+        try:
+            return [sanitize_for_json(item, _seen, _depth + 1, _budget) for item in obj]
+        finally:
+            _seen.discard(obj_id)
     elif isinstance(obj, pd.DataFrame):
         # Convert DataFrame to dict and sanitize
-        return sanitize_for_json(obj.to_dict("records"))
+        return sanitize_for_json(obj.to_dict("records"), _seen, _depth + 1, _budget)
     elif pd.isna(obj):
         return None
     elif isinstance(obj, (str, int, bool, type(None))):
@@ -66,7 +100,14 @@ def sanitize_for_json(obj: Any) -> Any:
         try:
             # Try to get a dict representation if it has __dict__
             if hasattr(obj, '__dict__'):
-                return sanitize_for_json(obj.__dict__)
+                obj_id = id(obj)
+                if obj_id in _seen:
+                    return "<cycle>"
+                _seen.add(obj_id)
+                try:
+                    return sanitize_for_json(vars(obj), _seen, _depth + 1, _budget)
+                finally:
+                    _seen.discard(obj_id)
             # Try to get a string representation
             elif hasattr(obj, '__str__'):
                 return str(obj)

--- a/backend/app/modules/workflow/engine/nodes/workflow_executor_node.py
+++ b/backend/app/modules/workflow/engine/nodes/workflow_executor_node.py
@@ -82,6 +82,9 @@ class WorkflowExecutorNode(BaseNode):
                 persist=False  # Don't persist nested workflow executions
             )
 
+            # Nested runs use a separate state; carry their tool events up for evaluation.
+            self.get_state().absorb_tool_events(state)
+
             # Format and return the response
             result = state.format_state_as_response()
 

--- a/backend/app/modules/workflow/engine/workflow_state.py
+++ b/backend/app/modules/workflow/engine/workflow_state.py
@@ -3,6 +3,7 @@ Enhanced workflow state management for execution tracking and performance metric
 """
 
 import copy
+import json
 import logging
 import time
 import uuid
@@ -15,6 +16,50 @@ from app.modules.workflow.agents.memory import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Cap the size of tool arguments/results stored on an event so a large tool
+# result cannot bloat the persisted trace.
+_MAX_EVENT_VALUE_CHARS = 8000
+
+
+def _bound_event_value(value: Any) -> Any:
+    """Return a JSON-safe copy of the value, truncated when it serializes too large.
+
+    Serializing with default=str collapses custom objects (and cyclic graphs,
+    which raise) to strings, so no live object leaks into tool_events — a leak
+    would later blow up the recursive JSON sanitizer walking their __dict__.
+    """
+    if isinstance(value, str):
+        serialized = safe_value = value
+    else:
+        try:
+            serialized = json.dumps(value, default=str)
+            safe_value = json.loads(serialized)
+        except (TypeError, ValueError):
+            safe_value = serialized = str(value)
+    if len(serialized) <= _MAX_EVENT_VALUE_CHARS:
+        return safe_value
+    return {
+        "_truncated": True,
+        "chars": len(serialized),
+        "preview": serialized[:_MAX_EVENT_VALUE_CHARS],
+    }
+
+
+def _strip_live_tool_refs(node_execution_status: dict) -> dict:
+    """Drop live ``tools_reference`` tool objects from node inputs before serialization.
+
+    Each tool holds a back-reference to this WorkflowState, so leaving them in a
+    serialized trace creates a reference cycle. Returns a shallow copy; the live
+    state the agent is still using is left untouched.
+    """
+    cleaned = {}
+    for node_id, entry in node_execution_status.items():
+        node_input = entry.get("input") if isinstance(entry, dict) else None
+        if isinstance(node_input, dict) and "tools_reference" in node_input:
+            entry = {**entry, "input": {k: v for k, v in node_input.items() if k != "tools_reference"}}
+        cleaned[node_id] = entry
+    return cleaned
 
 
 class WorkflowPausedException(BaseException):
@@ -96,6 +141,9 @@ class WorkflowState:
 
         # LLM token usage and cost tracking (per request)
         self.llm_usage: list[dict] = []
+
+        # Normalized tool-execution events, one per tool call.
+        self.tool_events: list[dict] = []
 
         # Edge data and execution context
         self.source_edges = workflow.get("source_edges", {}) if workflow else {}
@@ -250,6 +298,41 @@ class WorkflowState:
             "node_id": node_id,
         })
 
+    def add_tool_event(
+        self,
+        *,
+        agent_id: str | None,
+        tool_id: str | None,
+        tool_name: str,
+        arguments: Any,
+        result: Any,
+        status: str,
+        error: str | None = None,
+    ) -> None:
+        """Record a single tool call. Arguments/result are redacted before storing."""
+        from app.core.utils.sensitive_data_utils import redact_structure
+
+        self.tool_events.append({
+            "event_id": str(uuid.uuid4()),
+            "agent_id": agent_id,
+            "tool_id": tool_id,
+            "tool_name": tool_name,
+            "arguments": _bound_event_value(redact_structure(arguments)),
+            "result": _bound_event_value(redact_structure(result)),
+            "status": status,
+            "error": error,
+            "sequence": len(self.tool_events),
+            "workflow_path": [self.workflow_id] if self.workflow_id else [],
+        })
+
+    def absorb_tool_events(self, child_state: "WorkflowState") -> None:
+        """Merge a sub-workflow's tool events, prepending this workflow to their path."""
+        parent = [self.workflow_id] if self.workflow_id else []
+        for event in child_state.tool_events:
+            self.tool_events.append(
+                {**event, "workflow_path": parent + event.get("workflow_path", [])}
+            )
+
     def get_total_llm_usage(self) -> dict:
         """Sum token usage and compute total cost in USD."""
         total_input = sum(u.get("input_tokens", 0) for u in self.llm_usage)
@@ -285,6 +368,7 @@ class WorkflowState:
         self.execution_history.clear()
         self.errors.clear()
         self.llm_usage.clear()
+        self.tool_events.clear()
         self.performance_metrics = {
             "totalExecutionTime": 0,
             "averageNodeExecutionTime": 0,
@@ -578,6 +662,7 @@ class WorkflowState:
         self.execution_path = [*self.execution_path, *state.execution_path]
         self.execution_history = [*self.execution_history, *state.execution_history]
         self.llm_usage = [*self.llm_usage, *state.llm_usage]
+        self.absorb_tool_events(state)
 
         # Merge stateful values from sub-workflow session into parent session
         # This ensures stateful values updated in sub-workflows propagate to parent
@@ -645,6 +730,7 @@ class WorkflowState:
         Format the workflow state as a response and sanitize for JSON compliance.
         """
         state = self.get_full_state()
+        state["nodeExecutionStatus"] = _strip_live_tool_refs(state.get("nodeExecutionStatus", {}))
         summary = self.get_execution_summary()
 
         _input = (
@@ -688,6 +774,7 @@ class WorkflowState:
             "state": state,
             "token_usage": token_usage,
             "cost_usd": token_usage.get("cost_usd", 0.0),
+            "tool_events": self.tool_events,
         }
 
         # Sanitize response to ensure JSON compliance (handle inf, -inf, nan values)

--- a/backend/app/repositories/test_suite.py
+++ b/backend/app/repositories/test_suite.py
@@ -11,6 +11,7 @@ from app.db.models.test_suite import (
     TestRunModel,
     TestResultModel,
     TestEvaluationModel,
+    TestToolRuleResultModel,
 )
 from app.repositories.db_repository import DbRepository
 
@@ -124,6 +125,33 @@ class TestResultRepository(DbRepository[TestResultModel]):
 
     async def get_all_for_run(self, run_id: UUID) -> List[TestResultModel]:
         stmt = select(TestResultModel).where(TestResultModel.run_id == str(run_id))
+        result = await self.db.execute(stmt)
+        return result.scalars().all()
+
+
+@inject
+class TestToolRuleResultRepository(DbRepository[TestToolRuleResultModel]):
+    def __init__(self, db: AsyncSession):
+        super().__init__(TestToolRuleResultModel, db)
+
+    async def create_many(
+        self, results: List[TestToolRuleResultModel]
+    ) -> List[TestToolRuleResultModel]:
+        if not results:
+            return []
+        self.db.add_all(results)
+        await self.db.commit()
+        return results
+
+    async def get_all_for_run(self, run_id: UUID) -> List[TestToolRuleResultModel]:
+        stmt = (
+            select(TestToolRuleResultModel)
+            .where(
+                TestToolRuleResultModel.run_id == str(run_id),
+                TestToolRuleResultModel.is_deleted == 0,
+            )
+            .order_by(TestToolRuleResultModel.created_at)
+        )
         result = await self.db.execute(stmt)
         return result.scalars().all()
 

--- a/backend/app/schemas/test_suite.py
+++ b/backend/app/schemas/test_suite.py
@@ -113,6 +113,8 @@ class TestResultMetrics(BaseModel):
     score: float | bool
     passed: bool
     comment: Optional[str] = None
+    # Per-rule breakdown for tool_used (and future multi-rule techniques).
+    details: Optional[List[Dict[str, Any]]] = None
 
 
 class TestResultBase(BaseModel):
@@ -147,6 +149,23 @@ class TestResultInDB(TestResultBase):
 
 class TestResult(TestResultInDB):
     pass
+
+
+class TestToolRuleResult(BaseModel):
+    """One Tool Usage rule outcome for a scope unit (turn or conversation)."""
+
+    id: UUID
+    run_id: UUID
+    rule_id: str
+    scope: str
+    case_id: Optional[UUID] = None
+    source_conversation_id: Optional[UUID] = None
+    status: str = Field(description="passed | failed | not_evaluated")
+    score: Optional[float] = None
+    details: Optional[Dict[str, Any]] = None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class TestRunBase(BaseModel):
@@ -258,6 +277,30 @@ class TestEvaluationInDB(TestEvaluationBase):
 
 class TestEvaluation(TestEvaluationInDB):
     pass
+
+
+class EvaluationToolInfo(BaseModel):
+    """A tool an agent can call, from the workflow graph. ``id`` matches tool events."""
+
+    id: str
+    name: str
+    label: str
+    type: str
+
+
+class EvaluationAgentInfo(BaseModel):
+    id: str
+    label: str
+    type: str
+    workflow_path: List[str] = Field(default_factory=list)
+    tools: List[EvaluationToolInfo] = Field(default_factory=list)
+
+
+class EvaluationToolCatalog(BaseModel):
+    """Agents and their tools for a workflow (incl. nested workflows), for the UI."""
+
+    workflow_id: UUID
+    agents: List[EvaluationAgentInfo] = Field(default_factory=list)
 
 
 class WorkflowEvaluationSummary(BaseModel):

--- a/backend/app/services/test_suite.py
+++ b/backend/app/services/test_suite.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import json
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
@@ -15,6 +16,7 @@ from app.db.models.test_suite import (
     TestRunModel,
     TestResultModel,
     TestEvaluationModel,
+    TestToolRuleResultModel,
 )
 from app.modules.workflow.engine.nodes.local_nli_model import local_nli_model
 from app.modules.workflow.engine.workflow_engine import (
@@ -30,6 +32,7 @@ from app.repositories.test_suite import (
     TestRunRepository,
     TestResultRepository,
     TestEvaluationRepository,
+    TestToolRuleResultRepository,
 )
 from app.schemas.test_suite import (
     ImportCasesFromConversationRequest,
@@ -46,9 +49,11 @@ from app.schemas.test_suite import (
     TestRunCreate,
     TestRunInDB,
     TestResultInDB,
+    TestToolRuleResult,
     TestSuiteCreate,
     TestSuiteUpdate,
     TestSuiteInDB,
+    EvaluationToolCatalog,
     WorkflowEvaluationSummary,
 )
 from app.schemas.workflow import WorkflowInDB
@@ -88,6 +93,9 @@ def _truncate_output(output: Any, max_length: int = 64000) -> Any:
 
 # Reserved key holding run-level counts alongside the per-technique metrics.
 RUN_TOTALS_KEY = "_totals"
+
+# Tool Usage is graded per scope from collected tool events, not per case.
+TOOL_USED_TECHNIQUE = "tool_used"
 
 
 class ResultStatus:
@@ -290,6 +298,8 @@ def _build_grading_context(execution_trace: Any) -> Dict[str, Any]:
         "errors": errors,
         "tokens": trace.get("token_usage") or {},
         "cost": trace.get("cost_usd"),
+        # Normalized tool-execution events for the rule-based tool_used evaluator.
+        "tool_events": trace.get("tool_events") or [],
     }
 
 
@@ -317,6 +327,49 @@ def _clean_forbidden_phrases(config: Dict[str, Any]) -> List[str]:
         seen.add(key)
         phrases.append(cleaned)
     return phrases
+
+
+def resolvers_from_agents(agents: List[Dict[str, Any]]):
+    """Build ``(resolve_tool_id, resolve_agent_id, agent_ids, all_tool_ids)`` from a
+    resolved agent catalogue.
+
+    The catalogue is the single source shared by the catalogue UI, config
+    canonicalization and run-time grading, so every tool it lists — including nested
+    and MCP tools, and tools never called — resolves the same way everywhere. The
+    agent-id set lets callers count only real agents as "executed"; ``all_tool_ids``
+    expands a legacy "any tool" config.
+    """
+    from app.services.tool_catalog import (
+        build_agent_index,
+        build_tool_index,
+        resolve_in_index,
+    )
+
+    tool_index = build_tool_index(agents)
+    agent_index = build_agent_index(agents)
+    agent_ids = {agent["id"] for agent in agents}
+    all_tool_ids = sorted({tool["id"] for agent in agents for tool in agent["tools"]})
+    return (
+        lambda name: resolve_in_index(tool_index, name, "tool"),
+        lambda label: resolve_in_index(agent_index, label, "agent"),
+        agent_ids,
+        all_tool_ids,
+    )
+
+
+def build_tool_usage_resolvers(workflow: Any):
+    """Resolvers over a single workflow graph (no nested-workflow expansion).
+
+    Used only by the direct registry evaluator, which has just the graph and no DB
+    access. Returns ``(None, None, None, None)`` when no workflow is available; the
+    parser then keeps ids/names as given. Nested/MCP-aware paths use the service's
+    full catalogue via :func:`resolvers_from_agents` instead.
+    """
+    from app.services.tool_catalog import resolve_agents
+
+    if workflow is None:
+        return None, None, None, None
+    return resolvers_from_agents(resolve_agents(workflow))
 
 
 class SimpleEvaluatorRegistry:
@@ -363,6 +416,7 @@ class SimpleEvaluatorRegistry:
         reference_outputs: Any,
         execution_trace: Any = None,
         technique_configs: Dict[str, Dict[str, Any]] | None = None,
+        workflow: Any = None,
     ) -> Dict[str, Dict[str, Any]]:
         results: Dict[str, Dict[str, Any]] = {}
         payload = {
@@ -370,6 +424,8 @@ class SimpleEvaluatorRegistry:
             "outputs": outputs,
             "reference_outputs": reference_outputs,
             "trace": _build_grading_context(execution_trace),
+            # Workflow graph for legacy name→id resolution via the full tool catalogue.
+            "workflow": workflow,
         }
         for key in techniques:
             fn = self._evaluators.get(key)
@@ -549,65 +605,58 @@ class SimpleEvaluatorRegistry:
         payload: Dict[str, Any],
         config: Dict[str, Any],
     ) -> Dict[str, Any]:
-        """Pass when the agent called the expected tool, optionally with matching args.
-        Set should_call=False to assert the tool (or any tool, if unset) was NOT called.
-        Set node (id or label) to only consider calls made by that agent node.
-        Set result_not_empty / result_contains to also assert on what the call returned."""
+        """Grade tool usage against a set of rules (all/any/none/only), reading the
+        normalized tool events on the trace. The legacy single-tool config is
+        converted automatically. Scope slicing across turns is applied by the run
+        loop; here every event in the trace is one slice."""
+        from app.services.tool_usage_rules import (
+            evaluate_rules,
+            parse_tool_usage_config,
+        )
+
         trace = payload.get("trace") or {}
-        tools = trace.get("tools") or []
-        expected = config.get("tool")
-        expected_args = config.get("expected_args") or {}
-        should_call = bool(config.get("should_call", True))
-        node_selector = config.get("node")
+        events = trace.get("tool_events") or []
 
-        if node_selector:
-            trace_nodes = (trace.get("nodes") or {}).values()
-            matching_node_ids = {
-                node.get("id") for node in trace_nodes if _node_matches_selector(node, node_selector)
-            }
-            tools = [t for t in tools if t.get("node") in matching_node_ids]
-
-        called_names = [tool.get("name") for tool in tools if tool.get("name")]
-        scope = f" by node {node_selector!r}" if node_selector else ""
-
-        matches = [t for t in tools if not expected or _names_equal(t.get("name"), expected)]
-
-        if not should_call:
-            passed = not matches
-            target = expected or "any tool"
-            comment = None if passed else f"Expected {target!r} not to be called{scope}, but it was (called: {called_names})."
-            return {"key": "tool_used", "score": passed, "passed": passed, "comment": comment}
-
-        if not matches:
-            comment = (
-                f"Tool {expected!r} not called{scope} (called: {called_names or 'none'})."
-                if expected else f"No tool was called{scope}."
+        resolve_tool_id, resolve_agent_id, agent_ids, all_tool_ids = build_tool_usage_resolvers(
+            payload.get("workflow")
+        )
+        executed_nodes = set((trace.get("nodes") or {}).keys())
+        # Only real agents count as "executed"; other node types can't use tools.
+        executed_agent_ids = executed_nodes & agent_ids if agent_ids is not None else executed_nodes
+        try:
+            parsed = parse_tool_usage_config(
+                config,
+                resolve_tool_id=resolve_tool_id,
+                resolve_agent_id=resolve_agent_id,
+                all_tool_ids=all_tool_ids,
             )
-            return {"key": "tool_used", "score": False, "passed": False, "comment": comment}
+        except Exception as exc:  # pylint: disable=broad-except
+            return {"key": "tool_used", "score": 0.0, "passed": False,
+                    "comment": f"Invalid tool usage config: {exc}"}
 
-        if expected_args:
-            matches = [c for c in matches if _args_superset_match(c.get("args"), expected_args)]
-            if not matches:
-                comment = f"No matching call had expected args {expected_args!r}."
-                return {"key": "tool_used", "score": False, "passed": False, "comment": comment}
+        if not parsed.rules:
+            return {"key": "tool_used", "score": 0.0, "passed": False,
+                    "comment": "No tool usage rules configured."}
 
-        result_not_empty = bool(config.get("result_not_empty", False))
-        result_contains = _normalize_text(config.get("result_contains"))
-        if result_not_empty or result_contains:
-            no_result_recorded = all(c.get("result") is None for c in matches)
-            if no_result_recorded:
-                comment = (
-                    "Result assertion configured, but this workflow's agent does not record "
-                    "tool results in the trace; cannot verify."
-                )
-                return {"key": "tool_used", "score": False, "passed": False, "comment": comment}
-            matches = [c for c in matches if _tool_result_satisfies(c, result_not_empty, result_contains)]
-            if not matches:
-                requirement = f"contain {result_contains!r}" if result_contains else "be non-empty"
-                comment = f"Tool was called but no call's result satisfied: must {requirement}."
-                return {"key": "tool_used", "score": False, "passed": False, "comment": comment}
-
-        return {"key": "tool_used", "score": True, "passed": True, "comment": None}
+        summary = evaluate_rules(parsed.rules, events, executed_agent_ids)
+        coverage = summary["coverage"]
+        score = summary["score"]
+        results = summary["results"]
+        # A single rule reports its own reason; multiple rules get the roll-up.
+        if len(results) == 1 and results[0].get("comment"):
+            comment = results[0]["comment"]
+        else:
+            comment = (
+                f"{coverage['passed']} of {coverage['total']} rule(s) passed; "
+                f"{coverage['not_evaluated']} not evaluated."
+            )
+        return {
+            "key": "tool_used",
+            "score": score if score is not None else 0.0,
+            "passed": summary["passed"],
+            "comment": comment,
+            "details": results,
+        }
 
     async def _route_taken(
         self,
@@ -950,6 +999,7 @@ class TestSuiteService:
         run_repo: TestRunRepository,
         result_repo: TestResultRepository,
         evaluation_repo: TestEvaluationRepository,
+        tool_rule_result_repo: TestToolRuleResultRepository,
         workflow_service: WorkflowService,
         conversation_repo: ConversationRepository,
     ) -> None:
@@ -958,6 +1008,7 @@ class TestSuiteService:
         self.run_repo = run_repo
         self.result_repo = result_repo
         self.evaluation_repo = evaluation_repo
+        self.tool_rule_result_repo = tool_rule_result_repo
         self.workflow_service = workflow_service
         self.conversation_repo = conversation_repo
         self.evaluators = SimpleEvaluatorRegistry()
@@ -1177,9 +1228,15 @@ class TestSuiteService:
         engine = WorkflowEngine(workflow_config)
 
         evaluator_keys = run.techniques or self.evaluators.default_techniques()
+        # tool_used is graded once per scope from collected events (not per case),
+        # so it is pulled out of the per-case techniques to avoid double counting.
+        tool_usage_requested = TOOL_USED_TECHNIQUE in evaluator_keys
+        per_case_keys = [k for k in evaluator_keys if k != TOOL_USED_TECHNIQUE]
 
         per_case_metrics: List[Dict[str, Any]] = []
         status_counts: Dict[str, int] = {}
+        case_events: Dict[str, List[Dict[str, Any]]] = {}
+        case_executed_agents: Dict[str, set] = {}
 
         async def record_case_error(
             case: TestCaseInDB, error: str, status: str
@@ -1251,8 +1308,12 @@ class TestSuiteService:
                 # Capture full workflow execution response in the same shape used
                 # elsewhere in the app.
                 execution_trace = state.format_state_as_response()
+                if tool_usage_requested:
+                    node_status = (execution_trace.get("state") or {}).get("nodeExecutionStatus") or {}
+                    case_events[str(case.id)] = execution_trace.get("tool_events") or []
+                    case_executed_agents[str(case.id)] = set(node_status.keys())
                 metrics = await self.evaluators.evaluate(
-                    evaluator_keys,
+                    per_case_keys,
                     inputs=merged_input,
                     outputs=output,
                     reference_outputs=case.expected_output,
@@ -1348,6 +1409,33 @@ class TestSuiteService:
                 "cases": count,
             }
 
+        # Tool Usage: grade rules across their scope from the collected events and
+        # persist per-rule results; the summary is computed from those, not per case.
+        # Bounded and isolated from the rest of the run — a bug or a stuck DB call
+        # here must not leave the whole run stuck in "running" forever.
+        if tool_usage_requested:
+            try:
+                tool_summary = await asyncio.wait_for(
+                    self._evaluate_tool_usage(
+                        run=run,
+                        cases=cases,
+                        conversations=conversations,
+                        technique_configs=technique_configs,
+                        workflow=workflow,
+                        case_events=case_events,
+                        case_executed_agents=case_executed_agents,
+                    ),
+                    timeout=60,
+                )
+                if tool_summary is not None:
+                    summary[TOOL_USED_TECHNIQUE] = tool_summary
+            except Exception as exc:  # pylint: disable=broad-except
+                logger.exception("Tool usage evaluation failed for run %s: %s", run.id, exc)
+                summary[TOOL_USED_TECHNIQUE] = {
+                    "avg_score": 0.0, "accuracy": 0.0, "cases": 0,
+                    "error": "Tool usage evaluation failed or timed out.",
+                }
+
         # Metrics above cover scored cases only. A case can run yet fail scoring, so
         # "executed" and "scored" are counted separately rather than merged.
         scored = status_counts.get(ResultStatus.SCORED, 0)
@@ -1364,6 +1452,185 @@ class TestSuiteService:
         run.status = "completed"
         run.summary_metrics = summary
         await self.run_repo.update(run)
+
+    async def _evaluate_tool_usage(
+        self,
+        *,
+        run: TestRunModel,
+        cases: List[TestCaseInDB],
+        conversations: List[List[TestCaseInDB]],
+        technique_configs: Dict[str, Dict[str, Any]] | None,
+        workflow: WorkflowInDB,
+        case_events: Dict[str, List[Dict[str, Any]]],
+        case_executed_agents: Dict[str, set],
+    ) -> Dict[str, Any] | None:
+        """Grade tool-usage rules per scope, persist one result per rule/scope unit,
+        and return a summary computed from those results (the canonical source)."""
+        from app.services.tool_usage_rules import (
+            describe_tool_rule,
+            parse_tool_usage_config,
+            plan_tool_rule_results,
+            summarize_planned_results,
+        )
+
+        config = (technique_configs or {}).get(TOOL_USED_TECHNIQUE)
+        if not config:
+            return None
+
+        # Resolve any legacy display names to graph ids via the full (nested/MCP) catalogue.
+        agents = await self._full_agent_catalog(workflow.id)
+        resolve_tool_id, resolve_agent_id, agent_ids, all_tool_ids = resolvers_from_agents(agents)
+        try:
+            parsed = parse_tool_usage_config(
+                config,
+                resolve_tool_id=resolve_tool_id,
+                resolve_agent_id=resolve_agent_id,
+                all_tool_ids=all_tool_ids,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception("Invalid tool_used config for run %s: %s", run.id, exc)
+            return {
+                "avg_score": 0.0, "accuracy": 0.0, "cases": 0, "error": str(exc),
+                "coverage": {"passed": 0, "failed": 0, "not_evaluated": 0, "evaluated": 0, "total": 0},
+            }
+
+        if not parsed.rules:
+            return None
+
+        # Only real agents count as "executed"; a required-tool rule then becomes
+        # not_evaluated (rather than failing) when no agent actually ran.
+        if agent_ids is not None:
+            case_executed_agents = {
+                case_id: (executed & agent_ids)
+                for case_id, executed in case_executed_agents.items()
+            }
+
+        # Describe turns/conversations by id so the scope planner stays ORM-free.
+        turns = [
+            {
+                "id": str(case.id),
+                "source_conversation_id": (
+                    str(case.source_conversation_id) if case.source_conversation_id else None
+                ),
+                "turn_index": case.turn_index,
+            }
+            for case in cases
+        ]
+        conversation_groups = [[str(case.id) for case in group] for group in conversations]
+
+        planned = plan_tool_rule_results(
+            parsed.rules, turns, conversation_groups, case_events, case_executed_agents
+        )
+
+        rule_by_id = {rule.id: rule for rule in parsed.rules}
+        # Turn index per case so a per-turn result can name the turn it graded.
+        turn_index_by_case = {turn["id"]: turn["turn_index"] for turn in turns}
+
+        # Human-readable snapshot captured at run time, so results stay legible even
+        # if a tool or agent is later renamed. Labels come from the resolved catalogue.
+        agent_labels = {agent["id"]: agent["label"] for agent in agents}
+        tool_labels = {
+            tool["id"]: tool["label"] for agent in agents for tool in agent["tools"]
+        }
+        rule_snapshot_by_id = {
+            rule.id: self._rule_snapshot(rule, index, agent_labels, tool_labels, describe_tool_rule)
+            for index, rule in enumerate(parsed.rules)
+        }
+        turn_count_by_conv, conv_number_by_id = self._conversation_index(conversations)
+
+        rows = [
+            TestToolRuleResultModel(
+                run_id=run.id,
+                rule_id=entry["rule_id"],
+                scope=entry["scope"],
+                case_id=entry["case_id"],
+                source_conversation_id=entry["source_conversation_id"],
+                status=entry["result"]["status"],
+                score=self._rule_score(entry["result"]["status"]),
+                details={
+                    **entry["result"],
+                    "rule": rule_by_id[entry["rule_id"]].model_dump(mode="json"),
+                    "turn_index": turn_index_by_case.get(entry["case_id"]),
+                    **rule_snapshot_by_id[entry["rule_id"]],
+                    "target": self._target_snapshot(
+                        entry, turn_index_by_case, turn_count_by_conv, conv_number_by_id
+                    ),
+                    # Label every tool the result mentions (including forbidden/outside
+                    # tools) so the UI never has to fall back to a raw id.
+                    "tools": self._entry_tool_labels(
+                        entry["result"], rule_by_id[entry["rule_id"]].tool_ids, tool_labels
+                    ),
+                },
+            )
+            for entry in planned
+        ]
+        await self.tool_rule_result_repo.create_many(rows)
+        return summarize_planned_results(planned)
+
+    @staticmethod
+    def _rule_snapshot(rule, index, agent_labels, tool_labels, describe_tool_rule) -> Dict[str, Any]:
+        """Readable, rename-proof snapshot of a rule stored with every result.
+
+        Tool labels are attached per-result by ``_entry_tool_labels`` (which also
+        covers forbidden/outside tools), so they are not duplicated here.
+        """
+        agent = (
+            {"id": rule.agent_id, "label": agent_labels.get(rule.agent_id, "Unknown agent")}
+            if rule.agent_id
+            else {"id": None, "label": "Any agent"}
+        )
+        return {
+            "rule_number": index + 1,
+            "rule_summary": describe_tool_rule(rule, agent_labels, tool_labels),
+            "agent": agent,
+        }
+
+    @staticmethod
+    def _entry_tool_labels(result: Dict[str, Any], target_ids: List[str], tool_labels: Dict[str, str]) -> Dict[str, Any]:
+        """{tool_id: {label}} for every tool this result references, target or not."""
+        ids = set(target_ids)
+        for key in ("observed_tools", "missing_tools", "failed_tools", "forbidden_tools"):
+            ids.update(result.get(key) or [])
+        ids.update((result.get("call_counts") or {}).keys())
+        return {tool_id: {"label": tool_labels.get(tool_id, tool_id)} for tool_id in ids}
+
+    @staticmethod
+    def _conversation_index(conversations: List[List[TestCaseInDB]]):
+        """(turn_count_by_conversation_id, conversation_number_by_id) for labelling."""
+        turn_count_by_conv: Dict[str, int] = {}
+        conv_number_by_id: Dict[str, int] = {}
+        for index, group in enumerate(conversations):
+            first = group[0] if group else None
+            conv_id = str(first.source_conversation_id) if first and first.source_conversation_id else None
+            if conv_id:
+                turn_count_by_conv[conv_id] = len(group)
+                conv_number_by_id[conv_id] = index + 1
+        return turn_count_by_conv, conv_number_by_id
+
+    @staticmethod
+    def _target_snapshot(entry, turn_index_by_case, turn_count_by_conv, conv_number_by_id) -> Dict[str, Any]:
+        """What this result graded: a whole conversation, or a single turn."""
+        if entry["scope"] == "conversation":
+            conv_id = entry.get("source_conversation_id")
+            number = conv_number_by_id.get(conv_id)
+            return {
+                "type": "conversation",
+                "label": f"Conversation {number}" if number else "Conversation",
+                "turn_count": turn_count_by_conv.get(conv_id, 1),
+            }
+        turn_index = turn_index_by_case.get(entry["case_id"])
+        return {
+            "type": "turn",
+            "label": f"Turn {turn_index + 1}" if turn_index is not None else "Turn",
+        }
+
+    @staticmethod
+    def _rule_score(status: str) -> Optional[float]:
+        if status == "passed":
+            return 1.0
+        if status == "failed":
+            return 0.0
+        return None
 
     async def get_runs_by_ids(self, ids: List[str]) -> List[TestRunInDB]:
         rows = await self.run_repo.get_by_ids(ids)
@@ -1383,11 +1650,60 @@ class TestSuiteService:
         rows = await self.result_repo.get_all_for_run(run_id)
         return [TestResultInDB.model_validate(r, from_attributes=True) for r in rows]
 
+    async def list_tool_rule_results_for_run(
+        self, run_id: UUID
+    ) -> List[TestToolRuleResult]:
+        rows = await self.tool_rule_result_repo.get_all_for_run(run_id)
+        return [TestToolRuleResult.model_validate(r, from_attributes=True) for r in rows]
+
     # ---- Evaluations -------------------------------------------------------
+
+    async def _effective_workflow_id(self, workflow_id: Any, suite_id: Any) -> Any:
+        """The workflow a run will actually use: the evaluation's own, or the
+        dataset's default when the evaluation defines none — the same rule the run
+        loop applies, so canonicalization validates against the real workflow."""
+        if workflow_id:
+            return workflow_id
+        if not suite_id:
+            return None
+        suite = await self.suite_repo.get_by_id(suite_id)
+        return suite.workflow_id if suite else None
+
+    async def _canonicalize_tool_used_configs(
+        self, workflow_id: Any, technique_configs: Dict[str, Any] | None
+    ) -> Dict[str, Any] | None:
+        """Resolve legacy tool/agent names in a tool_used config to canonical ids
+        before it is stored, so names are never persisted as if they were ids."""
+        if not technique_configs or TOOL_USED_TECHNIQUE not in technique_configs or not workflow_id:
+            return technique_configs
+        from app.services.tool_usage_rules import canonicalize_tool_usage_config
+
+        agents = await self._full_agent_catalog(workflow_id)
+        resolve_tool_id, resolve_agent_id, _, all_tool_ids = resolvers_from_agents(agents)
+        try:
+            canonical = canonicalize_tool_usage_config(
+                technique_configs[TOOL_USED_TECHNIQUE],
+                resolve_tool_id=resolve_tool_id,
+                resolve_agent_id=resolve_agent_id,
+                all_tool_ids=all_tool_ids,
+            )
+        except ValueError as exc:
+            raise AppException(
+                error_key=ErrorKey.TOOL_USAGE_CONFIG_INVALID,
+                status_code=400,
+                error_detail=str(exc),
+            ) from exc
+        return {**technique_configs, TOOL_USED_TECHNIQUE: canonical}
 
     async def create_evaluation(self, data: TestEvaluationCreate) -> TestEvaluationInDB:
         payload = data.model_dump()
         payload["run_ids"] = []
+        workflow_id = await self._effective_workflow_id(
+            payload.get("workflow_id"), payload.get("suite_id")
+        )
+        payload["technique_configs"] = await self._canonicalize_tool_used_configs(
+            workflow_id, payload.get("technique_configs")
+        )
         orm = TestEvaluationModel(**payload)
         created = await self.evaluation_repo.create(orm)
         return TestEvaluationInDB.model_validate(created, from_attributes=True)
@@ -1408,7 +1724,18 @@ class TestSuiteService:
         row = await self.evaluation_repo.get_by_id(evaluation_id)
         if not row:
             raise AppException(status_code=404, error_key=ErrorKey.NOT_FOUND)
-        for field, value in data.model_dump(exclude_none=True).items():
+        updates = data.model_dump(exclude_none=True)
+        if "technique_configs" in updates:
+            # Resolve against the evaluation's *new* dataset/workflow when either is
+            # being changed, so validation never uses the old dataset's workflow.
+            suite_id = updates.get("suite_id") or row.suite_id
+            workflow_id = await self._effective_workflow_id(
+                updates.get("workflow_id") or row.workflow_id, suite_id
+            )
+            updates["technique_configs"] = await self._canonicalize_tool_used_configs(
+                workflow_id, updates["technique_configs"]
+            )
+        for field, value in updates.items():
             setattr(row, field, value)
         updated = await self.evaluation_repo.update(row)
         return TestEvaluationInDB.model_validate(updated, from_attributes=True)
@@ -1479,6 +1806,45 @@ class TestSuiteService:
     ) -> List[TestEvaluationModel]:
         """The Run all scope: every evaluation for the workflow (DB-filtered)."""
         return await self.evaluation_repo.get_all_for_workflow(workflow_id)
+
+    async def _full_agent_catalog(self, workflow_id: Any) -> List[Dict[str, Any]]:
+        """Agents + tools for a workflow, expanding nested workflows (cycle-safe).
+
+        The single catalogue the UI, config canonicalization and run-time grading all
+        consume, so a nested or MCP tool shown in the UI resolves everywhere it is
+        used — never rejected as unknown, never treated as a non-agent node.
+        """
+        from app.services.tool_catalog import nested_workflow_refs, resolve_agents
+
+        agents: List[Dict[str, Any]] = []
+        visited: set[str] = set()
+
+        async def walk(current_id: str, path: List[str]) -> None:
+            if current_id in visited:
+                return
+            visited.add(current_id)
+            try:
+                workflow = await self.workflow_service.get_by_id(UUID(str(current_id)))
+            except Exception:  # pylint: disable=broad-except
+                return
+            graph = {
+                "id": str(workflow.id),
+                "nodes": workflow.nodes or [],
+                "edges": workflow.edges or [],
+            }
+            agents.extend(resolve_agents(graph, workflow_path=path))
+            for ref in nested_workflow_refs(graph):
+                await walk(ref["workflow_id"], path + [ref["label"]])
+
+        await walk(str(workflow_id), [])
+        return agents
+
+    async def get_evaluation_tool_catalog(
+        self, workflow_id: UUID
+    ) -> "EvaluationToolCatalog":
+        """Agents + tools for a workflow, expanding nested workflows (cycle-safe)."""
+        agents = await self._full_agent_catalog(workflow_id)
+        return EvaluationToolCatalog(workflow_id=workflow_id, agents=agents)
 
     async def get_workflow_evaluation_summaries(
         self,

--- a/backend/app/services/tool_catalog.py
+++ b/backend/app/services/tool_catalog.py
@@ -1,0 +1,159 @@
+"""
+Shared workflow tool-catalogue resolver.
+
+Walks a workflow graph to find each agent and the tools connected to it, using the
+same rule the runtime uses to attach tools (an edge whose ``targetHandle`` contains
+"tools"; the edge source is the tool node, the target is the agent). Keeping one
+resolver means the catalogue UI, rule validation and legacy-name conversion can
+never disagree with what actually runs.
+
+Tool ids match the ids recorded on tool events:
+  * single tool node  -> the tool node's id
+  * MCP tool          -> "{mcpNodeId}:{toolName}"
+
+Pure and synchronous over a single workflow. Nested-workflow expansion needs to load
+other workflows (async, DB), so this module only reports the nested references; the
+caller recurses with its own loader and cycle protection.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from app.modules.workflow.agents.base_tool import to_snake_case
+
+MCP_NODE_TYPE = "mcpNode"
+WORKFLOW_EXECUTOR_NODE_TYPE = "workflowExecutorNode"
+_TOOLS_HANDLE = "tools"
+
+
+def _nodes(workflow: Any) -> List[Dict[str, Any]]:
+    nodes = workflow.get("nodes") if isinstance(workflow, dict) else getattr(workflow, "nodes", None)
+    return nodes or []
+
+
+def _edges(workflow: Any) -> List[Dict[str, Any]]:
+    edges = workflow.get("edges") if isinstance(workflow, dict) else getattr(workflow, "edges", None)
+    return edges or []
+
+
+def _node_data(node: Dict[str, Any]) -> Dict[str, Any]:
+    return node.get("data") or {}
+
+
+def _node_label(node: Dict[str, Any]) -> str:
+    return _node_data(node).get("name") or f"Node_{node.get('id')}"
+
+
+def _tools_for_node(node: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Metadata for the tool(s) a source node exposes (an MCP node exposes many)."""
+    node_id = node.get("id")
+    node_type = node.get("type", "")
+    if node_type == MCP_NODE_TYPE:
+        whitelisted = _node_data(node).get("whitelistedTools") or []
+        return [
+            {"id": f"{node_id}:{name}", "name": name, "label": name, "type": MCP_NODE_TYPE}
+            for name in whitelisted
+        ]
+    label = _node_label(node)
+    return [{"id": node_id, "name": to_snake_case(label), "label": label, "type": node_type}]
+
+
+def _agent_entry(node: Dict[str, Any], workflow_path: List[str]) -> Dict[str, Any]:
+    return {
+        "id": node.get("id"),
+        "label": _node_label(node),
+        "type": node.get("type", ""),
+        "workflow_path": list(workflow_path),
+        "tools": [],
+    }
+
+
+def resolve_agents(workflow: Any, workflow_path: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+    """Return this workflow's agents, each with the tools connected to it."""
+    workflow_path = workflow_path or []
+    nodes_by_id = {n.get("id"): n for n in _nodes(workflow)}
+    agents: Dict[str, Dict[str, Any]] = {}
+    seen_tools: Dict[str, set] = {}
+
+    for edge in _edges(workflow):
+        target_handle = edge.get("targetHandle") or ""
+        if _TOOLS_HANDLE not in target_handle:
+            continue
+        agent_node = nodes_by_id.get(edge.get("target"))
+        tool_node = nodes_by_id.get(edge.get("source"))
+        if not agent_node or not tool_node:
+            continue
+
+        agent_id = agent_node.get("id")
+        if agent_id not in agents:
+            agents[agent_id] = _agent_entry(agent_node, workflow_path)
+            seen_tools[agent_id] = set()
+        for tool in _tools_for_node(tool_node):
+            if tool["id"] in seen_tools[agent_id]:
+                continue
+            seen_tools[agent_id].add(tool["id"])
+            agents[agent_id]["tools"].append(tool)
+
+    return list(agents.values())
+
+
+def nested_workflow_refs(workflow: Any) -> List[Dict[str, Any]]:
+    """Executor nodes that run another workflow, for the caller to expand recursively."""
+    refs = []
+    for node in _nodes(workflow):
+        if node.get("type") != WORKFLOW_EXECUTOR_NODE_TYPE:
+            continue
+        workflow_id = _node_data(node).get("workflowId")
+        if workflow_id:
+            refs.append({
+                "node_id": node.get("id"),
+                "label": _node_label(node),
+                "workflow_id": str(workflow_id),
+            })
+    return refs
+
+
+def _normalize_name(value: Any) -> str:
+    return str(value).strip().lower()
+
+
+def build_tool_index(agents: List[Dict[str, Any]]) -> Dict[str, List[str]]:
+    """Map each tool id/name/label (normalized) to the tool id(s) that use it.
+
+    A name or label shared by several tools maps to several ids; ``resolve_in_index``
+    treats that as ambiguous rather than silently choosing the first match.
+    """
+    index: Dict[str, set] = {}
+    for agent in agents:
+        for tool in agent["tools"]:
+            for key in (tool["id"], tool["name"], tool["label"]):
+                if key:
+                    index.setdefault(_normalize_name(key), set()).add(tool["id"])
+    return {key: sorted(ids) for key, ids in index.items()}
+
+
+def build_agent_index(agents: List[Dict[str, Any]]) -> Dict[str, List[str]]:
+    """Map each agent id/label (normalized) to the agent id(s) using it."""
+    index: Dict[str, set] = {}
+    for agent in agents:
+        for key in (agent["id"], agent["label"]):
+            if key:
+                index.setdefault(_normalize_name(key), set()).add(agent["id"])
+    return {key: sorted(ids) for key, ids in index.items()}
+
+
+def resolve_in_index(index: Dict[str, List[str]], value: Optional[str], kind: str = "name") -> Optional[str]:
+    """Resolve a legacy name/label/id to a single id, case-insensitively.
+
+    Returns None when the value is unknown; raises ``ValueError`` when it is
+    ambiguous (shared by more than one id) instead of picking one.
+    """
+    if value is None:
+        return None
+    ids = index.get(_normalize_name(value))
+    if not ids:
+        return None
+    if len(ids) > 1:
+        raise ValueError(f"ambiguous {kind} name {value!r}: matches ids {ids}")
+    return ids[0]

--- a/backend/app/services/tool_usage_rules.py
+++ b/backend/app/services/tool_usage_rules.py
@@ -1,0 +1,696 @@
+"""
+Tool Usage evaluation rules — pure logic, no DB or engine dependencies.
+
+A Tool Usage evaluation is a list of rules. Each rule asserts something about the
+tool calls an agent made, using one operator:
+
+    all   — every selected tool was called
+    any   — at least one selected tool was called
+    none  — no selected tool was attempted (a failed attempt still counts)
+    only  — only selected tools were called (no tool outside the list)
+
+Rules are graded against normalized tool events (see WorkflowState.tool_events).
+Each rule result is one of three states so incomplete runs never look healthy:
+
+    passed         — the assertion held
+    failed         — the assertion was violated (observed)
+    not_evaluated  — the agent never ran, so the assertion could not be checked
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable, List, Optional, Set
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+# ---- constants -------------------------------------------------------------
+
+OPERATORS = ("all", "any", "none", "only")
+SCOPES = ("specific_turn", "every_turn", "conversation")
+
+RULE_PASSED = "passed"
+RULE_FAILED = "failed"
+RULE_NOT_EVALUATED = "not_evaluated"
+
+# Operators that assert a tool WAS used (vs. forbidding/whitelisting usage).
+_REQUIRING_OPERATORS = ("all", "any")
+
+# No-result phrases emitted by the platform's retrieval layers.
+_EMPTY_RESULT_PREFIXES = ("no results found", "no relevant information found")
+
+
+# ---- schema ----------------------------------------------------------------
+
+
+class PerToolCheck(BaseModel):
+    """Optional extra assertions on a specific tool's call."""
+
+    result_not_empty: bool = False
+    result_contains: Optional[str] = None
+    expected_args: Optional[Dict[str, Any]] = None
+
+
+class ToolUsageRule(BaseModel):
+    """One tool-usage assertion. See module docstring for operator semantics."""
+
+    id: str
+    tool_ids: List[str] = Field(default_factory=list)
+    operator: str = "all"
+    agent_id: Optional[str] = None
+    require_success: bool = False
+    scope: str = "every_turn"
+
+    # Stable turn targeting: imported turns use (source_conversation_id, turn_index)
+    # so a rule survives a conversation re-import; manual cases use case_id.
+    target_case_id: Optional[str] = None
+    target_source_conversation_id: Optional[str] = None
+    target_turn_index: Optional[int] = None
+
+    min_calls: Optional[int] = None
+    max_calls: Optional[int] = None
+    per_tool: Dict[str, PerToolCheck] = Field(default_factory=dict)
+
+    @field_validator("operator")
+    @classmethod
+    def _valid_operator(cls, value: str) -> str:
+        if value not in OPERATORS:
+            raise ValueError(f"operator must be one of {OPERATORS}, got {value!r}")
+        return value
+
+    @field_validator("scope")
+    @classmethod
+    def _valid_scope(cls, value: str) -> str:
+        if value not in SCOPES:
+            raise ValueError(f"scope must be one of {SCOPES}, got {value!r}")
+        return value
+
+    @model_validator(mode="after")
+    def _check_targets_and_tools(self) -> "ToolUsageRule":
+        # "only" may forbid every tool (empty list); the others need a tool.
+        if self.operator != "only" and not self.tool_ids:
+            raise ValueError(f"rule {self.id!r}: operator {self.operator!r} requires at least one tool")
+        if self.scope == "specific_turn":
+            has_case = self.target_case_id is not None
+            has_turn = (
+                self.target_source_conversation_id is not None
+                and self.target_turn_index is not None
+            )
+            if not (has_case or has_turn):
+                raise ValueError(
+                    f"rule {self.id!r}: specific_turn scope requires target_case_id or "
+                    "(target_source_conversation_id + target_turn_index)"
+                )
+        if self.min_calls is not None and self.min_calls < 0:
+            raise ValueError(f"rule {self.id!r}: min_calls must be >= 0")
+        if self.max_calls is not None and self.max_calls < 0:
+            raise ValueError(f"rule {self.id!r}: max_calls must be >= 0")
+        if (
+            self.min_calls is not None
+            and self.max_calls is not None
+            and self.min_calls > self.max_calls
+        ):
+            raise ValueError(
+                f"rule {self.id!r}: min_calls ({self.min_calls}) must be <= max_calls ({self.max_calls})"
+            )
+        return self
+
+
+class ToolUsageConfig(BaseModel):
+    """The full ``tool_used`` technique config: a set of uniquely-identified rules."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    rules: List[ToolUsageRule] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _unique_ids(self) -> "ToolUsageConfig":
+        ids = [rule.id for rule in self.rules]
+        duplicates = {rid for rid in ids if ids.count(rid) > 1}
+        if duplicates:
+            raise ValueError(f"duplicate rule ids: {sorted(duplicates)}")
+        return self
+
+
+# ---- evaluation ------------------------------------------------------------
+
+
+def _as_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    try:
+        return json.dumps(value, default=str)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _result_is_empty(result: Any) -> bool:
+    text = _as_text(result)
+    structurally_empty = isinstance(result, (list, dict)) and not result
+    return (
+        not text
+        or structurally_empty
+        or text.lower().startswith(_EMPTY_RESULT_PREFIXES)
+    )
+
+
+def _args_superset_match(actual: Any, expected: Dict[str, Any]) -> bool:
+    if not isinstance(actual, dict):
+        return False
+    return all(_as_text(actual.get(k)) == _as_text(v) for k, v in expected.items())
+
+
+def _per_tool_failure_reason(check: PerToolCheck, events: List[Dict[str, Any]]) -> Optional[str]:
+    """None when some event meets the per-tool assertions; else a human reason.
+
+    Distinguishes a missing/None result ("does not record") from an empty or
+    sentinel result, so the failure message is honest about what was observed.
+    """
+    saw_result = False
+    for event in events:
+        result = event.get("result")
+        if result is not None:
+            saw_result = True
+        if check.result_not_empty and _result_is_empty(result):
+            continue
+        if check.result_contains and check.result_contains not in _as_text(result):
+            continue
+        if check.expected_args and not _args_superset_match(event.get("arguments"), check.expected_args):
+            continue
+        return None
+    if check.result_not_empty and not saw_result:
+        return "the trace does not record a result for this tool"
+    if check.result_not_empty:
+        return "the tool result was empty or a no-results sentinel"
+    if check.result_contains:
+        return f"the tool result did not contain {check.result_contains!r}"
+    if check.expected_args:
+        return "the tool was not called with the expected arguments"
+    return "the tool call did not satisfy the configured checks"
+
+
+def _events_for_rule(rule: ToolUsageRule, events: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Events attributable to this rule's agent (or all agents when unscoped)."""
+    if rule.agent_id is None:
+        return list(events)
+    return [e for e in events if e.get("agent_id") == rule.agent_id]
+
+
+def _agent_ran(rule: ToolUsageRule, executed_agent_ids: Set[str]) -> bool:
+    if rule.agent_id is not None:
+        return rule.agent_id in executed_agent_ids
+    return len(executed_agent_ids) > 0
+
+
+def _result(rule: ToolUsageRule, status: str, *, comment: str,
+            observed: Optional[List[str]] = None,
+            missing: Optional[List[str]] = None,
+            forbidden: Optional[List[str]] = None,
+            failed: Optional[List[str]] = None,
+            check_failures: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+    return {
+        "rule_id": rule.id,
+        "operator": rule.operator,
+        "agent_id": rule.agent_id,
+        "scope": rule.scope,
+        "status": status,
+        # missing = never called; failed = called but never succeeded (require_success);
+        # check_failures = called successfully but result/arguments did not match.
+        "observed_tools": observed or [],
+        "missing_tools": missing or [],
+        "forbidden_tools": forbidden or [],
+        "failed_tools": failed or [],
+        "check_failures": check_failures or {},
+        # Filled in by evaluate_rule so the UI can say "used successfully N times".
+        "call_counts": {},
+        "successful_call_counts": {},
+        "comment": comment,
+    }
+
+
+def _count_calls(scoped: List[Dict[str, Any]]) -> "tuple[Dict[str, int], Dict[str, int]]":
+    """Total and successful call counts per tool id observed in this scope."""
+    call_counts: Dict[str, int] = {}
+    successful: Dict[str, int] = {}
+    for event in scoped:
+        tool_id = event.get("tool_id")
+        if not tool_id:
+            continue
+        call_counts[tool_id] = call_counts.get(tool_id, 0) + 1
+        if event.get("status") == "succeeded":
+            successful[tool_id] = successful.get(tool_id, 0) + 1
+    return call_counts, successful
+
+
+def evaluate_rule(
+    rule: ToolUsageRule,
+    events: Iterable[Dict[str, Any]],
+    executed_agent_ids: Optional[Set[str]] = None,
+) -> Dict[str, Any]:
+    """Grade one rule against a scoped set of tool events. Returns a three-state result."""
+    executed_agent_ids = executed_agent_ids or set()
+    scoped = _events_for_rule(rule, events)
+    target_set: Set[str] = set(rule.tool_ids)
+
+    call_counts, successful_call_counts = _count_calls(scoped)
+
+    def done(result: Dict[str, Any]) -> Dict[str, Any]:
+        # Record what actually happened so the UI can say "used successfully N times".
+        result["call_counts"] = call_counts
+        result["successful_call_counts"] = successful_call_counts
+        return result
+
+    attempted = {e.get("tool_id") for e in scoped}
+    used = {
+        e.get("tool_id")
+        for e in scoped
+        if not rule.require_success or e.get("status") == "succeeded"
+    }
+    agent_ran = _agent_ran(rule, executed_agent_ids)
+
+    # Forbidding / whitelisting operators are attempt-based: a forbidden attempt is a
+    # failure even if the call failed or the turn later errored.
+    if rule.operator == "none":
+        violated = sorted(t for t in (target_set & attempted) if t)
+        if violated:
+            return done(_result(rule, RULE_FAILED, forbidden=violated,
+                                comment=f"Forbidden tool(s) attempted: {violated}."))
+        if not agent_ran:
+            return done(_result(rule, RULE_NOT_EVALUATED,
+                                comment="Agent did not run; forbidden-tool rule could not be checked."))
+        return done(_result(rule, RULE_PASSED, comment="No forbidden tools were attempted."))
+
+    if rule.operator == "only":
+        outside = sorted(t for t in (attempted - target_set) if t)
+        if outside:
+            return done(_result(rule, RULE_FAILED, forbidden=outside,
+                                comment=f"Tool(s) outside the allowed set were used: {outside}."))
+        if not agent_ran:
+            return done(_result(rule, RULE_NOT_EVALUATED,
+                                comment="Agent did not run; allowed-only rule could not be checked."))
+        if not _calls_within_bounds(rule, target_set, scoped):
+            return done(_result(rule, RULE_FAILED,
+                                comment=_bounds_comment(rule, target_set, scoped)))
+        return done(_result(rule, RULE_PASSED, comment="Only allowed tools were used."))
+
+    # Required operators (all / any): if the agent never ran, we cannot judge usage.
+    if not agent_ran:
+        return done(_result(rule, RULE_NOT_EVALUATED,
+                            comment="Agent did not run; required-tool rule could not be checked."))
+
+    used_targets = {t for t in target_set if t in used}
+    per_tool_reasons = {t: reason for t in used_targets if (reason := _per_tool_failure(rule, t, scoped))}
+    satisfied = used_targets - set(per_tool_reasons)
+    observed = sorted(satisfied)
+
+    # Separate "never called" from "called but did not succeed" so a failed call
+    # (with require_success on) is not reported as if the tool were missing.
+    attempted_targets = {t for t in target_set if t in attempted}
+    not_called = sorted(target_set - attempted_targets)
+    called_but_failed = sorted(attempted_targets - used_targets)
+
+    if rule.operator == "all":
+        ok = not not_called and not called_but_failed and not per_tool_reasons
+    else:  # any
+        ok = bool(satisfied)
+
+    if ok and not _calls_within_bounds(rule, target_set, scoped):
+        return done(_result(rule, RULE_FAILED, observed=observed, missing=not_called,
+                            comment=_bounds_comment(rule, target_set, scoped)))
+    if ok:
+        return done(_result(rule, RULE_PASSED, observed=observed,
+                            comment="Required tool usage satisfied."))
+
+    scope = f" by node {rule.agent_id}" if rule.agent_id else ""
+    parts: List[str] = []
+    if not_called:
+        parts.append(f"not called: {not_called}")
+    if called_but_failed:
+        parts.append(f"called but did not succeed: {called_but_failed}")
+    if per_tool_reasons:
+        reasons = "; ".join(f"{tool_id}: {reason}" for tool_id, reason in sorted(per_tool_reasons.items()))
+        parts.append(f"result/argument checks failed — {reasons}")
+    comment = f"Required tool usage not satisfied{scope}: " + "; ".join(parts) + "."
+    return done(_result(rule, RULE_FAILED, observed=observed, missing=not_called,
+                        failed=called_but_failed, check_failures=per_tool_reasons, comment=comment))
+
+
+def _qualifying_calls(rule: ToolUsageRule, target_set: Set[str], scoped: List[Dict[str, Any]]) -> int:
+    return sum(
+        1
+        for e in scoped
+        if e.get("tool_id") in target_set
+        and (not rule.require_success or e.get("status") == "succeeded")
+    )
+
+
+def _calls_within_bounds(rule: ToolUsageRule, target_set: Set[str], scoped: List[Dict[str, Any]]) -> bool:
+    if rule.min_calls is None and rule.max_calls is None:
+        return True
+    count = _qualifying_calls(rule, target_set, scoped)
+    if rule.min_calls is not None and count < rule.min_calls:
+        return False
+    if rule.max_calls is not None and count > rule.max_calls:
+        return False
+    return True
+
+
+def _bounds_comment(rule: ToolUsageRule, target_set: Set[str], scoped: List[Dict[str, Any]]) -> str:
+    count = _qualifying_calls(rule, target_set, scoped)
+    return f"Call count {count} outside bounds (min={rule.min_calls}, max={rule.max_calls})."
+
+
+def _tool_events(tool_id: str, scoped: List[Dict[str, Any]], require_success: bool) -> List[Dict[str, Any]]:
+    """This tool's events in scope; only successful ones when require_success."""
+    return [
+        e for e in scoped
+        if e.get("tool_id") == tool_id and (not require_success or e.get("status") == "succeeded")
+    ]
+
+
+def _per_tool_failure(rule: ToolUsageRule, tool_id: str, scoped: List[Dict[str, Any]]) -> Optional[str]:
+    """Reason the per-tool checks failed for ``tool_id``, or None if they pass.
+
+    When ``require_success`` is set, result/argument checks inspect only the
+    tool's successful events, so a failed call cannot satisfy them.
+    """
+    check = rule.per_tool.get(tool_id)
+    if check is None:
+        return None
+    return _per_tool_failure_reason(check, _tool_events(tool_id, scoped, rule.require_success))
+
+
+def evaluate_rules(
+    rules: Iterable[ToolUsageRule],
+    events: Iterable[Dict[str, Any]],
+    executed_agent_ids: Optional[Set[str]] = None,
+) -> Dict[str, Any]:
+    """Grade every rule and summarize with pass/fail/coverage. ``events`` is one scope slice."""
+    events = list(events)
+    results = [evaluate_rule(rule, events, executed_agent_ids) for rule in rules]
+
+    passed = sum(1 for r in results if r["status"] == RULE_PASSED)
+    failed = sum(1 for r in results if r["status"] == RULE_FAILED)
+    not_evaluated = sum(1 for r in results if r["status"] == RULE_NOT_EVALUATED)
+    evaluated = passed + failed
+
+    return {
+        "results": results,
+        "coverage": {
+            "passed": passed,
+            "failed": failed,
+            "not_evaluated": not_evaluated,
+            "evaluated": evaluated,
+            "total": len(results),
+        },
+        # Score is over evaluated rules only; None when nothing could be evaluated.
+        "score": (passed / evaluated) if evaluated else None,
+        # Healthy only when something was evaluated and nothing failed.
+        "passed": failed == 0 and evaluated > 0,
+    }
+
+
+# ---- scope planning --------------------------------------------------------
+
+
+def _not_evaluated_result(rule: ToolUsageRule, comment: str) -> Dict[str, Any]:
+    return {
+        "rule_id": rule.id, "operator": rule.operator, "scope": rule.scope,
+        "status": RULE_NOT_EVALUATED, "observed_tools": [], "missing_tools": [],
+        "forbidden_tools": [], "failed_tools": [], "check_failures": {},
+        "call_counts": {}, "successful_call_counts": {}, "comment": comment,
+    }
+
+
+def plan_tool_rule_results(
+    rules: Iterable[ToolUsageRule],
+    turns: List[Dict[str, Any]],
+    conversation_groups: List[List[str]],
+    events_by_turn: Dict[str, List[Dict[str, Any]]],
+    executed_by_turn: Dict[str, Set[str]],
+) -> List[Dict[str, Any]]:
+    """Grade every rule over its scope and return placed results (no DB, no ORM).
+
+    ``turns`` are ``{"id", "source_conversation_id", "turn_index"}`` dicts;
+    ``conversation_groups`` lists turn ids grouped per conversation. Each planned
+    entry carries where the result belongs (``case_id`` / ``source_conversation_id``).
+    """
+    turns_by_id = {t["id"]: t for t in turns}
+    by_conversation_turn = {
+        (t["source_conversation_id"], t["turn_index"]): t["id"]
+        for t in turns
+        if t.get("source_conversation_id") is not None and t.get("turn_index") is not None
+    }
+
+    def place(rule, result, *, case_id=None, source_conversation_id=None):
+        return {
+            "rule_id": rule.id, "scope": rule.scope, "case_id": case_id,
+            "source_conversation_id": source_conversation_id, "result": result,
+        }
+
+    planned: List[Dict[str, Any]] = []
+    for rule in rules:
+        if rule.scope == "specific_turn":
+            target_id = None
+            if rule.target_case_id and rule.target_case_id in turns_by_id:
+                target_id = rule.target_case_id
+            elif rule.target_source_conversation_id is not None and rule.target_turn_index is not None:
+                target_id = by_conversation_turn.get(
+                    (rule.target_source_conversation_id, rule.target_turn_index)
+                )
+            if target_id is None:
+                planned.append(place(rule, _not_evaluated_result(rule, "Target turn not found in this run.")))
+                continue
+            result = evaluate_rule(rule, events_by_turn.get(target_id, []), executed_by_turn.get(target_id, set()))
+            planned.append(place(rule, result, case_id=target_id))
+
+        elif rule.scope == "every_turn":
+            for turn in turns:
+                tid = turn["id"]
+                result = evaluate_rule(rule, events_by_turn.get(tid, []), executed_by_turn.get(tid, set()))
+                planned.append(place(rule, result, case_id=tid))
+
+        else:  # conversation: merge every turn's events and grade once
+            for group in conversation_groups:
+                merged_events: List[Dict[str, Any]] = []
+                merged_executed: Set[str] = set()
+                for tid in group:
+                    merged_events.extend(events_by_turn.get(tid, []))
+                    merged_executed |= executed_by_turn.get(tid, set())
+                representative = group[0] if group else None
+                conversation_id = turns_by_id.get(representative, {}).get("source_conversation_id")
+                result = evaluate_rule(rule, merged_events, merged_executed)
+                planned.append(place(
+                    rule, result,
+                    case_id=None if conversation_id is not None else representative,
+                    source_conversation_id=conversation_id,
+                ))
+
+    return planned
+
+
+def summarize_planned_results(planned: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Run-level Tool Usage summary (accuracy + coverage) from planned results."""
+    statuses = [entry["result"]["status"] for entry in planned]
+    passed = statuses.count(RULE_PASSED)
+    failed = statuses.count(RULE_FAILED)
+    not_evaluated = statuses.count(RULE_NOT_EVALUATED)
+    evaluated = passed + failed
+    accuracy = (passed / evaluated) if evaluated else 0.0
+
+    # How many checks ran at each scope, so the card can say e.g.
+    # "2 conversation checks · 13 turn checks".
+    by_scope: Dict[str, int] = {}
+    for entry in planned:
+        scope = entry.get("scope", "every_turn")
+        by_scope[scope] = by_scope.get(scope, 0) + 1
+
+    return {
+        "avg_score": accuracy,
+        "accuracy": accuracy,
+        "cases": evaluated,
+        "passed": passed,
+        "failed": failed,
+        "not_evaluated": not_evaluated,
+        "by_scope": by_scope,
+        "coverage": {
+            "passed": passed, "failed": failed, "not_evaluated": not_evaluated,
+            "evaluated": evaluated, "total": len(planned),
+        },
+    }
+
+
+# ---- human-readable description --------------------------------------------
+
+
+def _quote_join(items: List[str], conjunction: str) -> str:
+    if not items:
+        return "a tool"
+    quoted = [f'"{item}"' for item in items]
+    if len(quoted) == 1:
+        return quoted[0]
+    return f"{', '.join(quoted[:-1])} {conjunction} {quoted[-1]}"
+
+
+def _scope_phrase(rule: "ToolUsageRule") -> str:
+    if rule.scope == "conversation":
+        return "during the conversation"
+    if rule.scope == "specific_turn":
+        if rule.target_turn_index is not None:
+            return f"on turn {rule.target_turn_index + 1}"
+        return "on the selected turn"
+    return "on every turn"
+
+
+def describe_tool_rule(
+    rule: "ToolUsageRule",
+    agent_labels: Optional[Dict[str, str]] = None,
+    tool_labels: Optional[Dict[str, str]] = None,
+) -> str:
+    """A plain-language sentence for a rule, using human labels where available.
+
+    Captured at evaluation time so a later rename never rewrites past results.
+    """
+    agent_labels = agent_labels or {}
+    tool_labels = tool_labels or {}
+
+    subject = agent_labels.get(rule.agent_id, "The agent") if rule.agent_id else "Any agent"
+    names = [tool_labels.get(tool_id, tool_id) for tool_id in rule.tool_ids]
+    scope_phrase = _scope_phrase(rule)
+
+    if rule.operator == "none":
+        return f"{subject} must not use {_quote_join(names, 'or')} {scope_phrase}."
+    if rule.operator == "only":
+        if not names:
+            return f"{subject} must not use any tools {scope_phrase}."
+        return f"{subject} may only use {_quote_join(names, 'or')} {scope_phrase}."
+    conjunction = "and" if rule.operator == "all" else "or"
+    successfully = "successfully " if rule.require_success else ""
+    return f"{subject} must {successfully}use {_quote_join(names, conjunction)} {scope_phrase}."
+
+
+# ---- config parsing + legacy conversion ------------------------------------
+
+
+def parse_tool_usage_config(
+    raw: Optional[Dict[str, Any]],
+    *,
+    resolve_tool_id=None,
+    resolve_agent_id=None,
+    all_tool_ids: Optional[List[str]] = None,
+) -> ToolUsageConfig:
+    """Parse a ``tool_used`` config, converting the legacy single-tool shape.
+
+    ``resolve_tool_id(name) -> id`` and ``resolve_agent_id(label) -> id`` map legacy
+    display names to graph ids; when omitted the raw names are kept as-is (useful for
+    pure unit tests). A legacy name that a provided resolver cannot map raises.
+
+    ``all_tool_ids`` is the workflow's full tool set, used to expand a legacy
+    "any tool" config (``should_call: true`` with no tool named).
+    """
+    raw = raw or {}
+    if "rules" in raw:
+        return ToolUsageConfig.model_validate(raw)
+    # Legacy shape: a single tool/agent, or a bare should_call ("any" / "no" tool).
+    if "tool" in raw or "node" in raw or "should_call" in raw:
+        return ToolUsageConfig(
+            rules=[_legacy_rule(raw, resolve_tool_id, resolve_agent_id, all_tool_ids)]
+        )
+    return ToolUsageConfig(rules=[])
+
+
+def canonicalize_tool_usage_config(
+    raw: Optional[Dict[str, Any]],
+    *,
+    resolve_tool_id=None,
+    resolve_agent_id=None,
+    all_tool_ids: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Return a ``{"rules": [...]}`` config with every tool/agent reference resolved
+    to a canonical id. Raises ``ValueError`` on an unknown or ambiguous name so a
+    create/update boundary can refuse to store a non-canonical config.
+
+    Unlike :func:`parse_tool_usage_config`, this also resolves ids/names *inside* an
+    already ``rules``-shaped config — the frontend can save legacy names into
+    ``tool_ids``/``agent_id``. Resolving an id returns it unchanged (idempotent).
+    """
+    parsed = parse_tool_usage_config(
+        raw,
+        resolve_tool_id=resolve_tool_id,
+        resolve_agent_id=resolve_agent_id,
+        all_tool_ids=all_tool_ids,
+    )
+    if resolve_tool_id is None and resolve_agent_id is None:
+        return parsed.model_dump(mode="json")
+
+    canonical: List[ToolUsageRule] = []
+    for rule in parsed.rules:
+        tool_ids = [_resolve_or_raise(resolve_tool_id, tool_id, "tool") for tool_id in rule.tool_ids]
+        agent_id = _resolve_or_raise(resolve_agent_id, rule.agent_id, "agent")
+        per_tool = {
+            _resolve_or_raise(resolve_tool_id, tool_id, "tool"): check
+            for tool_id, check in rule.per_tool.items()
+        }
+        canonical.append(
+            rule.model_copy(update={"tool_ids": tool_ids, "agent_id": agent_id, "per_tool": per_tool})
+        )
+    return ToolUsageConfig(rules=canonical).model_dump(mode="json")
+
+
+def _resolve_or_raise(resolver, value, kind: str):
+    if value is None:
+        return None
+    if resolver is None:
+        return value
+    resolved = resolver(value)
+    if not resolved:
+        raise ValueError(f"could not resolve legacy {kind} {value!r} in this workflow")
+    return resolved
+
+
+def _legacy_rule(
+    raw: Dict[str, Any],
+    resolve_tool_id,
+    resolve_agent_id,
+    all_tool_ids: Optional[List[str]] = None,
+) -> ToolUsageRule:
+    tool_name = raw.get("tool")
+    tool_id = _resolve_or_raise(resolve_tool_id, tool_name, "tool")
+    agent_id = _resolve_or_raise(resolve_agent_id, raw.get("node"), "agent")
+    should_call = bool(raw.get("should_call", True))
+
+    per_tool: Dict[str, PerToolCheck] = {}
+    if tool_id and should_call and (
+        raw.get("result_not_empty") or raw.get("result_contains") or raw.get("expected_args")
+    ):
+        per_tool[tool_id] = PerToolCheck(
+            result_not_empty=bool(raw.get("result_not_empty", False)),
+            result_contains=raw.get("result_contains"),
+            expected_args=raw.get("expected_args"),
+        )
+
+    operator, tool_ids = _legacy_operator_and_tools(tool_id, should_call, all_tool_ids)
+    return ToolUsageRule(
+        id="legacy-tool-rule",
+        tool_ids=tool_ids,
+        operator=operator,
+        agent_id=agent_id,
+        scope="every_turn",
+        per_tool=per_tool,
+    )
+
+
+def _legacy_operator_and_tools(tool_id, should_call, all_tool_ids):
+    """Map a legacy (tool, should_call) pair to a canonical operator + tool list.
+
+    The old UI allowed "any tool" by leaving the tool empty, so a bare should_call
+    is expanded: true -> "any" over every workflow tool; false -> "only" nothing.
+    """
+    if tool_id:
+        return ("all" if should_call else "none"), [tool_id]
+    if should_call:
+        return "any", sorted(all_tool_ids or [])
+    return "only", []

--- a/backend/app/tasks/test_suite_tasks.py
+++ b/backend/app/tasks/test_suite_tasks.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from celery import shared_task
 
+from app.core.config.settings import settings
 from app.core.tenant_scope import set_tenant_context, clear_tenant_context
 from app.tasks.base import create_task_wrapper, run_async_in_celery
 from app.core.tenant_scope import get_tenant_context
@@ -89,6 +90,11 @@ def execute_test_suite_run_task(
     """
     logger.info("Starting test suite run execution: %s (tenant: %s)", run_id, tenant_id)
     set_tenant_context(tenant_id)
+    # Forces get_tenant_engine() onto the NullPool ("_background") engine instead of
+    # the pooled one, so this task never reuses a connection whose event loop
+    # run_async_in_celery already closed (a stale pooled connection hangs silently
+    # rather than erroring — see the ml-worker asyncio-loop crash history).
+    settings.BACKGROUND_TASK = True
     try:
         async def _run():
             async def task(**kwargs):
@@ -115,3 +121,4 @@ def execute_test_suite_run_task(
         raise
     finally:
         clear_tenant_context()
+        settings.BACKGROUND_TASK = False

--- a/backend/tests/unit/test_dataset_conversations.py
+++ b/backend/tests/unit/test_dataset_conversations.py
@@ -26,6 +26,7 @@ def _service() -> EvalService:
         run_repo=AsyncMock(),
         result_repo=AsyncMock(),
         evaluation_repo=AsyncMock(),
+        tool_rule_result_repo=AsyncMock(),
         workflow_service=AsyncMock(),
         conversation_repo=AsyncMock(),
     )

--- a/backend/tests/unit/test_evaluators.py
+++ b/backend/tests/unit/test_evaluators.py
@@ -364,8 +364,36 @@ def _agent_trace(*, tool_name="lookup_tool", tool_args=None, tool_result="sample
                 },
             },
         },
+        "tool_events": [
+            {
+                "agent_id": "agent1",
+                "tool_id": f"node_{tool_name}",
+                "tool_name": tool_name,
+                "arguments": tool_args or {"topic": "sample"},
+                "result": tool_result,
+                "status": "succeeded",
+            }
+        ],
         "token_usage": {},
         "cost_usd": None,
+    }
+
+
+def _agent_workflow():
+    """Workflow catalogue matching _agent_trace: agent1 exposes lookup_tool (called
+    in the trace) and other_tool (available but never called). Legacy names resolve
+    from this catalogue, so an uncalled tool still maps to its id."""
+    return {
+        "id": "wf1",
+        "nodes": [
+            {"id": "agent1", "type": "agentNode", "data": {"name": "Sample Agent"}},
+            {"id": "node_lookup_tool", "type": "toolNode", "data": {"name": "Lookup Tool"}},
+            {"id": "node_other_tool", "type": "toolNode", "data": {"name": "Other Tool"}},
+        ],
+        "edges": [
+            {"source": "node_lookup_tool", "target": "agent1", "targetHandle": "tools"},
+            {"source": "node_other_tool", "target": "agent1", "targetHandle": "tools"},
+        ],
     }
 
 
@@ -405,6 +433,12 @@ def _multi_agent_trace():
                 },
             },
         },
+        "tool_events": [
+            {"agent_id": "analyst", "tool_id": "node_read_homepage", "tool_name": "read_homepage",
+             "arguments": {"url": "https://x.com"}, "result": "Homepage text.", "status": "succeeded"},
+            {"agent_id": "strategist", "tool_id": "node_opportunity_playbook", "tool_name": "opportunity_playbook",
+             "arguments": {"query": "saas"}, "result": "Playbook text.", "status": "succeeded"},
+        ],
         "token_usage": {},
         "cost_usd": None,
     }
@@ -414,44 +448,52 @@ class TestToolUsageMultiAgent:
     def setup_method(self):
         self.registry = SimpleEvaluatorRegistry()
 
-    async def _tool_used(self, config):
+    async def _tool_used(self, rule):
+        rule.setdefault("id", "r1")
         metrics = await self.registry.evaluate(
             ["tool_used"],
             inputs={},
             outputs="",
             reference_outputs=None,
             execution_trace=_multi_agent_trace(),
-            technique_configs={"tool_used": config},
+            technique_configs={"tool_used": {"rules": [rule]}},
         )
         return metrics["tool_used"]
 
     @pytest.mark.asyncio
     async def test_tool_scoped_to_owning_agent_passes(self):
-        result = await self._tool_used({"tool": "read_homepage", "node": "Analyst"})
+        result = await self._tool_used(
+            {"agent_id": "analyst", "tool_ids": ["node_read_homepage"], "operator": "all"}
+        )
         assert result["passed"] is True
 
     @pytest.mark.asyncio
     async def test_tool_scoped_to_other_agent_fails(self):
-        result = await self._tool_used({"tool": "read_homepage", "node": "Strategist"})
+        result = await self._tool_used(
+            {"agent_id": "strategist", "tool_ids": ["node_read_homepage"], "operator": "all"}
+        )
         assert result["passed"] is False
-        assert "by node" in (result["comment"] or "")
 
     @pytest.mark.asyncio
     async def test_each_agent_matches_its_own_tool(self):
-        analyst = await self._tool_used({"tool": "read_homepage", "node": "Analyst"})
-        strategist = await self._tool_used({"tool": "opportunity_playbook", "node": "Strategist"})
+        analyst = await self._tool_used(
+            {"agent_id": "analyst", "tool_ids": ["node_read_homepage"], "operator": "all"}
+        )
+        strategist = await self._tool_used(
+            {"agent_id": "strategist", "tool_ids": ["node_opportunity_playbook"], "operator": "all"}
+        )
         assert analyst["passed"] is True
         assert strategist["passed"] is True
 
     @pytest.mark.asyncio
     async def test_forbidden_tool_not_called_by_any_agent_passes(self):
-        result = await self._tool_used({"tool": "escalate", "should_call": False})
+        result = await self._tool_used({"tool_ids": ["node_escalate"], "operator": "none"})
         assert result["passed"] is True
 
     @pytest.mark.asyncio
     async def test_forbidden_tool_scoped_to_agent_that_did_not_call_it_passes(self):
         result = await self._tool_used(
-            {"tool": "read_homepage", "should_call": False, "node": "Strategist"}
+            {"agent_id": "strategist", "tool_ids": ["node_read_homepage"], "operator": "none"}
         )
         assert result["passed"] is True
 
@@ -459,10 +501,15 @@ class TestToolUsageMultiAgent:
     async def test_expected_args_and_result_together(self):
         result = await self._tool_used(
             {
-                "tool": "read_homepage",
-                "node": "Analyst",
-                "expected_args": {"url": "https://x.com"},
-                "result_not_empty": True,
+                "agent_id": "analyst",
+                "tool_ids": ["node_read_homepage"],
+                "operator": "all",
+                "per_tool": {
+                    "node_read_homepage": {
+                        "expected_args": {"url": "https://x.com"},
+                        "result_not_empty": True,
+                    }
+                },
             }
         )
         assert result["passed"] is True
@@ -515,81 +562,67 @@ class TestProcessCheckEvaluators:
     def setup_method(self):
         self.registry = SimpleEvaluatorRegistry()
 
-    @pytest.mark.asyncio
-    async def test_tool_used_passes_for_expected_tool(self):
+    async def _tool_used(self, trace, rule):
+        rule.setdefault("id", "r1")
         metrics = await self.registry.evaluate(
             ["tool_used"],
             inputs={},
             outputs="",
             reference_outputs=None,
-            execution_trace=_agent_trace(tool_name="lookup_tool"),
-            technique_configs={"tool_used": {"tool": "lookup_tool"}},
+            execution_trace=trace,
+            technique_configs={"tool_used": {"rules": [rule]}},
         )
-        assert metrics["tool_used"]["passed"] is True
+        return metrics["tool_used"]
+
+    @pytest.mark.asyncio
+    async def test_tool_used_passes_for_expected_tool(self):
+        result = await self._tool_used(
+            _agent_trace(tool_name="lookup_tool"),
+            {"tool_ids": ["node_lookup_tool"], "operator": "all"},
+        )
+        assert result["passed"] is True
 
     @pytest.mark.asyncio
     async def test_tool_used_fails_for_missing_tool(self):
-        metrics = await self.registry.evaluate(
-            ["tool_used"],
-            inputs={},
-            outputs="",
-            reference_outputs=None,
-            execution_trace=_agent_trace(tool_name="lookup_tool"),
-            technique_configs={"tool_used": {"tool": "other_tool"}},
+        result = await self._tool_used(
+            _agent_trace(tool_name="lookup_tool"),
+            {"tool_ids": ["node_other_tool"], "operator": "all"},
         )
-        assert metrics["tool_used"]["passed"] is False
+        assert result["passed"] is False
 
     @pytest.mark.asyncio
-    async def test_tool_used_should_call_false_fails_when_tool_was_called(self):
-        metrics = await self.registry.evaluate(
-            ["tool_used"],
-            inputs={},
-            outputs="",
-            reference_outputs=None,
-            execution_trace=_agent_trace(tool_name="lookup_tool"),
-            technique_configs={"tool_used": {"tool": "lookup_tool", "should_call": False}},
+    async def test_tool_used_none_fails_when_tool_was_called(self):
+        result = await self._tool_used(
+            _agent_trace(tool_name="lookup_tool"),
+            {"tool_ids": ["node_lookup_tool"], "operator": "none"},
         )
-        assert metrics["tool_used"]["passed"] is False
+        assert result["passed"] is False
 
     @pytest.mark.asyncio
-    async def test_tool_used_should_call_false_passes_when_tool_was_not_called(self):
-        metrics = await self.registry.evaluate(
-            ["tool_used"],
-            inputs={},
-            outputs="",
-            reference_outputs=None,
-            execution_trace=_agent_trace(tool_name="lookup_tool"),
-            technique_configs={"tool_used": {"tool": "other_tool", "should_call": False}},
+    async def test_tool_used_none_passes_when_tool_was_not_called(self):
+        result = await self._tool_used(
+            _agent_trace(tool_name="lookup_tool"),
+            {"tool_ids": ["node_other_tool"], "operator": "none"},
         )
-        assert metrics["tool_used"]["passed"] is True
+        assert result["passed"] is True
 
     @pytest.mark.asyncio
     async def test_tool_used_with_expected_args(self):
-        metrics = await self.registry.evaluate(
-            ["tool_used"],
-            inputs={},
-            outputs="",
-            reference_outputs=None,
-            execution_trace=_agent_trace(tool_name="notify_tool", tool_args={"priority": "high"}),
-            technique_configs={
-                "tool_used": {"tool": "notify_tool", "expected_args": {"priority": "high"}}
-            },
+        result = await self._tool_used(
+            _agent_trace(tool_name="notify_tool", tool_args={"priority": "high"}),
+            {"tool_ids": ["node_notify_tool"], "operator": "all",
+             "per_tool": {"node_notify_tool": {"expected_args": {"priority": "high"}}}},
         )
-        assert metrics["tool_used"]["passed"] is True
+        assert result["passed"] is True
 
     @pytest.mark.asyncio
     async def test_tool_used_fails_on_wrong_args(self):
-        metrics = await self.registry.evaluate(
-            ["tool_used"],
-            inputs={},
-            outputs="",
-            reference_outputs=None,
-            execution_trace=_agent_trace(tool_name="notify_tool", tool_args={"priority": "low"}),
-            technique_configs={
-                "tool_used": {"tool": "notify_tool", "expected_args": {"priority": "high"}}
-            },
+        result = await self._tool_used(
+            _agent_trace(tool_name="notify_tool", tool_args={"priority": "low"}),
+            {"tool_ids": ["node_notify_tool"], "operator": "all",
+             "per_tool": {"node_notify_tool": {"expected_args": {"priority": "high"}}}},
         )
-        assert metrics["tool_used"]["passed"] is False
+        assert result["passed"] is False
 
     @pytest.mark.asyncio
     async def test_tool_used_scoped_to_node_id_passes(self):
@@ -600,6 +633,7 @@ class TestProcessCheckEvaluators:
             reference_outputs=None,
             execution_trace=_agent_trace(tool_name="lookup_tool"),
             technique_configs={"tool_used": {"tool": "lookup_tool", "node": "agent1"}},
+            workflow=_agent_workflow(),
         )
         assert metrics["tool_used"]["passed"] is True
 
@@ -612,21 +646,40 @@ class TestProcessCheckEvaluators:
             reference_outputs=None,
             execution_trace=_agent_trace(tool_name="lookup_tool"),
             technique_configs={"tool_used": {"tool": "lookup_tool", "node": "Sample Agent"}},
+            workflow=_agent_workflow(),
         )
         assert metrics["tool_used"]["passed"] is True
 
     @pytest.mark.asyncio
-    async def test_tool_used_scoped_to_other_node_fails(self):
+    async def test_tool_used_scoped_required_tool_not_used_fails(self):
+        # other_tool is available to agent1 but never called; the scoped failure names the node.
         metrics = await self.registry.evaluate(
             ["tool_used"],
             inputs={},
             outputs="",
             reference_outputs=None,
             execution_trace=_agent_trace(tool_name="lookup_tool"),
-            technique_configs={"tool_used": {"tool": "lookup_tool", "node": "kb1"}},
+            technique_configs={"tool_used": {"tool": "other_tool", "node": "agent1"}},
+            workflow=_agent_workflow(),
         )
         assert metrics["tool_used"]["passed"] is False
         assert "by node" in (metrics["tool_used"]["comment"] or "")
+
+    @pytest.mark.asyncio
+    async def test_tool_used_must_not_use_uncalled_tool_passes(self):
+        # Regression: a "must not use" rule for a tool that was correctly never called
+        # must resolve from the workflow catalogue (not observed calls) and PASS,
+        # instead of erroring because the uncalled tool's name can't be resolved.
+        metrics = await self.registry.evaluate(
+            ["tool_used"],
+            inputs={},
+            outputs="",
+            reference_outputs=None,
+            execution_trace=_agent_trace(tool_name="lookup_tool"),
+            technique_configs={"tool_used": {"tool": "other_tool", "should_call": False}},
+            workflow=_agent_workflow(),
+        )
+        assert metrics["tool_used"]["passed"] is True
 
     @pytest.mark.asyncio
     async def test_tool_used_result_not_empty_passes_with_real_result(self):
@@ -637,6 +690,7 @@ class TestProcessCheckEvaluators:
             reference_outputs=None,
             execution_trace=_agent_trace(tool_name="lookup_tool", tool_result="useful content"),
             technique_configs={"tool_used": {"tool": "lookup_tool", "result_not_empty": True}},
+            workflow=_agent_workflow(),
         )
         assert metrics["tool_used"]["passed"] is True
 
@@ -649,6 +703,7 @@ class TestProcessCheckEvaluators:
             reference_outputs=None,
             execution_trace=_agent_trace(tool_name="lookup_tool", tool_result="No results found."),
             technique_configs={"tool_used": {"tool": "lookup_tool", "result_not_empty": True}},
+            workflow=_agent_workflow(),
         )
         assert metrics["tool_used"]["passed"] is False
         assert "result" in (metrics["tool_used"]["comment"] or "")
@@ -662,6 +717,7 @@ class TestProcessCheckEvaluators:
             reference_outputs=None,
             execution_trace=_agent_trace(tool_name="lookup_tool", tool_result=""),
             technique_configs={"tool_used": {"tool": "lookup_tool", "result_not_empty": True}},
+            workflow=_agent_workflow(),
         )
         assert metrics["tool_used"]["passed"] is False
 
@@ -674,6 +730,7 @@ class TestProcessCheckEvaluators:
             reference_outputs=None,
             execution_trace=_agent_trace(tool_name="lookup_tool", tool_result=None),
             technique_configs={"tool_used": {"tool": "lookup_tool", "result_not_empty": True}},
+            workflow=_agent_workflow(),
         )
         assert metrics["tool_used"]["passed"] is False
         assert "does not record" in (metrics["tool_used"]["comment"] or "")
@@ -687,6 +744,7 @@ class TestProcessCheckEvaluators:
             reference_outputs=None,
             execution_trace=_agent_trace(tool_name="lookup_tool", tool_result=[]),
             technique_configs={"tool_used": {"tool": "lookup_tool", "result_not_empty": True}},
+            workflow=_agent_workflow(),
         )
         assert metrics["tool_used"]["passed"] is False
 
@@ -700,6 +758,7 @@ class TestProcessCheckEvaluators:
             reference_outputs=None,
             execution_trace=trace,
             technique_configs={"tool_used": {"tool": "lookup_tool", "result_contains": "remote work"}},
+            workflow=_agent_workflow(),
         )
         failing = await self.registry.evaluate(
             ["tool_used"],
@@ -708,23 +767,10 @@ class TestProcessCheckEvaluators:
             reference_outputs=None,
             execution_trace=trace,
             technique_configs={"tool_used": {"tool": "lookup_tool", "result_contains": "vacation days"}},
+            workflow=_agent_workflow(),
         )
         assert passing["tool_used"]["passed"] is True
         assert failing["tool_used"]["passed"] is False
-
-    @pytest.mark.asyncio
-    async def test_tool_used_should_call_false_scoped_to_other_node_passes(self):
-        metrics = await self.registry.evaluate(
-            ["tool_used"],
-            inputs={},
-            outputs="",
-            reference_outputs=None,
-            execution_trace=_agent_trace(tool_name="lookup_tool"),
-            technique_configs={
-                "tool_used": {"tool": "lookup_tool", "node": "kb1", "should_call": False}
-            },
-        )
-        assert metrics["tool_used"]["passed"] is True
 
     @pytest.mark.asyncio
     async def test_route_taken(self):

--- a/backend/tests/unit/test_tool_catalog.py
+++ b/backend/tests/unit/test_tool_catalog.py
@@ -1,0 +1,138 @@
+"""Unit tests for the shared workflow tool-catalogue resolver."""
+
+import pytest
+
+from app.services.tool_catalog import (
+    build_agent_index,
+    build_tool_index,
+    nested_workflow_refs,
+    resolve_agents,
+    resolve_in_index,
+)
+
+
+def _agent(node_id, name):
+    return {"id": node_id, "type": "agentNode", "data": {"name": name}}
+
+
+def _tool(node_id, name, node_type="knowledgeBaseNode"):
+    return {"id": node_id, "type": node_type, "data": {"name": name}}
+
+
+def _tools_edge(tool_id, agent_id):
+    return {"source": tool_id, "target": agent_id, "targetHandle": "tools"}
+
+
+def test_single_agent_single_tool():
+    wf = {
+        "id": "wf1",
+        "nodes": [_agent("a1", "Research Agent"), _tool("t1", "Knowledge Search")],
+        "edges": [_tools_edge("t1", "a1")],
+    }
+    agents = resolve_agents(wf)
+    assert len(agents) == 1
+    agent = agents[0]
+    assert agent["id"] == "a1"
+    assert agent["label"] == "Research Agent"
+    assert agent["tools"] == [
+        {"id": "t1", "name": "knowledge_search", "label": "Knowledge Search", "type": "knowledgeBaseNode"}
+    ]
+
+
+def test_multiple_tools_one_agent_deduped():
+    wf = {
+        "nodes": [_agent("a1", "Agent"), _tool("t1", "Search"), _tool("t2", "Web")],
+        "edges": [_tools_edge("t1", "a1"), _tools_edge("t2", "a1"), _tools_edge("t1", "a1")],
+    }
+    agents = resolve_agents(wf)
+    assert len(agents) == 1
+    assert {t["id"] for t in agents[0]["tools"]} == {"t1", "t2"}
+
+
+def test_mcp_node_expands_to_composite_ids():
+    mcp = {"id": "m1", "type": "mcpNode", "data": {"name": "MCP", "whitelistedTools": ["search", "fetch"]}}
+    wf = {
+        "nodes": [_agent("a1", "Agent"), mcp],
+        "edges": [_tools_edge("m1", "a1")],
+    }
+    agents = resolve_agents(wf)
+    tool_ids = {t["id"] for t in agents[0]["tools"]}
+    assert tool_ids == {"m1:search", "m1:fetch"}
+
+
+def test_two_agents_each_own_tools():
+    wf = {
+        "nodes": [
+            _agent("a1", "A1"), _agent("a2", "A2"),
+            _tool("t1", "T1"), _tool("t2", "T2"),
+        ],
+        "edges": [_tools_edge("t1", "a1"), _tools_edge("t2", "a2")],
+    }
+    agents = {a["id"]: a for a in resolve_agents(wf)}
+    assert agents["a1"]["tools"][0]["id"] == "t1"
+    assert agents["a2"]["tools"][0]["id"] == "t2"
+
+
+def test_non_tools_edges_ignored():
+    wf = {
+        "nodes": [_agent("a1", "Agent"), _tool("t1", "T1")],
+        "edges": [{"source": "t1", "target": "a1", "targetHandle": "input"}],
+    }
+    assert resolve_agents(wf) == []
+
+
+def test_nested_workflow_refs():
+    wf = {
+        "nodes": [
+            {"id": "x1", "type": "workflowExecutorNode", "data": {"name": "Child", "workflowId": "wf-child"}},
+            {"id": "x2", "type": "workflowExecutorNode", "data": {"name": "NoId"}},
+        ],
+        "edges": [],
+    }
+    refs = nested_workflow_refs(wf)
+    assert refs == [{"node_id": "x1", "label": "Child", "workflow_id": "wf-child"}]
+
+
+def test_indexes_map_names_and_labels():
+    wf = {
+        "nodes": [_agent("a1", "Research Agent"), _tool("t1", "Knowledge Search")],
+        "edges": [_tools_edge("t1", "a1")],
+    }
+    agents = resolve_agents(wf)
+    tool_index = build_tool_index(agents)
+    agent_index = build_agent_index(agents)
+    # Case-insensitive resolution by label, snake name, and id.
+    assert resolve_in_index(tool_index, "Knowledge Search", "tool") == "t1"
+    assert resolve_in_index(tool_index, "KNOWLEDGE_SEARCH", "tool") == "t1"
+    assert resolve_in_index(tool_index, "t1", "tool") == "t1"
+    assert resolve_in_index(agent_index, "research agent", "agent") == "a1"
+    assert resolve_in_index(tool_index, "nonexistent", "tool") is None
+
+
+def test_duplicate_tool_name_is_ambiguous():
+    wf = {
+        "nodes": [_agent("a1", "Agent"), _tool("t1", "Search"), _tool("t2", "Search")],
+        "edges": [_tools_edge("t1", "a1"), _tools_edge("t2", "a1")],
+    }
+    tool_index = build_tool_index(resolve_agents(wf))
+    with pytest.raises(ValueError, match="ambiguous"):
+        resolve_in_index(tool_index, "Search", "tool")
+    # Each concrete id still resolves uniquely despite the shared name.
+    assert resolve_in_index(tool_index, "t1", "tool") == "t1"
+    assert resolve_in_index(tool_index, "t2", "tool") == "t2"
+
+
+def test_mcp_node_exposes_composite_tool_ids():
+    wf = {
+        "nodes": [
+            _agent("a1", "Agent"),
+            {"id": "mcp1", "type": "mcpNode", "data": {"name": "MCP", "whitelistedTools": ["search", "fetch"]}},
+        ],
+        "edges": [_tools_edge("mcp1", "a1")],
+    }
+    agents = resolve_agents(wf)
+    assert {tool["id"] for tool in agents[0]["tools"]} == {"mcp1:search", "mcp1:fetch"}
+    # Legacy resolution maps the MCP tool name (case-insensitively) to its composite id.
+    tool_index = build_tool_index(agents)
+    assert resolve_in_index(tool_index, "search", "tool") == "mcp1:search"
+    assert resolve_in_index(tool_index, "mcp1:fetch", "tool") == "mcp1:fetch"

--- a/backend/tests/unit/test_tool_serialization_safety.py
+++ b/backend/tests/unit/test_tool_serialization_safety.py
@@ -1,0 +1,139 @@
+"""Regression tests for tool-object serialization safety.
+
+These guard the fix for the ML-worker freeze where an agent that *called* a tool
+produced a reference cycle (workflow state -> node input -> tool -> state) that
+stalled ``sanitize_for_json`` and wedged the solo worker. The three layers of
+defence are exercised here: the dangerous wire is removed (tools_reference
+stripped), the back-reference is weak, and the sanitizer is cycle/depth/size safe.
+"""
+
+import gc
+import time
+
+from app.modules.workflow.agents.base_tool import BaseTool
+from app.modules.workflow.engine.nodes.ml.ml_utils import (
+    _MAX_SANITIZE_DEPTH,
+    sanitize_for_json,
+)
+from app.modules.workflow.engine.workflow_state import _strip_live_tool_refs
+
+
+class _FakeState:
+    """Minimal WorkflowState stand-in exposing an add_tool_event sink."""
+
+    def __init__(self):
+        self.node_execution_status = {}
+        self.events = []
+
+    def add_tool_event(self, **kwargs):
+        self.events.append(kwargs)
+
+
+def _make_tool(state):
+    return BaseTool(
+        node_id="tool-1",
+        name="search handbook",
+        description="d",
+        parameters={},
+        function=lambda payload: "ok",
+        state=state,
+    )
+
+
+# --- Step 2: BaseTool holds the workflow state weakly ---
+
+def test_base_tool_state_resolves_but_is_not_a_strong_field():
+    state = _FakeState()
+    tool = _make_tool(state)
+    assert tool.state is state
+    assert "state" not in vars(tool)  # no strong ref that sanitize would follow
+    assert "_state_ref" in vars(tool)
+
+
+def test_base_tool_state_is_none_after_collection():
+    state = _FakeState()
+    tool = _make_tool(state)
+    del state
+    gc.collect()
+    assert tool.state is None
+
+
+def test_base_tool_accepts_none_state():
+    assert _make_tool(None).state is None
+
+
+def test_called_tool_still_records_event():
+    state = _FakeState()
+    tool = _make_tool(state)
+    tool._record_event({"q": "hi"}, "answer", status="succeeded")
+    assert len(state.events) == 1
+    assert state.events[0]["tool_id"] == "tool-1"
+
+
+# --- Step 3: sanitize_for_json is cycle / depth / size safe ---
+
+def test_sanitize_breaks_direct_dict_cycle():
+    node = {}
+    node["self"] = node
+    assert sanitize_for_json(node)["self"] == "<cycle>"
+
+
+def test_sanitize_survives_state_tool_cycle_fast():
+    # The exact production shape: state -> node_execution_status -> tool -> state.
+    state = _FakeState()
+    tool = _make_tool(state)
+    state.node_execution_status = {"agent": {"input": {"tools_reference": [tool]}}}
+    start = time.monotonic()
+    out = sanitize_for_json({"nodeExecutionStatus": state.node_execution_status})
+    assert time.monotonic() - start < 5.0
+    assert isinstance(out, dict)
+
+
+def test_sanitize_is_depth_bounded():
+    root = current = {}
+    for _ in range(_MAX_SANITIZE_DEPTH + 50):
+        current["x"] = {}
+        current = current["x"]
+    assert sanitize_for_json(root) is not None  # no RecursionError, returns
+
+
+def test_sanitize_preserves_shared_acyclic_refs():
+    shared = {"a": 1}
+    out = sanitize_for_json({"one": shared, "two": shared})
+    assert out == {"one": {"a": 1}, "two": {"a": 1}}  # diamond kept, not "<cycle>"
+
+
+# --- Step 1: tools_reference stripped from serialized traces ---
+
+def test_strip_removes_tools_reference_when_tool_called():
+    state = _FakeState()
+    tool = _make_tool(state)
+    node_status = {"agent": {"input": {"prompt": "hi", "tools_reference": [tool]}, "status": "success"}}
+    cleaned = _strip_live_tool_refs(node_status)
+    assert "tools_reference" not in cleaned["agent"]["input"]
+    assert cleaned["agent"]["input"]["prompt"] == "hi"
+    assert "tools_reference" in node_status["agent"]["input"]  # original untouched
+
+
+def test_strip_is_noop_when_no_tool_called():
+    node_status = {"agent": {"input": {"prompt": "hi"}, "status": "success"}}
+    assert _strip_live_tool_refs(node_status) == node_status
+
+
+def test_bound_event_value_truncates_long_strings():
+    from app.modules.workflow.engine.workflow_state import (
+        _MAX_EVENT_VALUE_CHARS,
+        _bound_event_value,
+    )
+
+    long_result = "x" * (_MAX_EVENT_VALUE_CHARS + 100)
+    out = _bound_event_value(long_result)
+    assert isinstance(out, dict) and out["_truncated"] is True
+    assert out["chars"] == len(long_result)
+    assert len(out["preview"]) == _MAX_EVENT_VALUE_CHARS
+
+
+def test_bound_event_value_keeps_short_strings():
+    from app.modules.workflow.engine.workflow_state import _bound_event_value
+
+    assert _bound_event_value("short result") == "short result"

--- a/backend/tests/unit/test_tool_usage_rules.py
+++ b/backend/tests/unit/test_tool_usage_rules.py
@@ -1,0 +1,516 @@
+"""Unit tests for tool-usage rule evaluation (pure logic)."""
+
+import pytest
+
+from app.services.tool_usage_rules import (
+    RULE_FAILED,
+    RULE_NOT_EVALUATED,
+    RULE_PASSED,
+    PerToolCheck,
+    ToolUsageRule,
+    canonicalize_tool_usage_config,
+    describe_tool_rule,
+    evaluate_rule,
+    evaluate_rules,
+    parse_tool_usage_config,
+    plan_tool_rule_results,
+    summarize_planned_results,
+)
+
+
+def _event(tool_id, *, agent_id="agent-1", status="succeeded", tool_name=None, result="ok", arguments=None):
+    return {
+        "agent_id": agent_id,
+        "tool_id": tool_id,
+        "tool_name": tool_name or tool_id,
+        "arguments": arguments or {},
+        "result": result,
+        "status": status,
+    }
+
+
+def _rule(**kw):
+    kw.setdefault("id", "r1")
+    kw.setdefault("agent_id", "agent-1")
+    return ToolUsageRule(**kw)
+
+
+# ---- operators -------------------------------------------------------------
+
+def test_all_passes_when_every_tool_called():
+    rule = _rule(tool_ids=["a", "b"], operator="all")
+    res = evaluate_rule(rule, [_event("a"), _event("b")], {"agent-1"})
+    assert res["status"] == RULE_PASSED
+
+
+def test_all_fails_with_missing_tool():
+    rule = _rule(tool_ids=["a", "b"], operator="all")
+    res = evaluate_rule(rule, [_event("a")], {"agent-1"})
+    assert res["status"] == RULE_FAILED
+    assert res["missing_tools"] == ["b"]
+
+
+def test_any_passes_with_one_tool():
+    rule = _rule(tool_ids=["a", "b"], operator="any")
+    res = evaluate_rule(rule, [_event("b")], {"agent-1"})
+    assert res["status"] == RULE_PASSED
+
+
+def test_none_fails_on_forbidden_attempt_even_if_call_failed():
+    # Forbidden tool attempted, and it failed — must still fail the rule.
+    rule = _rule(tool_ids=["danger"], operator="none")
+    res = evaluate_rule(rule, [_event("danger", status="failed")], {"agent-1"})
+    assert res["status"] == RULE_FAILED
+    assert res["forbidden_tools"] == ["danger"]
+
+
+def test_none_passes_when_not_attempted():
+    rule = _rule(tool_ids=["danger"], operator="none")
+    res = evaluate_rule(rule, [_event("safe")], {"agent-1"})
+    assert res["status"] == RULE_PASSED
+
+
+def test_require_success_checks_only_successful_events():
+    # One successful call with the wrong result, one failed call with the expected
+    # result. With require_success, only the successful (wrong) event is inspected,
+    # so the per-tool result check must FAIL.
+    rule = _rule(
+        tool_ids=["a"], operator="all", require_success=True,
+        per_tool={"a": PerToolCheck(result_contains="expected")},
+    )
+    events = [
+        _event("a", status="succeeded", result="wrong value"),
+        _event("a", status="failed", result="the expected value"),
+    ]
+    res = evaluate_rule(rule, events, {"agent-1"})
+    assert res["status"] == RULE_FAILED
+    assert "result" in res["comment"]
+
+
+def test_per_tool_reason_distinguishes_missing_result_from_empty():
+    used_but_none = _rule(
+        tool_ids=["a"], operator="all",
+        per_tool={"a": PerToolCheck(result_not_empty=True)},
+    )
+    res = evaluate_rule(used_but_none, [_event("a", result=None)], {"agent-1"})
+    assert res["status"] == RULE_FAILED
+    assert "does not record" in res["comment"]
+
+
+def test_min_calls_greater_than_max_calls_rejected():
+    with pytest.raises(ValueError, match="min_calls"):
+        _rule(tool_ids=["a"], min_calls=3, max_calls=1)
+
+
+# ---- canonicalization (editing an old evaluation) --------------------------
+
+def test_canonicalize_resolves_names_inside_rules():
+    # The frontend can save legacy names into tool_ids/agent_id; canonicalize maps
+    # them to ids (and leaves real ids unchanged).
+    tool_map = {"search": "tool-1", "tool-1": "tool-1"}
+    agent_map = {"researcher": "agent-1", "agent-1": "agent-1"}
+    raw = {"rules": [{"id": "r1", "tool_ids": ["search"], "operator": "all", "agent_id": "researcher"}]}
+    out = canonicalize_tool_usage_config(
+        raw,
+        resolve_tool_id=lambda name: tool_map.get(name),
+        resolve_agent_id=lambda label: agent_map.get(label),
+    )
+    assert out["rules"][0]["tool_ids"] == ["tool-1"]
+    assert out["rules"][0]["agent_id"] == "agent-1"
+
+
+def test_canonicalize_converts_legacy_shape():
+    # Idempotent resolver (id -> id), mirroring the real catalogue resolver.
+    tool_map = {"search": "tool-1", "tool-1": "tool-1"}
+    out = canonicalize_tool_usage_config(
+        {"tool": "search", "should_call": False},
+        resolve_tool_id=lambda name: tool_map.get(name),
+        resolve_agent_id=lambda label: None,
+    )
+    assert out["rules"][0]["tool_ids"] == ["tool-1"]
+    assert out["rules"][0]["operator"] == "none"
+
+
+def test_canonicalize_raises_on_unknown_name():
+    with pytest.raises(ValueError):
+        canonicalize_tool_usage_config(
+            {"rules": [{"id": "r1", "tool_ids": ["ghost"], "operator": "all"}]},
+            resolve_tool_id=lambda name: None,
+            resolve_agent_id=lambda label: None,
+        )
+
+
+def test_only_fails_when_outside_tool_used():
+    rule = _rule(tool_ids=["a"], operator="only")
+    res = evaluate_rule(rule, [_event("a"), _event("b")], {"agent-1"})
+    assert res["status"] == RULE_FAILED
+    assert res["forbidden_tools"] == ["b"]
+
+
+def test_only_passes_when_all_within_set():
+    rule = _rule(tool_ids=["a", "b"], operator="only")
+    res = evaluate_rule(rule, [_event("a")], {"agent-1"})
+    assert res["status"] == RULE_PASSED
+
+
+# ---- require_success -------------------------------------------------------
+
+def test_require_success_fails_when_only_failed_calls():
+    rule = _rule(tool_ids=["a"], operator="all", require_success=True)
+    res = evaluate_rule(rule, [_event("a", status="failed")], {"agent-1"})
+    assert res["status"] == RULE_FAILED
+
+
+def test_require_success_passes_on_success():
+    rule = _rule(tool_ids=["a"], operator="all", require_success=True)
+    res = evaluate_rule(rule, [_event("a", status="succeeded")], {"agent-1"})
+    assert res["status"] == RULE_PASSED
+
+
+# ---- not-called vs called-but-failed vs check-mismatch ----------------------
+
+def test_called_but_failed_reported_separately_from_missing():
+    # require_success on: "a" was attempted but only failed; "b" was never attempted.
+    rule = _rule(tool_ids=["a", "b"], operator="all", require_success=True)
+    res = evaluate_rule(rule, [_event("a", status="failed")], {"agent-1"})
+    assert res["status"] == RULE_FAILED
+    assert res["failed_tools"] == ["a"]   # called but never succeeded
+    assert res["missing_tools"] == ["b"]  # never called
+    assert "called but did not succeed" in res["comment"]
+
+
+def test_check_mismatch_is_neither_missing_nor_failed():
+    # The tool was called and succeeded, but its result check did not match.
+    rule = _rule(tool_ids=["a"], operator="all", per_tool={"a": PerToolCheck(result_contains="xyz")})
+    res = evaluate_rule(rule, [_event("a", result="nope")], {"agent-1"})
+    assert res["status"] == RULE_FAILED
+    assert "a" in res["check_failures"]
+    assert res["missing_tools"] == []
+    assert res["failed_tools"] == []
+
+
+# ---- three-state / not_evaluated ------------------------------------------
+
+def test_required_rule_not_evaluated_when_agent_never_ran():
+    rule = _rule(tool_ids=["a"], operator="all")
+    res = evaluate_rule(rule, [], executed_agent_ids=set())
+    assert res["status"] == RULE_NOT_EVALUATED
+
+
+def test_forbidden_attempt_fails_even_when_agent_not_in_executed_set():
+    # Execution stopped, but a forbidden attempt was already observed -> fail.
+    rule = _rule(tool_ids=["danger"], operator="none")
+    res = evaluate_rule(rule, [_event("danger")], executed_agent_ids=set())
+    assert res["status"] == RULE_FAILED
+
+
+# ---- multi-agent -----------------------------------------------------------
+
+def test_agent_filter_ignores_other_agents_calls():
+    rule = _rule(tool_ids=["a"], operator="all", agent_id="agent-1")
+    events = [_event("a", agent_id="agent-2")]  # wrong agent
+    res = evaluate_rule(rule, events, {"agent-1", "agent-2"})
+    assert res["status"] == RULE_FAILED
+
+
+def test_any_agent_rule_considers_all_agents():
+    rule = _rule(tool_ids=["a"], operator="all", agent_id=None)
+    res = evaluate_rule(rule, [_event("a", agent_id="agent-9")], {"agent-9"})
+    assert res["status"] == RULE_PASSED
+
+
+# ---- min/max calls ---------------------------------------------------------
+
+def test_min_calls_enforced():
+    rule = _rule(tool_ids=["a"], operator="all", min_calls=2)
+    one = evaluate_rule(rule, [_event("a")], {"agent-1"})
+    two = evaluate_rule(rule, [_event("a"), _event("a")], {"agent-1"})
+    assert one["status"] == RULE_FAILED
+    assert two["status"] == RULE_PASSED
+
+
+def test_max_calls_enforced():
+    rule = _rule(tool_ids=["a"], operator="all", max_calls=1)
+    res = evaluate_rule(rule, [_event("a"), _event("a")], {"agent-1"})
+    assert res["status"] == RULE_FAILED
+
+
+# ---- per-tool advanced -----------------------------------------------------
+
+def test_per_tool_result_not_empty():
+    rule = _rule(tool_ids=["a"], operator="all", per_tool={"a": {"result_not_empty": True}})
+    empty = evaluate_rule(rule, [_event("a", result="No results found")], {"agent-1"})
+    full = evaluate_rule(rule, [_event("a", result="here is your answer")], {"agent-1"})
+    assert empty["status"] == RULE_FAILED
+    assert full["status"] == RULE_PASSED
+
+
+def test_per_tool_expected_args():
+    rule = _rule(tool_ids=["a"], operator="all", per_tool={"a": {"expected_args": {"q": "pto"}}})
+    ok = evaluate_rule(rule, [_event("a", arguments={"q": "pto", "extra": 1})], {"agent-1"})
+    bad = evaluate_rule(rule, [_event("a", arguments={"q": "vacation"})], {"agent-1"})
+    assert ok["status"] == RULE_PASSED
+    assert bad["status"] == RULE_FAILED
+
+
+# ---- coverage aggregation --------------------------------------------------
+
+def test_coverage_and_overall():
+    rules = [
+        _rule(id="pass", tool_ids=["a"], operator="all"),
+        _rule(id="fail", tool_ids=["b"], operator="all"),
+        _rule(id="skip", tool_ids=["c"], operator="all", agent_id="agent-2"),
+    ]
+    summary = evaluate_rules(rules, [_event("a")], {"agent-1"})
+    assert summary["coverage"] == {
+        "passed": 1, "failed": 1, "not_evaluated": 1, "evaluated": 2, "total": 3,
+    }
+    assert summary["score"] == 0.5
+    assert summary["passed"] is False  # a failure means not healthy
+
+
+def test_all_not_evaluated_is_not_healthy():
+    rules = [_rule(id="x", tool_ids=["a"], operator="all", agent_id="never")]
+    summary = evaluate_rules(rules, [], set())
+    assert summary["score"] is None
+    assert summary["passed"] is False
+
+
+# ---- validation ------------------------------------------------------------
+
+def test_duplicate_rule_ids_rejected():
+    with pytest.raises(ValueError):
+        parse_tool_usage_config({"rules": [
+            {"id": "x", "tool_ids": ["a"], "operator": "all"},
+            {"id": "x", "tool_ids": ["b"], "operator": "all"},
+        ]})
+
+
+def test_specific_turn_requires_target():
+    with pytest.raises(ValueError):
+        ToolUsageRule(id="x", tool_ids=["a"], operator="all", scope="specific_turn")
+
+
+def test_specific_turn_accepts_conversation_turn_target():
+    rule = ToolUsageRule(
+        id="x", tool_ids=["a"], operator="all", scope="specific_turn",
+        target_source_conversation_id="conv-1", target_turn_index=2,
+    )
+    assert rule.scope == "specific_turn"
+
+
+def test_only_allows_empty_tool_ids():
+    rule = ToolUsageRule(id="x", tool_ids=[], operator="only")
+    assert rule.operator == "only"
+
+
+def test_bad_operator_rejected():
+    with pytest.raises(ValueError):
+        ToolUsageRule(id="x", tool_ids=["a"], operator="sometimes")
+
+
+# ---- legacy conversion -----------------------------------------------------
+
+def test_legacy_should_call_true_becomes_all():
+    cfg = parse_tool_usage_config({"tool": "search", "node": "Research Agent"})
+    assert len(cfg.rules) == 1
+    rule = cfg.rules[0]
+    assert rule.operator == "all"
+    assert rule.tool_ids == ["search"]
+    assert rule.agent_id == "Research Agent"
+    assert rule.scope == "every_turn"
+
+
+def test_legacy_should_call_false_becomes_none():
+    cfg = parse_tool_usage_config({"tool": "delete", "should_call": False})
+    assert cfg.rules[0].operator == "none"
+
+
+def test_legacy_result_options_map_to_per_tool():
+    cfg = parse_tool_usage_config({"tool": "search", "result_not_empty": True})
+    rule = cfg.rules[0]
+    assert rule.per_tool["search"].result_not_empty is True
+
+
+def test_legacy_resolver_maps_names_to_ids():
+    cfg = parse_tool_usage_config(
+        {"tool": "search", "node": "Research Agent"},
+        resolve_tool_id=lambda name: "tool-node-7",
+        resolve_agent_id=lambda label: "agent-node-3",
+    )
+    rule = cfg.rules[0]
+    assert rule.tool_ids == ["tool-node-7"]
+    assert rule.agent_id == "agent-node-3"
+
+
+def test_legacy_unresolvable_name_raises():
+    with pytest.raises(ValueError):
+        parse_tool_usage_config(
+            {"tool": "ghost"}, resolve_tool_id=lambda name: None
+        )
+
+
+def test_legacy_any_tool_expands_to_any_over_all_tools():
+    # Old "any tool" config: should_call true with no tool named.
+    cfg = parse_tool_usage_config({"should_call": True}, all_tool_ids=["tool-1", "tool-2"])
+    rule = cfg.rules[0]
+    assert rule.operator == "any"
+    assert rule.tool_ids == ["tool-1", "tool-2"]
+    used = evaluate_rule(rule, [_event("tool-1", agent_id="ag")], {"ag"})
+    idle = evaluate_rule(rule, [], {"ag"})
+    assert used["status"] == RULE_PASSED
+    assert idle["status"] == RULE_FAILED
+
+
+def test_legacy_no_tool_forbids_all_tools():
+    # Old "no tool may be used" config: should_call false with no tool named.
+    cfg = parse_tool_usage_config({"should_call": False})
+    rule = cfg.rules[0]
+    assert rule.operator == "only"
+    assert rule.tool_ids == []
+    used = evaluate_rule(rule, [_event("x", agent_id="ag")], {"ag"})
+    clean = evaluate_rule(rule, [], {"ag"})
+    assert used["status"] == RULE_FAILED
+    assert clean["status"] == RULE_PASSED
+
+
+def test_canonicalize_legacy_any_tool_uses_all_tool_ids():
+    out = canonicalize_tool_usage_config(
+        {"should_call": True},
+        resolve_tool_id=lambda name: name,  # idempotent id -> id
+        resolve_agent_id=lambda label: None,
+        all_tool_ids=["tool-1", "tool-2"],
+    )
+    assert out["rules"][0]["operator"] == "any"
+    assert out["rules"][0]["tool_ids"] == ["tool-1", "tool-2"]
+
+
+# ---- scope planning --------------------------------------------------------
+
+def _turn(tid, conv=None, idx=None):
+    return {"id": tid, "source_conversation_id": conv, "turn_index": idx}
+
+
+def test_every_turn_grades_each_turn_separately():
+    rule = ToolUsageRule(id="r", tool_ids=["a"], operator="all", scope="every_turn", agent_id="ag")
+    turns = [_turn("t1"), _turn("t2")]
+    events = {"t1": [_event("a", agent_id="ag")], "t2": []}
+    executed = {"t1": {"ag"}, "t2": {"ag"}}
+    planned = plan_tool_rule_results([rule], turns, [["t1"], ["t2"]], events, executed)
+    assert [p["case_id"] for p in planned] == ["t1", "t2"]
+    assert planned[0]["result"]["status"] == RULE_PASSED
+    assert planned[1]["result"]["status"] == RULE_FAILED
+
+
+def test_conversation_scope_merges_turns_and_grades_once():
+    rule = ToolUsageRule(id="r", tool_ids=["a"], operator="any", scope="conversation", agent_id="ag")
+    turns = [_turn("t1", "conv-1", 0), _turn("t2", "conv-1", 1)]
+    events = {"t1": [], "t2": [_event("a", agent_id="ag")]}  # tool used only on turn 2
+    executed = {"t1": {"ag"}, "t2": {"ag"}}
+    planned = plan_tool_rule_results([rule], turns, [["t1", "t2"]], events, executed)
+    assert len(planned) == 1  # one result for the whole conversation
+    assert planned[0]["result"]["status"] == RULE_PASSED
+    assert planned[0]["source_conversation_id"] == "conv-1"
+    assert planned[0]["case_id"] is None
+
+
+def test_specific_turn_targets_by_conversation_and_index():
+    rule = ToolUsageRule(
+        id="r", tool_ids=["a"], operator="all", scope="specific_turn", agent_id="ag",
+        target_source_conversation_id="conv-1", target_turn_index=1,
+    )
+    turns = [_turn("t1", "conv-1", 0), _turn("t2", "conv-1", 1)]
+    events = {"t1": [_event("a", agent_id="ag")], "t2": []}  # tool used on turn 0, not turn 1
+    executed = {"t1": {"ag"}, "t2": {"ag"}}
+    planned = plan_tool_rule_results([rule], turns, [["t1", "t2"]], events, executed)
+    assert len(planned) == 1
+    assert planned[0]["case_id"] == "t2"  # resolved to the turn-1 case
+    assert planned[0]["result"]["status"] == RULE_FAILED
+
+
+def test_specific_turn_missing_target_is_not_evaluated():
+    rule = ToolUsageRule(
+        id="r", tool_ids=["a"], operator="all", scope="specific_turn",
+        target_source_conversation_id="conv-9", target_turn_index=5,
+    )
+    planned = plan_tool_rule_results([rule], [_turn("t1", "conv-1", 0)], [["t1"]], {"t1": []}, {"t1": set()})
+    assert planned[0]["result"]["status"] == RULE_NOT_EVALUATED
+    assert "not found" in planned[0]["result"]["comment"]
+
+
+def test_summary_from_planned_results_reports_coverage():
+    rules = [
+        ToolUsageRule(id="p", tool_ids=["a"], operator="all", scope="every_turn", agent_id="ag"),
+        ToolUsageRule(id="f", tool_ids=["b"], operator="all", scope="every_turn", agent_id="ag"),
+    ]
+    turns = [_turn("t1")]
+    planned = plan_tool_rule_results(rules, turns, [["t1"]], {"t1": [_event("a", agent_id="ag")]}, {"t1": {"ag"}})
+    summary = summarize_planned_results(planned)
+    assert summary["coverage"] == {
+        "passed": 1, "failed": 1, "not_evaluated": 0, "evaluated": 2, "total": 2,
+    }
+    assert summary["accuracy"] == 0.5
+
+
+# ---- call counts -----------------------------------------------------------
+
+def test_result_records_call_counts():
+    rule = _rule(tool_ids=["a"], operator="all")
+    res = evaluate_rule(rule, [_event("a"), _event("a", status="failed")], {"agent-1"})
+    assert res["call_counts"]["a"] == 2
+    assert res["successful_call_counts"]["a"] == 1
+
+
+# ---- describe_tool_rule ----------------------------------------------------
+
+def test_describe_all_rule_uses_labels_and_conjunction():
+    rule = _rule(tool_ids=["t1", "t2"], operator="all", agent_id="ag", scope="conversation")
+    text = describe_tool_rule(rule, {"ag": "Support Agent"}, {"t1": "Knowledge Search", "t2": "Create Ticket"})
+    assert text == 'Support Agent must use "Knowledge Search" and "Create Ticket" during the conversation.'
+
+
+def test_describe_none_rule():
+    rule = _rule(tool_ids=["t1"], operator="none", agent_id="ag")
+    text = describe_tool_rule(rule, {"ag": "Support Agent"}, {"t1": "Delete Customer"})
+    assert text == 'Support Agent must not use "Delete Customer" on every turn.'
+
+
+def test_describe_require_success_specific_turn():
+    rule = ToolUsageRule(
+        id="r", tool_ids=["t1"], operator="all", agent_id="ag", require_success=True,
+        scope="specific_turn", target_source_conversation_id="c", target_turn_index=1,
+    )
+    text = describe_tool_rule(rule, {"ag": "Support Agent"}, {"t1": "Create Ticket"})
+    assert "successfully use" in text
+    assert "on turn 2" in text
+
+
+def test_describe_only_no_tools():
+    rule = ToolUsageRule(id="r", tool_ids=[], operator="only", agent_id="ag")
+    text = describe_tool_rule(rule, {"ag": "Support Agent"}, {})
+    assert text == "Support Agent must not use any tools on every turn."
+
+
+def test_describe_falls_back_to_ids_without_labels():
+    rule = _rule(tool_ids=["tool-xyz"], operator="all", agent_id=None)
+    text = describe_tool_rule(rule)
+    assert text == 'Any agent must use "tool-xyz" on every turn.'
+
+
+# ---- by_scope --------------------------------------------------------------
+
+def test_summary_includes_by_scope():
+    rules = [
+        ToolUsageRule(id="c", tool_ids=["a"], operator="any", scope="conversation", agent_id="ag"),
+        ToolUsageRule(id="t", tool_ids=["a"], operator="all", scope="every_turn", agent_id="ag"),
+    ]
+    turns = [_turn("t1", "conv-1", 0), _turn("t2", "conv-1", 1)]
+    planned = plan_tool_rule_results(
+        rules, turns, [["t1", "t2"]],
+        {"t1": [_event("a", agent_id="ag")], "t2": []},
+        {"t1": {"ag"}, "t2": {"ag"}},
+    )
+    summary = summarize_planned_results(planned)
+    # conversation rule -> 1 result; every_turn rule -> 2 results (one per turn)
+    assert summary["by_scope"] == {"conversation": 1, "every_turn": 2}
+    assert summary["passed"] + summary["failed"] + summary["not_evaluated"] == 3

--- a/backend/tests/unit/test_workflow_evaluations_batch.py
+++ b/backend/tests/unit/test_workflow_evaluations_batch.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 
 from app.services.test_suite import TestSuiteService as EvalService
+from app.services.test_suite import resolvers_from_agents
 
 
 def _service() -> EvalService:
@@ -16,6 +17,7 @@ def _service() -> EvalService:
         run_repo=AsyncMock(),
         result_repo=AsyncMock(),
         evaluation_repo=AsyncMock(),
+        tool_rule_result_repo=AsyncMock(),
         workflow_service=AsyncMock(),
         conversation_repo=AsyncMock(),
     )
@@ -64,6 +66,175 @@ class TestEvaluationsForWorkflow:
 
         assert result == rows
         service.evaluation_repo.get_all_for_workflow.assert_awaited_once_with(wf)
+
+
+class TestFullNestedToolCatalog:
+    """#1: the catalogue, canonicalization and run-time all expand nested workflows,
+    so a nested/MCP tool resolves everywhere — never rejected as unknown."""
+
+    @staticmethod
+    def _nested_workflows():
+        parent_id, child_id = uuid4(), uuid4()
+        parent = SimpleNamespace(
+            id=parent_id,
+            nodes=[{
+                "id": "exec-1", "type": "workflowExecutorNode",
+                "data": {"name": "Child", "workflowId": str(child_id)},
+            }],
+            edges=[],
+        )
+        child = SimpleNamespace(
+            id=child_id,
+            nodes=[
+                {"id": "a1", "type": "agentNode", "data": {"name": "Child Agent"}},
+                {"id": "t1", "type": "knowledgeBaseNode", "data": {"name": "Nested Search"}},
+            ],
+            edges=[{"source": "t1", "target": "a1", "targetHandle": "tools"}],
+        )
+        by_id = {str(parent_id): parent, str(child_id): child}
+        return parent_id, child_id, by_id
+
+    def _service_with(self, by_id):
+        service = _service()
+        service.workflow_service.get_by_id = AsyncMock(
+            side_effect=lambda wid: by_id[str(wid)]
+        )
+        return service
+
+    @pytest.mark.asyncio
+    async def test_catalog_includes_nested_agent_and_tool(self):
+        parent_id, _, by_id = self._nested_workflows()
+        service = self._service_with(by_id)
+
+        agents = await service._full_agent_catalog(parent_id)
+        resolve_tool_id, _, agent_ids, all_tool_ids = resolvers_from_agents(agents)
+
+        assert "a1" in agent_ids                       # nested agent counts as an agent
+        assert "t1" in all_tool_ids
+        assert resolve_tool_id("Nested Search") == "t1"  # nested tool resolves by name
+
+    @pytest.mark.asyncio
+    async def test_canonicalize_resolves_nested_tool_name(self):
+        parent_id, _, by_id = self._nested_workflows()
+        service = self._service_with(by_id)
+
+        out = await service._canonicalize_tool_used_configs(
+            parent_id,
+            {"tool_used": {"rules": [
+                {"id": "r", "tool_ids": ["Nested Search"], "operator": "all"},
+            ]}},
+        )
+        assert out["tool_used"]["rules"][0]["tool_ids"] == ["t1"]
+
+    @pytest.mark.asyncio
+    async def test_update_uses_new_dataset_workflow_for_canonicalization(self):
+        # Moving the evaluation to a new dataset must validate against the NEW
+        # dataset's workflow, not the row's old one.
+        from datetime import datetime as _dt
+        from app.schemas.test_suite import TestEvaluationUpdate
+
+        _, child_id, by_id = self._nested_workflows()
+        service = self._service_with(by_id)
+        old_suite, new_suite = uuid4(), uuid4()
+
+        row = SimpleNamespace(
+            id=uuid4(), name="eval", description=None, suite_id=old_suite, workflow_id=None,
+            techniques=["tool_used"], technique_configs=None, input_metadata=None,
+            run_ids=[], created_at=_dt(2026, 1, 1), updated_at=_dt(2026, 1, 1),
+        )
+        service.evaluation_repo.get_by_id = AsyncMock(return_value=row)
+        service.evaluation_repo.update = AsyncMock(side_effect=lambda r: r)
+        # New dataset -> the workflow that actually has the tool; old -> none.
+        service.suite_repo.get_by_id = AsyncMock(
+            side_effect=lambda sid: SimpleNamespace(workflow_id=child_id if sid == new_suite else None)
+        )
+
+        data = TestEvaluationUpdate(
+            suite_id=new_suite,
+            technique_configs={"tool_used": {"rules": [
+                {"id": "r", "tool_ids": ["Nested Search"], "operator": "all"},
+            ]}},
+        )
+        updated = await service.update_evaluation(row.id, data)
+        assert updated.technique_configs["tool_used"]["rules"][0]["tool_ids"] == ["t1"]
+
+    @pytest.mark.asyncio
+    async def test_canonicalize_falls_back_to_dataset_default_workflow(self):
+        # The evaluation has no workflow_id of its own; canonicalization must use the
+        # dataset's default workflow instead of skipping validation.
+        _, child_id, by_id = self._nested_workflows()
+        service = self._service_with(by_id)
+        suite_id = uuid4()
+        service.suite_repo.get_by_id = AsyncMock(
+            return_value=SimpleNamespace(workflow_id=child_id)
+        )
+
+        workflow_id = await service._effective_workflow_id(None, suite_id)
+        assert workflow_id == child_id
+
+        out = await service._canonicalize_tool_used_configs(
+            workflow_id,
+            {"tool_used": {"rules": [
+                {"id": "r", "tool_ids": ["Nested Search"], "operator": "all"},
+            ]}},
+        )
+        assert out["tool_used"]["rules"][0]["tool_ids"] == ["t1"]
+
+
+class TestToolResultSnapshot:
+    """Item 1: each result carries a readable, rename-proof snapshot."""
+
+    def test_rule_snapshot_captures_labels_number_and_summary(self):
+        from app.services.tool_usage_rules import ToolUsageRule, describe_tool_rule
+        rule = ToolUsageRule(id="r", tool_ids=["t1"], operator="all", agent_id="a1")
+        snap = EvalService._rule_snapshot(
+            rule, 0, {"a1": "Support Agent"}, {"t1": "Knowledge Search"}, describe_tool_rule
+        )
+        assert snap["rule_number"] == 1
+        assert snap["agent"] == {"id": "a1", "label": "Support Agent"}
+        assert "Knowledge Search" in snap["rule_summary"]
+        # Tool labels are attached per-result by _entry_tool_labels, not here.
+        assert "tools" not in snap
+
+    def test_target_snapshot_conversation_and_turn(self):
+        turn_snap = EvalService._target_snapshot(
+            {"scope": "every_turn", "source_conversation_id": None, "case_id": "case-1"},
+            {"case-1": 1}, {}, {},
+        )
+        conv_snap = EvalService._target_snapshot(
+            {"scope": "conversation", "source_conversation_id": "c1", "case_id": None},
+            {}, {"c1": 6}, {"c1": 1},
+        )
+        assert turn_snap == {"type": "turn", "label": "Turn 2"}
+        assert conv_snap == {"type": "conversation", "label": "Conversation 1", "turn_count": 6}
+
+    def test_entry_tool_labels_cover_forbidden_and_counts(self):
+        # Every tool the result mentions gets a label, not just the rule's targets.
+        result = {
+            "observed_tools": ["t1"],
+            "forbidden_tools": ["t2"],
+            "missing_tools": [],
+            "failed_tools": [],
+            "call_counts": {"t3": 1},
+        }
+        labels = EvalService._entry_tool_labels(
+            result, ["t1"], {"t1": "Search", "t2": "Delete", "t3": "Web"}
+        )
+        assert labels == {
+            "t1": {"label": "Search"},
+            "t2": {"label": "Delete"},
+            "t3": {"label": "Web"},
+        }
+
+    def test_conversation_index_numbers_multi_turn_groups(self):
+        group = [
+            SimpleNamespace(source_conversation_id="c1"),
+            SimpleNamespace(source_conversation_id="c1"),
+        ]
+        manual = [SimpleNamespace(source_conversation_id=None)]
+        counts, numbers = EvalService._conversation_index([group, manual])
+        assert counts == {"c1": 2}
+        assert numbers == {"c1": 1}
 
 
 class TestStartWorkflowEvaluations:

--- a/frontend/src/interfaces/testEvaluation.interface.ts
+++ b/frontend/src/interfaces/testEvaluation.interface.ts
@@ -37,3 +37,96 @@ export interface PaginatedEvaluations {
   any_running: boolean;
 }
 
+// ---- Tool Usage catalogue + rules ----
+
+export interface EvaluationToolInfo {
+  id: string;
+  name: string;
+  label: string;
+  type: string;
+}
+
+export interface EvaluationAgentInfo {
+  id: string;
+  label: string;
+  type: string;
+  workflow_path: string[];
+  tools: EvaluationToolInfo[];
+}
+
+export interface EvaluationToolCatalog {
+  workflow_id: string;
+  agents: EvaluationAgentInfo[];
+}
+
+export type ToolUsageOperator = "all" | "any" | "none" | "only";
+export type ToolUsageScope = "specific_turn" | "every_turn" | "conversation";
+
+// Extra per-tool assertions (result/argument checks). Not edited in the builder yet,
+// but preserved verbatim so editing a rule never drops them.
+export interface ToolUsagePerToolCheck {
+  result_not_empty?: boolean;
+  result_contains?: string | null;
+  expected_args?: Record<string, unknown> | null;
+}
+
+export interface ToolUsageRule {
+  id: string;
+  agent_id?: string | null;
+  tool_ids: string[];
+  operator: ToolUsageOperator;
+  require_success?: boolean;
+  scope: ToolUsageScope;
+  target_case_id?: string | null;
+  target_source_conversation_id?: string | null;
+  target_turn_index?: number | null;
+  min_calls?: number | null;
+  max_calls?: number | null;
+  per_tool?: Record<string, ToolUsagePerToolCheck>;
+}
+
+// The readable, rename-proof snapshot the backend stores with each result.
+export interface ToolRuleTargetInfo {
+  type: "conversation" | "turn";
+  label: string;
+  turn_count?: number;
+}
+
+export interface ToolRuleResultDetails {
+  rule_number?: number;
+  rule_summary?: string;
+  agent?: { id: string | null; label: string };
+  tools?: Record<string, { label: string }>;
+  target?: ToolRuleTargetInfo;
+  observed_tools?: string[];
+  missing_tools?: string[];
+  failed_tools?: string[];
+  forbidden_tools?: string[];
+  check_failures?: Record<string, string>;
+  call_counts?: Record<string, number>;
+  successful_call_counts?: Record<string, number>;
+  comment?: string;
+  turn_index?: number | null;
+  operator?: string;
+  rule?: {
+    tool_ids?: string[];
+    operator?: string;
+    require_success?: boolean;
+    min_calls?: number | null;
+    max_calls?: number | null;
+  };
+}
+
+export interface TestToolRuleResult {
+  id: string;
+  run_id: string;
+  rule_id: string;
+  scope: string;
+  case_id?: string | null;
+  source_conversation_id?: string | null;
+  status: "passed" | "failed" | "not_evaluated";
+  score?: number | null;
+  details?: Record<string, unknown> | null;
+  created_at: string;
+}
+

--- a/frontend/src/services/testEvaluations.ts
+++ b/frontend/src/services/testEvaluations.ts
@@ -1,8 +1,10 @@
 import { apiRequest } from "@/config/api";
 import {
+  EvaluationToolCatalog,
   PaginatedEvaluations,
   StartedEvaluationRun,
   TestEvaluationConfig,
+  TestToolRuleResult,
   WorkflowEvaluationSummary,
 } from "@/interfaces/testEvaluation.interface";
 
@@ -81,3 +83,15 @@ export const getWorkflowEvaluationsPage = (
     `${BASE}/workflows/${workflowId}/evaluations?${query.toString()}`,
   );
 };
+
+export const getEvaluationToolCatalog = (workflowId: string) =>
+  apiRequest<EvaluationToolCatalog>(
+    "GET",
+    `${BASE}/workflows/${workflowId}/evaluation-tool-catalog`,
+  );
+
+export const getToolRuleResults = (runId: string) =>
+  apiRequest<TestToolRuleResult[]>(
+    "GET",
+    `${BASE}/runs/${runId}/tool-rule-results`,
+  );

--- a/frontend/src/views/TestSuites/components/EvaluationWizard.tsx
+++ b/frontend/src/views/TestSuites/components/EvaluationWizard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Button } from "@/components/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -25,6 +25,85 @@ import { cn } from "@/helpers/utils";
 import type { TestSuite } from "@/interfaces/testSuite.interface";
 import type { WorkflowMinimal } from "@/interfaces/workflow.interface";
 import type { LLMProviderMinimal } from "@/interfaces/llmProvider.interface";
+import type {
+  EvaluationAgentInfo,
+  ToolUsagePerToolCheck,
+  ToolUsageRule,
+} from "@/interfaces/testEvaluation.interface";
+import { getEvaluationToolCatalog } from "@/services/testEvaluations";
+import { listTestCases } from "@/services/testSuites";
+import type { TestCase } from "@/interfaces/testSuite.interface";
+import { ToolUsageRuleBuilder, type RuleConversation } from "./ToolUsageRuleBuilder";
+
+// Group imported multi-turn cases into conversations for specific-turn targeting.
+const deriveConversations = (cases: TestCase[]): RuleConversation[] => {
+  const groups = new Map<string, TestCase[]>();
+  for (const testCase of cases) {
+    if (!testCase.source_conversation_id) continue;
+    const group = groups.get(testCase.source_conversation_id) ?? [];
+    group.push(testCase);
+    groups.set(testCase.source_conversation_id, group);
+  }
+  return Array.from(groups.entries()).map(([id, turns]) => {
+    const sorted = [...turns].sort((a, b) => (a.turn_index ?? 0) - (b.turn_index ?? 0));
+    return {
+      id,
+      label: `Conversation ${id.slice(0, 8)} (${sorted.length} turns)`,
+      turns: sorted.map((turn) => ({
+        caseId: turn.id,
+        turnIndex: turn.turn_index ?? 0,
+        label: `Turn ${(turn.turn_index ?? 0) + 1}`,
+      })),
+    };
+  });
+};
+
+// Case-insensitive name/label/id -> id map, keeping only unambiguous keys (a name
+// shared by two tools is left unmapped, mirroring the backend, so it can't silently
+// resolve to the wrong tool).
+const uniqueNameToId = (entries: { id: string; keys: (string | undefined)[] }[]): Map<string, string> => {
+  const idsByKey = new Map<string, Set<string>>();
+  for (const entry of entries) {
+    for (const key of entry.keys) {
+      if (!key) continue;
+      const normalized = key.toLowerCase();
+      const ids = idsByKey.get(normalized) ?? new Set<string>();
+      ids.add(entry.id);
+      idsByKey.set(normalized, ids);
+    }
+  }
+  const map = new Map<string, string>();
+  for (const [key, ids] of idsByKey) {
+    if (ids.size === 1) map.set(key, [...ids][0]);
+  }
+  return map;
+};
+
+const buildToolNameToId = (catalog: EvaluationAgentInfo[]): Map<string, string> =>
+  uniqueNameToId(
+    catalog.flatMap((agent) =>
+      agent.tools.map((tool) => ({ id: tool.id, keys: [tool.id, tool.name, tool.label] })),
+    ),
+  );
+
+const buildAgentNameToId = (catalog: EvaluationAgentInfo[]): Map<string, string> =>
+  uniqueNameToId(catalog.map((agent) => ({ id: agent.id, keys: [agent.id, agent.label] })));
+
+// Rewrite per_tool keys (legacy tool names) to canonical ids, matching tool_ids.
+const remapPerToolKeys = (
+  perTool: Record<string, ToolUsagePerToolCheck> | undefined,
+  toolMap: Map<string, string>,
+): Record<string, ToolUsagePerToolCheck> | undefined => {
+  if (!perTool || Object.keys(perTool).length === 0) return perTool;
+  let changed = false;
+  const remapped: Record<string, ToolUsagePerToolCheck> = {};
+  for (const [key, value] of Object.entries(perTool)) {
+    const mapped = toolMap.get(key.toLowerCase()) ?? key;
+    if (mapped !== key) changed = true;
+    remapped[mapped] = value;
+  }
+  return changed ? remapped : perTool;
+};
 
 interface MetricDef {
   value: string;
@@ -70,15 +149,6 @@ const CONFIG_METRICS = [
   "action_taken",
   "llm_judge",
 ];
-
-const isJsonObject = (text: string): boolean => {
-  try {
-    const parsed = JSON.parse(text);
-    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed);
-  } catch {
-    return false;
-  }
-};
 
 // A score field is valid when empty (a default applies) or a number in [0, 1].
 const isValidScore = (text: string): boolean => {
@@ -147,12 +217,7 @@ export interface EvaluationWizardData {
   provFailOnViolation: boolean;
   provLlmProviderId: string;
   provLlmJudgeSystemPromptSuffix: string;
-  toolName: string;
-  toolShouldCall: boolean;
-  toolExpectedArgsText: string;
-  toolNode: string;
-  toolResultNotEmpty: boolean;
-  toolResultContains: string;
+  toolRules: ToolUsageRule[];
   notContainsText: string;
   routeExpected: string;
   routeNode: string;
@@ -227,28 +292,94 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
     initialData?.provLlmJudgeSystemPromptSuffix ?? ""
   );
 
-  // Tool Used config
-  const [toolName, setToolName] = useState(initialData?.toolName ?? "");
-  const [toolShouldCall, setToolShouldCall] = useState(initialData?.toolShouldCall ?? true);
-  const [toolExpectedArgsText, setToolExpectedArgsText] = useState(initialData?.toolExpectedArgsText ?? "");
-  const [toolNode, setToolNode] = useState(initialData?.toolNode ?? "");
-  const [toolResultNotEmpty, setToolResultNotEmpty] = useState(initialData?.toolResultNotEmpty ?? false);
-  const [toolResultContains, setToolResultContains] = useState(initialData?.toolResultContains ?? "");
-  const [toolAdvancedOpen, setToolAdvancedOpen] = useState(false);
+  // Tool Usage rules + workflow tool catalogue
+  const [toolRules, setToolRules] = useState<ToolUsageRule[]>(initialData?.toolRules ?? []);
+  const [toolCatalog, setToolCatalog] = useState<EvaluationAgentInfo[]>([]);
+  const [catalogLoading, setCatalogLoading] = useState(false);
+  const [catalogError, setCatalogError] = useState<string | null>(null);
 
-  const toolRuleSummary = (): string => {
-    const agentPart = toolNode.trim() ? `the "${toolNode.trim()}" agent` : "any agent";
-    const toolPart = toolName.trim() ? `"${toolName.trim()}"` : "any tool";
-    if (!toolShouldCall) {
-      return `Passes when ${agentPart} does NOT call ${toolPart}.`;
+  const toolUsageSelected = metrics.includes("tool_used");
+
+  // Fall back to the dataset's default workflow when none is explicitly chosen,
+  // so the tool catalogue still loads.
+  const selectedSuite = suites.find((s) => s.id === suiteId);
+  const effectiveWorkflowId =
+    workflowId && workflowId !== "none" ? workflowId : selectedSuite?.workflow_id;
+
+  useEffect(() => {
+    if (!toolUsageSelected || !effectiveWorkflowId) {
+      setToolCatalog([]);
+      return;
     }
-    const extraClauses: string[] = [];
-    if (toolExpectedArgsText.trim()) extraClauses.push("the arguments match your JSON");
-    if (toolResultNotEmpty) extraClauses.push("the result is not empty");
-    if (toolResultContains.trim()) extraClauses.push(`the result contains "${toolResultContains.trim()}"`);
-    const extras = extraClauses.length ? `, and ${extraClauses.join(", and ")}` : "";
-    return `Passes when ${agentPart} calls ${toolPart}${extras}.`;
-  };
+    let cancelled = false;
+    setCatalogLoading(true);
+    setCatalogError(null);
+    getEvaluationToolCatalog(effectiveWorkflowId)
+      .then((catalog) => {
+        if (!cancelled) setToolCatalog(catalog.agents ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setCatalogError("Failed to load tools");
+      })
+      .finally(() => {
+        if (!cancelled) setCatalogLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [toolUsageSelected, effectiveWorkflowId]);
+
+  // Imported conversations for specific-turn targeting, derived from the suite's cases.
+  const [conversations, setConversations] = useState<RuleConversation[]>([]);
+  useEffect(() => {
+    if (!toolUsageSelected || !suiteId) {
+      setConversations([]);
+      return;
+    }
+    let cancelled = false;
+    listTestCases(suiteId)
+      .then((cases) => {
+        if (!cancelled) setConversations(deriveConversations(cases));
+      })
+      .catch(() => {
+        if (!cancelled) setConversations([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [toolUsageSelected, suiteId]);
+
+  // When the catalogue loads, rewrite any legacy tool/agent NAMES (from an old
+  // evaluation) to canonical ids so they aren't later saved as if they were ids.
+  useEffect(() => {
+    if (toolCatalog.length === 0 || toolRules.length === 0) return;
+    const toolMap = buildToolNameToId(toolCatalog);
+    const agentMap = buildAgentNameToId(toolCatalog);
+    const allToolIds = [...new Set(toolCatalog.flatMap((a) => a.tools.map((t) => t.id)))];
+    let changed = false;
+    const remapped = toolRules.map((rule) => {
+      // A legacy "any tool" rule (any + no tools) expands to every workflow tool.
+      const isAnyToolMarker = rule.operator === "any" && rule.tool_ids.length === 0;
+      const tool_ids = isAnyToolMarker
+        ? allToolIds
+        : rule.tool_ids.map((id) => toolMap.get(id.toLowerCase()) ?? id);
+      const agent_id = rule.agent_id
+        ? agentMap.get(rule.agent_id.toLowerCase()) ?? rule.agent_id
+        : rule.agent_id;
+      const per_tool = remapPerToolKeys(rule.per_tool, toolMap);
+      if (
+        tool_ids.some((id, i) => id !== rule.tool_ids[i]) ||
+        agent_id !== rule.agent_id ||
+        per_tool !== rule.per_tool
+      ) {
+        changed = true;
+        return { ...rule, tool_ids, agent_id, per_tool };
+      }
+      return rule;
+    });
+    if (changed) setToolRules(remapped);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [toolCatalog]);
 
   // Does Not Contain config
   const [notContainsText, setNotContainsText] = useState(initialData?.notContainsText ?? "");
@@ -272,11 +403,31 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
 
   const currentStepIndex = STEPS.findIndex((s) => s.key === step);
 
-  const toolArgsInvalid =
-    metrics.includes("tool_used") &&
-    toolShouldCall &&
-    toolExpectedArgsText.trim() !== "" &&
-    !isJsonObject(toolExpectedArgsText);
+  // Canonical id sets to catch legacy names that never resolved (block save on them).
+  const catalogLoaded = toolCatalog.length > 0;
+  const catalogToolIds = new Set(toolCatalog.flatMap((a) => a.tools.map((t) => t.id)));
+  const catalogAgentIds = new Set(toolCatalog.map((a) => a.id));
+
+  const ruleHasUnresolvedRef = (rule: ToolUsageRule): boolean => {
+    if (!catalogLoaded) return false;
+    const toolUnresolved = rule.tool_ids.some((id) => !catalogToolIds.has(id));
+    const agentUnresolved = Boolean(rule.agent_id) && !catalogAgentIds.has(rule.agent_id as string);
+    return toolUnresolved || agentUnresolved;
+  };
+
+  const ruleSpecificTurnIncomplete = (rule: ToolUsageRule): boolean =>
+    rule.scope === "specific_turn" &&
+    (!rule.target_source_conversation_id || rule.target_turn_index == null);
+
+  const toolRulesInvalid =
+    toolUsageSelected &&
+    (toolRules.length === 0 ||
+      toolRules.some(
+        (rule) =>
+          (rule.operator !== "only" && rule.tool_ids.length === 0) ||
+          ruleHasUnresolvedRef(rule) ||
+          ruleSpecificTurnIncomplete(rule),
+      ));
   const nliScoreInvalid = metrics.includes("nli_eval") && !isValidScore(nliMinEntailScore);
   const provScoreInvalid = metrics.includes("provenance_eval") && !isValidScore(provMinScore);
   const judgeScoreInvalid = metrics.includes("llm_judge") && !isValidScore(judgeMinScore);
@@ -286,7 +437,7 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
     if (metrics.includes("not_contains") && !notContainsText.trim()) return false;
     if (metrics.includes("route_taken") && !routeExpected.trim()) return false;
     if (metrics.includes("action_taken") && !actionNode.trim() && !actionNodeType.trim()) return false;
-    if (toolArgsInvalid || nliScoreInvalid || provScoreInvalid || judgeScoreInvalid) return false;
+    if (toolRulesInvalid || nliScoreInvalid || provScoreInvalid || judgeScoreInvalid) return false;
     return true;
   };
 
@@ -338,12 +489,7 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
         provFailOnViolation,
         provLlmProviderId,
         provLlmJudgeSystemPromptSuffix,
-        toolName,
-        toolShouldCall,
-        toolExpectedArgsText,
-        toolNode,
-        toolResultNotEmpty,
-        toolResultContains,
+        toolRules,
         notContainsText,
         routeExpected,
         routeNode,
@@ -384,13 +530,7 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
     setProvFailOnViolation(false);
     setProvLlmProviderId(providers[0]?.id ?? "");
     setProvLlmJudgeSystemPromptSuffix("");
-    setToolName("");
-    setToolShouldCall(true);
-    setToolExpectedArgsText("");
-    setToolNode("");
-    setToolResultNotEmpty(false);
-    setToolResultContains("");
-    setToolAdvancedOpen(false);
+    setToolRules([]);
     setNotContainsText("");
     setRouteExpected("");
     setRouteNode("");
@@ -695,103 +835,26 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
               <div className="border rounded-lg p-4 space-y-3">
                 <div className="text-sm font-semibold flex items-center gap-2">
                   <span className="w-2 h-2 rounded-full bg-purple-500"></span>
-                  Tool Usage Config
+                  Tool Usage
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  Checks whether an agent called a specific tool during the run.
+                  Add rules about which tools an agent should or should not use. Agents and
+                  tools come from the selected workflow.
                 </p>
-                <div>
-                  <Label className="text-xs">Tool Name</Label>
-                  <Input
-                    value={toolName}
-                    onChange={(e) => setToolName(e.target.value)}
-                    placeholder="e.g. search_handbook"
-                    className="mt-1"
-                  />
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Leave empty to check whether any tool was called.
+                {!effectiveWorkflowId ? (
+                  <p className="text-sm text-muted-foreground">
+                    Select a workflow in the Data Source step to load its agents and tools.
                   </p>
-                </div>
-                <div>
-                  <Label className="text-xs">Agent (optional)</Label>
-                  <Input
-                    value={toolNode}
-                    onChange={(e) => setToolNode(e.target.value)}
-                    placeholder="Any agent"
-                    className="mt-1"
+                ) : (
+                  <ToolUsageRuleBuilder
+                    rules={toolRules}
+                    onChange={setToolRules}
+                    catalog={toolCatalog}
+                    conversations={conversations}
+                    loading={catalogLoading}
+                    error={catalogError}
                   />
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Defaults to any agent. Name one (id or label) to only count its calls — useful
-                    when several agents share tool names.
-                  </p>
-                </div>
-                <div className="flex items-center justify-between rounded-lg border px-3 py-2">
-                  <div>
-                    <div className="text-xs font-medium">
-                      {toolShouldCall ? "Must be called" : "Should not be used"}
-                    </div>
-                    <div className="text-xs text-muted-foreground">
-                      Turn off to assert the tool was NOT called
-                    </div>
-                  </div>
-                  <Switch checked={toolShouldCall} onCheckedChange={setToolShouldCall} />
-                </div>
-
-                {toolShouldCall && (
-                  <div>
-                    <button
-                      type="button"
-                      onClick={() => setToolAdvancedOpen((open) => !open)}
-                      className="text-xs font-medium text-muted-foreground hover:text-muted-foreground"
-                    >
-                      {toolAdvancedOpen ? "▾" : "▸"} Advanced validation
-                    </button>
-                    {toolAdvancedOpen && (
-                      <div className="space-y-3 mt-3">
-                        <div>
-                          <Label className="text-xs">Expected Arguments (JSON, optional)</Label>
-                          <Textarea
-                            value={toolExpectedArgsText}
-                            onChange={(e) => setToolExpectedArgsText(e.target.value)}
-                            placeholder='{"query": "vacation policy"}'
-                            rows={2}
-                            className="mt-1 font-mono text-xs"
-                          />
-                          {toolArgsInvalid && (
-                            <p className="text-xs text-red-500 mt-1">
-                              Enter a valid JSON object, e.g. {'{"query": "vacation policy"}'}.
-                            </p>
-                          )}
-                        </div>
-                        <div className="flex items-center justify-between rounded-lg border px-3 py-2">
-                          <div>
-                            <div className="text-xs font-medium">Result must not be empty</div>
-                            <div className="text-xs text-muted-foreground">
-                              Fail if the call returned nothing (e.g. an empty retrieval)
-                            </div>
-                          </div>
-                          <Switch checked={toolResultNotEmpty} onCheckedChange={setToolResultNotEmpty} />
-                        </div>
-                        <div>
-                          <Label className="text-xs">Result must contain (optional)</Label>
-                          <Input
-                            value={toolResultContains}
-                            onChange={(e) => setToolResultContains(e.target.value)}
-                            placeholder="Text the tool's result must include"
-                            className="mt-1"
-                          />
-                        </div>
-                      </div>
-                    )}
-                  </div>
                 )}
-
-                <div className="rounded-lg bg-muted border border-border px-3 py-2">
-                  <div className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold mb-0.5">
-                    Rule
-                  </div>
-                  <p className="text-xs text-muted-foreground">{toolRuleSummary()}</p>
-                </div>
               </div>
             )}
 

--- a/frontend/src/views/TestSuites/components/ToolUsageResultCard.tsx
+++ b/frontend/src/views/TestSuites/components/ToolUsageResultCard.tsx
@@ -1,0 +1,154 @@
+import React from "react";
+import { CheckCircle2, XCircle, MinusCircle } from "lucide-react";
+import { Badge } from "@/components/badge";
+import type {
+  TestToolRuleResult,
+  ToolRuleResultDetails,
+} from "@/interfaces/testEvaluation.interface";
+import { cn } from "@/helpers/utils";
+
+const STATUS_META = {
+  passed: { icon: CheckCircle2, className: "text-emerald-600", border: "border-l-emerald-500", label: "Passed" },
+  failed: { icon: XCircle, className: "text-destructive", border: "border-l-destructive", label: "Failed" },
+  not_evaluated: { icon: MinusCircle, className: "text-muted-foreground", border: "border-l-muted", label: "Not evaluated" },
+} as const;
+
+const scopeLabel = (scope: string): string =>
+  scope === "conversation"
+    ? "Whole conversation"
+    : scope === "specific_turn"
+      ? "Specific turn"
+      : "Every turn";
+
+const toolName = (details: ToolRuleResultDetails, id: string): string =>
+  details.tools?.[id]?.label ?? id;
+
+const listPhrase = (names: string[], conjunction: "and" | "or"): string => {
+  if (names.length === 0) return "a tool";
+  const quoted = names.map((name) => `"${name}"`);
+  if (quoted.length === 1) return quoted[0];
+  return `${quoted.slice(0, -1).join(", ")} ${conjunction} ${quoted[quoted.length - 1]}`;
+};
+
+const times = (n: number): string => `${n} time${n === 1 ? "" : "s"}`;
+
+// One-line "what the rule requires", derived from the stored rule snapshot.
+const expectedText = (details: ToolRuleResultDetails): string => {
+  const rule = details.rule ?? {};
+  const operator = rule.operator ?? details.operator ?? "all";
+  const ids = rule.tool_ids ?? Object.keys(details.tools ?? {});
+  const names = ids.map((id) => toolName(details, id));
+
+  if (operator === "none") return `Do not use ${listPhrase(names, "or")}.`;
+  if (operator === "only") {
+    return names.length ? `Use only ${listPhrase(names, "or")}.` : "Do not use any tools.";
+  }
+
+  const conjunction = operator === "all" ? "and" : "or";
+  const successfully = rule.require_success ? " successfully" : "";
+  const { min_calls: min, max_calls: max } = rule;
+  let count = "at least once";
+  if (min != null && max != null) count = `between ${min} and ${max} times`;
+  else if (min != null) count = `at least ${times(min)}`;
+  else if (max != null) count = `at most ${times(max)}`;
+  return `Use ${listPhrase(names, conjunction)}${successfully} ${count}.`;
+};
+
+// One-line "what actually happened", from observed/missing/failed tools + counts.
+const actualText = (details: ToolRuleResultDetails, status: string): string => {
+  if (status === "not_evaluated") {
+    return details.comment ?? "This rule could not be checked.";
+  }
+  const counts = details.call_counts ?? {};
+  const successful = details.successful_call_counts ?? {};
+  const parts: string[] = [];
+
+  for (const id of details.observed_tools ?? []) {
+    const total = counts[id] ?? 0;
+    const succeeded = successful[id] ?? 0;
+    // Only say "successfully" when the calls actually succeeded (a rule without
+    // require_success is satisfied even by a failed call).
+    if (succeeded > 0 && succeeded === total) {
+      parts.push(`Used "${toolName(details, id)}" successfully ${times(total)}`);
+    } else {
+      parts.push(`Called "${toolName(details, id)}" ${times(total)}; ${succeeded} succeeded`);
+    }
+  }
+  for (const id of details.failed_tools ?? []) {
+    parts.push(`"${toolName(details, id)}" was called ${times(counts[id] ?? 0)}, but did not succeed`);
+  }
+  for (const id of details.missing_tools ?? []) {
+    parts.push(`"${toolName(details, id)}" was not called`);
+  }
+  for (const id of details.forbidden_tools ?? []) {
+    parts.push(`"${toolName(details, id)}" was used ${times(counts[id] ?? 0)} (not allowed)`);
+  }
+  for (const [id, reason] of Object.entries(details.check_failures ?? {})) {
+    parts.push(`"${toolName(details, id)}": ${reason}`);
+  }
+
+  if (parts.length === 0) {
+    return details.comment ?? (status === "passed" ? "Expectation met." : "");
+  }
+  return `${parts.join(". ")}.`;
+};
+
+const targetLine = (details: ToolRuleResultDetails): string | null => {
+  const target = details.target;
+  if (!target) return null;
+  if (target.type === "conversation" && target.turn_count) {
+    return `${target.label} · ${times(target.turn_count).replace("time", "turn")}`;
+  }
+  return target.label;
+};
+
+interface Props {
+  result: TestToolRuleResult;
+}
+
+export const ToolUsageResultCard: React.FC<Props> = ({ result }) => {
+  const details = (result.details ?? {}) as ToolRuleResultDetails;
+  const meta = STATUS_META[result.status] ?? STATUS_META.not_evaluated;
+  const Icon = meta.icon;
+  const target = targetLine(details);
+
+  return (
+    <div className={cn("rounded-lg border border-l-2 bg-card p-3 space-y-2", meta.border)}>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Icon className={cn("h-4 w-4 shrink-0", meta.className)} />
+          <span className={cn("text-sm font-medium", meta.className)}>{meta.label}</span>
+          {details.rule_number != null && (
+            <Badge variant="secondary" className="text-[10px]">Rule {details.rule_number}</Badge>
+          )}
+        </div>
+        <Badge variant="outline" className="text-[10px]">{scopeLabel(result.scope)}</Badge>
+      </div>
+
+      {target && <p className="text-xs text-muted-foreground">{target}</p>}
+
+      {details.rule_summary && (
+        <p className="text-sm text-foreground">{details.rule_summary}</p>
+      )}
+
+      {result.status !== "not_evaluated" && (
+        <div className="grid gap-2 sm:grid-cols-2">
+          <div>
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Expected</div>
+            <p className="text-xs text-foreground">{expectedText(details)}</p>
+          </div>
+          <div>
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Actual</div>
+            <p className={cn("text-xs", result.status === "passed" ? "text-foreground" : "text-destructive")}>
+              {actualText(details, result.status)}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {result.status === "not_evaluated" && details.comment && (
+        <p className="text-xs text-muted-foreground">{details.comment}</p>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/views/TestSuites/components/ToolUsageResults.tsx
+++ b/frontend/src/views/TestSuites/components/ToolUsageResults.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import type { TestToolRuleResult } from "@/interfaces/testEvaluation.interface";
+import { ToolUsageResultCard } from "./ToolUsageResultCard";
+
+interface Props {
+  // All tool-usage results for the run; the page fetches once and passes them in.
+  results: TestToolRuleResult[];
+}
+
+const isTurnScope = (scope: string): boolean =>
+  scope === "every_turn" || scope === "specific_turn";
+
+// Scope-aware headline: conversations, turns, or mixed "rule checks".
+const summaryLine = (results: TestToolRuleResult[]): { headline: string; subline: string | null } => {
+  const passed = results.filter((r) => r.status === "passed").length;
+  const failed = results.filter((r) => r.status === "failed").length;
+  const evaluated = passed + failed;
+  const rate = evaluated ? Math.round((passed / evaluated) * 100) : 0;
+
+  const conversationCount = results.filter((r) => r.scope === "conversation").length;
+  const turnCount = results.filter((r) => isTurnScope(r.scope)).length;
+  const onlyConversations = conversationCount > 0 && turnCount === 0;
+  const onlyTurns = turnCount > 0 && conversationCount === 0;
+
+  const unit = onlyConversations ? "conversations" : onlyTurns ? "turns" : "rule checks";
+  const headline = `${passed} of ${evaluated || results.length} ${unit} passed · ${rate}% pass rate`;
+  const subline =
+    !onlyConversations && !onlyTurns && (conversationCount || turnCount)
+      ? `${conversationCount} conversation check${conversationCount === 1 ? "" : "s"} · ${turnCount} turn check${turnCount === 1 ? "" : "s"}`
+      : null;
+  return { headline, subline };
+};
+
+export const ToolUsageResults: React.FC<Props> = ({ results }) => {
+  if (results.length === 0) return null;
+
+  const conversationResults = results.filter((r) => r.scope === "conversation");
+  const notEvaluated = results.filter((r) => r.status === "not_evaluated").length;
+  const { headline, subline } = summaryLine(results);
+
+  return (
+    <section className="rounded-lg border border-border bg-card">
+      <header className="border-b border-border px-4 py-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="text-sm font-semibold">Tool Usage</h3>
+          {notEvaluated > 0 && (
+            <span className="text-xs text-muted-foreground">{notEvaluated} not evaluated</span>
+          )}
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">{headline}</p>
+        {subline && <p className="text-[11px] text-muted-foreground">{subline}</p>}
+      </header>
+
+      <div className="space-y-2 p-3">
+        {conversationResults.length > 0 ? (
+          conversationResults.map((result) => (
+            <ToolUsageResultCard key={result.id} result={result} />
+          ))
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Turn-level tool checks appear with each test case below.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+};

--- a/frontend/src/views/TestSuites/components/ToolUsageRuleBuilder.tsx
+++ b/frontend/src/views/TestSuites/components/ToolUsageRuleBuilder.tsx
@@ -1,0 +1,547 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/button";
+import { Label } from "@/components/label";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/select";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/command";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/collapsible";
+import { Check, ChevronDown, ChevronRight, Plus, Trash2, X } from "lucide-react";
+import { cn } from "@/helpers/utils";
+import type {
+  EvaluationAgentInfo,
+  ToolUsageOperator,
+  ToolUsageRule,
+  ToolUsageScope,
+} from "@/interfaces/testEvaluation.interface";
+
+const ANY_AGENT = "__any__";
+
+type Expectation = "must_use" | "must_not_use" | "only";
+type MatchMode = "all" | "any";
+
+const EXPECTATION_OPTIONS: { value: Expectation; label: string }[] = [
+  { value: "must_use", label: "Must use" },
+  { value: "must_not_use", label: "Must not use" },
+  { value: "only", label: "May use only" },
+];
+
+const MATCH_OPTIONS: { value: MatchMode; label: string }[] = [
+  { value: "all", label: "All selected tools" },
+  { value: "any", label: "At least one" },
+];
+
+const SCOPE_OPTIONS: { value: ToolUsageScope; label: string }[] = [
+  { value: "every_turn", label: "Every turn" },
+  { value: "conversation", label: "Whole conversation" },
+  { value: "specific_turn", label: "Specific turn" },
+];
+
+// An imported multi-turn conversation available for specific-turn targeting.
+export interface RuleConversation {
+  id: string; // source_conversation_id
+  label: string;
+  turns: { caseId: string; turnIndex: number; label: string }[];
+}
+
+const operatorToExpectation = (operator: ToolUsageOperator): Expectation =>
+  operator === "none" ? "must_not_use" : operator === "only" ? "only" : "must_use";
+
+const operatorToMatch = (operator: ToolUsageOperator): MatchMode =>
+  operator === "any" ? "any" : "all";
+
+const toOperator = (expectation: Expectation, match: MatchMode): ToolUsageOperator => {
+  if (expectation === "must_not_use") return "none";
+  if (expectation === "only") return "only";
+  return match;
+};
+
+export const newToolRule = (): ToolUsageRule => ({
+  id:
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `rule-${Math.random().toString(36).slice(2)}`,
+  agent_id: null,
+  tool_ids: [],
+  operator: "all",
+  require_success: false,
+  scope: "every_turn",
+});
+
+const joinPhrases = (items: string[], conjunction: "and" | "or"): string => {
+  if (items.length === 0) return "a tool";
+  if (items.length === 1) return items[0];
+  return `${items.slice(0, -1).join(", ")} ${conjunction} ${items[items.length - 1]}`;
+};
+
+const toNumberOrNull = (value: string): number | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+};
+
+// ---- one rule card ---------------------------------------------------------
+
+interface RuleCardProps {
+  rule: ToolUsageRule;
+  index: number;
+  catalog: EvaluationAgentInfo[];
+  conversations: RuleConversation[];
+  onChange: (patch: Partial<ToolUsageRule>) => void;
+  onRemove: () => void;
+}
+
+const RuleCard: React.FC<RuleCardProps> = ({
+  rule,
+  index,
+  catalog,
+  conversations,
+  onChange,
+  onRemove,
+}) => {
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const toolsRef = useRef<HTMLDivElement>(null);
+
+  // Close the tools dropdown when clicking outside it.
+  useEffect(() => {
+    if (!toolsOpen) return;
+    const handleClick = (event: MouseEvent) => {
+      if (toolsRef.current && !toolsRef.current.contains(event.target as Node)) {
+        setToolsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [toolsOpen]);
+
+  const expectation = operatorToExpectation(rule.operator);
+  const match = operatorToMatch(rule.operator);
+
+  const toolLabelById = new Map<string, string>();
+  catalog.forEach((agent) =>
+    agent.tools.forEach((tool) => toolLabelById.set(tool.id, tool.label)),
+  );
+
+  const availableTools = (() => {
+    if (!rule.agent_id) {
+      const seen = new Map<string, { id: string; label: string }>();
+      catalog.forEach((agent) =>
+        agent.tools.forEach((tool) => seen.set(tool.id, { id: tool.id, label: tool.label })),
+      );
+      return Array.from(seen.values());
+    }
+    const agent = catalog.find((a) => a.id === rule.agent_id);
+    return agent ? agent.tools.map((t) => ({ id: t.id, label: t.label })) : [];
+  })();
+
+  const changeAgent = (value: string) => {
+    const agentId = value === ANY_AGENT ? null : value;
+    const allowed = new Set(
+      (agentId ? catalog.find((a) => a.id === agentId)?.tools ?? [] : availableTools).map(
+        (t) => t.id,
+      ),
+    );
+    onChange({ agent_id: agentId, tool_ids: rule.tool_ids.filter((id) => allowed.has(id)) });
+  };
+
+  const toggleTool = (toolId: string) => {
+    const tool_ids = rule.tool_ids.includes(toolId)
+      ? rule.tool_ids.filter((id) => id !== toolId)
+      : [...rule.tool_ids, toolId];
+    onChange({ tool_ids });
+  };
+
+  const selectedConversation = conversations.find(
+    (conversation) => conversation.id === rule.target_source_conversation_id,
+  );
+
+  const changeScope = (scope: ToolUsageScope) => {
+    if (scope === "specific_turn") {
+      onChange({ scope });
+      return;
+    }
+    onChange({
+      scope,
+      target_source_conversation_id: null,
+      target_turn_index: null,
+      target_case_id: null,
+    });
+  };
+
+  const selectConversation = (conversationId: string) =>
+    onChange({
+      target_source_conversation_id: conversationId,
+      target_turn_index: null,
+      target_case_id: null,
+    });
+
+  const selectTurn = (turnValue: string) => {
+    const turn = selectedConversation?.turns.find((t) => String(t.turnIndex) === turnValue);
+    onChange({
+      target_turn_index: turn ? turn.turnIndex : null,
+      target_case_id: turn ? turn.caseId : null,
+    });
+  };
+
+  const scopePhrase = (): string => {
+    if (rule.scope === "conversation") return "during the conversation";
+    if (rule.scope === "specific_turn") {
+      if (!selectedConversation || rule.target_turn_index == null) return "on the selected turn";
+      const turn = selectedConversation.turns.find((t) => t.turnIndex === rule.target_turn_index);
+      return `on ${selectedConversation.label}, ${turn?.label ?? `turn ${rule.target_turn_index + 1}`}`;
+    }
+    return "on every turn";
+  };
+
+  const summary = (): string => {
+    const agent = rule.agent_id ? catalog.find((a) => a.id === rule.agent_id) : null;
+    const agentLabel = agent ? `"${agent.label}"` : "Any agent";
+    const tools = rule.tool_ids.map((id) => `"${toolLabelById.get(id) ?? id}"`);
+    const scope = scopePhrase();
+    const successfully = rule.require_success ? "successfully " : "";
+    if (expectation === "must_not_use")
+      return `${agentLabel} must not use ${joinPhrases(tools, "or")} ${scope}.`;
+    if (expectation === "only")
+      return `${agentLabel} may only use ${joinPhrases(tools, "or")} ${scope}.`;
+    const conjunction = match === "all" ? "and" : "or";
+    return `${agentLabel} must ${successfully}use ${joinPhrases(tools, conjunction)} ${scope}.`;
+  };
+
+  const toolsRequired = expectation !== "only" && rule.tool_ids.length === 0;
+  const matchDisabled = expectation !== "must_use";
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-semibold">Rule {index + 1}</span>
+        <Button type="button" variant="ghost" size="sm" onClick={onRemove} aria-label="Remove rule">
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <div className="space-y-1.5">
+          <Label>Agent</Label>
+          <Select value={rule.agent_id ?? ANY_AGENT} onValueChange={changeAgent}>
+            <SelectTrigger>
+              <SelectValue placeholder="Any agent" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ANY_AGENT}>Any agent</SelectItem>
+              {catalog.map((agent) => (
+                <SelectItem key={agent.id} value={agent.id}>
+                  {agent.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>Expectation</Label>
+          <Select
+            value={expectation}
+            onValueChange={(value) =>
+              onChange({ operator: toOperator(value as Expectation, match) })
+            }
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {EXPECTATION_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label className={cn(matchDisabled && "text-muted-foreground")}>Match</Label>
+          <Select
+            value={match}
+            disabled={matchDisabled}
+            onValueChange={(value) => onChange({ operator: toOperator("must_use", value as MatchMode) })}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {MATCH_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Tools multi-select — inline dropdown so it stays anchored inside the dialog */}
+      <div className="space-y-1.5">
+        <Label>Tools{expectation === "only" ? " (allowed set)" : ""}</Label>
+        <div className="relative" ref={toolsRef}>
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={() => setToolsOpen((open) => !open)}
+            className="flex min-h-10 w-full cursor-pointer flex-wrap items-center gap-1.5 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            {rule.tool_ids.map((id) => (
+              <span
+                key={id}
+                className="inline-flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 text-xs text-primary"
+              >
+                {toolLabelById.get(id) ?? id}
+                <button
+                  type="button"
+                  aria-label={`Remove ${toolLabelById.get(id) ?? id}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    toggleTool(id);
+                  }}
+                  className="hover:text-primary/70"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            ))}
+            {rule.tool_ids.length === 0 && (
+              <span className="text-muted-foreground">Select tools…</span>
+            )}
+            <ChevronDown className="ml-auto h-4 w-4 shrink-0 text-muted-foreground" />
+          </div>
+
+          {toolsOpen && (
+            <div className="absolute left-0 right-0 top-full z-50 mt-1 rounded-md border bg-popover shadow-md">
+              <Command>
+                <CommandInput placeholder="Search tools…" />
+                <CommandList>
+                  <CommandEmpty>No tools for this agent.</CommandEmpty>
+                  <CommandGroup>
+                    {availableTools.map((tool) => {
+                      const selected = rule.tool_ids.includes(tool.id);
+                      return (
+                        <CommandItem
+                          key={tool.id}
+                          value={tool.label}
+                          onSelect={() => toggleTool(tool.id)}
+                        >
+                          <Check className={cn("mr-2 h-4 w-4", selected ? "opacity-100" : "opacity-0")} />
+                          {tool.label}
+                        </CommandItem>
+                      );
+                    })}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </div>
+          )}
+        </div>
+        {toolsRequired && <p className="text-xs text-destructive">Select at least one tool.</p>}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label>When</Label>
+          <Select value={rule.scope} onValueChange={(value) => changeScope(value as ToolUsageScope)}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {SCOPE_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {expectation !== "must_not_use" && (
+          <div className="flex items-center justify-between rounded-md border border-border px-3 py-2">
+            <div>
+              <Label className="cursor-pointer">Must succeed</Label>
+              <p className="text-xs text-muted-foreground">Only count successful calls</p>
+            </div>
+            <Switch
+              checked={Boolean(rule.require_success)}
+              onCheckedChange={(checked) => onChange({ require_success: checked })}
+            />
+          </div>
+        )}
+      </div>
+
+      {rule.scope === "specific_turn" &&
+        (conversations.length === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            No imported conversations in this dataset to target.
+          </p>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label>Conversation</Label>
+              <Select
+                value={rule.target_source_conversation_id ?? ""}
+                onValueChange={selectConversation}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a conversation" />
+                </SelectTrigger>
+                <SelectContent>
+                  {conversations.map((conversation) => (
+                    <SelectItem key={conversation.id} value={conversation.id}>
+                      {conversation.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label>Turn</Label>
+              <Select
+                value={rule.target_turn_index != null ? String(rule.target_turn_index) : ""}
+                disabled={!selectedConversation}
+                onValueChange={selectTurn}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a turn" />
+                </SelectTrigger>
+                <SelectContent>
+                  {(selectedConversation?.turns ?? []).map((turn) => (
+                    <SelectItem key={turn.caseId} value={String(turn.turnIndex)}>
+                      {turn.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        ))}
+
+      {/* Advanced settings */}
+      <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
+        <CollapsibleTrigger className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground">
+          <ChevronRight className={cn("h-4 w-4 transition-transform", advancedOpen && "rotate-90")} />
+          <span className="font-medium">Advanced settings</span>
+          <span className="text-xs">Call limits</span>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="pt-3">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label>Min calls</Label>
+              <Input
+                type="number"
+                min={0}
+                placeholder="No minimum"
+                value={rule.min_calls ?? ""}
+                onChange={(event) => onChange({ min_calls: toNumberOrNull(event.target.value) })}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Max calls</Label>
+              <Input
+                type="number"
+                min={0}
+                placeholder="No maximum"
+                value={rule.max_calls ?? ""}
+                onChange={(event) => onChange({ max_calls: toNumberOrNull(event.target.value) })}
+              />
+            </div>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+
+      <div className="rounded-md bg-primary/5 px-3 py-2">
+        <p className="text-sm text-primary">{summary()}</p>
+      </div>
+    </div>
+  );
+};
+
+// ---- builder ---------------------------------------------------------------
+
+interface Props {
+  rules: ToolUsageRule[];
+  onChange: (rules: ToolUsageRule[]) => void;
+  catalog: EvaluationAgentInfo[];
+  conversations?: RuleConversation[];
+  loading?: boolean;
+  error?: string | null;
+}
+
+export const ToolUsageRuleBuilder: React.FC<Props> = ({
+  rules,
+  onChange,
+  catalog,
+  conversations = [],
+  loading,
+  error,
+}) => {
+  if (loading) {
+    return <p className="text-sm text-muted-foreground">Loading agents and tools…</p>;
+  }
+  if (error) {
+    return (
+      <p className="text-sm text-destructive">
+        Could not load this workflow&apos;s tools. You can still save, but tools cannot be picked here.
+      </p>
+    );
+  }
+
+  const updateRule = (index: number, patch: Partial<ToolUsageRule>) =>
+    onChange(rules.map((rule, i) => (i === index ? { ...rule, ...patch } : rule)));
+
+  return (
+    <div className="space-y-4">
+      {catalog.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          This workflow has no agents with connected tools.
+        </p>
+      )}
+
+      {rules.map((rule, index) => (
+        <RuleCard
+          key={rule.id}
+          rule={rule}
+          index={index}
+          catalog={catalog}
+          conversations={conversations}
+          onChange={(patch) => updateRule(index, patch)}
+          onRemove={() => onChange(rules.filter((_, i) => i !== index))}
+        />
+      ))}
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => onChange([...rules, newToolRule()])}
+      >
+        <Plus className="mr-1.5 h-4 w-4" />
+        Add rule
+      </Button>
+    </div>
+  );
+};

--- a/frontend/src/views/TestSuites/helpers/evaluationForm.test.ts
+++ b/frontend/src/views/TestSuites/helpers/evaluationForm.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { buildTechniqueConfigs, getEditInitialData } from "./evaluationForm";
+import type { EvaluationWizardData } from "../components/EvaluationWizard";
+import type { TestEvaluationConfig } from "@/interfaces/testEvaluation.interface";
+
+const evalWith = (toolUsed: Record<string, unknown>): TestEvaluationConfig =>
+  ({
+    id: "e1",
+    name: "eval",
+    suite_id: "s1",
+    techniques: ["tool_used"],
+    technique_configs: { tool_used: toolUsed },
+    run_ids: [],
+    created_at: "",
+    updated_at: "",
+  }) as TestEvaluationConfig;
+
+const parseRules = (toolUsed: Record<string, unknown>) =>
+  getEditInitialData(evalWith(toolUsed), []).toolRules ?? [];
+
+describe("parseToolRules legacy shapes", () => {
+  it("keeps a bare should_call:false as a 'no tools' rule instead of dropping it", () => {
+    const rules = parseRules({ should_call: false });
+    expect(rules).toHaveLength(1);
+    expect(rules[0].operator).toBe("only");
+    expect(rules[0].tool_ids).toEqual([]);
+  });
+
+  it("turns a bare should_call:true into an any-tool marker instead of dropping it", () => {
+    const rules = parseRules({ should_call: true });
+    expect(rules).toHaveLength(1);
+    expect(rules[0].operator).toBe("any");
+    expect(rules[0].tool_ids).toEqual([]);
+  });
+
+  it("maps a named tool with should_call:false to 'none'", () => {
+    const rules = parseRules({ tool: "search", should_call: false });
+    expect(rules[0].operator).toBe("none");
+    expect(rules[0].tool_ids).toEqual(["search"]);
+  });
+
+  it("folds legacy top-level result checks into the tool's per_tool entry", () => {
+    const rules = parseRules({ tool: "search", result_contains: "ok" });
+    expect(rules[0].per_tool?.search?.result_contains).toBe("ok");
+  });
+});
+
+describe("serializeToolRule round-trips per_tool", () => {
+  it("preserves per_tool through parse -> serialize (edit without loss)", () => {
+    const stored = {
+      rules: [
+        {
+          id: "r1",
+          tool_ids: ["t1"],
+          operator: "all",
+          scope: "every_turn",
+          per_tool: { t1: { result_not_empty: true, result_contains: "x", expected_args: { q: "1" } } },
+        },
+      ],
+    };
+    const rules = parseRules(stored);
+    const data = { metrics: ["tool_used"], toolRules: rules } as unknown as EvaluationWizardData;
+    const out = buildTechniqueConfigs(data).tool_used as {
+      rules: { per_tool?: Record<string, unknown> }[];
+    };
+    expect(out.rules[0].per_tool).toEqual({
+      t1: { result_not_empty: true, result_contains: "x", expected_args: { q: "1" } },
+    });
+  });
+});

--- a/frontend/src/views/TestSuites/helpers/evaluationForm.ts
+++ b/frontend/src/views/TestSuites/helpers/evaluationForm.ts
@@ -1,6 +1,108 @@
 import { EvaluationWizardData } from "../components/EvaluationWizard";
-import { TestEvaluationConfig } from "@/interfaces/testEvaluation.interface";
+import {
+  TestEvaluationConfig,
+  ToolUsageOperator,
+  ToolUsagePerToolCheck,
+  ToolUsageRule,
+  ToolUsageScope,
+} from "@/interfaces/testEvaluation.interface";
 import { LLMProviderMinimal } from "@/interfaces/llmProvider.interface";
+
+// Read back a stored per_tool map, keeping only the recognized check fields.
+const parsePerTool = (
+  raw: unknown,
+): Record<string, ToolUsagePerToolCheck> => {
+  if (!raw || typeof raw !== "object") return {};
+  const out: Record<string, ToolUsagePerToolCheck> = {};
+  for (const [toolId, value] of Object.entries(raw as Record<string, unknown>)) {
+    const check = (value ?? {}) as Record<string, unknown>;
+    out[toolId] = {
+      result_not_empty: Boolean(check.result_not_empty),
+      result_contains: (check.result_contains as string) ?? null,
+      expected_args: (check.expected_args as Record<string, unknown>) ?? null,
+    };
+  }
+  return out;
+};
+
+// Fold a legacy config's top-level result/argument checks into the tool's per_tool entry.
+const legacyPerTool = (cfg: Record<string, unknown>): Record<string, ToolUsagePerToolCheck> => {
+  const tool = cfg.tool as string | undefined;
+  const hasChecks = cfg.result_not_empty || cfg.result_contains || cfg.expected_args;
+  if (!tool || cfg.should_call === false || !hasChecks) return {};
+  return {
+    [tool]: {
+      result_not_empty: Boolean(cfg.result_not_empty),
+      result_contains: (cfg.result_contains as string) ?? null,
+      expected_args: (cfg.expected_args as Record<string, unknown>) ?? null,
+    },
+  };
+};
+
+// Parse a stored tool_used config into builder rules, converting the legacy shape.
+const parseToolRules = (
+  cfg: Record<string, unknown> | undefined,
+): ToolUsageRule[] => {
+  if (!cfg) return [];
+  if (Array.isArray(cfg.rules)) {
+    return (cfg.rules as Record<string, unknown>[]).map((rule, index) => ({
+      id: (rule.id as string) ?? `rule-${index}`,
+      agent_id: (rule.agent_id as string) ?? null,
+      tool_ids: Array.isArray(rule.tool_ids) ? (rule.tool_ids as string[]) : [],
+      operator: (rule.operator as ToolUsageOperator) ?? "all",
+      require_success: Boolean(rule.require_success),
+      scope: (rule.scope as ToolUsageScope) ?? "every_turn",
+      target_case_id: (rule.target_case_id as string) ?? null,
+      target_source_conversation_id: (rule.target_source_conversation_id as string) ?? null,
+      target_turn_index: (rule.target_turn_index as number) ?? null,
+      min_calls: (rule.min_calls as number) ?? null,
+      max_calls: (rule.max_calls as number) ?? null,
+      per_tool: parsePerTool(rule.per_tool),
+    }));
+  }
+  // Legacy shape: a named tool/agent, or a bare should_call ("any"/"no" tool). The
+  // catalogue-load effect later expands an "any tool" rule to the workflow's tools.
+  if (cfg.tool || cfg.node || "should_call" in cfg) {
+    const shouldCall = cfg.should_call !== false;
+    const operator: ToolUsageOperator = cfg.tool
+      ? shouldCall
+        ? "all"
+        : "none"
+      : shouldCall
+        ? "any"
+        : "only";
+    return [
+      {
+        id: "legacy-tool-rule",
+        agent_id: (cfg.node as string) ?? null,
+        tool_ids: cfg.tool ? [cfg.tool as string] : [],
+        operator,
+        require_success: false,
+        scope: "every_turn",
+        per_tool: legacyPerTool(cfg),
+      },
+    ];
+  }
+  return [];
+};
+
+// Serialize a builder rule to the backend config, dropping empty optional fields.
+const serializeToolRule = (rule: ToolUsageRule): Record<string, unknown> => ({
+  id: rule.id,
+  tool_ids: rule.tool_ids,
+  operator: rule.operator,
+  scope: rule.scope,
+  ...(rule.agent_id ? { agent_id: rule.agent_id } : {}),
+  ...(rule.require_success ? { require_success: true } : {}),
+  ...(rule.target_case_id ? { target_case_id: rule.target_case_id } : {}),
+  ...(rule.target_source_conversation_id
+    ? { target_source_conversation_id: rule.target_source_conversation_id }
+    : {}),
+  ...(rule.target_turn_index != null ? { target_turn_index: rule.target_turn_index } : {}),
+  ...(rule.min_calls != null ? { min_calls: rule.min_calls } : {}),
+  ...(rule.max_calls != null ? { max_calls: rule.max_calls } : {}),
+  ...(rule.per_tool && Object.keys(rule.per_tool).length ? { per_tool: rule.per_tool } : {}),
+});
 
 const parseJsonObject = (
   text: string,
@@ -93,18 +195,8 @@ export const buildTechniqueConfigs = (
   }
 
   if (data.metrics.includes("tool_used")) {
-    // Advanced validation only applies when the tool must be called; drop it otherwise.
-    const includeAdvanced = data.toolShouldCall;
-    const expectedArgs = includeAdvanced ? parseJsonObject(data.toolExpectedArgsText) : undefined;
     configs.tool_used = {
-      should_call: data.toolShouldCall,
-      ...(data.toolName.trim() ? { tool: data.toolName.trim() } : {}),
-      ...(data.toolNode.trim() ? { node: data.toolNode.trim() } : {}),
-      ...(expectedArgs ? { expected_args: expectedArgs } : {}),
-      ...(includeAdvanced && data.toolResultNotEmpty ? { result_not_empty: true } : {}),
-      ...(includeAdvanced && data.toolResultContains.trim()
-        ? { result_contains: data.toolResultContains.trim() }
-        : {}),
+      rules: data.toolRules.map(serializeToolRule),
     };
   }
 
@@ -168,14 +260,7 @@ export const getEditInitialData = (
     provFailOnViolation: Boolean(provCfg?.fail_on_violation),
     provLlmProviderId: (provCfg?.llm_provider_id as string) ?? providers[0]?.id ?? "",
     provLlmJudgeSystemPromptSuffix: (provCfg?.llm_judge_system_prompt_suffix as string) ?? "",
-    toolName: (toolCfg?.tool as string) ?? "",
-    toolShouldCall: toolCfg?.should_call === undefined ? true : Boolean(toolCfg.should_call),
-    toolExpectedArgsText: toolCfg?.expected_args
-      ? JSON.stringify(toolCfg.expected_args, null, 2)
-      : "",
-    toolNode: (toolCfg?.node as string) ?? "",
-    toolResultNotEmpty: Boolean(toolCfg?.result_not_empty),
-    toolResultContains: (toolCfg?.result_contains as string) ?? "",
+    toolRules: parseToolRules(toolCfg),
     notContainsText: forbiddenPhrasesToText(notContainsCfg),
     routeExpected: (routeCfg?.expected as string) ?? "",
     routeNode: (routeCfg?.node as string) ?? "",

--- a/frontend/src/views/TestSuites/pages/EvaluationDetailPage.tsx
+++ b/frontend/src/views/TestSuites/pages/EvaluationDetailPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { PageLayout } from "@/components/PageLayout";
 import JsonViewer from "@/components/JsonViewer";
@@ -17,8 +17,10 @@ import { getWorkflowsMinimal } from "@/services/workflows";
 import {
   getTestEvaluationById,
   appendRunToEvaluation,
+  getToolRuleResults,
 } from "@/services/testEvaluations";
 import { TestResult, TestRun, TestSuite } from "@/interfaces/testSuite.interface";
+import type { TestToolRuleResult } from "@/interfaces/testEvaluation.interface";
 import { WorkflowMinimal } from "@/interfaces/workflow.interface";
 import {
   Dialog,
@@ -30,11 +32,16 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Skeleton } from "@/components/skeleton";
 import { Progress } from "@/components/progress";
 import { cn } from "@/helpers/utils";
+import { ToolUsageResults } from "../components/ToolUsageResults";
+import { ToolUsageResultCard } from "../components/ToolUsageResultCard";
 
 type ResultFilter = "all" | "passed" | "failed" | "not_scored";
 
 /** Execution counts the backend stores alongside the per-technique metrics. */
 const RUN_TOTALS_KEY = "_totals";
+// Tool Usage has its own dedicated, readable section, so it is left out of the
+// generic per-technique summary grid to avoid a confusing "Avg Score" card.
+const TOOL_USED_TECHNIQUE = "tool_used";
 
 interface RunTotals {
   cases: number;
@@ -140,6 +147,7 @@ const EvaluationDetailPage: React.FC = () => {
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [runs, setRuns] = useState<TestRun[]>([]);
   const [resultsByRun, setResultsByRun] = useState<Record<string, TestResult[]>>({});
+  const [toolResultsByRun, setToolResultsByRun] = useState<Record<string, TestToolRuleResult[]>>({});
   const [expandedResultId, setExpandedResultId] = useState<string | null>(null);
   const [suite, setSuite] = useState<TestSuite | null>(null);
   const [workflowName, setWorkflowName] = useState<string>("Dataset default");
@@ -230,8 +238,12 @@ const EvaluationDetailPage: React.FC = () => {
       if (!selectedRunId) return;
       setIsLoadingResults(true);
       try {
-        const data = await listResultsForRun(selectedRunId);
+        const [data, toolRows] = await Promise.all([
+          listResultsForRun(selectedRunId),
+          getToolRuleResults(selectedRunId).catch(() => []),
+        ]);
         setResultsByRun((prev) => ({ ...prev, [selectedRunId]: data ?? [] }));
+        setToolResultsByRun((prev) => ({ ...prev, [selectedRunId]: toolRows ?? [] }));
       } finally {
         setIsLoadingResults(false);
       }
@@ -266,8 +278,12 @@ const EvaluationDetailPage: React.FC = () => {
           if (updated.status === "completed" || updated.status === "failed") {
             clearInterval(pollInterval);
             setIsRunning(false);
-            const results = await listResultsForRun(created.id);
+            const [results, toolRows] = await Promise.all([
+              listResultsForRun(created.id),
+              getToolRuleResults(created.id).catch(() => []),
+            ]);
             setResultsByRun((prev) => ({ ...prev, [created.id]: results ?? [] }));
+            setToolResultsByRun((prev) => ({ ...prev, [created.id]: toolRows ?? [] }));
           }
         }, 10_000);
         // Return early — setIsRunning(false) is handled by the interval above.
@@ -281,19 +297,58 @@ const EvaluationDetailPage: React.FC = () => {
 
   const selectedRun = runs.find((run) => run.id === selectedRunId);
   const selectedRunResults = selectedRunId ? resultsByRun[selectedRunId] ?? [] : [];
+  const selectedRunToolResults = selectedRunId ? toolResultsByRun[selectedRunId] ?? [] : [];
+
+  // Turn-level tool results are shown inside the matching test-case row; conversation
+  // results stay in the run-level Tool Usage section.
+  const toolResultsByCaseId = useMemo(() => {
+    const rows = selectedRunId ? toolResultsByRun[selectedRunId] ?? [] : [];
+    const map = new Map<string, TestToolRuleResult[]>();
+    for (const toolResult of rows) {
+      const isTurnScope =
+        toolResult.scope === "every_turn" || toolResult.scope === "specific_turn";
+      if (isTurnScope && toolResult.case_id) {
+        const existing = map.get(toolResult.case_id) ?? [];
+        existing.push(toolResult);
+        map.set(toolResult.case_id, existing);
+      }
+    }
+    return map;
+  }, [selectedRunId, toolResultsByRun]);
+
+  // A case's displayed status must reflect its turn-level Tool Usage results too: a
+  // tool failure fails the case, and a tool pass can score an otherwise-unscored case.
+  const caseTools = (result: TestResult): TestToolRuleResult[] =>
+    result.case_id ? toolResultsByCaseId.get(result.case_id) ?? [] : [];
+
+  const casePassed = (result: TestResult): boolean => {
+    const tools = caseTools(result);
+    const toolFailed = tools.some((t) => t.status === "failed");
+    const toolPassed = tools.some((t) => t.status === "passed");
+    if (toolFailed) return false;
+    return isResultPassed(result) || (isResultNotScored(result) && toolPassed);
+  };
+
+  const caseFailed = (result: TestResult): boolean => {
+    const toolFailed = caseTools(result).some((t) => t.status === "failed");
+    return toolFailed || (!casePassed(result) && isResultFailed(result));
+  };
+
+  const caseNotScored = (result: TestResult): boolean =>
+    !casePassed(result) && !caseFailed(result);
 
   const filterResults = () => {
-    if (resultFilter === "passed") return selectedRunResults.filter(isResultPassed);
-    if (resultFilter === "not_scored") return selectedRunResults.filter(isResultNotScored);
-    if (resultFilter === "failed") return selectedRunResults.filter(isResultFailed);
+    if (resultFilter === "passed") return selectedRunResults.filter(casePassed);
+    if (resultFilter === "not_scored") return selectedRunResults.filter(caseNotScored);
+    if (resultFilter === "failed") return selectedRunResults.filter(caseFailed);
     return selectedRunResults;
   };
 
   const filteredResults = filterResults();
 
-  const passedCount = selectedRunResults.filter(isResultPassed).length;
-  const failedCount = selectedRunResults.filter(isResultFailed).length;
-  const notScoredCount = selectedRunResults.filter(isResultNotScored).length;
+  const passedCount = selectedRunResults.filter(casePassed).length;
+  const failedCount = selectedRunResults.filter(caseFailed).length;
+  const notScoredCount = selectedRunResults.filter(caseNotScored).length;
 
   const runTotals = (selectedRun?.summary_metrics as Record<string, unknown> | undefined)?.[
     RUN_TOTALS_KEY
@@ -527,7 +582,7 @@ const EvaluationDetailPage: React.FC = () => {
                             { accuracy?: number; avg_score?: number; cases?: number }
                           >,
                         )
-                          .filter(([tech]) => tech !== RUN_TOTALS_KEY)
+                          .filter(([tech]) => tech !== RUN_TOTALS_KEY && tech !== TOOL_USED_TECHNIQUE)
                           .map(([tech, summary]) => {
                           const acc = typeof summary.accuracy === "number" ? summary.accuracy : null;
                           return (
@@ -571,6 +626,9 @@ const EvaluationDetailPage: React.FC = () => {
                       <div className="text-sm text-muted-foreground">No metrics available</div>
                     )}
                   </div>
+
+                  {/* Tool Usage: run-level summary + conversation-scoped results */}
+                  <ToolUsageResults results={selectedRunToolResults} />
 
                   {/* Results with filter tabs */}
                   <div>
@@ -629,8 +687,8 @@ const EvaluationDetailPage: React.FC = () => {
                     ) : (
                       <div className="space-y-2 max-h-[50vh] overflow-y-auto">
                         {filteredResults.map((result) => {
-                          const passed = isResultPassed(result);
-                          const notScored = isResultNotScored(result);
+                          const passed = casePassed(result);
+                          const notScored = caseNotScored(result);
                           const isExpanded = expandedResultId === result.id;
                           const gradedTechniques = Object.keys(result.metrics ?? {});
                           const caseExpectedOutput = result.case_id
@@ -759,6 +817,26 @@ const EvaluationDetailPage: React.FC = () => {
                                       })}
                                     </div>
                                   )}
+
+                                  {/* Turn-level Tool Usage for this case */}
+                                  {result.case_id &&
+                                    (toolResultsByCaseId.get(result.case_id)?.length ?? 0) > 0 && (
+                                      <div>
+                                        <div className="text-xs font-medium text-muted-foreground mb-1">
+                                          Tool Usage
+                                        </div>
+                                        <div className="space-y-2">
+                                          {toolResultsByCaseId
+                                            .get(result.case_id)!
+                                            .map((toolResult) => (
+                                              <ToolUsageResultCard
+                                                key={toolResult.id}
+                                                result={toolResult}
+                                              />
+                                            ))}
+                                        </div>
+                                      </div>
+                                    )}
 
                                   {/* Input/Output comparison */}
                                   <div


### PR DESCRIPTION
## Description

- Rule engine: all/any/none/only operators, per-turn / whole-conversation / specific-turn scope, per-tool result & argument checks, min/max calls, require-success.
- Nested & MCP-aware tool catalogue; configs canonicalized to tool ids on save (legacy names/“any tool” configs still accepted).
- Rule builder in the evaluation wizard; results show plain-language expected/actual per rule, with per-turn results inline on each test case and a scope-aware summary.
- Fix: workflow tool-trace serialization is now cycle/size-safe, so eval runs no longer stall.

Tests: backend unit suites + frontend tsc/lint/vitest pass; live eval verified green.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
