### PR TITLE
fix: scope analytics reads by agent visibility

### DIFF
--- a/backend/app/core/utils/analytics_agent_scope.py
+++ b/backend/app/core/utils/analytics_agent_scope.py
@@ -4,8 +4,11 @@ from uuid import UUID
 
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette_context import context
+from starlette_context.errors import ContextDoesNotExistError
 
-from app.db.events.group_scope import GROUP_SCOPE_BYPASS_FLAG
+from app.auth.utils import current_user_is_admin
+from app.db.events.group_scope import GROUP_SCOPE_BYPASS_FLAG, get_group_scope_clause
 from app.db.models.agent import AgentModel
 from app.db.models.operator import OperatorModel
 from app.db.models.user import UserModel
@@ -79,5 +82,70 @@ async def get_agents_for_group(db: AsyncSession, group_id: UUID) -> list[dict]:
         .order_by(AgentModel.name)
     )
     stmt = stmt.execution_options(**{GROUP_SCOPE_BYPASS_FLAG: True})
+    result = await db.execute(stmt)
+    return [{"id": row.id, "name": row.name} for row in result.all()]
+
+
+def _caller_scope() -> tuple[bool, object | None]:
+    """Return whether the current caller is an admin and their agent visibility filter"""
+    try:
+        user_id = context.get("user_id")
+    except (LookupError, ContextDoesNotExistError):
+        return False, None
+
+    if not user_id:
+        return False, None
+
+    try:
+        if current_user_is_admin():
+            return True, None
+    except Exception:
+        return False, None
+
+    return False, get_group_scope_clause(AgentModel)
+
+
+async def resolve_authorized_agent_ids(
+    db: AsyncSession,
+    agent_id: UUID | None = None,
+    group_id: UUID | None = None,
+) -> list[UUID] | None:
+    """Return the agent IDs the current caller is allowed to query"""
+    is_admin, visibility = _caller_scope()
+    if is_admin:
+        return await resolve_scoped_agent_ids(db, agent_id, group_id)
+    if visibility is None:
+        return []
+
+    stmt = select(AgentModel.id).where(AgentModel.is_deleted == 0, visibility)
+    if agent_id is not None:
+        stmt = stmt.where(AgentModel.id == agent_id)
+    if group_id is not None:
+        stmt = (
+            stmt.outerjoin(OperatorModel, AgentModel.operator_id == OperatorModel.id)
+            .outerjoin(WorkflowModel, AgentModel.workflow_id == WorkflowModel.id)
+            .where(_agents_for_group_clause(group_id))
+            .distinct()
+        )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_authorized_agents_for_group(db: AsyncSession, group_id: UUID) -> list[dict]:
+    """Id/name pairs for the group dropdown, limited to agents the caller may read"""
+    is_admin, visibility = _caller_scope()
+    if is_admin:
+        return await get_agents_for_group(db, group_id)
+    if visibility is None:
+        return []
+
+    stmt = (
+        select(AgentModel.id, AgentModel.name)
+        .outerjoin(OperatorModel, AgentModel.operator_id == OperatorModel.id)
+        .outerjoin(WorkflowModel, AgentModel.workflow_id == WorkflowModel.id)
+        .where(AgentModel.is_deleted == 0, visibility, _agents_for_group_clause(group_id))
+        .distinct()
+        .order_by(AgentModel.name)
+    )
     result = await db.execute(stmt)
     return [{"id": row.id, "name": row.name} for row in result.all()]

--- a/backend/app/repositories/analytics_read.py
+++ b/backend/app/repositories/analytics_read.py
@@ -1,7 +1,11 @@
 import logging
 from datetime import date, datetime, time, timezone
 
-from app.core.utils.analytics_agent_scope import get_agents_for_group, resolve_scoped_agent_ids
+from app.core.utils.analytics_agent_scope import (
+    get_authorized_agents_for_group,
+    resolve_authorized_agent_ids,
+    resolve_scoped_agent_ids,
+)
 from app.core.utils.date_time_utils import previous_period
 from app.core.utils.enums.conversation_status_enum import ConversationStatus
 from uuid import UUID
@@ -36,7 +40,7 @@ class AnalyticsReadRepository:
         self.db = db
 
     async def get_agents_for_group(self, group_id: UUID) -> list[dict]:
-        return await get_agents_for_group(self.db, group_id)
+        return await get_authorized_agents_for_group(self.db, group_id)
 
     async def get_agent_daily_stats(
         self,
@@ -45,7 +49,7 @@ class AnalyticsReadRepository:
         from_date: date | None = None,
         to_date: date | None = None,
     ) -> list[AgentExecutionDailyStatsModel]:
-        agent_ids = await resolve_scoped_agent_ids(self.db, agent_id, group_id)
+        agent_ids = await resolve_authorized_agent_ids(self.db, agent_id, group_id)
         if agent_ids is not None and not agent_ids:
             return []
 
@@ -69,7 +73,7 @@ class AnalyticsReadRepository:
         from_date: date | None = None,
         to_date: date | None = None,
     ) -> list[NodeExecutionDailyStatsModel]:
-        agent_ids = await resolve_scoped_agent_ids(self.db, agent_id, group_id)
+        agent_ids = await resolve_authorized_agent_ids(self.db, agent_id, group_id)
         if agent_ids is not None and not agent_ids:
             return []
 
@@ -220,7 +224,7 @@ class AnalyticsReadRepository:
         from_date: date | None = None,
         to_date: date | None = None,
     ) -> dict:
-        agent_ids = await resolve_scoped_agent_ids(self.db, agent_id, group_id)
+        agent_ids = await resolve_authorized_agent_ids(self.db, agent_id, group_id)
         if agent_ids is not None and not agent_ids and group_id is None:
             return {
                 "total_executions": 0,
@@ -309,6 +313,10 @@ class AnalyticsReadRepository:
         from_date: date | None = None,
         to_date: date | None = None,
     ) -> list[dict]:
+        agent_ids = await resolve_authorized_agent_ids(self.db, agent_id=agent_id)
+        if not agent_ids:
+            return []
+
         stmt = select(
             NodeExecutionDailyStatsModel.node_type,
             func.sum(NodeExecutionDailyStatsModel.execution_count).label("execution_count"),
@@ -349,21 +357,15 @@ class AnalyticsReadRepository:
         from app.db.models.workflow import WorkflowModel
         from app.core.utils.custom_attributes import get_filterable_keys
 
-        agent_ids = await resolve_scoped_agent_ids(self.db, agent_id, group_id)
-        if agent_ids is not None and not agent_ids and group_id is None:
+        agent_ids = await resolve_authorized_agent_ids(self.db, agent_id, group_id)
+        if agent_ids is not None and not agent_ids:
             return []
 
-        if agent_ids is not None and agent_ids:
+        if agent_ids is not None:
             stmt = (
                 select(WorkflowModel.nodes)
                 .join(AgentModel, AgentModel.workflow_id == WorkflowModel.id)
                 .where(AgentModel.id.in_(agent_ids))
-            )
-        elif agent_id is not None:
-            stmt = (
-                select(WorkflowModel.nodes)
-                .join(AgentModel, AgentModel.workflow_id == WorkflowModel.id)
-                .where(AgentModel.id == agent_id)
             )
         else:
             stmt = select(WorkflowModel.nodes)

--- a/backend/app/repositories/dashboard.py
+++ b/backend/app/repositories/dashboard.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import selectinload
 
+from app.core.utils.analytics_agent_scope import resolve_authorized_agent_ids
 from app.core.utils.date_time_utils import utc_day_start
 from app.db.events.group_scope import get_group_scope_clause
 from app.db.models.agent import AgentModel
@@ -62,17 +63,29 @@ class DashboardRepository:
         result = await self.db.execute(query)
         return result.scalar() or 0
 
+    async def resolve_visible_agent_ids(self) -> list[UUID] | None:
+        """Caller's agent scope for the summary aggregates (None = unrestricted admin)"""
+        return await resolve_authorized_agent_ids(self.db)
+
     async def get_avg_response_time(
         self,
         from_date: Optional[datetime] = None,
-        to_date: Optional[datetime] = None
+        to_date: Optional[datetime] = None,
+        *,
+        agent_ids: list[UUID] | None,
     ) -> int:
         """Get average response time in milliseconds from the pre-aggregated daily stats.
 
         Reads the twice-daily aggregated agent_execution_daily_stats table instead of
         recomputing from raw transcript messages on every request. Days are combined as
         an execution-count-weighted average, matching the analytics summary convention.
+
+        ``agent_ids`` is required because the stats table is not group-scoped: ``None``
+        is an explicit tenant-wide (admin) scope, ``[]`` short-circuits to zero.
         """
+        if agent_ids is not None and not agent_ids:
+            return 0
+
         weighted_sum = func.sum(
             AgentExecutionDailyStatsModel.avg_response_ms
             * AgentExecutionDailyStatsModel.execution_count
@@ -83,6 +96,8 @@ class DashboardRepository:
             weighted_sum / func.nullif(total_executions, 0)
         ).where(AgentExecutionDailyStatsModel.is_deleted == 0)
 
+        if agent_ids is not None:
+            query = query.where(AgentExecutionDailyStatsModel.agent_id.in_(agent_ids))
         if from_date:
             query = query.where(AgentExecutionDailyStatsModel.stat_date >= from_date)
         if to_date:
@@ -346,13 +361,20 @@ class DashboardRepository:
         result = await self.db.execute(query)
         return list(result.scalars().all())
 
-    async def get_total_cost_usd(self, from_date: datetime, to_date: datetime) -> float:
+    async def get_total_cost_usd(
+        self, from_date: datetime, to_date: datetime, *, agent_ids: list[UUID] | None
+    ) -> float:
         """Total priced LLM cost over the range from the usage ledger"""
+        if agent_ids is not None and not agent_ids:
+            return 0.0
+
         window_start, window_end = _ledger_window(from_date, to_date)
         query = select(func.coalesce(func.sum(LlmUsageEventModel.cost_usd), 0)).where(
             LlmUsageEventModel.is_deleted == 0,
             LlmUsageEventModel.occurred_at >= window_start,
             LlmUsageEventModel.occurred_at < window_end,
         )
+        if agent_ids is not None:
+            query = query.where(LlmUsageEventModel.agent_id.in_(agent_ids))
         result = await self.db.execute(query)
         return float(result.scalar() or 0.00)

--- a/backend/app/repositories/llm_usage_read.py
+++ b/backend/app/repositories/llm_usage_read.py
@@ -6,7 +6,7 @@ from sqlalchemy import Date, cast, distinct, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config.llm_pricing import PricingStatus
-from app.core.utils.analytics_agent_scope import resolve_scoped_agent_ids
+from app.core.utils.analytics_agent_scope import resolve_authorized_agent_ids
 from app.db.models.llm_usage import LlmUsageEventModel
 from app.repositories.db_repository import DbRepository
 
@@ -40,7 +40,7 @@ class LlmUsageReadRepository(DbRepository[LlmUsageEventModel]):
         super().__init__(LlmUsageEventModel, db)
 
     async def resolve_scope(self, params) -> list[UUID] | None:
-        return await resolve_scoped_agent_ids(self.db, params.agent_id, params.group_id)
+        return await resolve_authorized_agent_ids(self.db, params.agent_id, params.group_id)
 
     @staticmethod
     def _conditions(params, scope: list[UUID] | None, *, use_provider: bool = True, use_model: bool = True) -> list:

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -75,8 +75,13 @@ class DashboardService:
         """Get summary statistics for the dashboard header."""
         active_agents = await self.dashboard_repo.get_active_agents_count()
         workflow_runs = await self.dashboard_repo.get_workflow_runs_count(from_date, to_date)
-        avg_response_time = await self.dashboard_repo.get_avg_response_time(from_date, to_date)
-        total_cost_usd = await self.dashboard_repo.get_total_cost_usd(from_date, to_date)
+        visible_agent_ids = await self.dashboard_repo.resolve_visible_agent_ids()
+        avg_response_time = await self.dashboard_repo.get_avg_response_time(
+            from_date, to_date, agent_ids=visible_agent_ids
+        )
+        total_cost_usd = await self.dashboard_repo.get_total_cost_usd(
+            from_date, to_date, agent_ids=visible_agent_ids
+        )
 
         return DashboardSummaryStats(
             active_agents=active_agents,

--- a/backend/tests/integration/analytics/test_group_authorization.py
+++ b/backend/tests/integration/analytics/test_group_authorization.py
@@ -1,0 +1,564 @@
+"""Integration tests for cross-group authorization of the analytics and LLM-usage reads"""
+
+from contextlib import contextmanager
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from starlette_context import context, request_cycle_context
+
+from app.core.config.settings import settings
+from app.db.models.agent import AgentModel
+from app.db.models.agent_execution_daily_stats import AgentExecutionDailyStatsModel
+from app.db.models.agent_response_log import AgentResponseLogModel
+from app.db.models.conversation import ConversationModel
+from app.db.models.llm_usage import LlmUsageEventModel
+from app.db.models.message_model import TranscriptMessageModel
+from app.db.models.node_execution_daily_stats import NodeExecutionDailyStatsModel
+from app.db.models.operator import OperatorModel, OperatorStatisticsModel
+from app.db.models.user import UserModel
+from app.db.models.user_group import UserGroupModel
+from app.db.models.workflow import WorkflowModel
+from app.repositories.agent import AgentRepository
+from app.repositories.analytics_read import AnalyticsReadRepository
+from app.repositories.dashboard import DashboardRepository
+from app.repositories.llm_usage_read import LlmUsageReadRepository
+from app.schemas.llm_usage import LlmUsageQueryParams
+from app.services.llm_usage_read import LlmUsageReadService
+
+COST = {"a1": Decimal("0.11"), "a2": Decimal("0.22"), "a1_deleted": Decimal("0.33"), "unattributed": Decimal("0.44")}
+TOTAL_COST = float(sum(COST.values()))
+
+# Distinct per agent so a weighted average differs by scope: (ms, executions).
+RESPONSE = {"a1": (100.0, 10), "a2": (500.0, 30), "a1_deleted": (900.0, 5)}
+BLENDED_MS = int(sum(ms * n for ms, n in RESPONSE.values()) / sum(n for _, n in RESPONSE.values()))
+
+NODE_TYPE = {"a1": "authzNodeA", "a2": "authzNodeB"}
+ATTRIBUTE_KEY = {"a1": "authz_attr_a", "a2": "authz_attr_b"}
+PROVIDER = {"a1": "authzprov-a", "a2": "authzprov-b", "a1_deleted": "authzprov-del", "unattributed": "authzprov-none"}
+MODEL = {k: f"{v}-model" for k, v in PROVIDER.items()}
+
+PROBE_START = date(2099, 1, 15)
+
+
+@contextmanager
+def caller(*, user_id=None, group_id=None, supervised=(), admin=False):
+    """Request context for one principal — the four keys ``auth()`` populates."""
+    with request_cycle_context():
+        context["user_id"] = user_id
+        context["group_id"] = group_id
+        context["supervised_group_ids"] = list(supervised)
+        context["user_roles"] = [SimpleNamespace(name="admin" if admin else "operator")]
+        yield
+
+
+@contextmanager
+def acting_as(user_id):
+    """Own the rows flushed inside this block.
+
+    The audit ``before_flush`` listener overwrites ``created_by`` with the request
+    context's user on every insert, so a constructor-set ``created_by`` is discarded.
+    Admin roles keep the group-scope listener off the fixture's own reads.
+    """
+    with caller(user_id=user_id, admin=True):
+        yield
+
+
+def _workflow(name: str, user_id, attribute_key: str) -> WorkflowModel:
+    nodes = [
+        {
+            "id": "chat-input",
+            "type": "chatInputNode",
+            "data": {"inputSchema": {attribute_key: {"useInFilter": True}}},
+        }
+    ]
+    return WorkflowModel(id=uuid4(), name=name, version="1", nodes=nodes, edges=[], user_id=user_id, is_deleted=0)
+
+
+def _event(agent_id, *, provider: str, occurred_at: datetime, cost: Decimal) -> LlmUsageEventModel:
+    return LlmUsageEventModel(
+        id=uuid4(),
+        execution_id=f"authz-{uuid4()}",
+        call_index=0,
+        source_type="workflow",
+        source="chat",
+        agent_id=agent_id,
+        provider_key=provider,
+        model_key=f"{provider}-model",
+        input_tokens=100,
+        output_tokens=50,
+        total_tokens=150,
+        cost_usd=cost,
+        pricing_status="configured",
+        occurred_at=occurred_at,
+        is_deleted=0,
+    )
+
+
+async def _free_window(session) -> date:
+    """First far-future day with no rows in any table this suite asserts totals over.
+
+    The local database keeps seeded and prior-run rows, and admin reads are tenant-wide,
+    so every total below is only deterministic inside an otherwise empty day.
+    """
+    day = PROBE_START
+    for _ in range(365):
+        start = datetime.combine(day, datetime.min.time(), tzinfo=timezone.utc)
+        end = start + timedelta(days=1)
+        counts = [
+            select(func.count()).select_from(LlmUsageEventModel).where(
+                LlmUsageEventModel.occurred_at >= start, LlmUsageEventModel.occurred_at < end
+            ),
+            select(func.count()).select_from(AgentExecutionDailyStatsModel).where(
+                AgentExecutionDailyStatsModel.stat_date == day
+            ),
+            select(func.count()).select_from(NodeExecutionDailyStatsModel).where(
+                NodeExecutionDailyStatsModel.stat_date == day
+            ),
+            select(func.count()).select_from(AgentResponseLogModel).where(
+                AgentResponseLogModel.logged_at >= start, AgentResponseLogModel.logged_at < end
+            ),
+        ]
+        occupied = False
+        for stmt in counts:
+            if (await session.execute(stmt)).scalar():
+                occupied = True
+                break
+        if not occupied:
+            return day
+        day += timedelta(days=1)
+    raise AssertionError("no collision-free window found")
+
+
+class World:
+
+    def __init__(self, maker):
+        self.maker = maker
+        self.groups: dict[str, UserGroupModel] = {}
+        self.users: dict[str, UserModel] = {}
+        self.agents: dict[str, AgentModel] = {}
+        self.workflows: dict[str, WorkflowModel] = {}
+        self.operator_ids: list = []
+        self.statistics_ids: list = []
+        self.event_ids: list = []
+        self.conversation_id = None
+        self.message_id = None
+        self.response_log_id = None
+        self.day: date = PROBE_START
+
+    def agent_id(self, key):
+        return self.agents[key].id
+
+    def group_id(self, key):
+        return self.groups[key].id
+
+    def user_id(self, key):
+        return self.users[key].id
+
+    @property
+    def window(self) -> tuple[datetime, datetime]:
+        start = datetime.combine(self.day, datetime.min.time(), tzinfo=timezone.utc)
+        return start, start
+
+    @property
+    def params(self) -> LlmUsageQueryParams:
+        return LlmUsageQueryParams(from_date=self.day, to_date=self.day)
+
+
+@pytest_asyncio.fixture(loop_scope="module")
+async def world(app_def):
+    engine = create_async_engine(settings.DATABASE_URL)
+    maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    built = World(maker)
+
+    async with maker() as session:
+        built.day = await _free_window(session)
+        noon = datetime.combine(built.day, datetime.min.time(), tzinfo=timezone.utc) + timedelta(hours=12)
+        user_type_id = (await session.execute(select(UserModel.user_type_id).limit(1))).scalar_one()
+
+        for key in ("g1", "g2"):
+            built.groups[key] = UserGroupModel(id=uuid4(), name=f"authz-{key}-{uuid4().hex[:8]}", is_deleted=0)
+        session.add_all(built.groups.values())
+
+        for user_key, group_key in (("u1", "g1"), ("u2", "g2")):
+            suffix = uuid4().hex[:12]
+            built.users[user_key] = UserModel(
+                id=uuid4(),
+                username=f"authz-{user_key}-{suffix}",
+                email=f"authz-{user_key}-{suffix}@example.test",
+                hashed_password="x",
+                user_type_id=user_type_id,
+                is_active=1,
+                group_id=built.groups[group_key].id,
+                is_deleted=0,
+            )
+        session.add_all(built.users.values())
+        await session.flush()
+
+        # a1_deleted needs its own operator: AgentModel.operator_id is unique.
+        for agent_key, user_key, is_deleted in (("a1", "u1", 0), ("a2", "u2", 0), ("a1_deleted", "u1", 1)):
+            user_id = built.users[user_key].id
+            with acting_as(user_id):
+                statistics = OperatorStatisticsModel(id=uuid4(), is_deleted=0)
+                session.add(statistics)
+                built.statistics_ids.append(statistics.id)
+                operator = OperatorModel(
+                    id=uuid4(),
+                    first_name="Authz",
+                    last_name=agent_key,
+                    statistics_id=statistics.id,
+                    is_active=1,
+                    user_id=user_id,
+                    is_deleted=0,
+                )
+                session.add(operator)
+                built.operator_ids.append(operator.id)
+                workflow = _workflow(
+                    f"authz-{agent_key}", user_id, ATTRIBUTE_KEY.get(agent_key, f"authz_attr_{agent_key}")
+                )
+                built.workflows[agent_key] = workflow
+                session.add(workflow)
+                agent = AgentModel(
+                    id=uuid4(),
+                    name=f"authz-{agent_key}",
+                    is_active=1,
+                    operator_id=operator.id,
+                    welcome_message="Welcome",
+                    workflow_id=workflow.id,
+                    is_deleted=is_deleted,
+                )
+                built.agents[agent_key] = agent
+                session.add(agent)
+                await session.flush()
+
+        for agent_key, (avg_ms, executions) in RESPONSE.items():
+            session.add(
+                AgentExecutionDailyStatsModel(
+                    id=uuid4(),
+                    agent_id=built.agent_id(agent_key),
+                    stat_date=built.day,
+                    execution_count=executions,
+                    success_count=executions,
+                    error_count=0,
+                    avg_response_ms=avg_ms,
+                    avg_success_rate=100.0,
+                    last_aggregated_at=noon,
+                    is_deleted=0,
+                )
+            )
+        for agent_key, node_type in NODE_TYPE.items():
+            session.add(
+                NodeExecutionDailyStatsModel(
+                    id=uuid4(),
+                    agent_id=built.agent_id(agent_key),
+                    node_type=node_type,
+                    stat_date=built.day,
+                    execution_count=RESPONSE[agent_key][1],
+                    success_count=RESPONSE[agent_key][1],
+                    failure_count=0,
+                    total_execution_ms=1000.0,
+                    is_deleted=0,
+                )
+            )
+
+        for key, cost in COST.items():
+            agent_id = None if key == "unattributed" else built.agent_id(key)
+            event = _event(agent_id, provider=PROVIDER[key], occurred_at=noon, cost=cost)
+            built.event_ids.append(event.id)
+            session.add(event)
+
+        # Group B conversation chain — the foreign-conversation regression only.
+        built.conversation_id = uuid4()
+        session.add(
+            ConversationModel(
+                id=built.conversation_id,
+                operator_id=built.agents["a2"].operator_id,
+                group_id=built.group_id("g2"),
+                conversation_type="chat",
+                conversation_date=noon,
+                status="finalized",
+                is_deleted=0,
+            )
+        )
+        await session.flush()
+        built.message_id = uuid4()
+        session.add(
+            TranscriptMessageModel(
+                id=built.message_id,
+                conversation_id=built.conversation_id,
+                start_time=0.0,
+                end_time=1.0,
+                speaker="agent",
+                text="authz fixture message",
+                type="text",
+                sequence_number=1,
+                is_deleted=0,
+            )
+        )
+        await session.flush()
+        built.response_log_id = uuid4()
+        session.add(
+            AgentResponseLogModel(
+                id=built.response_log_id,
+                transcript_message_id=built.message_id,
+                conversation_id=built.conversation_id,
+                raw_response="{}",
+                logged_at=noon,
+                is_deleted=0,
+            )
+        )
+        await session.commit()
+
+    try:
+        yield built
+    finally:
+        agent_ids = [a.id for a in built.agents.values()]
+        async with maker() as session:
+            await session.execute(delete(LlmUsageEventModel).where(LlmUsageEventModel.id.in_(built.event_ids)))
+            await session.execute(delete(AgentResponseLogModel).where(AgentResponseLogModel.id == built.response_log_id))
+            await session.execute(delete(TranscriptMessageModel).where(TranscriptMessageModel.id == built.message_id))
+            await session.execute(delete(ConversationModel).where(ConversationModel.id == built.conversation_id))
+            await session.execute(
+                delete(AgentExecutionDailyStatsModel).where(AgentExecutionDailyStatsModel.agent_id.in_(agent_ids))
+            )
+            await session.execute(
+                delete(NodeExecutionDailyStatsModel).where(NodeExecutionDailyStatsModel.agent_id.in_(agent_ids))
+            )
+            await session.execute(delete(AgentModel).where(AgentModel.id.in_(agent_ids)))
+            await session.execute(delete(OperatorModel).where(OperatorModel.id.in_(built.operator_ids)))
+            await session.execute(
+                delete(OperatorStatisticsModel).where(OperatorStatisticsModel.id.in_(built.statistics_ids))
+            )
+            await session.execute(
+                delete(WorkflowModel).where(WorkflowModel.id.in_([w.id for w in built.workflows.values()]))
+            )
+            await session.execute(delete(UserModel).where(UserModel.id.in_([u.id for u in built.users.values()])))
+            await session.execute(delete(UserGroupModel).where(UserGroupModel.id.in_([g.id for g in built.groups.values()])))
+            await session.commit()
+        await engine.dispose()
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_admin_reads_remain_tenant_wide_including_unattributed_spend(world):
+    async with world.maker() as session:
+        repo = LlmUsageReadRepository(session)
+        with caller(user_id=uuid4(), admin=True):
+            scope = await repo.resolve_scope(world.params)
+            row = await repo.summary(world.params, scope)
+
+    assert scope is None
+    assert float(row[0]) == pytest.approx(TOTAL_COST)
+    assert row[4] == len(COST)
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_regular_user_sees_only_their_groups_agent_stats(world):
+    async with world.maker() as session:
+        repo = AnalyticsReadRepository(session)
+        with caller(user_id=world.user_id("u1"), group_id=world.group_id("g1")):
+            daily = await repo.get_agent_daily_stats(from_date=world.day, to_date=world.day)
+            nodes = await repo.get_node_daily_stats(from_date=world.day, to_date=world.day)
+            summary = await repo.get_agent_stats_summary(from_date=world.day, to_date=world.day)
+
+    assert [row.agent_id for row in daily] == [world.agent_id("a1")]
+    assert [row.node_type for row in nodes] == [NODE_TYPE["a1"]]
+    assert summary["total_executions"] == RESPONSE["a1"][1]
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_regular_user_cannot_widen_scope_with_a_foreign_group_filter(world):
+    async with world.maker() as session:
+        repo = AnalyticsReadRepository(session)
+        with caller(user_id=world.user_id("u1"), group_id=world.group_id("g1")):
+            daily = await repo.get_agent_daily_stats(
+                group_id=world.group_id("g2"), from_date=world.day, to_date=world.day
+            )
+            summary = await repo.get_agent_stats_summary(
+                group_id=world.group_id("g2"), from_date=world.day, to_date=world.day
+            )
+
+    assert daily == []
+    assert summary["total_executions"] == 0
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_foreign_group_filter_reveals_no_foreign_conversations(world):
+    """Conversation counts keep their own group visibility — foreign rows stay hidden."""
+    async with world.maker() as session:
+        repo = AnalyticsReadRepository(session)
+        with caller(user_id=world.user_id("u1"), group_id=world.group_id("g1")):
+            restricted = await repo.get_agent_stats_summary(
+                group_id=world.group_id("g2"), from_date=world.day, to_date=world.day
+            )
+        with caller(user_id=uuid4(), admin=True):
+            unrestricted = await repo.get_agent_stats_summary(
+                group_id=world.group_id("g2"), from_date=world.day, to_date=world.day
+            )
+
+    assert restricted["total_unique_conversations"] == 0
+    assert unrestricted["total_unique_conversations"] == 1
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_foreign_agent_filter_returns_empty_rather_than_existence_info(world):
+    async with world.maker() as session:
+        repo = AnalyticsReadRepository(session)
+        with caller(user_id=world.user_id("u1"), group_id=world.group_id("g1")):
+            rows = await repo.get_agent_daily_stats(
+                agent_id=world.agent_id("a2"), from_date=world.day, to_date=world.day
+            )
+    assert rows == []
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_agent_and_group_mismatch_resolves_to_nothing(world):
+    async with world.maker() as session:
+        repo = AnalyticsReadRepository(session)
+        with caller(user_id=world.user_id("u1"), group_id=world.group_id("g1")):
+            rows = await repo.get_agent_daily_stats(
+                agent_id=world.agent_id("a1"),
+                group_id=world.group_id("g2"),
+                from_date=world.day,
+                to_date=world.day,
+            )
+    assert rows == []
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_node_breakdown_is_denied_for_foreign_agents_and_served_for_own(world):
+    async with world.maker() as session:
+        repo = AnalyticsReadRepository(session)
+        with caller(user_id=world.user_id("u1"), group_id=world.group_id("g1")):
+            foreign = await repo.get_node_type_breakdown(world.agent_id("a2"), world.day, world.day)
+            own = await repo.get_node_type_breakdown(world.agent_id("a1"), world.day, world.day)
+
+    assert foreign == []
+    assert [row["node_type"] for row in own] == [NODE_TYPE["a1"]]
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_group_agent_dropdown_only_lists_agents_the_caller_can_see(world):
+    async with world.maker() as session:
+        repo = AnalyticsReadRepository(session)
+        with caller(user_id=world.user_id("u1"), group_id=world.group_id("g1")):
+            foreign = await repo.get_agents_for_group(world.group_id("g2"))
+            own = await repo.get_agents_for_group(world.group_id("g1"))
+        with caller(user_id=uuid4(), admin=True):
+            as_admin = await repo.get_agents_for_group(world.group_id("g2"))
+
+    assert foreign == []
+    assert [row["id"] for row in own] == [world.agent_id("a1")]
+    assert [row["id"] for row in as_admin] == [world.agent_id("a2")]
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_supervisor_context_grants_all_supervised_groups(world):
+    async with world.maker() as session:
+        repo = AnalyticsReadRepository(session)
+        with caller(
+            user_id=world.user_id("u1"),
+            group_id=world.group_id("g1"),
+            supervised=[world.group_id("g1"), world.group_id("g2")],
+        ):
+            rows = await repo.get_agent_daily_stats(from_date=world.day, to_date=world.day)
+
+    assert {row.agent_id for row in rows} == {world.agent_id("a1"), world.agent_id("a2")}
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_soft_deleted_agents_are_invisible_to_non_admins(world):
+    async with world.maker() as session:
+        repo = AnalyticsReadRepository(session)
+        with caller(user_id=world.user_id("u1"), group_id=world.group_id("g1")):
+            rows = await repo.get_agent_daily_stats(from_date=world.day, to_date=world.day)
+            denied = await repo.get_agent_daily_stats(
+                agent_id=world.agent_id("a1_deleted"), from_date=world.day, to_date=world.day
+            )
+
+    assert world.agent_id("a1_deleted") not in {row.agent_id for row in rows}
+    assert denied == []
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_missing_context_fails_closed_for_every_scoped_read(world):
+    async with world.maker() as session:
+        analytics = AnalyticsReadRepository(session)
+        daily = await analytics.get_agent_daily_stats(from_date=world.day, to_date=world.day)
+        nodes = await analytics.get_node_daily_stats(from_date=world.day, to_date=world.day)
+        breakdown = await analytics.get_node_type_breakdown(world.agent_id("a1"), world.day, world.day)
+        keys = await analytics.get_custom_attribute_keys()
+        summary = await analytics.get_agent_stats_summary(from_date=world.day, to_date=world.day)
+        ledger_scope = await LlmUsageReadRepository(session).resolve_scope(world.params)
+        dashboard_scope = await DashboardRepository(session).resolve_visible_agent_ids()
+
+    assert (daily, nodes, breakdown, keys) == ([], [], [], [])
+    assert summary["total_executions"] == 0
+    assert ledger_scope == [] and dashboard_scope == []
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_custom_attribute_keys_are_limited_to_visible_workflows(world):
+    async with world.maker() as session:
+        repo = AnalyticsReadRepository(session)
+        with caller(user_id=world.user_id("u1"), group_id=world.group_id("g1")):
+            keys = await repo.get_custom_attribute_keys()
+
+    assert ATTRIBUTE_KEY["a1"] in keys
+    assert ATTRIBUTE_KEY["a2"] not in keys
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_llm_usage_filter_options_expose_only_visible_providers_models_and_agents(world):
+    async with world.maker() as session:
+        service = LlmUsageReadService(LlmUsageReadRepository(session), AgentRepository(session))
+        with caller(user_id=world.user_id("u1"), group_id=world.group_id("g1")):
+            options = await service.get_filter_options(world.params)
+
+    assert options.providers == [PROVIDER["a1"]]
+    assert options.models == [MODEL["a1"]]
+    assert [a.id for a in options.agents] == [world.agent_id("a1")]
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_llm_usage_scope_excludes_foreign_and_unattributed_events(world):
+    async with world.maker() as session:
+        repo = LlmUsageReadRepository(session)
+        with caller(user_id=world.user_id("u1"), group_id=world.group_id("g1")):
+            scope = await repo.resolve_scope(world.params)
+            row = await repo.summary(world.params, scope)
+
+    assert scope == [world.agent_id("a1")]
+    assert row[4] == 1
+    assert float(row[0]) == pytest.approx(float(COST["a1"]))
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_dashboard_cost_and_response_time_follow_the_visible_scope(world):
+    start, end = world.window
+    async with world.maker() as session:
+        dashboard = DashboardRepository(session)
+        service = LlmUsageReadService(LlmUsageReadRepository(session), AgentRepository(session))
+
+        with caller(user_id=uuid4(), admin=True):
+            admin_scope = await dashboard.resolve_visible_agent_ids()
+            admin_cost = await dashboard.get_total_cost_usd(start, end, agent_ids=admin_scope)
+            admin_ms = await dashboard.get_avg_response_time(start, end, agent_ids=admin_scope)
+            admin_explorer = (await service.get_summary(world.params)).total_cost_usd
+
+        with caller(user_id=world.user_id("u1"), group_id=world.group_id("g1")):
+            user_scope = await dashboard.resolve_visible_agent_ids()
+            user_cost = await dashboard.get_total_cost_usd(start, end, agent_ids=user_scope)
+            user_ms = await dashboard.get_avg_response_time(start, end, agent_ids=user_scope)
+            user_explorer = (await service.get_summary(world.params)).total_cost_usd
+
+    assert admin_scope is None and user_scope == [world.agent_id("a1")]
+    assert admin_cost == pytest.approx(TOTAL_COST) and admin_ms == BLENDED_MS
+    assert user_cost == pytest.approx(float(COST["a1"])) and user_ms == int(RESPONSE["a1"][0])
+    assert admin_explorer == pytest.approx(admin_cost)
+    assert user_explorer == pytest.approx(user_cost)

--- a/backend/tests/integration/llm_usage/test_dashboard_ledger_cost.py
+++ b/backend/tests/integration/llm_usage/test_dashboard_ledger_cost.py
@@ -1,7 +1,9 @@
 """Integration tests for the dashboard reading LLM cost from the ledger"""
 
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
@@ -9,6 +11,7 @@ import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
+from starlette_context import context, request_cycle_context
 
 from app.core.config.settings import settings
 from app.db.models.agent import AgentModel
@@ -62,16 +65,26 @@ def _today_range() -> tuple[datetime, datetime]:
     return start, start
 
 
+@contextmanager
+def _admin_context():
+    with request_cycle_context():
+        context["user_id"] = uuid4()
+        context["group_id"] = None
+        context["supervised_group_ids"] = []
+        context["user_roles"] = [SimpleNamespace(name="admin")]
+        yield
+
+
 @pytest.mark.asyncio
 async def test_ledger_total_sums_priced_cost(db):
     repo = DashboardRepository(db)
     start, end = _today_range()
-    before = await repo.get_total_cost_usd(start, end)
+    before = await repo.get_total_cost_usd(start, end, agent_ids=None)
 
     db.add(_event(cost_usd=Decimal("0.25")))
     await db.flush()
 
-    after = await repo.get_total_cost_usd(start, end)
+    after = await repo.get_total_cost_usd(start, end, agent_ids=None)
     assert after - before == pytest.approx(0.25)
 
 
@@ -79,12 +92,12 @@ async def test_ledger_total_sums_priced_cost(db):
 async def test_ledger_total_excludes_unpriced(db):
     repo = DashboardRepository(db)
     start, end = _today_range()
-    before = await repo.get_total_cost_usd(start, end)
+    before = await repo.get_total_cost_usd(start, end, agent_ids=None)
 
     db.add(_event(cost_usd=None, input_per_1k=None, output_per_1k=None, pricing_status="unpriced"))
     await db.flush()
 
-    after = await repo.get_total_cost_usd(start, end)
+    after = await repo.get_total_cost_usd(start, end, agent_ids=None)
     assert after == pytest.approx(before)
 
 
@@ -92,12 +105,12 @@ async def test_ledger_total_excludes_unpriced(db):
 async def test_ledger_total_excludes_events_outside_window(db):
     repo = DashboardRepository(db)
     start, end = _today_range()
-    before = await repo.get_total_cost_usd(start, end)
+    before = await repo.get_total_cost_usd(start, end, agent_ids=None)
 
     db.add(_event(cost_usd=Decimal("0.99"), occurred_at=start - timedelta(hours=1)))
     await db.flush()
 
-    after = await repo.get_total_cost_usd(start, end)
+    after = await repo.get_total_cost_usd(start, end, agent_ids=None)
     assert after == pytest.approx(before)
 
 
@@ -105,12 +118,12 @@ async def test_ledger_total_excludes_events_outside_window(db):
 async def test_ledger_total_upper_bound_is_exclusive_of_the_next_day(db):
     repo = DashboardRepository(db)
     start, end = _today_range()
-    before = await repo.get_total_cost_usd(start, end)
+    before = await repo.get_total_cost_usd(start, end, agent_ids=None)
 
     db.add(_event(cost_usd=Decimal("0.99"), occurred_at=start + timedelta(days=1)))
     await db.flush()
 
-    after = await repo.get_total_cost_usd(start, end)
+    after = await repo.get_total_cost_usd(start, end, agent_ids=None)
     assert after == pytest.approx(before)
 
 
@@ -119,12 +132,12 @@ async def test_ledger_total_drops_the_day_of_a_mid_day_lower_bound(db):
     repo = DashboardRepository(db)
     start, end = _today_range()
     mid_day = start + timedelta(hours=13)
-    before = await repo.get_total_cost_usd(mid_day, end)
+    before = await repo.get_total_cost_usd(mid_day, end, agent_ids=None)
 
     db.add(_event(cost_usd=Decimal("0.99"), occurred_at=start + timedelta(hours=20)))
     await db.flush()
 
-    after = await repo.get_total_cost_usd(mid_day, end)
+    after = await repo.get_total_cost_usd(mid_day, end, agent_ids=None)
     assert after == pytest.approx(before)
 
 
@@ -132,12 +145,12 @@ async def test_ledger_total_drops_the_day_of_a_mid_day_lower_bound(db):
 async def test_ledger_total_excludes_soft_deleted_events(db):
     repo = DashboardRepository(db)
     start, end = _today_range()
-    before = await repo.get_total_cost_usd(start, end)
+    before = await repo.get_total_cost_usd(start, end, agent_ids=None)
 
     db.add(_event(cost_usd=Decimal("0.77"), is_deleted=1))
     await db.flush()
 
-    after = await repo.get_total_cost_usd(start, end)
+    after = await repo.get_total_cost_usd(start, end, agent_ids=None)
     assert after == pytest.approx(before)
 
 
@@ -261,12 +274,12 @@ async def test_agent_cost_today_ledger_excludes_soft_deleted_events(db):
 async def test_ledger_total_includes_analyst_source(db):
     repo = DashboardRepository(db)
     start, end = _today_range()
-    before = await repo.get_total_cost_usd(start, end)
+    before = await repo.get_total_cost_usd(start, end, agent_ids=None)
 
     db.add(_event(source_type="llm_analyst", source="conversation_analysis", cost_usd=Decimal("0.30")))
     await db.flush()
 
-    after = await repo.get_total_cost_usd(start, end)
+    after = await repo.get_total_cost_usd(start, end, agent_ids=None)
     assert after - before == pytest.approx(0.30)
 
 
@@ -305,14 +318,16 @@ async def test_cost_explorer_summary_total_matches_dashboard_total(db):
     start, end = _today_range()
     params = LlmUsageQueryParams(from_date=start.date(), to_date=end.date())
 
-    dashboard_before = await dashboard_repo.get_total_cost_usd(start, end)
-    summary_before = (await read_service.get_summary(params)).total_cost_usd
+    dashboard_before = await dashboard_repo.get_total_cost_usd(start, end, agent_ids=None)
+    with _admin_context():
+        summary_before = (await read_service.get_summary(params)).total_cost_usd
     assert summary_before == pytest.approx(dashboard_before)
 
     db.add(_event(cost_usd=Decimal("0.65")))
     await db.flush()
 
-    dashboard_after = await dashboard_repo.get_total_cost_usd(start, end)
-    summary_after = (await read_service.get_summary(params)).total_cost_usd
+    dashboard_after = await dashboard_repo.get_total_cost_usd(start, end, agent_ids=None)
+    with _admin_context():
+        summary_after = (await read_service.get_summary(params)).total_cost_usd
     assert summary_after == pytest.approx(dashboard_after)
     assert dashboard_after - dashboard_before == pytest.approx(0.65)

--- a/backend/tests/unit/test_analytics_agent_scope.py
+++ b/backend/tests/unit/test_analytics_agent_scope.py
@@ -1,0 +1,205 @@
+"""Unit tests for the analytics authorization resolver, asserting the SQL it emits"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.dialects import postgresql
+from starlette_context import context, request_cycle_context
+
+import app.db.models
+import app.db.models.test_suite
+from app.core.utils import analytics_agent_scope
+from app.core.utils.analytics_agent_scope import (
+    get_authorized_agents_for_group,
+    resolve_authorized_agent_ids,
+)
+from app.db.events.group_scope import GROUP_SCOPE_BYPASS_FLAG
+
+
+class _Result:
+    def scalars(self):
+        return self
+
+    def all(self):
+        return []
+
+
+class CapturingDb:
+
+    def __init__(self):
+        self.statements = []
+
+    async def execute(self, stmt):
+        self.statements.append(stmt)
+        return _Result()
+
+
+def _sql(stmt) -> str:
+    return str(stmt.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}))
+
+
+@contextmanager
+def caller(*, user_id=None, group_id=None, supervised=(), admin=False):
+    with request_cycle_context():
+        context["user_id"] = user_id
+        context["group_id"] = group_id
+        context["supervised_group_ids"] = list(supervised)
+        context["user_roles"] = [SimpleNamespace(name="admin" if admin else "operator")]
+        yield
+
+
+@pytest.mark.asyncio
+async def test_no_request_context_fails_closed_to_empty_scope():
+    db = CapturingDb()
+    assert await resolve_authorized_agent_ids(db) == []
+    assert await get_authorized_agents_for_group(db, uuid4()) == []
+    assert db.statements == []
+
+
+@pytest.mark.asyncio
+async def test_context_without_user_id_fails_closed():
+    db = CapturingDb()
+    with caller(user_id=None, group_id=uuid4()):
+        assert await resolve_authorized_agent_ids(db) == []
+        assert db.statements == []
+
+
+@pytest.mark.asyncio
+async def test_admin_without_a_filter_is_unrestricted_and_queries_nothing():
+    db = CapturingDb()
+    with caller(user_id=uuid4(), admin=True):
+        assert await resolve_authorized_agent_ids(db) is None
+        assert db.statements == []
+
+
+@pytest.mark.asyncio
+async def test_admin_agent_filter_is_taken_verbatim_without_a_query():
+    db = CapturingDb()
+    agent_id = uuid4()
+    with caller(user_id=uuid4(), admin=True):
+        assert await resolve_authorized_agent_ids(db, agent_id=agent_id) == [agent_id]
+        assert db.statements == []
+
+
+@pytest.mark.asyncio
+async def test_admin_group_filter_delegates_to_the_bypassing_helper():
+    db = CapturingDb()
+    group_id = uuid4()
+    with caller(user_id=uuid4(), admin=True):
+        assert await resolve_authorized_agent_ids(db, group_id=group_id) == []
+        stmt = db.statements[0]
+        assert stmt.get_execution_options().get(GROUP_SCOPE_BYPASS_FLAG) is True
+        sql = _sql(stmt)
+        # The legacy 3-way group definition: creator, operator user, or workflow owner.
+        assert "agents.created_by IN" in sql
+        assert "operators.user_id IN" in sql
+        assert "workflows.user_id IN" in sql
+        assert f"users.group_id = '{group_id}'" in sql
+
+
+@pytest.mark.asyncio
+async def test_group_user_without_a_filter_is_limited_to_their_groups_agents():
+    db = CapturingDb()
+    group_id = uuid4()
+    with caller(user_id=uuid4(), group_id=group_id):
+        assert await resolve_authorized_agent_ids(db) == []
+        stmt = db.statements[0]
+        assert stmt.get_execution_options().get(GROUP_SCOPE_BYPASS_FLAG) is None
+        sql = _sql(stmt)
+        assert "agents.is_deleted = 0" in sql
+        assert "agents.created_by IN (SELECT users.id" in sql
+        assert f"users.group_id = '{group_id}'" in sql
+
+
+@pytest.mark.asyncio
+async def test_group_user_agent_filter_intersects_with_visibility():
+    db = CapturingDb()
+    agent_id = uuid4()
+    with caller(user_id=uuid4(), group_id=uuid4()):
+        await resolve_authorized_agent_ids(db, agent_id=agent_id)
+        sql = _sql(db.statements[0])
+        assert f"agents.id = '{agent_id}'" in sql
+        assert "agents.created_by IN (SELECT users.id" in sql
+
+
+@pytest.mark.asyncio
+async def test_group_user_group_filter_intersects_with_visibility():
+    db = CapturingDb()
+    own_group, requested_group = uuid4(), uuid4()
+    with caller(user_id=uuid4(), group_id=own_group):
+        await resolve_authorized_agent_ids(db, group_id=requested_group)
+        sql = _sql(db.statements[0])
+        assert f"users.group_id = '{own_group}'" in sql
+        assert f"users.group_id = '{requested_group}'" in sql
+        assert "operators.user_id IN" in sql and "workflows.user_id IN" in sql
+
+
+@pytest.mark.asyncio
+async def test_group_user_with_both_filters_is_a_three_way_intersection():
+    db = CapturingDb()
+    agent_id, own_group, requested_group = uuid4(), uuid4(), uuid4()
+    with caller(user_id=uuid4(), group_id=own_group):
+        await resolve_authorized_agent_ids(db, agent_id=agent_id, group_id=requested_group)
+        sql = _sql(db.statements[0])
+        assert f"agents.id = '{agent_id}'" in sql
+        assert f"users.group_id = '{own_group}'" in sql
+        assert f"users.group_id = '{requested_group}'" in sql
+
+
+@pytest.mark.asyncio
+async def test_groupless_user_sees_only_their_own_agents():
+    db = CapturingDb()
+    user_id = uuid4()
+    with caller(user_id=user_id):
+        await resolve_authorized_agent_ids(db)
+        assert f"agents.created_by = '{user_id}'" in _sql(db.statements[0])
+
+
+@pytest.mark.asyncio
+async def test_supervisor_sees_every_supervised_group():
+    db = CapturingDb()
+    supervised = [uuid4(), uuid4()]
+    with caller(user_id=uuid4(), group_id=uuid4(), supervised=supervised):
+        await resolve_authorized_agent_ids(db)
+        sql = _sql(db.statements[0])
+        assert "users.group_id IN" in sql
+        for gid in supervised:
+            assert f"'{gid}'" in sql
+
+
+@pytest.mark.asyncio
+async def test_non_admin_with_no_visibility_clause_fails_closed(monkeypatch):
+    monkeypatch.setattr(analytics_agent_scope, "get_group_scope_clause", lambda model: None)
+    db = CapturingDb()
+    with caller(user_id=uuid4(), group_id=uuid4()):
+        assert await resolve_authorized_agent_ids(db) == []
+        assert await get_authorized_agents_for_group(db, uuid4()) == []
+        assert db.statements == []
+
+
+@pytest.mark.asyncio
+async def test_group_dropdown_delegates_for_admins():
+    db = CapturingDb()
+    group_id = uuid4()
+    with caller(user_id=uuid4(), admin=True):
+        await get_authorized_agents_for_group(db, group_id)
+        stmt = db.statements[0]
+        assert stmt.get_execution_options().get(GROUP_SCOPE_BYPASS_FLAG) is True
+        assert f"users.group_id = '{group_id}'" in _sql(stmt)
+
+
+@pytest.mark.asyncio
+async def test_group_dropdown_for_a_group_user_is_the_readable_intersection():
+    db = CapturingDb()
+    own_group, requested_group = uuid4(), uuid4()
+    with caller(user_id=uuid4(), group_id=own_group):
+        await get_authorized_agents_for_group(db, requested_group)
+        stmt = db.statements[0]
+        assert stmt.get_execution_options().get(GROUP_SCOPE_BYPASS_FLAG) is None
+        sql = _sql(stmt)
+        assert "agents.is_deleted = 0" in sql
+        assert f"users.group_id = '{own_group}'" in sql
+        assert f"users.group_id = '{requested_group}'" in sql
+        assert "ORDER BY agents.name" in sql

--- a/backend/tests/unit/test_analytics_read_repo_scope.py
+++ b/backend/tests/unit/test_analytics_read_repo_scope.py
@@ -1,0 +1,157 @@
+"""Unit tests proving the analytics reads are wired to the authorization resolver"""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+# Register every mapper before a statement is compiled.
+import app.db.models  # noqa: F401
+import app.db.models.test_suite  # noqa: F401
+from app.repositories import analytics_read
+from app.repositories.analytics_read import AnalyticsReadRepository
+
+
+class _Result:
+    def scalars(self):
+        return self
+
+    def all(self):
+        return []
+
+    def mappings(self):
+        return self
+
+
+class CapturingDb:
+
+    def __init__(self):
+        self.statements = []
+
+    async def execute(self, stmt):
+        self.statements.append(stmt)
+        return _Result()
+
+
+def _sql(stmt) -> str:
+    return str(stmt.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}))
+
+
+def _repo_with_scope(monkeypatch, scope):
+    db = CapturingDb()
+
+    async def _resolver(_db, agent_id=None, group_id=None):
+        return scope
+
+    monkeypatch.setattr(analytics_read, "resolve_authorized_agent_ids", _resolver)
+    return AnalyticsReadRepository(db), db
+
+
+@pytest.mark.asyncio
+async def test_agent_daily_stats_denied_scope_returns_nothing_without_querying(monkeypatch):
+    repo, db = _repo_with_scope(monkeypatch, [])
+    assert await repo.get_agent_daily_stats(group_id=uuid4()) == []
+    assert db.statements == []
+
+
+@pytest.mark.asyncio
+async def test_agent_daily_stats_restricts_to_the_authorized_agents(monkeypatch):
+    repo, db = _repo_with_scope(monkeypatch, [uuid4(), uuid4()])
+    await repo.get_agent_daily_stats()
+    assert "agent_id IN" in _sql(db.statements[0])
+
+
+@pytest.mark.asyncio
+async def test_node_daily_stats_denied_scope_returns_nothing_without_querying(monkeypatch):
+    repo, db = _repo_with_scope(monkeypatch, [])
+    assert await repo.get_node_daily_stats(group_id=uuid4()) == []
+    assert db.statements == []
+
+
+@pytest.mark.asyncio
+async def test_node_daily_stats_restricts_to_the_authorized_agents(monkeypatch):
+    repo, db = _repo_with_scope(monkeypatch, [uuid4(), uuid4()])
+    await repo.get_node_daily_stats()
+    assert "agent_id IN" in _sql(db.statements[0])
+
+
+@pytest.mark.asyncio
+async def test_node_breakdown_authorizes_before_it_queries(monkeypatch):
+    repo, db = _repo_with_scope(monkeypatch, [])
+    assert await repo.get_node_type_breakdown(uuid4()) == []
+    assert db.statements == []
+
+
+@pytest.mark.asyncio
+async def test_node_breakdown_keeps_its_equality_predicate_for_an_authorized_agent(monkeypatch):
+    agent_id = uuid4()
+    repo, db = _repo_with_scope(monkeypatch, [agent_id])
+    await repo.get_node_type_breakdown(agent_id)
+    assert f"agent_id = '{agent_id}'" in _sql(db.statements[0])
+
+
+@pytest.mark.asyncio
+async def test_custom_attribute_keys_denied_scope_returns_nothing_without_querying(monkeypatch):
+    repo, db = _repo_with_scope(monkeypatch, [])
+    assert await repo.get_custom_attribute_keys(agent_id=uuid4()) == []
+    assert db.statements == []
+
+
+@pytest.mark.asyncio
+async def test_custom_attribute_keys_admin_agentless_group_now_returns_empty(monkeypatch):
+    repo, db = _repo_with_scope(monkeypatch, [])
+    assert await repo.get_custom_attribute_keys(group_id=uuid4()) == []
+    assert db.statements == []
+
+
+@pytest.mark.asyncio
+async def test_custom_attribute_keys_unrestricted_scope_reads_every_workflow(monkeypatch):
+    repo, db = _repo_with_scope(monkeypatch, None)
+    await repo.get_custom_attribute_keys()
+    sql = _sql(db.statements[0])
+    assert "FROM workflows" in sql
+    assert "JOIN agents" not in sql
+
+
+@pytest.mark.asyncio
+async def test_custom_attribute_keys_joins_agents_for_a_restricted_scope(monkeypatch):
+    repo, db = _repo_with_scope(monkeypatch, [uuid4()])
+    await repo.get_custom_attribute_keys()
+    sql = _sql(db.statements[0])
+    assert "JOIN agents" in sql
+    assert "agents.id IN" in sql
+
+
+@pytest.mark.asyncio
+async def test_agent_stats_summary_keeps_the_conversation_tier_on_a_group_request(monkeypatch):
+    agent_id, group_id = uuid4(), uuid4()
+    repo, db = _repo_with_scope(monkeypatch, [])
+    seen = {}
+
+    async def _conversation_counts(agent_id=None, group_id=None, from_date=None, to_date=None, *, group_by_agent=False):
+        seen.update(agent_id=agent_id, group_id=group_id)
+        return [
+            {
+                "total_unique_conversations": 4,
+                "total_finalized_conversations": 3,
+                "total_in_progress_conversations": 1,
+            }
+        ]
+
+    monkeypatch.setattr(repo, "get_conversation_status_counts", _conversation_counts)
+
+    summary = await repo.get_agent_stats_summary(agent_id=agent_id, group_id=group_id)
+
+    assert summary["total_executions"] == 0
+    assert summary["total_unique_conversations"] == 4
+    assert seen == {"agent_id": agent_id, "group_id": group_id}
+    assert db.statements == []
+
+
+@pytest.mark.asyncio
+async def test_agent_stats_summary_zeroes_everything_when_no_group_was_requested(monkeypatch):
+    repo, db = _repo_with_scope(monkeypatch, [])
+    summary = await repo.get_agent_stats_summary(agent_id=uuid4())
+    assert summary["total_executions"] == 0
+    assert summary["total_unique_conversations"] == 0
+    assert db.statements == []

--- a/backend/tests/unit/test_dashboard_service.py
+++ b/backend/tests/unit/test_dashboard_service.py
@@ -14,11 +14,17 @@ PER_CONVERSATION = 0.55
 FROM_DATE = datetime(2026, 1, 1, tzinfo=timezone.utc)
 TO_DATE = datetime(2026, 1, 31, tzinfo=timezone.utc)
 
+_UNSET = object()
+
 
 class FakeDashboardRepo:
-    def __init__(self, agent_id):
+    def __init__(self, agent_id, visible_agent_ids=None):
         self._agent_id = agent_id
+        self._visible_agent_ids = visible_agent_ids
         self.total_cost_calls = 0
+        self.scope_calls = 0
+        self.response_time_scope = _UNSET
+        self.total_cost_scope = _UNSET
         self.agents_kwargs = None
 
     async def get_active_agents_count(self):
@@ -27,12 +33,18 @@ class FakeDashboardRepo:
     async def get_workflow_runs_count(self, from_date, to_date):
         return 7
 
-    async def get_avg_response_time(self, from_date, to_date):
-        return 250
+    async def resolve_visible_agent_ids(self):
+        self.scope_calls += 1
+        return self._visible_agent_ids
 
-    async def get_total_cost_usd(self, from_date, to_date):
+    async def get_avg_response_time(self, from_date, to_date, *, agent_ids):
+        self.response_time_scope = agent_ids
+        return 0 if agent_ids == [] else 250
+
+    async def get_total_cost_usd(self, from_date, to_date, *, agent_ids):
         self.total_cost_calls += 1
-        return TOTAL_COST
+        self.total_cost_scope = agent_ids
+        return 0.0 if agent_ids == [] else TOTAL_COST
 
     async def get_agents_with_stats(self, from_date, to_date, limit):
         self.agents_kwargs = {"from_date": from_date, "to_date": to_date, "limit": limit}
@@ -50,8 +62,8 @@ class FakeDashboardRepo:
         ]
 
 
-def _service():
-    repo = FakeDashboardRepo(uuid4())
+def _service(visible_agent_ids=None):
+    repo = FakeDashboardRepo(uuid4(), visible_agent_ids)
     return DashboardService(repo), repo
 
 
@@ -67,6 +79,24 @@ async def test_summary_reads_the_ledger_total():
     assert summary.total_cost_usd == TOTAL_COST
     assert repo.total_cost_calls == 1
     assert (summary.active_agents, summary.workflow_runs, summary.avg_response_time_ms) == (3, 7, 250)
+
+
+@pytest.mark.asyncio
+async def test_summary_resolves_visible_scope_once_and_passes_it_to_both_reads():
+    scope = [uuid4()]
+    service, repo = _service(visible_agent_ids=scope)
+    await service.get_summary_stats(FROM_DATE, TO_DATE)
+    assert repo.scope_calls == 1
+    assert repo.response_time_scope == scope
+    assert repo.total_cost_scope == scope
+
+
+@pytest.mark.asyncio
+async def test_summary_passes_empty_scope_to_both_reads():
+    service, repo = _service(visible_agent_ids=[])
+    summary = await service.get_summary_stats(FROM_DATE, TO_DATE)
+    assert repo.response_time_scope == [] and repo.total_cost_scope == []
+    assert (summary.avg_response_time_ms, summary.total_cost_usd) == (0, 0.0)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_llm_usage_read_repo_sql.py
+++ b/backend/tests/unit/test_llm_usage_read_repo_sql.py
@@ -12,6 +12,9 @@ from app.repositories.dashboard import DashboardRepository, _ledger_window
 from app.repositories.llm_usage_read import LlmUsageReadRepository
 from app.schemas.llm_usage import LlmUsageQueryParams
 
+WINDOW_START = datetime(2026, 1, 1, tzinfo=timezone.utc)
+WINDOW_END = datetime(2026, 1, 31, tzinfo=timezone.utc)
+
 
 class _Result:
     def scalar(self):
@@ -103,12 +106,58 @@ async def test_summary_scopes_agent_studio_cost_to_the_two_studio_test_sources()
 async def test_dashboard_ledger_total_is_half_open_and_skips_deleted():
     db = CapturingDb()
     await DashboardRepository(db).get_total_cost_usd(
-        datetime(2026, 1, 1, tzinfo=timezone.utc), datetime(2026, 1, 31, tzinfo=timezone.utc)
+        datetime(2026, 1, 1, tzinfo=timezone.utc), datetime(2026, 1, 31, tzinfo=timezone.utc), agent_ids=None
     )
     sql = _sql(db.statements[0])
     assert "occurred_at >= '2026-01-01 00:00:00+00:00'" in sql
     assert "occurred_at < '2026-02-01 00:00:00+00:00'" in sql
     assert "is_deleted = 0" in sql
+
+
+@pytest.mark.asyncio
+async def test_dashboard_ledger_total_without_a_scope_has_no_agent_predicate():
+    db = CapturingDb()
+    await DashboardRepository(db).get_total_cost_usd(WINDOW_START, WINDOW_END, agent_ids=None)
+    assert "agent_id" not in _sql(db.statements[0])
+
+
+@pytest.mark.asyncio
+async def test_dashboard_ledger_total_restricts_to_the_visible_agents():
+    db = CapturingDb()
+    scope = [uuid4(), uuid4()]
+    await DashboardRepository(db).get_total_cost_usd(WINDOW_START, WINDOW_END, agent_ids=scope)
+    assert "agent_id IN" in _sql(db.statements[0])
+
+
+@pytest.mark.asyncio
+async def test_dashboard_ledger_total_short_circuits_on_an_empty_scope():
+    db = CapturingDb()
+    total = await DashboardRepository(db).get_total_cost_usd(WINDOW_START, WINDOW_END, agent_ids=[])
+    assert total == 0.0
+    assert db.statements == []
+
+
+@pytest.mark.asyncio
+async def test_dashboard_response_time_without_a_scope_has_no_agent_predicate():
+    db = CapturingDb()
+    await DashboardRepository(db).get_avg_response_time(WINDOW_START, WINDOW_END, agent_ids=None)
+    assert "agent_id" not in _sql(db.statements[0])
+
+
+@pytest.mark.asyncio
+async def test_dashboard_response_time_restricts_to_the_visible_agents():
+    db = CapturingDb()
+    scope = [uuid4(), uuid4()]
+    await DashboardRepository(db).get_avg_response_time(WINDOW_START, WINDOW_END, agent_ids=scope)
+    assert "agent_id IN" in _sql(db.statements[0])
+
+
+@pytest.mark.asyncio
+async def test_dashboard_response_time_short_circuits_on_an_empty_scope():
+    db = CapturingDb()
+    avg = await DashboardRepository(db).get_avg_response_time(WINDOW_START, WINDOW_END, agent_ids=[])
+    assert avg == 0
+    assert db.statements == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_llm_usage_read_service.py
+++ b/backend/tests/unit/test_llm_usage_read_service.py
@@ -21,18 +21,22 @@ class FakeReadRepo:
         self._timeseries = timeseries_rows or []
         self.scope_resolutions = 0
         self.distinct_calls = []
+        self.queries = []
 
     async def resolve_scope(self, params):
         self.scope_resolutions += 1
         return self._scope
 
     async def summary(self, params, scope):
+        self.queries.append("summary")
         return self._summary
 
     async def timeseries(self, params, scope):
+        self.queries.append("timeseries")
         return self._timeseries
 
     async def breakdown(self, params, scope, column):
+        self.queries.append("breakdown")
         return self._breakdown
 
     async def distinct_values(self, params, scope, column, *, use_provider=True, use_model=True):
@@ -209,6 +213,16 @@ async def test_empty_scope_returns_zeroed_responses_without_querying():
     options = await service.get_filter_options(_params())
     assert (options.providers, options.models, options.agents) == ([], [], [])
     assert repo.distinct_calls == []
+    assert repo.queries == []
+
+
+@pytest.mark.asyncio
+async def test_export_report_on_an_empty_scope_returns_nothing_without_querying():
+    service, repo = _service(summary_row=_row(), breakdown_rows=[("openai", Decimal("1"), 0, 5, 1)], scope=[])
+    summary, breakdown = await service.get_export_report(_params(group_id=uuid4()), "provider")
+    assert summary.total_cost_usd == 0.0 and summary.total_calls == 0
+    assert breakdown.items == []
+    assert repo.queries == []
 
 
 @pytest.mark.asyncio

--- a/docs/features/analytics-reporting.md
+++ b/docs/features/analytics-reporting.md
@@ -194,6 +194,23 @@ All endpoints require `auth` + `read:dashboard` permission.
 
 - `GET /audio/metrics` — moved to `/analytics/metrics`
 
+### Authorization & scoping
+
+`read:dashboard` grants access to these endpoints; which **rows** come back is decided separately, in two tiers.
+
+**Agent-attributed aggregates** — agent and node daily stats, the node breakdown, custom-attribute keys, every LLM-usage read, and the dashboard's total cost and average response time — are limited to the agents the caller can see:
+
+- regular users see agents created by anyone in their own group;
+- supervisors see agents across all their supervised groups (supervision takes precedence over their own group);
+- users with no group see only agents they created themselves;
+- admins are unrestricted, and are the only callers whose totals include unattributed ledger rows (LLM calls with no owning agent).
+
+Soft-deleted agents are excluded for non-admins. The `agent_id` and `group_id` query parameters **narrow** this scope and never widen it: an unauthorized filter yields empty agent-scoped data rather than a `403`, so the endpoints cannot be used to probe for the existence of another group's agents. Scoping is evaluated per request against current group membership — historical rows follow whoever can see the agent *today*, and membership changes take effect immediately (there is no cache).
+
+**Conversation-derived metrics** — the conversation counts in `/analytics/agents/summary`, the dashboard conversation lists, and the `/analytics/metrics` endpoints — keep their existing conversation-level group visibility instead. A caller's summary can therefore report conversations while its authorized *agent* scope is empty (for example, conversations that outlived their agent); foreign groups' conversations are never revealed.
+
+Capture control, rate configuration and integrations stay tenant-level and are unaffected.
+
 
 ---
 


### PR DESCRIPTION
## Description

Restricts agent-attributed analytics and LLM usage data to agents visible to the current caller. Previously, users with `read:dashboard` permission could access tenant-wide analytics and LLM spend when no `agent_id` or `group_id` filter was provided. This change applies the caller’s group and agent visibility to those reads while preserving unrestricted tenant-wide access for administrators. Explicit `agent_id` and `group_id` filters now only narrow the caller’s existing visibility. Unauthorized filters return empty results instead of revealing whether another group’s agents exist. Existing conversation-based analytics continue using their current conversation-level group scoping.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [x] 📚 Documentation update
- [ ] 🔧 Configuration change
- [x] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

- Added a shared authorization resolver for determining the agents visible to the current caller
- Applied agent visibility to agent and node analytics aggregates
- Scoped Cost Explorer and other LLM usage reads by visible agent IDs
- Scoped dashboard total cost and average response time calculations
- Restricted group agent dropdowns and custom-attribute keys to visible agents and workflows
- Made missing or invalid authentication context fail closed
- Ensured explicit agent and group filters narrow authorization rather than widening it
- Preserved unrestricted analytics access for administrators
- Preserved the existing conversation-level authorization behavior for conversation-derived metrics
- Added authorization behavior to the analytics reporting documentation
- Added unit and integration coverage for group users, supervisors, groupless users, administrators, unauthorized filters, soft-deleted agents, unattributed usage, and missing authentication context


## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] Multi-tenant considerations addressed (if applicable)

## Related Issues


Closes #

## Screenshots (if applicable)


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
