### PR TITLE
fix: preserve feature-gated routes on refresh

### DIFF
--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -50,7 +50,7 @@ import { FileManagerFiles } from "./views/Settings/pages/FileManagerFiles";
 import { NotificationsSettings } from "./views/Settings/pages/Notifications";
 import { Maintenance } from "./views/Settings/pages/Maintenance";
 import { FeatureFlags as FeatureFlagKeys } from "@/config/featureFlags";
-import { useFeatureFlagVisible } from "@/components/featureFlag";
+import FeatureFlagRoute from "@/layout/FeatureFlagRoute";
 import { GlobalChat } from "./components/GlobalChat";
 import ServerDownPage from "@/components/ServerDownPage";
 import { useServerStatus } from "@/context/ServerStatusContext";
@@ -101,19 +101,6 @@ const ProtectedLayout = () => {
 export type RegistrationStatus = "loading" | "new" | "existing";
 
 export const RoutesProvider = () => {
-  const showLocalFineTune = useFeatureFlagVisible(
-    FeatureFlagKeys.LLM_SETTINGS.SHOW_LOCAL_FINE_TUNE
-  );
-  const showBedrockFineTune = useFeatureFlagVisible(
-    FeatureFlagKeys.LLM_SETTINGS.SHOW_BEDROCK_FINE_TUNE
-  );
-  const showLlmUsage = useFeatureFlagVisible(
-    FeatureFlagKeys.ANALYTICS.SHOW_COST_PER_CONVERSATION
-  );
-  const showTemplateMarketplace = useFeatureFlagVisible(
-    FeatureFlagKeys.FEATURE.TEMPLATE_MARKETPLACE
-  );
-
   const [registrationStatus, setRegistrationStatus] = useState<RegistrationStatus>("loading");
   const [skipOnboarding, setSkipOnboarding] = useState(false);
 
@@ -202,13 +189,11 @@ export const RoutesProvider = () => {
             {
               path: "analytics/llm-usage",
               element: (
-                showLlmUsage ? (
+                <FeatureFlagRoute flagKey={FeatureFlagKeys.ANALYTICS.SHOW_COST_PER_CONVERSATION}>
                   <ProtectedRoute requiredPermissions={["read:dashboard"]}>
                     <LlmUsagePage />
                   </ProtectedRoute>
-                ) : (
-                  <Navigate to="/dashboard" replace />
-                )
+                </FeatureFlagRoute>
               ),
             },
             {
@@ -221,12 +206,12 @@ export const RoutesProvider = () => {
             },
             {
               path: "templates",
-              element: showTemplateMarketplace ? (
-                <ProtectedRoute requiredPermissions={["read:template"]}>
-                  <TemplatesPage />
-                </ProtectedRoute>
-              ) : (
-                <Navigate to="/dashboard" replace />
+              element: (
+                <FeatureFlagRoute flagKey={FeatureFlagKeys.FEATURE.TEMPLATE_MARKETPLACE}>
+                  <ProtectedRoute requiredPermissions={["read:template"]}>
+                    <TemplatesPage />
+                  </ProtectedRoute>
+                </FeatureFlagRoute>
               ),
             },
             {
@@ -364,49 +349,41 @@ export const RoutesProvider = () => {
             {
               path: "bedrock-fine-tune",
               element: (
-                showBedrockFineTune ? (
+                <FeatureFlagRoute flagKey={FeatureFlagKeys.LLM_SETTINGS.SHOW_BEDROCK_FINE_TUNE}>
                   <ProtectedRoute requiredPermissions={["*", "read:bedrock_job"]}>
                     <BedrockFineTune />
                   </ProtectedRoute>
-                ) : (
-                  <Navigate to="/dashboard" replace />
-                )
+                </FeatureFlagRoute>
               ),
             },
             {
               path: "bedrock-fine-tune/:id",
               element: (
-                showBedrockFineTune ? (
+                <FeatureFlagRoute flagKey={FeatureFlagKeys.LLM_SETTINGS.SHOW_BEDROCK_FINE_TUNE}>
                   <ProtectedRoute requiredPermissions={["*", "read:bedrock_job"]}>
                     <BedrockFineTuneJobDetail />
                   </ProtectedRoute>
-                ) : (
-                  <Navigate to="/dashboard" replace />
-                )
+                </FeatureFlagRoute>
               ),
             },
             {
               path: "local-fine-tune",
               element: (
-                showLocalFineTune ? (
+                <FeatureFlagRoute flagKey={FeatureFlagKeys.LLM_SETTINGS.SHOW_LOCAL_FINE_TUNE}>
                   <ProtectedRoute requiredPermissions={["*", "read:local_fine_tuning"]}>
                     <LocalFineTune />
                   </ProtectedRoute>
-                ) : (
-                  <Navigate to="/dashboard" replace />
-                )
+                </FeatureFlagRoute>
               ),
             },
             {
               path: "local-fine-tune/:id",
               element: (
-                showLocalFineTune ? (
+                <FeatureFlagRoute flagKey={FeatureFlagKeys.LLM_SETTINGS.SHOW_LOCAL_FINE_TUNE}>
                   <ProtectedRoute requiredPermissions={["*", "read:local_fine_tuning"]}>
                     <LocalFineTuneJobDetail />
                   </ProtectedRoute>
-                ) : (
-                  <Navigate to="/dashboard" replace />
-                )
+                </FeatureFlagRoute>
               ),
             },
             {
@@ -627,7 +604,7 @@ export const RoutesProvider = () => {
         { path: "office365/oauth/callback", element: <Office365OAuthCallback />},
         { path: "*", element: <NotFound /> }
       ]),
-    [showLocalFineTune, showBedrockFineTune, showLlmUsage, showTemplateMarketplace],
+    [],
   );
 
   const organizationRouter = useMemo(

--- a/frontend/src/context/FeatureFlagContext.tsx
+++ b/frontend/src/context/FeatureFlagContext.tsx
@@ -7,6 +7,8 @@ import { isAuthenticated } from '@/services/auth';
 interface FeatureFlagContextType {
   flags: FeatureFlag[];
   loading: boolean;
+  /** Latches true once the first fetch settles; never returns to false. */
+  hydrated: boolean;
   error: string | null;
   isEnabled: (key: string) => boolean;
   getValue: (key: string) => string | null;
@@ -24,6 +26,7 @@ interface FeatureFlagProviderProps {
 export const FeatureFlagProvider: React.FC<FeatureFlagProviderProps> = ({ children }) => {
   const [flags, setFlags] = useState<FeatureFlag[]>([]);
   const [loading, setLoading] = useState(true);
+  const [hydrated, setHydrated] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const fetchFlags = async () => {
@@ -36,6 +39,7 @@ export const FeatureFlagProvider: React.FC<FeatureFlagProviderProps> = ({ childr
       setError('Failed to load feature flags');
     } finally {
       setLoading(false);
+      setHydrated(true);
     }
   };
 
@@ -43,7 +47,10 @@ export const FeatureFlagProvider: React.FC<FeatureFlagProviderProps> = ({ childr
     // check if the user is authenticated
     if (isAuthenticated()) {
       fetchFlags();
+      return;
     }
+    // no fetch runs for anonymous visitors, so flag state is already final
+    setHydrated(true);
   }, []);
 
   const isEnabled = (key: string): boolean => {
@@ -69,6 +76,7 @@ export const FeatureFlagProvider: React.FC<FeatureFlagProviderProps> = ({ childr
   const value = {
     flags,
     loading,
+    hydrated,
     error,
     isEnabled,
     getValue,

--- a/frontend/src/layout/FeatureFlagRoute.tsx
+++ b/frontend/src/layout/FeatureFlagRoute.tsx
@@ -1,0 +1,27 @@
+import { Navigate } from "react-router-dom";
+import { useFeatureFlagVisible } from "@/components/featureFlag";
+import { useFeatureFlag } from "@/context/FeatureFlagContext";
+import RouteLoadingFallback from "@/layout/RouteLoadingFallback";
+
+interface FeatureFlagRouteProps {
+  children: React.ReactNode;
+  flagKey: string;
+}
+
+const FeatureFlagRoute: React.FC<FeatureFlagRouteProps> = ({ children, flagKey }) => {
+  const { hydrated } = useFeatureFlag();
+  const isVisible = useFeatureFlagVisible(flagKey);
+
+  // Hold the route until flags settle, otherwise a refresh reads as a disabled flag
+  if (!hydrated) {
+    return <RouteLoadingFallback />;
+  }
+
+  if (!isVisible) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default FeatureFlagRoute;

--- a/frontend/src/layout/ProtectedRoute.tsx
+++ b/frontend/src/layout/ProtectedRoute.tsx
@@ -5,7 +5,7 @@ import {
   useIsLoadingPermissions,
   useRefreshPermissions,
 } from "@/context/PermissionContext";
-import { Skeleton } from "@/components/skeleton";
+import RouteLoadingFallback from "@/layout/RouteLoadingFallback";
 import { useEffect } from "react";
 import { useServerStatus } from "@/context/ServerStatusContext";
 
@@ -46,17 +46,7 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   }
 
   if (isLoading) {
-    return (
-      <div className="flex justify-center items-center h-screen">
-        <div className="flex flex-col space-y-3">
-          <Skeleton className="h-[125px] w-[250px] rounded-xl" />
-          <div className="space-y-2">
-            <Skeleton className="h-4 w-[250px]" />
-            <Skeleton className="h-4 w-[200px]" />
-          </div>
-        </div>
-      </div>
-    );
+    return <RouteLoadingFallback />;
   }
 
   if (
@@ -64,17 +54,7 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
     Array.isArray(requiredPermissions) &&
     requiredPermissions.length > 0
   ) {
-    return (
-      <div className="flex justify-center items-center h-screen">
-        <div className="flex flex-col space-y-3">
-          <Skeleton className="h-[125px] w-[250px] rounded-xl" />
-          <div className="space-y-2">
-            <Skeleton className="h-4 w-[250px]" />
-            <Skeleton className="h-4 w-[200px]" />
-          </div>
-        </div>
-      </div>
-    );
+    return <RouteLoadingFallback />;
   }
 
   const normalize = (input?: string | string[]) =>

--- a/frontend/src/layout/RouteLoadingFallback.tsx
+++ b/frontend/src/layout/RouteLoadingFallback.tsx
@@ -1,0 +1,15 @@
+import { Skeleton } from "@/components/skeleton";
+
+const RouteLoadingFallback = () => (
+  <div className="flex justify-center items-center h-screen">
+    <div className="flex flex-col space-y-3">
+      <Skeleton className="h-[125px] w-[250px] rounded-xl" />
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-[250px]" />
+        <Skeleton className="h-4 w-[200px]" />
+      </div>
+    </div>
+  </div>
+);
+
+export default RouteLoadingFallback;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -23,19 +23,22 @@ const shouldRetry = (failureCount: number, error: unknown): boolean => {
     return false;
   }
 
-  if (error instanceof AxiosError) {
-    const status = error.response?.status;
-    const code = error.code;
+  // Validation errors raised by our own services carry no status; a retry repeats them
+  if (!(error instanceof AxiosError)) {
+    return false;
+  }
 
-    // Don't retry on server errors (5xx)
-    if (status && status >= 500) {
-      return false;
-    }
+  const status = error.response?.status;
+  const code = error.code;
 
-    // Don't retry on network errors (server unreachable)
-    if (NETWORK_ERROR_CODES.has(code ?? "")) {
-      return false;
-    }
+  // Don't retry on server errors (5xx)
+  if (status && status >= 500) {
+    return false;
+  }
+
+  // Don't retry on network errors (server unreachable)
+  if (NETWORK_ERROR_CODES.has(code ?? "")) {
+    return false;
   }
 
   return true;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -23,22 +23,19 @@ const shouldRetry = (failureCount: number, error: unknown): boolean => {
     return false;
   }
 
-  // Validation errors raised by our own services carry no status; a retry repeats them
-  if (!(error instanceof AxiosError)) {
-    return false;
-  }
+  if (error instanceof AxiosError) {
+    const status = error.response?.status;
+    const code = error.code;
 
-  const status = error.response?.status;
-  const code = error.code;
+    // Don't retry on server errors (5xx)
+    if (status && status >= 500) {
+      return false;
+    }
 
-  // Don't retry on server errors (5xx)
-  if (status && status >= 500) {
-    return false;
-  }
-
-  // Don't retry on network errors (server unreachable)
-  if (NETWORK_ERROR_CODES.has(code ?? "")) {
-    return false;
+    // Don't retry on network errors (server unreachable)
+    if (NETWORK_ERROR_CODES.has(code ?? "")) {
+      return false;
+    }
   }
 
   return true;

--- a/frontend/src/services/analyticsReports.ts
+++ b/frontend/src/services/analyticsReports.ts
@@ -17,14 +17,9 @@ function buildQueryString(params: Record<string, string | undefined>): string {
 }
 
 export const fetchGroupAgents = async (groupId: string): Promise<GroupAgentItem[]> => {
-  try {
-    return (
-      (await apiRequest<GroupAgentItem[]>("get", `/analytics/groups/${groupId}/agents`)) ?? []
-    );
-  } catch (error) {
-    console.error("Error fetching group agents:", error);
-    return [];
-  }
+  const data = await apiRequest<GroupAgentItem[]>("get", `/analytics/groups/${groupId}/agents`);
+  if (!Array.isArray(data)) throw new Error("Failed to fetch group agents");
+  return data;
 };
 
 export const fetchAgentDailyStats = async (

--- a/frontend/src/services/userGroups.ts
+++ b/frontend/src/services/userGroups.ts
@@ -3,7 +3,10 @@ import { UserGroup } from "@/interfaces/userGroup.interface";
 
 export const getAllUserGroups = async (): Promise<UserGroup[]> => {
   const data = await apiRequest<UserGroup[]>("GET", "user-groups/");
-  return data || [];
+  // apiRequest returns null on 403. Failing loudly keeps that distinct from "no groups",
+  // so callers never cache a permission error as an empty list
+  if (!Array.isArray(data)) throw new Error("Failed to fetch user groups");
+  return data;
 };
 
 export const createUserGroup = async (data: Partial<UserGroup>): Promise<UserGroup> => {

--- a/frontend/src/views/Analytics/components/LlmUsageFilterMenu.tsx
+++ b/frontend/src/views/Analytics/components/LlmUsageFilterMenu.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/dropdown-menu";
 import { cn } from "@/helpers/utils";
+import type { UserGroup } from "@/interfaces/userGroup.interface";
 
 export const ALL_FILTER_VALUE = "all";
 
@@ -29,6 +30,10 @@ interface FilterGroup {
 }
 
 interface LlmUsageFilterMenuProps {
+  groups?: UserGroup[];
+  groupFilter?: string;
+  onGroupFilterChange?: (value: string) => void;
+
   agents: Array<{ id: string; name: string }>;
   agentFilter: string;
   onAgentFilterChange: (value: string) => void;
@@ -40,8 +45,11 @@ interface LlmUsageFilterMenuProps {
   onModelChange: (value: string) => void;
 }
 
-/** Agent, provider and model in one pill menu, matching the Transcripts quality filter */
+/** Group, agent, provider and model in one pill menu, matching the Transcripts quality filter */
 export function LlmUsageFilterMenu({
+  groups,
+  groupFilter,
+  onGroupFilterChange,
   agents,
   agentFilter,
   onAgentFilterChange,
@@ -52,7 +60,19 @@ export function LlmUsageFilterMenu({
   model,
   onModelChange,
 }: LlmUsageFilterMenuProps) {
-  const groups: FilterGroup[] = [
+  const filterGroups: FilterGroup[] = [
+    ...(groups && onGroupFilterChange
+      ? [
+          {
+            key: "group",
+            label: "Group",
+            allLabel: "All groups",
+            value: groupFilter ?? ALL_FILTER_VALUE,
+            options: groups.map((g) => ({ value: g.id, label: g.name })),
+            onChange: onGroupFilterChange,
+          },
+        ]
+      : []),
     {
       key: "agent",
       label: "Agent",
@@ -79,11 +99,13 @@ export function LlmUsageFilterMenu({
     },
   ];
 
-  const activeCount = groups.filter((g) => g.value !== ALL_FILTER_VALUE).length;
+  const activeCount = filterGroups.filter((g) => g.value !== ALL_FILTER_VALUE).length;
   const selectedLabel = (group: FilterGroup) =>
     group.options.find((o) => o.value === group.value)?.label ?? group.value;
 
   const clearAll = () => {
+    // Group first, so the agent reset it triggers cannot clobber the value set after it
+    onGroupFilterChange?.(ALL_FILTER_VALUE);
     onAgentFilterChange(ALL_FILTER_VALUE);
     onProviderChange(ALL_FILTER_VALUE);
     onModelChange(ALL_FILTER_VALUE);
@@ -113,7 +135,7 @@ export function LlmUsageFilterMenu({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-[14rem]">
-        {groups.map((group) => (
+        {filterGroups.map((group) => (
           <DropdownMenuSub key={group.key}>
             <DropdownMenuSubTrigger className="flex items-center gap-2">
               <span className="shrink-0">{group.label}</span>

--- a/frontend/src/views/Analytics/components/LlmUsageFilterMenu.tsx
+++ b/frontend/src/views/Analytics/components/LlmUsageFilterMenu.tsx
@@ -81,14 +81,15 @@ export function LlmUsageFilterMenu({
       options: agents.map((a) => ({ value: a.id, label: a.name })),
       onChange: onAgentFilterChange,
     },
-    {
-      key: "provider",
-      label: "Provider",
-      allLabel: "All providers",
-      value: provider,
-      options: providers.map((p) => ({ value: p, label: p })),
-      onChange: onProviderChange,
-    },
+ // Keep it in case we need it :)   
+ // {
+ //   key: "provider",
+ //   label: "Provider",
+ //   allLabel: "All providers",
+ //   value: provider,
+ //   options: providers.map((p) => ({ value: p, label: p })),
+ //   onChange: onProviderChange,
+ //   },
     {
       key: "model",
       label: "Model",

--- a/frontend/src/views/Analytics/hooks/useAgentsList.ts
+++ b/frontend/src/views/Analytics/hooks/useAgentsList.ts
@@ -4,10 +4,17 @@ import type { AgentListItem } from "@/interfaces/ai-agent.interface";
 
 export const useAgentsList = () => {
   const [agents, setAgents] = useState<AgentListItem[]>([]);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     getAgentConfigsList(1, 100)
-      .then((r) => setAgents(r.items))
+      .then((r) => {
+        // Response is null on 403. Leaving loaded false stops callers treating a failed
+        // fetch as proof an agent is gone
+        if (!Array.isArray(r?.items)) return;
+        setAgents(r.items);
+        setLoaded(true);
+      })
       .catch(() => {});
   }, []);
 
@@ -16,5 +23,5 @@ export const useAgentsList = () => {
     [agents],
   );
 
-  return { agents, agentNameMap };
+  return { agents, agentNameMap, loaded };
 };

--- a/frontend/src/views/Analytics/hooks/useAnalyticsFilters.ts
+++ b/frontend/src/views/Analytics/hooks/useAnalyticsFilters.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { currentUserIsAdmin } from "@/services/auth";
 import { getAllUserGroups } from "@/services/userGroups";
@@ -9,15 +9,27 @@ import { useAgentsList } from "./useAgentsList";
 
 export function useAnalyticsFilters() {
   const isAdmin = currentUserIsAdmin();
-  const [groupFilter, setGroupFilterState] = useState("all");
-  const [agentFilter, setAgentFilter] = useState("all");
-  const { agents: allAgents, agentNameMap: allAgentNameMap } = useAgentsList();
+  const [selectedGroup, setSelectedGroup] = useState("all");
+  const [selectedAgent, setSelectedAgent] = useState("all");
+  const {
+    agents: allAgents,
+    agentNameMap: allAgentNameMap,
+    loaded: allAgentsLoaded,
+  } = useAgentsList();
 
-  const { data: groups = [] } = useQuery<UserGroup[]>({
+  const { data: groupsData } = useQuery<UserGroup[]>({
     queryKey: ["user-groups"],
     queryFn: getAllUserGroups,
     enabled: isAdmin,
   });
+  const groupsLoaded = Array.isArray(groupsData);
+  const groups = groupsLoaded ? groupsData : [];
+  const groupExists = groups.some((g) => g.id === selectedGroup);
+  const groupFilter = isAdmin && groupExists ? selectedGroup : "all";
+  const groupWasDeleted = selectedGroup !== "all" && groupsLoaded && !groupExists;
+  useEffect(() => {
+    if (groupWasDeleted) setSelectedGroup("all");
+  }, [groupWasDeleted]);
 
   const { data: groupAgents } = useQuery({
     queryKey: ["analytics-group-agents", groupFilter],
@@ -30,6 +42,16 @@ export function useAnalyticsFilters() {
     return groupAgents ?? [];
   }, [isAdmin, groupFilter, allAgents, groupAgents]);
 
+  const agentsLoaded =
+    isAdmin && groupFilter !== "all" ? groupAgents !== undefined : allAgentsLoaded;
+  const agentExists = agents.some((a) => a.id === selectedAgent);
+  const agentFilter = agentExists ? selectedAgent : "all";
+
+  const agentWasDeleted = selectedAgent !== "all" && agentsLoaded && !agentExists;
+  useEffect(() => {
+    if (agentWasDeleted) setSelectedAgent("all");
+  }, [agentWasDeleted]);
+
   const agentNameMap = useMemo(() => {
     const map = { ...allAgentNameMap };
     for (const a of groupAgents ?? []) {
@@ -39,8 +61,8 @@ export function useAnalyticsFilters() {
   }, [allAgentNameMap, groupAgents]);
 
   const setGroupFilter = useCallback((value: string) => {
-    setGroupFilterState(value);
-    setAgentFilter("all");
+    setSelectedGroup(value);
+    setSelectedAgent("all");
   }, []);
 
   const filterParams: Pick<AnalyticsFilterParams, "agent_id" | "group_id"> = useMemo(
@@ -62,7 +84,7 @@ export function useAnalyticsFilters() {
     groupFilter,
     setGroupFilter,
     agentFilter,
-    setAgentFilter,
+    setAgentFilter: setSelectedAgent,
     agents,
     agentNameMap,
     filterParams,

--- a/frontend/src/views/Analytics/pages/LlmUsagePage.tsx
+++ b/frontend/src/views/Analytics/pages/LlmUsagePage.tsx
@@ -326,15 +326,15 @@ function LlmUsagePage() {
           subtitle="Token consumption and LLM spend across workflows and metric analysis"
         >
           <AnalyticsFilters
-            groups={showGroupFilter ? groups : undefined}
-            groupFilter={groupFilter}
-            onGroupFilterChange={setGroupFilter}
             dateRange={dateRange}
             onDateRangeChange={setDateRange}
             compareDateRange={compareDateRange}
             onCompareDateRangeChange={setCompareDateRange}
           >
             <LlmUsageFilterMenu
+              groups={showGroupFilter ? groups : undefined}
+              groupFilter={groupFilter}
+              onGroupFilterChange={setGroupFilter}
               agents={agents}
               agentFilter={agentFilter}
               onAgentFilterChange={setAgentFilter}

--- a/frontend/src/views/Notifications/pages/NotificationsPage.tsx
+++ b/frontend/src/views/Notifications/pages/NotificationsPage.tsx
@@ -18,6 +18,7 @@ import { type NotificationTypeFilter } from "@/services/dashboard"
 import { EmptyNotificationsState } from "../components/EmptyNotificationsState"
 import { NotificationCard } from "../components/NotificationCard"
 import { getAllUserGroups } from "@/services/userGroups"
+import { currentUserIsAdmin } from "@/services/auth"
 
 type ConversationTypeFilter = Exclude<NotificationTypeFilter, "all">
 
@@ -82,9 +83,11 @@ const NotificationsPage = () => {
     isLoading,
   } = useNotificationsInfinite({ typeFilter, levelFilter })
 
+  // /user-groups is admin-only; non-admins got an empty list here anyway
   const { data: groups = [] } = useQuery({
     queryKey: ["user-groups-all"],
     queryFn: () => getAllUserGroups(),
+    enabled: currentUserIsAdmin(),
   })
   const groupNameById = useMemo(
     () => Object.fromEntries(groups.map((g) => [g.id, g.name])),


### PR DESCRIPTION
## Description

Fixes feature-flagged pages redirecting to the dashboard when refreshed before feature flags finish loading.
Introduces a hydration-aware feature-flag route guard applied to Cost Explorer, Templates, and the Bedrock and Local fine-tuning routes. Improvements in Cost Explorer group and agent filtering by validating selections only after filter data has loaded, distinguishing request failures from valid empty responses, and consolidating the group filter into the existing filter menu.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

- Added a hydration-aware feature-flag route guard that waits for the initial feature-flag request before deciding whether to render or redirect.
- Preserved the current URL when refreshing Cost Explorer, Templates, Bedrock fine-tune, and Local fine-tune pages with enabled feature flags.
- Preserved fine-tune detail route identifiers when refreshing detail pages.
- Extracted the shared route loading skeleton to remove duplicated loading markup.
- Moved the Cost Explorer group filter into the unified filter menu.
- Added loaded-state validation for group and agent selections so failed requests are not treated as deleted data.
- Reset group and agent filters when their selected values no longer exist after a successful load.
- Temporarily removed the Provider option from the Cost Explorer filter menu.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] Multi-tenant considerations addressed (if applicable)

## Related Issues


Closes #

## Screenshots (if applicable)


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
