### PR TITLE
feat: lean saved-versions list via workflow summaries endpoint

### DIFF
--- a/backend/app/api/v1/routes/workflows.py
+++ b/backend/app/api/v1/routes/workflows.py
@@ -18,7 +18,7 @@ from app.modules.workflow.engine.workflow_engine import WorkflowEngine
 from app.modules.workflow.llm.provider import LLMProvider
 from app.modules.workflow.utils import generate_python_function_template
 from app.schemas.dynamic_form_schemas.nodes import NODE_DIALOG_SCHEMAS
-from app.schemas.workflow import Workflow, WorkflowCreate, WorkflowMinimal, WorkflowUpdate
+from app.schemas.workflow import Workflow, WorkflowCreate, WorkflowMinimal, WorkflowSummary, WorkflowUpdate
 from app.services.llm_providers import LlmProviderService
 from app.services.workflow import WorkflowService
 
@@ -138,6 +138,17 @@ async def get_workflows_minimal(service: WorkflowService = Injected(WorkflowServ
     Get a lightweight list of all workflows (id, name, version only).
     """
     return await service.get_all_minimal()
+
+
+@router.get(
+    "/summaries",
+    response_model=List[WorkflowSummary],
+    dependencies=[Depends(auth), Depends(permissions(P.Workflow.READ))],
+)
+async def get_workflow_summaries(
+    agent_id: UUID, service: WorkflowService = Injected(WorkflowService)
+):
+    return await service.get_summaries_by_agent(agent_id)
 
 
 @router.put(

--- a/backend/app/repositories/workflow.py
+++ b/backend/app/repositories/workflow.py
@@ -1,4 +1,5 @@
 from typing import List
+from uuid import UUID
 
 from injector import inject
 from sqlalchemy import select
@@ -16,6 +17,27 @@ class WorkflowRepository(DbRepository[WorkflowModel]):
             WorkflowModel.id,
             WorkflowModel.name,
             WorkflowModel.version,
+        )
+        if hasattr(WorkflowModel, "is_deleted"):
+            stmt = stmt.where(WorkflowModel.is_deleted == 0)
+        result = await self.db.execute(stmt)
+        return result.all()
+
+    async def get_summaries_by_agent(self, agent_id: UUID) -> List:
+        stmt = (
+            select(
+                WorkflowModel.id,
+                WorkflowModel.name,
+                WorkflowModel.description,
+                WorkflowModel.version,
+                WorkflowModel.agent_id,
+                WorkflowModel.created_at,
+                WorkflowModel.updated_at,
+                WorkflowModel.created_by,
+                WorkflowModel.updated_by,
+            )
+            .where(WorkflowModel.agent_id == agent_id)
+            .order_by(WorkflowModel.created_at.desc())
         )
         if hasattr(WorkflowModel, "is_deleted"):
             stmt = stmt.where(WorkflowModel.is_deleted == 0)

--- a/backend/app/schemas/workflow.py
+++ b/backend/app/schemas/workflow.py
@@ -45,6 +45,21 @@ class WorkflowMinimal(BaseModel):
     )
 
 
+class WorkflowSummary(BaseModel):
+    id: UUID
+    name: str
+    description: Optional[str] = None
+    version: str
+    agent_id: Optional[UUID] = None
+    created_at: datetime
+    updated_at: datetime
+    updated_by_username: Optional[str] = None
+
+    model_config = ConfigDict(
+        from_attributes=True
+    )
+
+
 class WorkflowInDB(WorkflowBase):
     id: UUID
     user_id: Optional[UUID] = None

--- a/backend/app/services/workflow.py
+++ b/backend/app/services/workflow.py
@@ -17,7 +17,13 @@ from app.db.models.operator import OperatorModel
 from app.db.models.user import UserModel
 from app.db.models.workflow import WorkflowModel
 from app.repositories.workflow import WorkflowRepository
-from app.schemas.workflow import WorkflowCreate, WorkflowInDB, WorkflowMinimal, WorkflowUpdate
+from app.schemas.workflow import (
+    WorkflowCreate,
+    WorkflowInDB,
+    WorkflowMinimal,
+    WorkflowSummary,
+    WorkflowUpdate,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +42,17 @@ class WorkflowService:
     async def get_all_minimal(self) -> List[WorkflowMinimal]:
         rows = await self.repository.get_all_minimal()
         return [WorkflowMinimal.model_validate(r, from_attributes=True) for r in rows]
+
+    async def get_summaries_by_agent(self, agent_id: UUID) -> List[WorkflowSummary]:
+        rows = await self.repository.get_summaries_by_agent(agent_id)
+        username_map = await self._resolve_usernames(rows)
+        result: List[WorkflowSummary] = []
+        for r in rows:
+            summary = WorkflowSummary.model_validate(r, from_attributes=True)
+            editor_id = r.updated_by or r.created_by
+            summary.updated_by_username = username_map.get(editor_id)
+            result.append(summary)
+        return result
 
     async def get_all(self) -> List[WorkflowInDB]:
         orm_objs = await self.repository.get_all()

--- a/frontend/src/interfaces/workflow.interface.ts
+++ b/frontend/src/interfaces/workflow.interface.ts
@@ -42,6 +42,17 @@ export interface WorkflowMinimal {
   version: string;
 }
 
+export interface WorkflowSummary {
+  id: string;
+  name: string;
+  description?: string;
+  version: string;
+  agent_id?: string;
+  created_at?: string;
+  updated_at?: string;
+  updated_by_username?: string;
+}
+
 // Payload for creating a new workflow
 export interface WorkflowCreatePayload {
   name: string;

--- a/frontend/src/services/workflows.ts
+++ b/frontend/src/services/workflows.ts
@@ -5,6 +5,7 @@ import {
   Workflow,
   WorkflowCreatePayload,
   WorkflowMinimal,
+  WorkflowSummary,
   WorkflowUpdatePayload,
 } from "@/interfaces/workflow.interface";
 import { NodeData } from "@/views/AIAgents/Workflows/types/nodes";
@@ -17,6 +18,12 @@ export const getAllWorkflows = () => apiRequest<Workflow[]>("GET", `${BASE}/`);
 // Get lightweight workflow list (id, name, version only)
 export const getWorkflowsMinimal = () =>
   apiRequest<WorkflowMinimal[]>("GET", `${BASE}/minimal`);
+
+export const getWorkflowSummaries = (agentId: string) =>
+  apiRequest<WorkflowSummary[]>(
+    "GET",
+    `${BASE}/summaries?agent_id=${encodeURIComponent(agentId)}`
+  );
 
 // Get workflow by ID
 export const getWorkflowById = (id: string) =>

--- a/frontend/src/views/AIAgents/Workflows/components/panels/WorkflowsSavedPanel.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/panels/WorkflowsSavedPanel.tsx
@@ -12,7 +12,11 @@ import {
 } from "lucide-react";
 import { Checkbox } from "@/components/checkbox";
 import { Workflow } from "@/interfaces/workflow.interface";
-import { getAllWorkflows, deleteWorkflow } from "@/services/workflows";
+import {
+  getWorkflowSummaries,
+  getWorkflowById,
+  deleteWorkflow,
+} from "@/services/workflows";
 import VersionDiffDialog from "../diff/VersionDiffDialog";
 import {
   Dialog,
@@ -25,6 +29,7 @@ import { RichInput } from "@/components/richInput";
 import { Label } from "@/components/label";
 import { createWorkflow, updateWorkflow } from "@/services/workflows";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { PageListSkeleton } from "@/components/skeletons";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -76,6 +81,7 @@ const WorkflowsSavedPanel: React.FC<WorkflowsSavedPanelProps> = ({
   const [loading, setLoading] = useState(false);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [workflowToEdit, setWorkflowToEdit] = useState<Workflow | null>(null);
   const [workflowName, setWorkflowName] = useState(currentWorkflow.name || "");
   const [workflowVersion, setWorkflowVersion] = useState(
     currentWorkflow.version || ""
@@ -155,18 +161,14 @@ const WorkflowsSavedPanel: React.FC<WorkflowsSavedPanelProps> = ({
       : { base: second, target: first };
   }, [compareSelection, workflows]);
 
-  // Load workflows
   const loadWorkflows = async () => {
     setLoading(true);
     setError(null);
     try {
-      let workflowList = await getAllWorkflows();
-      workflowList = workflowList.filter(
-        (workflow) => workflow["agent_id"] === agentId
-      );
+      const workflowList = await getWorkflowSummaries(agentId);
       workflowList.sort((a, b) => {
-        const dateA = new Date(a.created_at).getTime();
-        const dateB = new Date(b.created_at).getTime();
+        const dateA = new Date(a.created_at ?? 0).getTime();
+        const dateB = new Date(b.created_at ?? 0).getTime();
         return dateB - dateA;
       });
       setWorkflows(workflowList || []);
@@ -174,6 +176,17 @@ const WorkflowsSavedPanel: React.FC<WorkflowsSavedPanelProps> = ({
       setError("Failed to load workflows. Please try again.");
     } finally {
       setLoading(false);
+    }
+  };
+
+  const selectVersion = async (workflow: Workflow) => {
+    if (!workflow.id) return;
+    try {
+      const full = await getWorkflowById(workflow.id);
+      onWorkflowSelect(full);
+      setSelectedWorkflowId(workflow.id);
+    } catch (err) {
+      setError("Failed to load workflow version. Please try again.");
     }
   };
 
@@ -229,15 +242,13 @@ const WorkflowsSavedPanel: React.FC<WorkflowsSavedPanelProps> = ({
       setWorkflowToSelect(workflow);
       setIsUnsavedChangesDialogOpen(true);
     } else {
-      setSelectedWorkflowId(workflow.id);
-      onWorkflowSelect(workflow);
+      selectVersion(workflow);
     }
   };
 
   const handleDiscardAndSwitch = () => {
     if (workflowToSelect) {
-      setSelectedWorkflowId(workflowToSelect.id);
-      onWorkflowSelect(workflowToSelect);
+      selectVersion(workflowToSelect);
     }
     setIsUnsavedChangesDialogOpen(false);
     setWorkflowToSelect(null);
@@ -247,21 +258,30 @@ const WorkflowsSavedPanel: React.FC<WorkflowsSavedPanelProps> = ({
     if (workflowToSelect) {
       setIsSwitching(true);
       await onSaveWorkflow();
-      onWorkflowSelect(workflowToSelect);
-      setSelectedWorkflowId(workflowToSelect.id);
+      await selectVersion(workflowToSelect);
       setIsSwitching(false);
     }
     setIsUnsavedChangesDialogOpen(false);
     setWorkflowToSelect(null);
   };
 
-  const handleEditClick = (workflow: Workflow) => {
+  const handleEditClick = async (workflow: Workflow) => {
     handleWorkflowSelect(workflow);
     setWorkflowName(workflow.name);
     setWorkflowVersion(workflow.version);
     setWorkflowDescription(workflow.description || "");
     setVersionError(null);
     setEditDialogOpen(true);
+
+    if (workflow.id && workflow.id !== currentWorkflow.id) {
+      try {
+        setWorkflowToEdit(await getWorkflowById(workflow.id));
+      } catch (err) {
+        setError("Failed to load workflow version. Please try again.");
+      }
+    } else {
+      setWorkflowToEdit(null);
+    }
   };
 
   const handleActivateClick = async (workflow: Workflow) => {
@@ -273,8 +293,7 @@ const WorkflowsSavedPanel: React.FC<WorkflowsSavedPanelProps> = ({
     setIsActivating(true);
 
     onActiveWorkflowChange(workflowToActivate);
-    setSelectedWorkflowId(workflowToActivate.id);
-    onWorkflowSelect(workflowToActivate);
+    await selectVersion(workflowToActivate);
 
     setWorkflowToActivate(null);
     setIsActivateDialogOpen(false);
@@ -290,14 +309,16 @@ const WorkflowsSavedPanel: React.FC<WorkflowsSavedPanelProps> = ({
   };
 
   const handleUpdateWorkflow = async () => {
-    if (!workflowName.trim() && !currentWorkflow.id) {
+    const target = workflowToEdit ?? currentWorkflow;
+
+    if (!workflowName.trim() && !target.id) {
       return;
     }
 
-    const finalVersion = workflowVersion != "" ? workflowVersion : currentWorkflow.version;
-    
+    const finalVersion = workflowVersion != "" ? workflowVersion : target.version;
+
     // Check for duplicate version (excluding current workflow)
-    if (isVersionDuplicate(workflows, finalVersion, currentWorkflow.id)) {
+    if (isVersionDuplicate(workflows, finalVersion, target.id)) {
       setVersionError(`Version "${finalVersion}" already exists. Please choose a different version number.`);
       return;
     }
@@ -306,16 +327,16 @@ const WorkflowsSavedPanel: React.FC<WorkflowsSavedPanelProps> = ({
     setVersionError(null);
     try {
       const workflowToSave = {
-        ...currentWorkflow,
-        name: workflowName != "" ? workflowName : currentWorkflow.name,
+        ...target,
+        name: workflowName != "" ? workflowName : target.name,
         description:
           workflowDescription != ""
             ? workflowDescription
-            : currentWorkflow.description,
+            : target.description,
         version: finalVersion,
       };
 
-      await updateWorkflow(currentWorkflow.id, workflowToSave);
+      await updateWorkflow(target.id, workflowToSave);
       closeDialogs();
       loadWorkflows();
     } catch (err) {
@@ -347,8 +368,7 @@ const WorkflowsSavedPanel: React.FC<WorkflowsSavedPanelProps> = ({
       
       // Auto-switch to previous version if we deleted the current workflow
       if (isCurrentlySelected && previousVersion) {
-        setSelectedWorkflowId(previousVersion.id);
-        onWorkflowSelect(previousVersion);
+        selectVersion(previousVersion);
       } else if (isCurrentlySelected && updatedWorkflows.length === 0) {
         // If no workflows left, clear selection
         setSelectedWorkflowId(null);
@@ -446,6 +466,9 @@ const WorkflowsSavedPanel: React.FC<WorkflowsSavedPanelProps> = ({
             </div>
           )}
 
+          {loading ? (
+            <PageListSkeleton variant="standard" rows={3} bordered={false} />
+          ) : (
           <div className="space-y-2">
             {workflows.map((workflow) => (
               <div
@@ -559,6 +582,7 @@ const WorkflowsSavedPanel: React.FC<WorkflowsSavedPanelProps> = ({
               </div>
             ))}
           </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Description

Add GET /genagent/workflow/summaries?agent_id= returning only card fields (no nodes/edges/executionState); panel loads this lean list and fetches the full graph by id on open/compare. 
Add skeleton loader.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
