### PR TITLE
feat: eval run against version

### DIFF
--- a/backend/app/api/v1/routes/test_evaluations.py
+++ b/backend/app/api/v1/routes/test_evaluations.py
@@ -11,12 +11,15 @@ from app.core.tenant_scope import get_tenant_context
 from app.dependencies.dependency_injection import RedisString
 from app.dependencies.injector import injector
 from app.schemas.test_suite import (
+    EvaluationRunRequest,
     EvaluationToolCatalog,
     PaginatedEvaluations,
+    RunWorkflowEvaluationsRequest,
     StartedEvaluationRun,
     TestEvaluation,
     TestEvaluationCreate,
     TestEvaluationUpdate,
+    TestRun,
     WorkflowEvaluationSummary,
 )
 from app.services.test_suite import TestSuiteService
@@ -120,6 +123,42 @@ async def append_run_to_evaluation(
     return await service.append_run_to_evaluation(evaluation_id, str(run_id))
 
 
+@router.post(
+    "/evaluations/{evaluation_id}/run",
+    response_model=TestRun,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(auth), Depends(permissions(P.Evaluation.RUN))],
+)
+async def run_evaluation(
+    evaluation_id: UUID,
+    data: Optional[EvaluationRunRequest] = None,
+    service: TestSuiteService = Injected(TestSuiteService),
+):
+    """Queue one evaluation's run, optionally against another version of its
+    workflow. Refuses with 409 while the evaluation is queued/running."""
+    if await service.evaluation_has_active_run(evaluation_id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This evaluation is already running.",
+        )
+
+    tenant = get_tenant_context()
+
+    def dispatch(run, input_metadata, technique_configs):
+        execute_test_suite_run_task.delay(
+            str(run.id),
+            tenant,
+            input_metadata,
+            technique_configs,
+        )
+
+    return await service.start_evaluation_run(
+        evaluation_id,
+        dispatch,
+        data.target_workflow_id if data else None,
+    )
+
+
 @router.delete(
     "/evaluations/{evaluation_id}",
     status_code=status.HTTP_204_NO_CONTENT,
@@ -147,6 +186,7 @@ async def delete_evaluation(
 )
 async def run_workflow_evaluations(
     workflow_id: UUID,
+    data: Optional[RunWorkflowEvaluationsRequest] = None,
     service: TestSuiteService = Injected(TestSuiteService),
 ):
     """
@@ -186,7 +226,11 @@ async def run_workflow_evaluations(
                 technique_configs,
             )
 
-        return await service.start_workflow_evaluations(workflow_id, dispatch)
+        return await service.start_workflow_evaluations(
+            workflow_id,
+            dispatch,
+            data.target_workflow_id if data else None,
+        )
     finally:
         # Compare-and-delete so we only release our own lock; never let a release
         # error mask the actual response.

--- a/backend/app/core/exceptions/error_messages.py
+++ b/backend/app/core/exceptions/error_messages.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 class ErrorKey(Enum):
     INTERNAL_ERROR = "error_500"
     TOOL_USAGE_CONFIG_INVALID = "tool_usage_config_invalid"
+    EVALUATION_TARGET_NOT_A_VERSION = "evaluation_target_not_a_version"
     NOT_FOUND = "not_found"
     AUDIT_LOG_NOT_FOUND = "audit_log_not_found"
     SENTIMENT_OBJECT_STRUCTURE = "sentiment_object_structure"
@@ -180,6 +181,7 @@ ERROR_MESSAGES = {
     "en": {
         ErrorKey.INTERNAL_ERROR: "An internal server error occurred. Please try again later.",
         ErrorKey.TOOL_USAGE_CONFIG_INVALID: "The tool usage configuration could not be resolved to canonical tool ids.",
+        ErrorKey.EVALUATION_TARGET_NOT_A_VERSION: "The target workflow is not a version of the evaluation's workflow.",
         ErrorKey.NOT_FOUND: "The requested resource was not found.",
         ErrorKey.AUDIT_LOG_NOT_FOUND: "The requested log was not found.",
         ErrorKey.SENTIMENT_OBJECT_STRUCTURE: "Sentiment object must have 'positive', 'neutral', and 'negative' fields.",

--- a/backend/app/repositories/workflow.py
+++ b/backend/app/repositories/workflow.py
@@ -17,7 +17,22 @@ class WorkflowRepository(DbRepository[WorkflowModel]):
             WorkflowModel.id,
             WorkflowModel.name,
             WorkflowModel.version,
+            WorkflowModel.agent_id,
         )
+        if hasattr(WorkflowModel, "is_deleted"):
+            stmt = stmt.where(WorkflowModel.is_deleted == 0)
+        result = await self.db.execute(stmt)
+        return result.all()
+
+    async def get_minimal_by_ids(self, ids: List[UUID]) -> List:
+        if not ids:
+            return []
+        stmt = select(
+            WorkflowModel.id,
+            WorkflowModel.name,
+            WorkflowModel.version,
+            WorkflowModel.agent_id,
+        ).where(WorkflowModel.id.in_(ids))
         if hasattr(WorkflowModel, "is_deleted"):
             stmt = stmt.where(WorkflowModel.is_deleted == 0)
         result = await self.db.execute(stmt)

--- a/backend/app/schemas/test_suite.py
+++ b/backend/app/schemas/test_suite.py
@@ -223,7 +223,10 @@ class TestRunInDB(TestRunBase):
 
 
 class TestRun(TestRunInDB):
-    pass
+    # Display metadata of the workflow version the run executed; populated on
+    # read paths, None on the create response.
+    workflow_name: Optional[str] = None
+    workflow_version: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -234,6 +237,30 @@ class BatchRunsRequest(BaseModel):
     ids: List[str] = Field(
         ...,
         description="List of test run UUIDs to fetch.",
+    )
+
+
+class EvaluationRunRequest(BaseModel):
+    """Options for starting a single evaluation run."""
+
+    target_workflow_id: Optional[UUID] = Field(
+        default=None,
+        description=(
+            "Run against this workflow version instead of the evaluation's own. "
+            "Must be a version of the same workflow (same agent)."
+        ),
+    )
+
+
+class RunWorkflowEvaluationsRequest(BaseModel):
+    """Options for the workflow-wide Run all."""
+
+    target_workflow_id: Optional[UUID] = Field(
+        default=None,
+        description=(
+            "Run every evaluation against this workflow version instead of its "
+            "own. Must be a version of the same workflow (same agent)."
+        ),
     )
 
 

--- a/backend/app/schemas/workflow.py
+++ b/backend/app/schemas/workflow.py
@@ -39,6 +39,7 @@ class WorkflowMinimal(BaseModel):
     id: UUID
     name: str
     version: str
+    agent_id: Optional[UUID] = None
 
     model_config = ConfigDict(
         from_attributes=True

--- a/backend/app/services/test_suite.py
+++ b/backend/app/services/test_suite.py
@@ -2146,19 +2146,32 @@ class TestSuiteService:
             return 0.0
         return None
 
-    async def get_runs_by_ids(self, ids: List[str]) -> List[TestRunInDB]:
+    async def _runs_with_workflow_labels(self, rows: List[Any]) -> List[TestRun]:
+        """Attach the executed workflow's name/version to each run for display."""
+        runs = [TestRun.model_validate(r, from_attributes=True) for r in rows]
+        ids = list({run.workflow_id for run in runs if run.workflow_id})
+        workflows = await self.workflow_service.get_minimal_by_ids(ids)
+        by_id = {workflow.id: workflow for workflow in workflows}
+        for run in runs:
+            workflow = by_id.get(run.workflow_id)
+            if workflow:
+                run.workflow_name = workflow.name
+                run.workflow_version = workflow.version
+        return runs
+
+    async def get_runs_by_ids(self, ids: List[str]) -> List[TestRun]:
         rows = await self.run_repo.get_by_ids(ids)
-        return [TestRunInDB.model_validate(r, from_attributes=True) for r in rows]
+        return await self._runs_with_workflow_labels(rows)
 
     async def get_run(self, run_id: UUID) -> TestRun:
         run = await self.run_repo.get_by_id(run_id)
         if not run:
             raise AppException(status_code=404, error_key=ErrorKey.NOT_FOUND)
-        return TestRun.model_validate(run, from_attributes=True)
+        return (await self._runs_with_workflow_labels([run]))[0]
 
-    async def list_runs_for_suite(self, suite_id: UUID) -> List[TestRunInDB]:
+    async def list_runs_for_suite(self, suite_id: UUID) -> List[TestRun]:
         rows = await self.run_repo.get_all_for_suite(suite_id)
-        return [TestRunInDB.model_validate(r, from_attributes=True) for r in rows]
+        return await self._runs_with_workflow_labels(rows)
 
     async def list_results_for_run(self, run_id: UUID) -> List[TestResultInDB]:
         rows = await self.result_repo.get_all_for_run(run_id)
@@ -2280,6 +2293,7 @@ class TestSuiteService:
         dispatch: Callable[
             [TestRunInDB, Optional[Dict[str, Any]], Optional[Dict[str, Any]]], None
         ],
+        target_workflow_id: Optional[UUID] = None,
     ) -> List[StartedEvaluationRun]:
         """Queue and dispatch a run for every evaluation targeting this workflow.
 
@@ -2287,13 +2301,29 @@ class TestSuiteService:
         through its dataset's default workflow. Each evaluation is created and
         dispatched independently: one failure is reported as ``failed_to_start``
         and does not prevent the rest from running.
+
+        ``target_workflow_id`` runs every evaluation against that version
+        instead of its own; it must be a version of ``workflow_id``.
         """
+        if target_workflow_id:
+            await self._ensure_version_of_same_workflow(
+                workflow_id, target_workflow_id
+            )
         targeted = await self._evaluations_for_workflow(workflow_id)
+
+        # Every evaluation in this scope shares ``workflow_id`` as its effective
+        # workflow, so the active version is the same for all of them: resolve it
+        # once instead of per evaluation.
+        batch_target = target_workflow_id
+        if not batch_target and targeted:
+            batch_target = await self.workflow_service.get_active_version_id(
+                workflow_id
+            )
 
         results: List[StartedEvaluationRun] = []
         for ev in targeted:
             try:
-                run = await self._start_evaluation_run(ev, dispatch)
+                run = await self._start_evaluation_run(ev, dispatch, batch_target)
                 results.append(
                     StartedEvaluationRun(
                         evaluation_id=ev.id,
@@ -2314,6 +2344,58 @@ class TestSuiteService:
                     )
                 )
         return results
+
+    async def start_evaluation_run(
+        self,
+        evaluation_id: UUID,
+        dispatch: Callable[
+            [TestRunInDB, Optional[Dict[str, Any]], Optional[Dict[str, Any]]], None
+        ],
+        target_workflow_id: Optional[UUID] = None,
+    ) -> TestRunInDB:
+        """Queue and dispatch one evaluation's run, optionally against another
+        version of its workflow."""
+        ev = await self.evaluation_repo.get_by_id(evaluation_id)
+        if not ev:
+            raise AppException(status_code=404, error_key=ErrorKey.NOT_FOUND)
+        if target_workflow_id:
+            base_workflow_id = await self._effective_workflow_id(
+                ev.workflow_id, ev.suite_id
+            )
+            await self._ensure_version_of_same_workflow(
+                base_workflow_id, target_workflow_id
+            )
+        return await self._start_evaluation_run(ev, dispatch, target_workflow_id)
+
+    async def _ensure_version_of_same_workflow(
+        self, base_workflow_id: Any, target_workflow_id: UUID
+    ) -> None:
+        """Reject a target that is not a saved version of the base workflow.
+
+        Versions of one workflow share its agent; comparing agent ids keeps an
+        evaluation from being pointed at an unrelated workflow by accident.
+        """
+        if not base_workflow_id:
+            raise AppException(
+                status_code=400,
+                error_key=ErrorKey.EVALUATION_TARGET_NOT_A_VERSION,
+                error_detail=(
+                    "The evaluation has no workflow, so a target version "
+                    "cannot be resolved."
+                ),
+            )
+        if str(base_workflow_id) == str(target_workflow_id):
+            return
+        base = await self.workflow_service.get_by_id(UUID(str(base_workflow_id)))
+        target = await self.workflow_service.get_by_id(target_workflow_id)
+        same_agent = (
+            base.agent_id is not None and base.agent_id == target.agent_id
+        )
+        if not same_agent:
+            raise AppException(
+                status_code=400,
+                error_key=ErrorKey.EVALUATION_TARGET_NOT_A_VERSION,
+            )
 
     async def _evaluations_for_workflow(
         self, workflow_id: UUID
@@ -2526,6 +2608,7 @@ class TestSuiteService:
         dispatch: Callable[
             [TestRunInDB, Optional[Dict[str, Any]], Optional[Dict[str, Any]]], None
         ],
+        target_workflow_id: Optional[UUID] = None,
     ) -> TestRunInDB:
         """Create, record and dispatch a single evaluation run.
 
@@ -2538,10 +2621,13 @@ class TestSuiteService:
         # would merge every conversation into a single memory thread.
         input_metadata = dict(ev.input_metadata or {})
         input_metadata.pop("thread_id", None)
+        resolved_workflow_id = (
+            target_workflow_id or await self._default_run_workflow_id(ev)
+        )
         data = TestRunCreate(
             techniques=list(ev.techniques or []),
             technique_configs=ev.technique_configs or None,
-            workflow_id=ev.workflow_id,
+            workflow_id=resolved_workflow_id,
             input_metadata=input_metadata or None,
         )
         run = await self.create_run(ev.suite_id, data)
@@ -2552,6 +2638,21 @@ class TestSuiteService:
             await self._mark_run_failed_to_start(run.id)
             raise
         return run
+
+    async def _default_run_workflow_id(self, ev: TestEvaluationModel) -> Any:
+        """The version a run executes when the caller names none.
+
+        The agent's active version, so an evaluation tests what is live rather
+        than the version it happened to be configured against. Falls back to its
+        own pinned workflow when the workflow has no agent or no active version.
+        """
+        pinned = await self._effective_workflow_id(ev.workflow_id, ev.suite_id)
+        if not pinned:
+            return None
+        active = await self.workflow_service.get_active_version_id(
+            UUID(str(pinned))
+        )
+        return active or pinned
 
     async def _mark_run_failed_to_start(self, run_id: UUID) -> None:
         """Flip a still-queued run to ``failed`` so it is not left dangling."""

--- a/backend/app/services/workflow.py
+++ b/backend/app/services/workflow.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Optional
 from uuid import UUID
 
 from injector import inject
@@ -41,6 +41,10 @@ class WorkflowService:
     # ---------- READ ----------
     async def get_all_minimal(self) -> List[WorkflowMinimal]:
         rows = await self.repository.get_all_minimal()
+        return [WorkflowMinimal.model_validate(r, from_attributes=True) for r in rows]
+
+    async def get_minimal_by_ids(self, ids: List[UUID]) -> List[WorkflowMinimal]:
+        rows = await self.repository.get_minimal_by_ids(ids)
         return [WorkflowMinimal.model_validate(r, from_attributes=True) for r in rows]
 
     async def get_summaries_by_agent(self, agent_id: UUID) -> List[WorkflowSummary]:
@@ -88,6 +92,26 @@ class WorkflowService:
             .execution_options(**{GROUP_SCOPE_BYPASS_FLAG: True})
         )
         return {row.id: row.username for row in rows}
+
+    async def get_active_version_id(self, workflow_id: UUID) -> Optional[UUID]:
+        """The live version of the workflow's agent — what the builder marks Active.
+
+        ``None`` when the workflow has no agent or the agent points nowhere, so
+        callers can fall back to the version they already hold.
+
+        Agents are group-scoped but workflows are not; the scope filter is
+        bypassed so this pointer resolves to the same version for every caller
+        instead of silently falling back for some. Only the id is read.
+        """
+        workflow = await self.repository.get_by_id(workflow_id)
+        if not workflow or not workflow.agent_id:
+            return None
+        rows = await self.repository.db.execute(
+            select(AgentModel.workflow_id)
+            .where(AgentModel.id == workflow.agent_id)
+            .execution_options(**{GROUP_SCOPE_BYPASS_FLAG: True})
+        )
+        return rows.scalar_one_or_none()
 
     async def get_by_id(self, workflow_id: UUID) -> WorkflowInDB:
         orm_obj = await self.repository.get_by_id(workflow_id)

--- a/backend/tests/unit/test_eval_version_targeting.py
+++ b/backend/tests/unit/test_eval_version_targeting.py
@@ -1,0 +1,261 @@
+"""Unit tests for version-targeted evaluation runs: the same-workflow guard and
+how a run resolves which workflow version to execute."""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from app.core.exceptions.exception_classes import AppException
+from app.schemas.test_suite import TestRunInDB
+from app.services.test_suite import TestSuiteService as EvalService
+
+
+def _service() -> EvalService:
+    return EvalService(
+        suite_repo=AsyncMock(),
+        case_repo=AsyncMock(),
+        run_repo=AsyncMock(),
+        result_repo=AsyncMock(),
+        evaluation_repo=AsyncMock(),
+        tool_rule_result_repo=AsyncMock(),
+        workflow_service=AsyncMock(),
+        conversation_repo=AsyncMock(),
+    )
+
+
+def _eval(*, suite_id=None, workflow_id=None, technique_configs=None):
+    return SimpleNamespace(
+        id=uuid4(),
+        workflow_id=workflow_id,
+        suite_id=suite_id or uuid4(),
+        input_metadata=None,
+        techniques=["no_errors"],
+        technique_configs=technique_configs,
+    )
+
+
+def _workflow(*, workflow_id=None, agent_id=None):
+    return SimpleNamespace(id=workflow_id or uuid4(), agent_id=agent_id)
+
+
+class TestSameWorkflowGuard:
+    @pytest.mark.asyncio
+    async def test_same_id_passes_without_lookups(self):
+        service = _service()
+        workflow_id = uuid4()
+
+        await service._ensure_version_of_same_workflow(workflow_id, workflow_id)
+
+        service.workflow_service.get_by_id.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_same_agent_passes(self):
+        service = _service()
+        agent_id = uuid4()
+        base, target = uuid4(), uuid4()
+        service.workflow_service.get_by_id = AsyncMock(
+            side_effect=[
+                _workflow(workflow_id=base, agent_id=agent_id),
+                _workflow(workflow_id=target, agent_id=agent_id),
+            ]
+        )
+
+        await service._ensure_version_of_same_workflow(base, target)
+
+    @pytest.mark.asyncio
+    async def test_different_agent_is_rejected(self):
+        service = _service()
+        base, target = uuid4(), uuid4()
+        service.workflow_service.get_by_id = AsyncMock(
+            side_effect=[
+                _workflow(workflow_id=base, agent_id=uuid4()),
+                _workflow(workflow_id=target, agent_id=uuid4()),
+            ]
+        )
+
+        with pytest.raises(AppException) as excinfo:
+            await service._ensure_version_of_same_workflow(base, target)
+        assert excinfo.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_missing_agent_is_rejected(self):
+        """Workflows without an agent cannot be proven related — refuse."""
+        service = _service()
+        base, target = uuid4(), uuid4()
+        service.workflow_service.get_by_id = AsyncMock(
+            side_effect=[
+                _workflow(workflow_id=base, agent_id=None),
+                _workflow(workflow_id=target, agent_id=None),
+            ]
+        )
+
+        with pytest.raises(AppException):
+            await service._ensure_version_of_same_workflow(base, target)
+
+    @pytest.mark.asyncio
+    async def test_no_base_workflow_is_rejected(self):
+        service = _service()
+
+        with pytest.raises(AppException) as excinfo:
+            await service._ensure_version_of_same_workflow(None, uuid4())
+        assert excinfo.value.status_code == 400
+
+
+class TestVersionTargetedRuns:
+    def _run_in_db(self, *, suite_id, workflow_id):
+        from datetime import datetime
+
+        return TestRunInDB(
+            id=uuid4(),
+            suite_id=suite_id,
+            workflow_id=workflow_id,
+            status="queued",
+            techniques=["no_errors"],
+            summary_metrics=None,
+            created_at=datetime(2026, 1, 1),
+            updated_at=datetime(2026, 1, 1),
+        )
+
+    @pytest.mark.asyncio
+    async def test_single_run_uses_target_version(self):
+        service = _service()
+        target = uuid4()
+        ev = _eval(workflow_id=uuid4())
+        service.evaluation_repo.get_by_id = AsyncMock(return_value=ev)
+        service._ensure_version_of_same_workflow = AsyncMock()
+        service.create_run = AsyncMock(
+            return_value=self._run_in_db(suite_id=ev.suite_id, workflow_id=target)
+        )
+        service.append_run_to_evaluation = AsyncMock()
+
+        await service.start_evaluation_run(ev.id, lambda *args: None, target)
+
+        data = service.create_run.await_args.args[1]
+        assert data.workflow_id == target
+        service._ensure_version_of_same_workflow.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_single_run_defaults_to_the_active_version(self):
+        """No explicit target runs what is live, not the pinned version."""
+        service = _service()
+        active = uuid4()
+        ev = _eval(workflow_id=uuid4())
+        service.evaluation_repo.get_by_id = AsyncMock(return_value=ev)
+        service._ensure_version_of_same_workflow = AsyncMock()
+        service.workflow_service.get_active_version_id = AsyncMock(return_value=active)
+        service.create_run = AsyncMock(
+            return_value=self._run_in_db(suite_id=ev.suite_id, workflow_id=active)
+        )
+        service.append_run_to_evaluation = AsyncMock()
+
+        await service.start_evaluation_run(ev.id, lambda *args: None)
+
+        data = service.create_run.await_args.args[1]
+        assert data.workflow_id == active
+        service._ensure_version_of_same_workflow.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_single_run_falls_back_to_pinned_without_an_active_version(self):
+        service = _service()
+        ev = _eval(workflow_id=uuid4())
+        service.evaluation_repo.get_by_id = AsyncMock(return_value=ev)
+        service.workflow_service.get_active_version_id = AsyncMock(return_value=None)
+        service.create_run = AsyncMock(
+            return_value=self._run_in_db(suite_id=ev.suite_id, workflow_id=ev.workflow_id)
+        )
+        service.append_run_to_evaluation = AsyncMock()
+
+        await service.start_evaluation_run(ev.id, lambda *args: None)
+
+        data = service.create_run.await_args.args[1]
+        assert data.workflow_id == ev.workflow_id
+
+    @pytest.mark.asyncio
+    async def test_explicit_target_wins_over_the_active_version(self):
+        service = _service()
+        target = uuid4()
+        ev = _eval(workflow_id=uuid4())
+        service.evaluation_repo.get_by_id = AsyncMock(return_value=ev)
+        service._ensure_version_of_same_workflow = AsyncMock()
+        service.workflow_service.get_active_version_id = AsyncMock(return_value=uuid4())
+        service.create_run = AsyncMock(
+            return_value=self._run_in_db(suite_id=ev.suite_id, workflow_id=target)
+        )
+        service.append_run_to_evaluation = AsyncMock()
+
+        await service.start_evaluation_run(ev.id, lambda *args: None, target)
+
+        data = service.create_run.await_args.args[1]
+        assert data.workflow_id == target
+        service.workflow_service.get_active_version_id.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_default_uses_the_dataset_workflow_when_evaluation_has_none(self):
+        """An evaluation with no workflow resolves through its dataset, then to active."""
+        service = _service()
+        suite_workflow, active = uuid4(), uuid4()
+        ev = _eval(workflow_id=None)
+        service.suite_repo.get_by_id = AsyncMock(
+            return_value=SimpleNamespace(id=ev.suite_id, workflow_id=suite_workflow)
+        )
+        service.workflow_service.get_active_version_id = AsyncMock(return_value=active)
+
+        resolved = await service._default_run_workflow_id(ev)
+
+        assert resolved == active
+        service.workflow_service.get_active_version_id.assert_awaited_once_with(
+            suite_workflow
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_all_resolves_the_active_version_once_for_the_batch(self):
+        """Every evaluation in the scope shares the workflow, so the lookup must
+        not repeat per evaluation."""
+        service = _service()
+        workflow_id, active = uuid4(), uuid4()
+        rows = [_eval(workflow_id=workflow_id) for _ in range(4)]
+        service.evaluation_repo.get_all_for_workflow = AsyncMock(return_value=rows)
+        service.workflow_service.get_active_version_id = AsyncMock(return_value=active)
+        service._start_evaluation_run = AsyncMock(
+            return_value=self._run_in_db(suite_id=rows[0].suite_id, workflow_id=active)
+        )
+
+        await service.start_workflow_evaluations(workflow_id, lambda *args: None)
+
+        service.workflow_service.get_active_version_id.assert_awaited_once_with(
+            workflow_id
+        )
+        for call in service._start_evaluation_run.await_args_list:
+            assert call.args[2] == active
+
+    @pytest.mark.asyncio
+    async def test_run_all_skips_the_lookup_when_no_evaluations_match(self):
+        service = _service()
+        service.evaluation_repo.get_all_for_workflow = AsyncMock(return_value=[])
+        service.workflow_service.get_active_version_id = AsyncMock()
+
+        results = await service.start_workflow_evaluations(uuid4(), lambda *args: None)
+
+        assert results == []
+        service.workflow_service.get_active_version_id.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_run_all_passes_target_to_every_evaluation(self):
+        service = _service()
+        workflow_id, target = uuid4(), uuid4()
+        rows = [_eval(workflow_id=workflow_id) for _ in range(2)]
+        service.evaluation_repo.get_all_for_workflow = AsyncMock(return_value=rows)
+        service._ensure_version_of_same_workflow = AsyncMock()
+        service._start_evaluation_run = AsyncMock(
+            return_value=self._run_in_db(suite_id=rows[0].suite_id, workflow_id=target)
+        )
+
+        dispatch = lambda *args: None  # noqa: E731
+        await service.start_workflow_evaluations(workflow_id, dispatch, target)
+
+        service._ensure_version_of_same_workflow.assert_awaited_once_with(
+            workflow_id, target
+        )
+        for call in service._start_evaluation_run.await_args_list:
+            assert call.args[2] == target

--- a/backend/tests/unit/test_workflow_evaluations_batch.py
+++ b/backend/tests/unit/test_workflow_evaluations_batch.py
@@ -245,7 +245,7 @@ class TestStartWorkflowEvaluations:
         service = _service()
         service._evaluations_for_workflow = AsyncMock(return_value=evals)
 
-        async def fake_start(ev, dispatch):
+        async def fake_start(ev, dispatch, target_workflow_id=None):
             if ev is evals[1]:
                 raise RuntimeError("boom - secret internals")
             return SimpleNamespace(id=uuid4(), suite_id=ev.suite_id, status="queued")
@@ -274,6 +274,8 @@ class TestStartEvaluationRunOrphanCleanup:
         run = SimpleNamespace(id=uuid4(), suite_id=suite, status="queued")
         service.create_run = AsyncMock(return_value=run)
         service.append_run_to_evaluation = AsyncMock()
+        # Runs default to the agent's active version; this workflow has none.
+        service.workflow_service.get_active_version_id = AsyncMock(return_value=None)
 
         # the persisted row the cleanup path fetches and flips
         row = SimpleNamespace(id=run.id, status="queued", summary_metrics=None)

--- a/backend/tests/unit/workflow/test_workflow_active_version.py
+++ b/backend/tests/unit/workflow/test_workflow_active_version.py
@@ -1,0 +1,65 @@
+"""Resolving a workflow's active version — the pointer evaluation runs default to."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.db.events.group_scope import GROUP_SCOPE_BYPASS_FLAG
+from app.services.workflow import WorkflowService
+
+
+def _service(*, workflow, agent_workflow_id=None):
+    """A service whose repository returns ``workflow`` and whose session returns
+    ``agent_workflow_id`` for the agent lookup."""
+    repository = MagicMock()
+    repository.get_by_id = AsyncMock(return_value=workflow)
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=agent_workflow_id)
+    repository.db = MagicMock()
+    repository.db.execute = AsyncMock(return_value=result)
+    return WorkflowService(repository=repository)
+
+
+@pytest.mark.asyncio
+async def test_returns_the_agents_workflow_id():
+    active = uuid4()
+    service = _service(
+        workflow=SimpleNamespace(id=uuid4(), agent_id=uuid4()),
+        agent_workflow_id=active,
+    )
+
+    assert await service.get_active_version_id(uuid4()) == active
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_the_workflow_has_no_agent():
+    service = _service(workflow=SimpleNamespace(id=uuid4(), agent_id=None))
+
+    assert await service.get_active_version_id(uuid4()) is None
+    service.repository.db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_the_workflow_is_missing():
+    service = _service(workflow=None)
+
+    assert await service.get_active_version_id(uuid4()) is None
+    service.repository.db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_bypasses_group_scope_so_every_caller_resolves_the_same_version():
+    """Agents are group-scoped and workflows are not; without the bypass the
+    lookup would silently return nothing for users outside the agent's group,
+    and their runs would target a different version."""
+    service = _service(
+        workflow=SimpleNamespace(id=uuid4(), agent_id=uuid4()),
+        agent_workflow_id=uuid4(),
+    )
+
+    await service.get_active_version_id(uuid4())
+
+    statement = service.repository.db.execute.await_args.args[0]
+    assert statement.get_execution_options().get(GROUP_SCOPE_BYPASS_FLAG) is True

--- a/frontend/src/interfaces/testSuite.interface.ts
+++ b/frontend/src/interfaces/testSuite.interface.ts
@@ -32,6 +32,8 @@ export interface TestRun {
   status: string;
   techniques: string[];
   summary_metrics?: Record<string, unknown>;
+  workflow_name?: string | null;
+  workflow_version?: string | null;
   created_at?: string;
   updated_at?: string;
 }
@@ -73,11 +75,4 @@ export interface CreateTestCasePayload {
   expected_output?: Record<string, unknown>;
   tags?: string[];
   weight?: number;
-}
-
-export interface StartTestRunPayload {
-  techniques: string[];
-  technique_configs?: Record<string, Record<string, unknown>>;
-  workflow_id?: string;
-  input_metadata?: Record<string, unknown>;
 }

--- a/frontend/src/interfaces/workflow.interface.ts
+++ b/frontend/src/interfaces/workflow.interface.ts
@@ -35,11 +35,12 @@ export interface Workflow {
   settings?: WorkflowSettings;
 }
 
-// Lightweight workflow data (id, name, version only)
+// Lightweight workflow data (id, name, version, agent only)
 export interface WorkflowMinimal {
   id: string;
   name: string;
   version: string;
+  agent_id?: string | null;
 }
 
 export interface WorkflowSummary {

--- a/frontend/src/services/testEvaluations.ts
+++ b/frontend/src/services/testEvaluations.ts
@@ -7,6 +7,7 @@ import {
   TestToolRuleResult,
   WorkflowEvaluationSummary,
 } from "@/interfaces/testEvaluation.interface";
+import { TestRun } from "@/interfaces/testSuite.interface";
 
 export type {
   PaginatedEvaluations,
@@ -51,16 +52,24 @@ export const updateTestEvaluation = (
 export const deleteTestEvaluation = (id: string) =>
   apiRequest<void>("DELETE", `${BASE}/evaluations/${id}`);
 
-export const appendRunToEvaluation = (evaluationId: string, runId: string) =>
-  apiRequest<TestEvaluationConfig>(
+export const runTestEvaluation = (
+  evaluationId: string,
+  targetWorkflowId?: string,
+) =>
+  apiRequest<TestRun>(
     "POST",
-    `${BASE}/evaluations/${evaluationId}/runs/${runId}`,
+    `${BASE}/evaluations/${evaluationId}/run`,
+    targetWorkflowId ? { target_workflow_id: targetWorkflowId } : {},
   );
 
-export const runWorkflowEvaluations = (workflowId: string) =>
+export const runWorkflowEvaluations = (
+  workflowId: string,
+  targetWorkflowId?: string,
+) =>
   apiRequest<StartedEvaluationRun[]>(
     "POST",
     `${BASE}/workflows/${workflowId}/evaluations/run`,
+    targetWorkflowId ? { target_workflow_id: targetWorkflowId } : undefined,
   );
 
 export const getWorkflowEvaluationSummaries = () =>

--- a/frontend/src/services/testSuites.ts
+++ b/frontend/src/services/testSuites.ts
@@ -2,7 +2,6 @@ import { apiRequest } from "@/config/api";
 import type {
   CreateTestCasePayload,
   CreateTestSuitePayload,
-  StartTestRunPayload,
   TestCase,
   TestResult,
   TestRun,
@@ -68,13 +67,6 @@ export const removeConversationFromSuite = (suiteId: string, conversationId: str
   apiRequest<void>(
     "DELETE",
     `${BASE}/suites/${suiteId}/conversations/${conversationId}`,
-  );
-
-export const startTestRun = (suiteId: string, payload: StartTestRunPayload) =>
-  apiRequest<TestRun>(
-    "POST",
-    `${BASE}/suites/${suiteId}/runs`,
-    payload as unknown as Record<string, unknown>,
   );
 
 export const listTestRunsForSuite = (suiteId: string) =>

--- a/frontend/src/views/TestSuites/components/CompareRunsDialog.tsx
+++ b/frontend/src/views/TestSuites/components/CompareRunsDialog.tsx
@@ -1,0 +1,388 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  AlertCircle,
+  ArrowDownRight,
+  ArrowUpRight,
+  CheckCircle2,
+  Loader2,
+  Minus,
+  XCircle,
+} from "lucide-react";
+
+import { Badge } from "@/components/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/select";
+import { listResultsForRun } from "@/services/testSuites";
+import { getToolRuleResults } from "@/services/testEvaluations";
+import { TestResult, TestRun } from "@/interfaces/testSuite.interface";
+import type { TestToolRuleResult } from "@/interfaces/testEvaluation.interface";
+import { cn } from "@/helpers/utils";
+import { methodLabel } from "../helpers/methodLabels";
+import { CaseStatus, caseStatusFor } from "../helpers/runResults";
+
+interface CompareRunsDialogProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** All runs of the evaluation, newest first. */
+  runs: TestRun[];
+}
+
+type CaseChange = "regression" | "improvement" | "unchanged" | "other";
+
+interface CaseComparison {
+  caseId: string;
+  baseline: CaseStatus | null;
+  candidate: CaseStatus | null;
+  change: CaseChange;
+}
+
+interface RunData {
+  results: TestResult[];
+  toolResults: TestToolRuleResult[];
+}
+
+/** Summary metric shape stored per technique on a run. */
+type TechniqueSummary = { accuracy?: number };
+
+const RUN_TOTALS_KEY = "_totals";
+
+const runLabel = (run: TestRun): string => {
+  const version = run.workflow_version ? ` · v${run.workflow_version}` : "";
+  const date = run.created_at
+    ? ` · ${new Date(run.created_at).toLocaleString()}`
+    : "";
+  return `Run #${run.id?.slice(-4)}${version}${date}`;
+};
+
+const classifyChange = (
+  baseline: CaseStatus | null,
+  candidate: CaseStatus | null,
+): CaseChange => {
+  if (baseline === "passed" && candidate === "failed") return "regression";
+  if (baseline === "failed" && candidate === "passed") return "improvement";
+  if (baseline === candidate) return "unchanged";
+  return "other";
+};
+
+const CHANGE_ORDER: Record<CaseChange, number> = {
+  regression: 0,
+  improvement: 1,
+  other: 2,
+  unchanged: 3,
+};
+
+const StatusIcon: React.FC<{ status: CaseStatus | null }> = ({ status }) => {
+  if (status === "passed") {
+    return <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />;
+  }
+  if (status === "failed") {
+    return <XCircle className="h-4 w-4 text-red-600 dark:text-red-400" />;
+  }
+  if (status === "not_scored") {
+    return <AlertCircle className="h-4 w-4 text-amber-600 dark:text-amber-400" />;
+  }
+  return <Minus className="h-4 w-4 text-muted-foreground/50" />;
+};
+
+const ChangeBadge: React.FC<{ change: CaseChange }> = ({ change }) => {
+  if (change === "regression") {
+    return (
+      <Badge className="bg-red-50 text-red-700 border border-red-200 dark:bg-red-500/15 dark:text-red-400 dark:border-red-500/30">
+        <ArrowDownRight className="mr-1 h-3 w-3" />
+        Regression
+      </Badge>
+    );
+  }
+  if (change === "improvement") {
+    return (
+      <Badge className="bg-green-50 text-green-700 border border-green-200 dark:bg-green-500/15 dark:text-green-400 dark:border-green-500/30">
+        <ArrowUpRight className="mr-1 h-3 w-3" />
+        Improved
+      </Badge>
+    );
+  }
+  return null;
+};
+
+const TechniqueDelta: React.FC<{
+  technique: string;
+  baseline: number | null;
+  candidate: number | null;
+}> = ({ technique, baseline, candidate }) => {
+  const hasBoth = baseline !== null && candidate !== null;
+  const delta = hasBoth ? candidate - baseline : null;
+  const deltaClass =
+    delta === null || Math.abs(delta) < 0.005
+      ? "text-muted-foreground"
+      : delta > 0
+        ? "text-green-600 dark:text-green-400"
+        : "text-red-600 dark:text-red-400";
+  const percent = (value: number | null) =>
+    value === null ? "–" : `${Math.round(value * 100)}%`;
+
+  return (
+    <div className="flex items-center justify-between gap-2 text-xs">
+      <span className="truncate text-muted-foreground">{methodLabel(technique)}</span>
+      <span className="shrink-0 tabular-nums">
+        {percent(baseline)} → {percent(candidate)}{" "}
+        {delta !== null && (
+          <span className={cn("font-medium", deltaClass)}>
+            ({delta > 0 ? "+" : ""}
+            {Math.round(delta * 100)}%)
+          </span>
+        )}
+      </span>
+    </div>
+  );
+};
+
+export const CompareRunsDialog: React.FC<CompareRunsDialogProps> = ({
+  isOpen,
+  onOpenChange,
+  runs,
+}) => {
+  const [baselineRunId, setBaselineRunId] = useState<string>("");
+  const [candidateRunId, setCandidateRunId] = useState<string>("");
+  const [dataByRunId, setDataByRunId] = useState<Record<string, RunData>>({});
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Only finished runs have stable results worth comparing.
+  const comparableRuns = useMemo(
+    () => runs.filter((run) => run.id && (run.status === "completed" || run.status === "failed")),
+    [runs],
+  );
+
+  // Default to the two most recent finished runs: newest as candidate.
+  useEffect(() => {
+    if (!isOpen) return;
+    setCandidateRunId(comparableRuns[0]?.id ?? "");
+    setBaselineRunId(comparableRuns[1]?.id ?? "");
+  }, [isOpen, comparableRuns]);
+
+  useEffect(() => {
+    const idsToLoad = [baselineRunId, candidateRunId].filter(
+      (id) => id && !dataByRunId[id],
+    );
+    if (!isOpen || idsToLoad.length === 0) return;
+    let isStale = false;
+    const load = async () => {
+      setIsLoading(true);
+      try {
+        const loaded = await Promise.all(
+          idsToLoad.map(async (runId) => {
+            const [results, toolResults] = await Promise.all([
+              listResultsForRun(runId),
+              getToolRuleResults(runId).catch(() => []),
+            ]);
+            return [runId, { results: results ?? [], toolResults: toolResults ?? [] }] as const;
+          }),
+        );
+        if (isStale) return;
+        setDataByRunId((prev) => ({ ...prev, ...Object.fromEntries(loaded) }));
+      } finally {
+        if (!isStale) setIsLoading(false);
+      }
+    };
+    void load();
+    return () => {
+      isStale = true;
+    };
+  }, [isOpen, baselineRunId, candidateRunId, dataByRunId]);
+
+  const statusByCase = (runId: string): Map<string, CaseStatus> => {
+    const data = dataByRunId[runId];
+    const map = new Map<string, CaseStatus>();
+    if (!data) return map;
+    const toolsByCase = new Map<string, TestToolRuleResult[]>();
+    for (const toolResult of data.toolResults) {
+      const isTurnScope =
+        toolResult.scope === "every_turn" || toolResult.scope === "specific_turn";
+      if (isTurnScope && toolResult.case_id) {
+        const existing = toolsByCase.get(toolResult.case_id) ?? [];
+        existing.push(toolResult);
+        toolsByCase.set(toolResult.case_id, existing);
+      }
+    }
+    for (const result of data.results) {
+      if (!result.case_id) continue;
+      map.set(result.case_id, caseStatusFor(result, toolsByCase.get(result.case_id) ?? []));
+    }
+    return map;
+  };
+
+  const comparisons: CaseComparison[] = useMemo(() => {
+    if (!baselineRunId || !candidateRunId) return [];
+    const baselineStatuses = statusByCase(baselineRunId);
+    const candidateStatuses = statusByCase(candidateRunId);
+    const caseIds = new Set([...baselineStatuses.keys(), ...candidateStatuses.keys()]);
+    const rows = [...caseIds].map((caseId) => {
+      const baseline = baselineStatuses.get(caseId) ?? null;
+      const candidate = candidateStatuses.get(caseId) ?? null;
+      return { caseId, baseline, candidate, change: classifyChange(baseline, candidate) };
+    });
+    return rows.sort((a, b) => CHANGE_ORDER[a.change] - CHANGE_ORDER[b.change]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [baselineRunId, candidateRunId, dataByRunId]);
+
+  const regressionCount = comparisons.filter((c) => c.change === "regression").length;
+  const improvementCount = comparisons.filter((c) => c.change === "improvement").length;
+
+  const baselineRun = comparableRuns.find((run) => run.id === baselineRunId);
+  const candidateRun = comparableRuns.find((run) => run.id === candidateRunId);
+
+  // Per-technique accuracy across both runs, keyed by technique.
+  const techniqueRows = useMemo(() => {
+    const accuracyOf = (run: TestRun | undefined, technique: string): number | null => {
+      const summary = run?.summary_metrics?.[technique] as TechniqueSummary | undefined;
+      return typeof summary?.accuracy === "number" ? summary.accuracy : null;
+    };
+    const techniques = new Set<string>();
+    [baselineRun, candidateRun].forEach((run) => {
+      Object.keys(run?.summary_metrics ?? {})
+        .filter((key) => key !== RUN_TOTALS_KEY)
+        .forEach((key) => techniques.add(key));
+    });
+    return [...techniques].map((technique) => ({
+      technique,
+      baseline: accuracyOf(baselineRun, technique),
+      candidate: accuracyOf(candidateRun, technique),
+    }));
+  }, [baselineRun, candidateRun]);
+
+  const verdict =
+    regressionCount > 0
+      ? `${regressionCount} regression${regressionCount !== 1 ? "s" : ""}`
+      : "No regressions";
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[85vh] w-[95vw] max-w-3xl flex-col gap-0 overflow-hidden p-0">
+        <DialogHeader className="shrink-0 border-b px-5 py-3">
+          <DialogTitle>Compare Runs</DialogTitle>
+        </DialogHeader>
+
+        <div className="shrink-0 space-y-3 border-b px-5 py-4">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <div className="mb-1 text-xs font-medium text-muted-foreground">Baseline</div>
+              <Select value={baselineRunId} onValueChange={setBaselineRunId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Choose a run" />
+                </SelectTrigger>
+                <SelectContent>
+                  {comparableRuns.map((run) => (
+                    <SelectItem key={run.id} value={run.id!}>
+                      {runLabel(run)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <div className="mb-1 text-xs font-medium text-muted-foreground">Candidate</div>
+              <Select value={candidateRunId} onValueChange={setCandidateRunId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Choose a run" />
+                </SelectTrigger>
+                <SelectContent>
+                  {comparableRuns.map((run) => (
+                    <SelectItem key={run.id} value={run.id!}>
+                      {runLabel(run)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {baselineRun && candidateRun && (
+            <>
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    regressionCount > 0
+                      ? "border-red-200 text-red-700 dark:border-red-500/30 dark:text-red-400"
+                      : "border-green-200 text-green-700 dark:border-green-500/30 dark:text-green-400",
+                  )}
+                >
+                  {verdict}
+                </Badge>
+                {improvementCount > 0 && (
+                  <Badge variant="outline" className="border-green-200 text-green-700 dark:border-green-500/30 dark:text-green-400">
+                    {improvementCount} improved
+                  </Badge>
+                )}
+              </div>
+              {techniqueRows.length > 0 && (
+                <div className="space-y-1 rounded border p-3">
+                  {techniqueRows.map((row) => (
+                    <TechniqueDelta
+                      key={row.technique}
+                      technique={row.technique}
+                      baseline={row.baseline}
+                      candidate={row.candidate}
+                    />
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-3">
+          {isLoading ? (
+            <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading results…
+            </div>
+          ) : !baselineRunId || !candidateRunId ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              Choose two finished runs to compare.
+            </div>
+          ) : comparisons.length === 0 ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              These runs share no scored test cases.
+            </div>
+          ) : (
+            <div className="divide-y divide-border">
+              <div className="flex items-center gap-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                <span className="flex-1">Case</span>
+                <span className="w-16 text-center">Baseline</span>
+                <span className="w-16 text-center">Candidate</span>
+                <span className="w-28" />
+              </div>
+              {comparisons.map((row) => (
+                <div key={row.caseId} className="flex items-center gap-3 py-2">
+                  <span className="flex-1 truncate text-sm">
+                    Case #{row.caseId.slice(-4)}
+                  </span>
+                  <span className="flex w-16 justify-center">
+                    <StatusIcon status={row.baseline} />
+                  </span>
+                  <span className="flex w-16 justify-center">
+                    <StatusIcon status={row.candidate} />
+                  </span>
+                  <span className="flex w-28 justify-end">
+                    <ChangeBadge change={row.change} />
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/views/TestSuites/components/RunAgainstVersionDialog.tsx
+++ b/frontend/src/views/TestSuites/components/RunAgainstVersionDialog.tsx
@@ -1,0 +1,182 @@
+import React, { useEffect, useState } from "react";
+import { Loader2, Play } from "lucide-react";
+
+import { Button } from "@/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/select";
+import { getWorkflowSummaries } from "@/services/workflows";
+import { getAgentConfig } from "@/services/api";
+import { WorkflowSummary } from "@/interfaces/workflow.interface";
+
+interface RunAgainstVersionDialogProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Groups the saved versions to choose from. */
+  agentId: string;
+  /** The version the evaluation runs against by default. */
+  currentWorkflowId?: string;
+  /** Named once in the description instead of repeated per option. */
+  workflowName?: string;
+  /** Confirm label, e.g. "Run" or "Run all". */
+  confirmLabel?: string;
+  isStarting?: boolean;
+  onRun: (targetWorkflowId: string) => void;
+}
+
+export const RunAgainstVersionDialog: React.FC<RunAgainstVersionDialogProps> = ({
+  isOpen,
+  onOpenChange,
+  agentId,
+  currentWorkflowId,
+  workflowName,
+  confirmLabel = "Run",
+  isStarting = false,
+  onRun,
+}) => {
+  const [versions, setVersions] = useState<WorkflowSummary[]>([]);
+  const [isLoadingVersions, setIsLoadingVersions] = useState(false);
+  const [hasLoadFailed, setHasLoadFailed] = useState(false);
+  const [selectedWorkflowId, setSelectedWorkflowId] = useState<string>("");
+  // The agent's live version — the pointer the builder marks Active, and what a
+  // plain Run executes.
+  const [activeWorkflowId, setActiveWorkflowId] = useState<string | null>(null);
+  // Bumped to refetch on retry.
+  const [loadAttempt, setLoadAttempt] = useState(0);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    // A response from a previous open (or another agent) must never overwrite
+    // the current one.
+    let isStale = false;
+    const loadVersions = async () => {
+      setIsLoadingVersions(true);
+      setHasLoadFailed(false);
+      try {
+        // A missing agent must not hide the version list; it only costs the marker.
+        const [rows, agent] = await Promise.all([
+          getWorkflowSummaries(agentId),
+          getAgentConfig(agentId).catch(() => null),
+        ]);
+        if (isStale) return;
+        setVersions(rows ?? []);
+        setActiveWorkflowId(agent?.workflow_id ?? null);
+        // Preselect what a plain Run would execute: the active version, or the
+        // evaluation's own when the workflow has no active version.
+        setSelectedWorkflowId(agent?.workflow_id ?? currentWorkflowId ?? "");
+      } catch {
+        // Distinct from an empty list: the versions are unknown, not absent.
+        if (!isStale) {
+          setVersions([]);
+          setHasLoadFailed(true);
+        }
+      } finally {
+        if (!isStale) setIsLoadingVersions(false);
+      }
+    };
+    void loadVersions();
+    return () => {
+      isStale = true;
+    };
+  }, [isOpen, agentId, currentWorkflowId, loadAttempt]);
+
+  // Each saved version carries its own name, so it is what tells two versions
+  // apart once a workflow has many of them. "current" marks the agent's live
+  // version, matching the wording of the wizard's workflow picker.
+  const versionLabel = (version: WorkflowSummary): string => {
+    const suffix = version.id === activeWorkflowId ? " (current)" : "";
+    if (!version.name?.trim()) return `v${version.version}${suffix}`;
+    return `v${version.version} · ${version.name}${suffix}`;
+  };
+
+  const hasOtherVersions = versions.length > 1;
+  const canRun = Boolean(selectedWorkflowId) && hasOtherVersions && !isStarting;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Run against a version</DialogTitle>
+        </DialogHeader>
+        <div className="mt-2 space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Execute against another saved version of{" "}
+            {workflowName ?? "this workflow"} — for example a draft you are
+            still working on.
+          </p>
+          <div className="space-y-1.5">
+            <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Version
+            </div>
+            {isLoadingVersions ? (
+              <div className="flex h-10 items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading versions…
+              </div>
+            ) : hasLoadFailed ? (
+              <div className="flex items-center gap-3">
+                <p className="flex-1 text-xs text-destructive">
+                  Couldn't load this workflow's versions.
+                </p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setLoadAttempt((attempt) => attempt + 1)}
+                >
+                  Retry
+                </Button>
+              </div>
+            ) : (
+              <Select
+                value={selectedWorkflowId}
+                onValueChange={setSelectedWorkflowId}
+                disabled={!hasOtherVersions}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Choose a version" />
+                </SelectTrigger>
+                <SelectContent>
+                  {versions.map((version) => (
+                    <SelectItem key={version.id} value={version.id}>
+                      {versionLabel(version)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+            {!isLoadingVersions && !hasLoadFailed && !hasOtherVersions && (
+              <p className="text-xs text-muted-foreground">
+                This workflow has only one saved version. Save another version in
+                the workflow builder to run against it here.
+              </p>
+            )}
+          </div>
+        </div>
+        <DialogFooter className="mt-6 gap-2 border-t pt-4">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button disabled={!canRun} onClick={() => onRun(selectedWorkflowId)}>
+            {isStarting ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Play className="mr-2 h-4 w-4" />
+            )}
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/views/TestSuites/helpers/runResults.ts
+++ b/frontend/src/views/TestSuites/helpers/runResults.ts
@@ -1,0 +1,52 @@
+import { TestResult, TestRun } from "@/interfaces/testSuite.interface";
+import type { TestToolRuleResult } from "@/interfaces/testEvaluation.interface";
+
+export type CaseStatus = "passed" | "failed" | "not_scored";
+
+export const hasMetrics = (result: TestResult): boolean =>
+  !!result.metrics && Object.keys(result.metrics).length > 0;
+
+// No metrics means no score, whatever the stored status claims.
+export const isResultNotScored = (result: TestResult): boolean =>
+  !hasMetrics(result) || (!!result.status && result.status !== "scored");
+
+export const isResultPassed = (result: TestResult): boolean =>
+  hasMetrics(result) &&
+  !isResultNotScored(result) &&
+  Object.values(result.metrics!).every((m) => m.passed);
+
+export const isResultFailed = (result: TestResult): boolean =>
+  !isResultPassed(result) && !isResultNotScored(result);
+
+export const notScoredLabel = (result: TestResult): string => {
+  if (result.status === "skipped") return "Skipped";
+  if (result.status === "scoring_failed") return "Scoring failed";
+  if (result.status === "execution_failed") return "Execution failed";
+  return "Not scored";
+};
+
+// A case's status reflects its turn-level Tool Usage results too: a tool failure
+// fails the case, and a tool pass can score an otherwise-unscored case.
+export const caseStatusFor = (
+  result: TestResult,
+  toolResults: TestToolRuleResult[],
+): CaseStatus => {
+  const toolFailed = toolResults.some((t) => t.status === "failed");
+  const toolPassed = toolResults.some((t) => t.status === "passed");
+  if (toolFailed) return "failed";
+  const passed = isResultPassed(result) || (isResultNotScored(result) && toolPassed);
+  if (passed) return "passed";
+  if (isResultFailed(result)) return "failed";
+  return "not_scored";
+};
+
+export const runAvgAccuracy = (run: TestRun): number | null => {
+  const summaryMetrics = run.summary_metrics as
+    | Record<string, { accuracy?: number }>
+    | undefined;
+  const scored = Object.values(summaryMetrics ?? {}).filter(
+    (m) => typeof m.accuracy === "number",
+  );
+  if (!scored.length) return null;
+  return scored.reduce((sum, m, _, arr) => sum + (m.accuracy ?? 0) / arr.length, 0);
+};

--- a/frontend/src/views/TestSuites/pages/EvaluationDetailPage.tsx
+++ b/frontend/src/views/TestSuites/pages/EvaluationDetailPage.tsx
@@ -1,23 +1,32 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import toast from "react-hot-toast";
 import { PageLayout } from "@/components/PageLayout";
 import JsonViewer from "@/components/JsonViewer";
 import { Button } from "@/components/button";
 import { Badge } from "@/components/badge";
-import { ChevronLeft, Play, CheckCircle2, XCircle, AlertCircle, Loader2 } from "lucide-react";
+import {
+  ChevronLeft,
+  GitBranch,
+  GitCompareArrows,
+  Play,
+  CheckCircle2,
+  XCircle,
+  AlertCircle,
+  Loader2,
+} from "lucide-react";
 import {
   getTestRun,
   getTestRunsBatch,
   listTestCases,
   listResultsForRun,
   listTestSuites,
-  startTestRun,
 } from "@/services/testSuites";
 import { getWorkflowsMinimal } from "@/services/workflows";
 import {
   getTestEvaluationById,
-  appendRunToEvaluation,
   getToolRuleResults,
+  runTestEvaluation,
 } from "@/services/testEvaluations";
 import { TestResult, TestRun, TestSuite } from "@/interfaces/testSuite.interface";
 import type { TestToolRuleResult } from "@/interfaces/testEvaluation.interface";
@@ -37,10 +46,21 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Skeleton } from "@/components/skeleton";
 import { Progress } from "@/components/progress";
 import { PaginationBar } from "@/components/PaginationBar";
+import { TooltipProvider } from "@/components/RadixTooltip";
+import { TooltipButton } from "@/components/tooltip-button";
 import { cn } from "@/helpers/utils";
 import { ToolUsageResults } from "../components/ToolUsageResults";
 import { ToolUsageResultCard } from "../components/ToolUsageResultCard";
+import { RunAgainstVersionDialog } from "../components/RunAgainstVersionDialog";
+import { CompareRunsDialog } from "../components/CompareRunsDialog";
 import { methodLabel } from "../helpers/methodLabels";
+import {
+  isResultFailed,
+  isResultNotScored,
+  isResultPassed,
+  notScoredLabel,
+  runAvgAccuracy,
+} from "../helpers/runResults";
 
 type ResultFilter = "all" | "passed" | "failed" | "not_scored";
 
@@ -117,28 +137,6 @@ const usesExpectedOutput = (
   }
 };
 
-const hasMetrics = (result: TestResult): boolean =>
-  !!result.metrics && Object.keys(result.metrics).length > 0;
-
-// No metrics means no score, whatever the stored status claims.
-const isResultNotScored = (result: TestResult): boolean =>
-  !hasMetrics(result) || (!!result.status && result.status !== "scored");
-
-const isResultPassed = (result: TestResult): boolean =>
-  hasMetrics(result) &&
-  !isResultNotScored(result) &&
-  Object.values(result.metrics!).every((m) => m.passed);
-
-const isResultFailed = (result: TestResult): boolean =>
-  !isResultPassed(result) && !isResultNotScored(result);
-
-const notScoredLabel = (result: TestResult): string => {
-  if (result.status === "skipped") return "Skipped";
-  if (result.status === "scoring_failed") return "Scoring failed";
-  if (result.status === "execution_failed") return "Execution failed";
-  return "Not scored";
-};
-
 const accuracyTextClass = (acc: number): string =>
   acc >= 0.9
     ? "text-green-600 dark:text-green-400"
@@ -172,6 +170,9 @@ const EvaluationDetailPage: React.FC = () => {
   const [toolResultsByRun, setToolResultsByRun] = useState<Record<string, TestToolRuleResult[]>>({});
   const [suite, setSuite] = useState<TestSuite | null>(null);
   const [workflowName, setWorkflowName] = useState<string>("Dataset default");
+  const [workflowAgentId, setWorkflowAgentId] = useState<string | null>(null);
+  const [isVersionDialogOpen, setIsVersionDialogOpen] = useState(false);
+  const [isCompareOpen, setIsCompareOpen] = useState(false);
   const [expectedOutputByCaseId, setExpectedOutputByCaseId] = useState<
     Record<string, Record<string, unknown> | undefined>
   >({});
@@ -205,6 +206,7 @@ const EvaluationDetailPage: React.FC = () => {
         (item: WorkflowMinimal) => item.id === evaluation.workflow_id,
       );
       setWorkflowName(workflowData?.name ?? "Dataset default");
+      setWorkflowAgentId(workflowData?.agent_id ?? null);
     };
     loadContext();
   }, [evaluation]);
@@ -275,20 +277,12 @@ const EvaluationDetailPage: React.FC = () => {
     loadSelectedRunResults();
   }, [selectedRunId]);
 
-  const handleRunEvaluation = async () => {
+  const handleRunEvaluation = async (targetWorkflowId?: string) => {
     if (!evaluation || !evaluationId) return;
     setIsRunning(true);
     try {
-      // Memory threads are generated per conversation by the backend at run time.
-      const runMetadata = evaluation.input_metadata ?? undefined;
-      const created = await startTestRun(evaluation.suite_id, {
-        techniques: evaluation.techniques,
-        technique_configs: evaluation.technique_configs,
-        workflow_id: evaluation.workflow_id,
-        input_metadata: runMetadata,
-      });
+      const created = await runTestEvaluation(evaluationId, targetWorkflowId);
       if (created?.id) {
-        await appendRunToEvaluation(evaluationId, created.id);
         setRuns((prev) => [created, ...prev]);
         setRunsPage(1); // jump back to the first page so the new run is visible
 
@@ -313,8 +307,16 @@ const EvaluationDetailPage: React.FC = () => {
         // Return early — setIsRunning(false) is handled by the interval above.
         return;
       }
-    } catch {
-      // fall through to finally
+    } catch (error) {
+      const status = (error as { response?: { status?: number } })?.response
+        ?.status;
+      if (status === 409) {
+        toast.error("This evaluation is already running.");
+      } else if (status === 400) {
+        toast.error("That version does not belong to this workflow.");
+      } else {
+        toast.error("Failed to start the evaluation.");
+      }
     }
     setIsRunning(false);
   };
@@ -387,13 +389,6 @@ const EvaluationDetailPage: React.FC = () => {
     RUN_TOTALS_KEY
   ] as RunTotals | undefined;
 
-  const runAvgAccuracy = (run: TestRun): number | null => {
-    const summaryMetrics = run.summary_metrics as Record<string, { accuracy?: number }> | undefined;
-    const scored = Object.values(summaryMetrics ?? {}).filter((m) => typeof m.accuracy === "number");
-    if (!scored.length) return null;
-    return scored.reduce((sum, m, _, arr) => sum + (m.accuracy ?? 0) / arr.length, 0);
-  };
-
   // Client-side pagination for the runs list (runs are all loaded up front).
   const runsTotalPages = Math.max(1, Math.ceil(runs.length / RUNS_PAGE_SIZE));
   const runsSafePage = Math.min(runsPage, runsTotalPages);
@@ -401,6 +396,13 @@ const EvaluationDetailPage: React.FC = () => {
     (runsSafePage - 1) * RUNS_PAGE_SIZE,
     runsSafePage * RUNS_PAGE_SIZE,
   );
+
+  // Offered whenever the evaluation targets a workflow; the dialog handles a
+  // workflow that has no second version to choose.
+  const canRunAgainstVersion = Boolean(workflowAgentId && evaluation?.workflow_id);
+  const finishedRunCount = runs.filter(
+    (run) => run.status === "completed" || run.status === "failed",
+  ).length;
 
   // Runs are sorted newest-first, so the most recent is the summary for the header.
   const lastRun = runs[0];
@@ -624,19 +626,38 @@ const EvaluationDetailPage: React.FC = () => {
             <p className="truncate text-sm text-muted-foreground">{evaluation.description}</p>
           )}
         </div>
-        <Button
-          onClick={handleRunEvaluation}
-          disabled={isRunning}
-          className="shrink-0"
-          aria-label="Run evaluation"
-        >
-          {isRunning ? (
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-          ) : (
-            <Play className="mr-2 h-4 w-4" />
+        <div className="flex shrink-0 items-center gap-2">
+          {canRunAgainstVersion && (
+            <TooltipProvider delayDuration={200}>
+              <TooltipButton
+                button={
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    disabled={isRunning}
+                    onClick={() => setIsVersionDialogOpen(true)}
+                    aria-label="Run against a version"
+                  >
+                    <GitBranch className="h-4 w-4" />
+                  </Button>
+                }
+                tooltipContent={{ children: <p>Run against a version</p> }}
+              />
+            </TooltipProvider>
           )}
-          {isRunning ? "Running..." : "Run"}
-        </Button>
+          <Button
+            onClick={() => handleRunEvaluation()}
+            disabled={isRunning}
+            aria-label="Run evaluation"
+          >
+            {isRunning ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Play className="mr-2 h-4 w-4" />
+            )}
+            {isRunning ? "Running..." : "Run"}
+          </Button>
+        </div>
       </div>
 
       {/* Configuration + Last Run summary */}
@@ -701,6 +722,11 @@ const EvaluationDetailPage: React.FC = () => {
               <div>
                 <div className="flex flex-wrap items-center gap-2">
                   <span className="font-medium">Run #{lastRun.id?.slice(-4)}</span>
+                  {lastRun.workflow_version && (
+                    <Badge variant="outline" className="text-[10px]">
+                      v{lastRun.workflow_version}
+                    </Badge>
+                  )}
                   <RunStatusBadge status={lastRun.status} />
                 </div>
                 <div className="mt-0.5 text-xs text-muted-foreground">
@@ -745,9 +771,17 @@ const EvaluationDetailPage: React.FC = () => {
       <div className="rounded-lg border bg-card p-4 dark:bg-zinc-900">
         <div className="mb-3 flex items-center justify-between">
           <h2 className="text-lg font-semibold">Previous Executions</h2>
-          <Badge variant="secondary" className="text-xs">
-            {runs.length} run{runs.length !== 1 ? "s" : ""}
-          </Badge>
+          <div className="flex items-center gap-2">
+            {finishedRunCount >= 2 && (
+              <Button variant="outline" size="sm" onClick={() => setIsCompareOpen(true)}>
+                <GitCompareArrows className="mr-1.5 h-3.5 w-3.5" />
+                Compare
+              </Button>
+            )}
+            <Badge variant="secondary" className="text-xs">
+              {runs.length} run{runs.length !== 1 ? "s" : ""}
+            </Badge>
+          </div>
         </div>
 
         {isLoadingRuns ? (
@@ -791,6 +825,11 @@ const EvaluationDetailPage: React.FC = () => {
                   <div className="flex items-center justify-between gap-2">
                     <div className="flex items-center gap-2">
                       <span className="font-medium">Run #{run.id?.slice(-4)}</span>
+                      {run.workflow_version && (
+                        <Badge variant="outline" className="text-[10px]">
+                          v{run.workflow_version}
+                        </Badge>
+                      )}
                       {avgAccuracy !== null && (
                         <div className="flex items-center gap-1">
                           <Progress
@@ -877,7 +916,14 @@ const EvaluationDetailPage: React.FC = () => {
         <DialogContent className="flex h-[90vh] max-h-[90vh] w-[95vw] max-w-[1400px] flex-col gap-0 overflow-hidden p-0">
           <DialogHeader className="shrink-0 border-b px-5 py-3">
             <div className="flex items-center justify-between gap-3">
-              <DialogTitle>Run Details #{selectedRun?.id?.slice(-4)}</DialogTitle>
+              <div className="flex items-center gap-2">
+                <DialogTitle>Run Details #{selectedRun?.id?.slice(-4)}</DialogTitle>
+                {selectedRun?.workflow_version && (
+                  <Badge variant="outline" className="text-[10px]">
+                    v{selectedRun.workflow_version}
+                  </Badge>
+                )}
+              </div>
               {selectedRun && <RunStatusBadge status={selectedRun.status} />}
             </div>
             {selectedRun?.created_at && (
@@ -1077,6 +1123,27 @@ const EvaluationDetailPage: React.FC = () => {
           </div>
         </DialogContent>
       </Dialog>
+
+      {canRunAgainstVersion && workflowAgentId && (
+        <RunAgainstVersionDialog
+          isOpen={isVersionDialogOpen}
+          onOpenChange={setIsVersionDialogOpen}
+          agentId={workflowAgentId}
+          currentWorkflowId={evaluation.workflow_id}
+          workflowName={workflowName}
+          isStarting={isRunning}
+          onRun={(targetWorkflowId) => {
+            setIsVersionDialogOpen(false);
+            void handleRunEvaluation(targetWorkflowId);
+          }}
+        />
+      )}
+
+      <CompareRunsDialog
+        isOpen={isCompareOpen}
+        onOpenChange={setIsCompareOpen}
+        runs={runs}
+      />
     </PageLayout>
   );
 };

--- a/frontend/src/views/TestSuites/pages/WorkflowEvaluationsPage.tsx
+++ b/frontend/src/views/TestSuites/pages/WorkflowEvaluationsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronLeft, ListChecks, Loader2, Play, Search } from "lucide-react";
+import { ChevronLeft, GitBranch, ListChecks, Loader2, Play, Search } from "lucide-react";
 import toast from "react-hot-toast";
 
 import { PageLayout } from "@/components/PageLayout";
@@ -16,14 +16,16 @@ import {
 } from "@/components/dialog";
 import { PaginationBar } from "@/components/PaginationBar";
 import { PageListSkeleton } from "@/components/skeletons";
+import { TooltipProvider } from "@/components/RadixTooltip";
+import { TooltipButton } from "@/components/tooltip-button";
 
 import { getWorkflowsMinimal } from "@/services/workflows";
-import { getTestRunsBatch, listTestSuites, startTestRun } from "@/services/testSuites";
+import { getTestRunsBatch, listTestSuites } from "@/services/testSuites";
 import { getLLMProvidersMinimal } from "@/services/llmProviders";
 import {
-  appendRunToEvaluation,
   deleteTestEvaluation,
   getWorkflowEvaluationsPage,
+  runTestEvaluation,
   runWorkflowEvaluations,
   updateTestEvaluation,
 } from "@/services/testEvaluations";
@@ -33,6 +35,7 @@ import { TestRun, TestSuite } from "@/interfaces/testSuite.interface";
 import { LLMProviderMinimal } from "@/interfaces/llmProvider.interface";
 import { EvaluationWizard, EvaluationWizardData } from "../components/EvaluationWizard";
 import { EvaluationListRow } from "../components/EvaluationListRow";
+import { RunAgainstVersionDialog } from "../components/RunAgainstVersionDialog";
 import { buildTechniqueConfigs, getEditInitialData, wizardMetadata } from "../helpers/evaluationForm";
 
 const PAGE_SIZE = 20;
@@ -94,6 +97,7 @@ const WorkflowEvaluationsPage: React.FC = () => {
 
   const [editingEvaluation, setEditingEvaluation] = useState<TestEvaluationConfig | null>(null);
   const [deletingEvaluationId, setDeletingEvaluationId] = useState<string | null>(null);
+  const [isRunAllVersionDialogOpen, setIsRunAllVersionDialogOpen] = useState(false);
 
   // staleTime 0 makes react-query refetch this when the tab regains focus. The
   // interval is the page's only poll: it runs when a batch is active that this
@@ -120,9 +124,13 @@ const WorkflowEvaluationsPage: React.FC = () => {
   const evaluations = pageData?.items ?? [];
   const total = pageData?.total ?? 0;
   const totalUnfiltered = pageData?.total_unfiltered ?? 0;
+  const currentWorkflow = workflows.find((w) => w.id === workflowId);
   const workflowName = isUnassigned
     ? "Unassigned evaluations"
-    : workflows.find((w) => w.id === workflowId)?.name ?? "Workflow";
+    : currentWorkflow?.name ?? "Workflow";
+  const workflowAgentId = isUnassigned ? null : currentWorkflow?.agent_id ?? null;
+  // Offered on every workflow; the dialog handles one with no second version.
+  const canRunAgainstVersion = Boolean(workflowAgentId);
 
   useEffect(() => {
     const load = async () => {
@@ -201,22 +209,19 @@ const WorkflowEvaluationsPage: React.FC = () => {
     if (!evaluation.id || isEvaluationRunning(evaluation)) return;
     setRunningEvalIds((prev) => new Set(prev).add(evaluation.id));
     try {
-      // Memory threads are generated per conversation by the backend at run time.
-      const runMetadata = evaluation.input_metadata ?? undefined;
-      const created = await startTestRun(evaluation.suite_id, {
-        techniques: evaluation.techniques,
-        technique_configs: evaluation.technique_configs,
-        workflow_id: evaluation.workflow_id,
-        input_metadata: runMetadata,
-      });
+      const created = await runTestEvaluation(evaluation.id);
       if (created?.id) {
-        await appendRunToEvaluation(evaluation.id, created.id);
         setLastRunsByEvaluationId((prev) => ({ ...prev, [evaluation.id as string]: created }));
         toast.success("Evaluation started");
         void refetchPage(); // any_running turns on, which starts the status poll
       }
-    } catch {
-      toast.error("Failed to start evaluation");
+    } catch (error) {
+      if (isRunningConflict(error)) {
+        toast.error("This evaluation is already running");
+        void refetchPage();
+      } else {
+        toast.error("Failed to start evaluation");
+      }
     } finally {
       setRunningEvalIds((prev) => {
         const next = new Set(prev);
@@ -226,7 +231,7 @@ const WorkflowEvaluationsPage: React.FC = () => {
     }
   };
 
-  const handleRunAll = async () => {
+  const handleRunAll = async (targetWorkflowId?: string) => {
     if (isUnassigned || isRunAllInFlight.current || isWorkflowRunning || pageData?.any_running) {
       return;
     }
@@ -243,7 +248,7 @@ const WorkflowEvaluationsPage: React.FC = () => {
     };
 
     try {
-      const started = await runWorkflowEvaluations(workflowId);
+      const started = await runWorkflowEvaluations(workflowId, targetWorkflowId);
       if (isStale()) return; // navigated away before the POST resolved
       const startedRuns = (started ?? []).filter(
         (s): s is typeof s & { run_id: string } => Boolean(s.run_id),
@@ -404,33 +409,53 @@ const WorkflowEvaluationsPage: React.FC = () => {
             />
           </div>
           {!isUnassigned && (
-            <Button
-              variant="outline"
-              disabled={isWorkflowRunning || Boolean(pageData?.any_running)}
-              onClick={handleRunAll}
-            >
-              {isWorkflowRunning && workflowProgress ? (
-                <>
-                  <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-                  {workflowProgress.done}/{workflowProgress.total}
-                </>
-              ) : isWorkflowRunning ? (
-                <>
-                  <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-                  Starting…
-                </>
-              ) : pageData?.any_running ? (
-                <>
-                  <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-                  Running…
-                </>
-              ) : (
-                <>
-                  <Play className="h-3.5 w-3.5 mr-1" />
-                  Run all
-                </>
+            <div className="flex items-center gap-2">
+              {canRunAgainstVersion && (
+                <TooltipProvider delayDuration={200}>
+                  <TooltipButton
+                    button={
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        disabled={isWorkflowRunning || Boolean(pageData?.any_running)}
+                        onClick={() => setIsRunAllVersionDialogOpen(true)}
+                        aria-label="Run all against a version"
+                      >
+                        <GitBranch className="h-4 w-4" />
+                      </Button>
+                    }
+                    tooltipContent={{ children: <p>Run all against a version</p> }}
+                  />
+                </TooltipProvider>
               )}
-            </Button>
+              <Button
+                variant="outline"
+                disabled={isWorkflowRunning || Boolean(pageData?.any_running)}
+                onClick={() => handleRunAll()}
+              >
+                {isWorkflowRunning && workflowProgress ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                    {workflowProgress.done}/{workflowProgress.total}
+                  </>
+                ) : isWorkflowRunning ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                    Starting…
+                  </>
+                ) : pageData?.any_running ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                    Running…
+                  </>
+                ) : (
+                  <>
+                    <Play className="h-3.5 w-3.5 mr-1" />
+                    Run all
+                  </>
+                )}
+              </Button>
+            </div>
           )}
         </div>
       </div>
@@ -485,6 +510,22 @@ const WorkflowEvaluationsPage: React.FC = () => {
           pageItemCount={evaluations.length}
           onPageChange={setPage}
           className="mt-4"
+        />
+      )}
+
+      {canRunAgainstVersion && workflowAgentId && (
+        <RunAgainstVersionDialog
+          isOpen={isRunAllVersionDialogOpen}
+          onOpenChange={setIsRunAllVersionDialogOpen}
+          agentId={workflowAgentId}
+          currentWorkflowId={workflowId}
+          workflowName={workflowName}
+          confirmLabel="Run all"
+          isStarting={isWorkflowRunning}
+          onRun={(targetWorkflowId) => {
+            setIsRunAllVersionDialogOpen(false);
+            void handleRunAll(targetWorkflowId);
+          }}
         />
       )}
 


### PR DESCRIPTION
## Description

- Plain Run now executes the agent's active version instead of the version the evaluation was configured with; the stored workflow still drives grouping and stays the fallback.
- New button on the evaluation and workflow pages to pick any saved version; an explicit choice wins over the active one.
- Each run records and shows the version it executed, and a new Compare view diffs two runs and flags cases that went pass → fail.
- `POST /evaluations/{id}/run` replaces the old create-run + attach round trip, and Run all resolves the active version once per batch.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
