### PR TITLE
fix: unify page title animations on load 

### DIFF
--- a/frontend/src/views/AIAgents/Scheduling/SchedulingView.tsx
+++ b/frontend/src/views/AIAgents/Scheduling/SchedulingView.tsx
@@ -171,8 +171,8 @@ const SchedulingView: React.FC<SchedulingViewProps> = ({ agentId, onBack }) => {
             </Button>
           )}
           <div className="min-w-0">
-            <h2 className="text-3xl font-bold">Scheduling</h2>
-            <p className="text-muted-foreground font-normal mt-1">
+            <h2 className="text-3xl font-bold animate-fade-down">Scheduling</h2>
+            <p className="text-muted-foreground font-normal mt-1 animate-fade-up">
               Schedule recurring runs of this workflow
             </p>
           </div>

--- a/frontend/src/views/AIAgents/components/AgentList.tsx
+++ b/frontend/src/views/AIAgents/components/AgentList.tsx
@@ -373,11 +373,11 @@ const AgentList: React.FC<AgentListProps> = ({
     <div className="space-y-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
-          <h2 className="text-3xl font-bold">
+          <h2 className="text-3xl font-bold animate-fade-down">
             Agent Studio{" "}
             <span className="hidden sm:inline text-xl sm:text-2xl text-muted-foreground font-normal">({activeCount} Active, {inactiveCount} Inactive)</span>
           </h2>
-          <p className="text-muted-foreground font-normal">View and manage workflows</p>
+          <p className="text-muted-foreground font-normal animate-fade-up">View and manage workflows</p>
           <div className="mt-2 sm:hidden">
             <span className="text-muted-foreground font-normal text-base">
               ({activeCount} Active, {inactiveCount} Inactive)

--- a/frontend/src/views/AIAgents/components/Customer/SecurityPage.tsx
+++ b/frontend/src/views/AIAgents/components/Customer/SecurityPage.tsx
@@ -26,8 +26,8 @@ export default function SecurityPage() {
                 <ArrowLeft className="h-4 w-4" />
               </Button>
               <div>
-                <h2 className="text-3xl font-bold">Security Settings</h2>
-                <p className="text-muted-foreground font-normal mt-1">
+                <h2 className="text-3xl font-bold animate-fade-down">Security Settings</h2>
+                <p className="text-muted-foreground font-normal mt-1 animate-fade-up">
                   Configure security settings for your agent
                 </p>
               </div>

--- a/frontend/src/views/HelpCenter/components/HelpCenterManager.tsx
+++ b/frontend/src/views/HelpCenter/components/HelpCenterManager.tsx
@@ -416,8 +416,8 @@ export default function HelpCenterManager() {
       <div className="flex flex-col gap-6">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="min-w-0 shrink-0">
-            <h2 className="text-2xl sm:text-3xl font-bold whitespace-nowrap">Help Center</h2>
-            <p className="text-muted-foreground font-normal text-sm mt-0.5 hidden sm:block">
+            <h2 className="text-2xl sm:text-3xl font-bold whitespace-nowrap animate-fade-down">Help Center</h2>
+            <p className="text-muted-foreground font-normal text-sm mt-0.5 hidden sm:block animate-fade-up">
               Report bugs and feature requests and track their status
             </p>
           </div>

--- a/frontend/src/views/HelpCenter/pages/TicketDetail.tsx
+++ b/frontend/src/views/HelpCenter/pages/TicketDetail.tsx
@@ -110,8 +110,8 @@ export default function TicketDetailPage() {
             </Link>
           </Button>
           <div className="min-w-0 flex-1">
-            <h2 className="text-2xl font-bold tracking-tight break-words">{ticket.title}</h2>
-            <div className="flex flex-wrap gap-2 mt-2 items-center text-sm text-muted-foreground">
+            <h2 className="text-2xl font-bold tracking-tight break-words animate-fade-down">{ticket.title}</h2>
+            <div className="flex flex-wrap gap-2 mt-2 items-center text-sm text-muted-foreground animate-fade-up">
               <TicketStatusBadge status={ticket.status} />
               <span className="capitalize">{ticket.ticket_type}</span>
               {ticket.vote_count > 1 && <span>{ticket.vote_count} reports</span>}

--- a/frontend/src/views/KnowledgeBase/components/KnowledgeBaseManager.tsx
+++ b/frontend/src/views/KnowledgeBase/components/KnowledgeBaseManager.tsx
@@ -144,8 +144,8 @@ const KnowledgeBaseManager: React.FC = () => {
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
-          <h2 className="text-2xl sm:text-3xl font-bold">Knowledge Base</h2>
-          <p className="text-muted-foreground font-normal">View and manage the knowledge base</p>
+          <h2 className="text-2xl sm:text-3xl font-bold animate-fade-down">Knowledge Base</h2>
+          <p className="text-muted-foreground font-normal animate-fade-up">View and manage the knowledge base</p>
         </div>
         <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
           <div className="relative">

--- a/frontend/src/views/KnowledgeBase/pages/KnowledgeBaseForm.tsx
+++ b/frontend/src/views/KnowledgeBase/pages/KnowledgeBaseForm.tsx
@@ -649,7 +649,7 @@ const KnowledgeBaseForm: React.FC = () => {
                 <Button variant="ghost" size="icon" onClick={() => navigate('/knowledge-base')} className="mr-2">
                   <ChevronLeft className="h-5 w-5" />
                 </Button>
-                <h2 className="text-2xl font-bold tracking-tight">
+                <h2 className="text-2xl font-bold tracking-tight animate-fade-down">
                   {isEditMode ? 'Edit Knowledge Base' : 'New Knowledge Base'}
                 </h2>
               </div>

--- a/frontend/src/views/MLModels/components/MLModelDetail.tsx
+++ b/frontend/src/views/MLModels/components/MLModelDetail.tsx
@@ -400,8 +400,8 @@ const MLModelDetail: React.FC = () => {
           <ChevronLeft className="h-5 w-5" />
         </Button>
         <div>
-          <h2 className="text-3xl font-bold">{model.name}</h2>
-          <p className="text-muted-foreground font-normal">{model.description}</p>
+          <h2 className="text-3xl font-bold animate-fade-down">{model.name}</h2>
+          <p className="text-muted-foreground font-normal animate-fade-up">{model.description}</p>
         </div>
       </div>
 

--- a/frontend/src/views/MLModels/components/MLModelsManager.tsx
+++ b/frontend/src/views/MLModels/components/MLModelsManager.tsx
@@ -662,8 +662,8 @@ const MLModelsManager: React.FC = () => {
           <div className="flex flex-col gap-6">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div className="min-w-0">
-                <h2 className="text-2xl sm:text-3xl font-bold">ML Models</h2>
-                <p className="text-muted-foreground font-normal">
+                <h2 className="text-2xl sm:text-3xl font-bold animate-fade-down">ML Models</h2>
+                <p className="text-muted-foreground font-normal animate-fade-up">
                   Manage machine learning model definitions
                 </p>
               </div>

--- a/frontend/src/views/Notifications/pages/NotificationsPage.tsx
+++ b/frontend/src/views/Notifications/pages/NotificationsPage.tsx
@@ -133,8 +133,8 @@ const NotificationsPage = () => {
             <div className="max-w-7xl mx-auto w-full">
             <div className="flex items-center justify-between mb-8">
               <div>
-                <h1 className="text-3xl font-bold">Notifications</h1>
-                <p className="text-muted-foreground mt-1">
+                <h1 className="text-3xl font-bold animate-fade-down">Notifications</h1>
+                <p className="text-muted-foreground mt-1 animate-fade-up">
                   Stay updated with your latest activities and alerts
                 </p>
               </div>

--- a/frontend/src/views/Settings/pages/FileManagerFiles.tsx
+++ b/frontend/src/views/Settings/pages/FileManagerFiles.tsx
@@ -689,8 +689,8 @@ export function FileManagerFiles() {
     <PageLayout>
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:flex-wrap">
         <div className="min-w-0">
-          <h1 className="text-2xl md:text-3xl font-bold mb-1">Manage Files</h1>
-          <p className="text-sm md:text-base text-muted-foreground">
+          <h1 className="text-2xl md:text-3xl font-bold mb-1 animate-fade-down">Manage Files</h1>
+          <p className="text-sm md:text-base text-muted-foreground animate-fade-up">
             Browse uploads, preview images, and manage metadata
           </p>
         </div>

--- a/frontend/src/views/Settings/pages/Notifications.tsx
+++ b/frontend/src/views/Settings/pages/Notifications.tsx
@@ -45,8 +45,8 @@ export function NotificationsSettings() {
   return (
     <PageLayout>
       <header className="mb-8">
-        <h1 className="text-2xl sm:text-3xl font-bold mb-2">Notifications</h1>
-        <p className="text-sm sm:text-base text-muted-foreground">
+        <h1 className="text-2xl sm:text-3xl font-bold mb-2 animate-fade-down">Notifications</h1>
+        <p className="text-sm sm:text-base text-muted-foreground animate-fade-up">
           Customize which notifications you want to receive.
         </p>
       </header>

--- a/frontend/src/views/TestSuites/pages/DatasetDetailPage.tsx
+++ b/frontend/src/views/TestSuites/pages/DatasetDetailPage.tsx
@@ -200,9 +200,9 @@ const DatasetDetailPage: React.FC = () => {
           </Button>
           {suite?.name && (
             <div className="text-right">
-              <h1 className="text-xl font-semibold text-foreground">{suite.name}</h1>
+              <h1 className="text-xl font-semibold text-foreground animate-fade-down">{suite.name}</h1>
               {suite.description && (
-                <p className="text-xs text-muted-foreground">{suite.description}</p>
+                <p className="text-xs text-muted-foreground animate-fade-up">{suite.description}</p>
               )}
             </div>
           )}

--- a/frontend/src/views/TestSuites/pages/EvaluationDetailPage.tsx
+++ b/frontend/src/views/TestSuites/pages/EvaluationDetailPage.tsx
@@ -325,9 +325,9 @@ const EvaluationDetailPage: React.FC = () => {
           </Button>
           <div className="flex items-center gap-3">
             <div className="text-right hidden sm:block">
-              <h1 className="text-xl font-semibold text-foreground">{evaluation.name}</h1>
+              <h1 className="text-xl font-semibold text-foreground animate-fade-down">{evaluation.name}</h1>
               {evaluation.description && (
-                <p className="text-xs text-muted-foreground">
+                <p className="text-xs text-muted-foreground animate-fade-up">
                   {evaluation.description}
                 </p>
               )}

--- a/frontend/src/views/TestSuites/pages/WorkflowEvaluationsPage.tsx
+++ b/frontend/src/views/TestSuites/pages/WorkflowEvaluationsPage.tsx
@@ -383,7 +383,7 @@ const WorkflowEvaluationsPage: React.FC = () => {
         </button>
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-2 min-w-0">
-            <h1 className="text-2xl font-semibold truncate">{workflowName}</h1>
+            <h1 className="text-2xl font-semibold truncate animate-fade-down">{workflowName}</h1>
             <Badge variant="secondary" className="shrink-0">
               {search
                 ? `Showing ${total} of ${totalUnfiltered}`

--- a/frontend/src/views/Tools/components/PageHeader.tsx
+++ b/frontend/src/views/Tools/components/PageHeader.tsx
@@ -17,6 +17,6 @@ export const PageHeader: FC<PageHeaderProps> = ({ title, onBack }) => (
     >
       <ArrowLeft className="w-8 h-8 text-muted-foreground" />
     </Button>
-    <h1 className="text-2xl font-semibold">{title}</h1>
+    <h1 className="text-2xl font-semibold animate-fade-down">{title}</h1>
   </div>
 );

--- a/frontend/src/views/Tools/pages/Tools.tsx
+++ b/frontend/src/views/Tools/pages/Tools.tsx
@@ -85,8 +85,8 @@ export default function Tools() {
             <div className="max-w-7xl mx-auto space-y-6">
             <header className="flex justify-between items-center">
               <div>
-                <h1 className="text-3xl font-bold">Tools</h1>
-                <p className="text-muted-foreground">
+                <h1 className="text-3xl font-bold animate-fade-down">Tools</h1>
+                <p className="text-muted-foreground animate-fade-up">
                   View and manage the tools
                 </p>
               </div>


### PR DESCRIPTION
## Description

Aligns page title and subtitle entrance animations across the app so headers use the same animate-fade-down / animate-fade-up pattern on load, matching pages that already had consistent title motion.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

- Add animate-fade-down to page titles that were missing the shared entrance animation
- Add animate-fade-up to matching subtitles/descriptions where present
- Cover Agent Studio, Scheduling, Security, Help Center, Knowledge Base, ML Models, Notifications, Settings, Test Suites, and Tools page headers

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

Closes #


## Screenshots (if applicable)


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
