### PR TITLE
feat: eval method quality

### DIFF
--- a/backend/app/api/v1/routes/test_evaluations.py
+++ b/backend/app/api/v1/routes/test_evaluations.py
@@ -11,12 +11,15 @@ from app.core.tenant_scope import get_tenant_context
 from app.dependencies.dependency_injection import RedisString
 from app.dependencies.injector import injector
 from app.schemas.test_suite import (
+    EvaluationRunRequest,
     EvaluationToolCatalog,
     PaginatedEvaluations,
+    RunWorkflowEvaluationsRequest,
     StartedEvaluationRun,
     TestEvaluation,
     TestEvaluationCreate,
     TestEvaluationUpdate,
+    TestRun,
     WorkflowEvaluationSummary,
 )
 from app.services.test_suite import TestSuiteService
@@ -120,6 +123,42 @@ async def append_run_to_evaluation(
     return await service.append_run_to_evaluation(evaluation_id, str(run_id))
 
 
+@router.post(
+    "/evaluations/{evaluation_id}/run",
+    response_model=TestRun,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(auth), Depends(permissions(P.Evaluation.RUN))],
+)
+async def run_evaluation(
+    evaluation_id: UUID,
+    data: Optional[EvaluationRunRequest] = None,
+    service: TestSuiteService = Injected(TestSuiteService),
+):
+    """Queue one evaluation's run, optionally against another version of its
+    workflow. Refuses with 409 while the evaluation is queued/running."""
+    if await service.evaluation_has_active_run(evaluation_id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This evaluation is already running.",
+        )
+
+    tenant = get_tenant_context()
+
+    def dispatch(run, input_metadata, technique_configs):
+        execute_test_suite_run_task.delay(
+            str(run.id),
+            tenant,
+            input_metadata,
+            technique_configs,
+        )
+
+    return await service.start_evaluation_run(
+        evaluation_id,
+        dispatch,
+        data.target_workflow_id if data else None,
+    )
+
+
 @router.delete(
     "/evaluations/{evaluation_id}",
     status_code=status.HTTP_204_NO_CONTENT,
@@ -147,6 +186,7 @@ async def delete_evaluation(
 )
 async def run_workflow_evaluations(
     workflow_id: UUID,
+    data: Optional[RunWorkflowEvaluationsRequest] = None,
     service: TestSuiteService = Injected(TestSuiteService),
 ):
     """
@@ -186,7 +226,11 @@ async def run_workflow_evaluations(
                 technique_configs,
             )
 
-        return await service.start_workflow_evaluations(workflow_id, dispatch)
+        return await service.start_workflow_evaluations(
+            workflow_id,
+            dispatch,
+            data.target_workflow_id if data else None,
+        )
     finally:
         # Compare-and-delete so we only release our own lock; never let a release
         # error mask the actual response.

--- a/backend/app/core/exceptions/error_messages.py
+++ b/backend/app/core/exceptions/error_messages.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 class ErrorKey(Enum):
     INTERNAL_ERROR = "error_500"
     TOOL_USAGE_CONFIG_INVALID = "tool_usage_config_invalid"
+    EVALUATION_TARGET_NOT_A_VERSION = "evaluation_target_not_a_version"
     NOT_FOUND = "not_found"
     AUDIT_LOG_NOT_FOUND = "audit_log_not_found"
     SENTIMENT_OBJECT_STRUCTURE = "sentiment_object_structure"
@@ -180,6 +181,7 @@ ERROR_MESSAGES = {
     "en": {
         ErrorKey.INTERNAL_ERROR: "An internal server error occurred. Please try again later.",
         ErrorKey.TOOL_USAGE_CONFIG_INVALID: "The tool usage configuration could not be resolved to canonical tool ids.",
+        ErrorKey.EVALUATION_TARGET_NOT_A_VERSION: "The target workflow is not a version of the evaluation's workflow.",
         ErrorKey.NOT_FOUND: "The requested resource was not found.",
         ErrorKey.AUDIT_LOG_NOT_FOUND: "The requested log was not found.",
         ErrorKey.SENTIMENT_OBJECT_STRUCTURE: "Sentiment object must have 'positive', 'neutral', and 'negative' fields.",

--- a/backend/app/repositories/workflow.py
+++ b/backend/app/repositories/workflow.py
@@ -17,7 +17,22 @@ class WorkflowRepository(DbRepository[WorkflowModel]):
             WorkflowModel.id,
             WorkflowModel.name,
             WorkflowModel.version,
+            WorkflowModel.agent_id,
         )
+        if hasattr(WorkflowModel, "is_deleted"):
+            stmt = stmt.where(WorkflowModel.is_deleted == 0)
+        result = await self.db.execute(stmt)
+        return result.all()
+
+    async def get_minimal_by_ids(self, ids: List[UUID]) -> List:
+        if not ids:
+            return []
+        stmt = select(
+            WorkflowModel.id,
+            WorkflowModel.name,
+            WorkflowModel.version,
+            WorkflowModel.agent_id,
+        ).where(WorkflowModel.id.in_(ids))
         if hasattr(WorkflowModel, "is_deleted"):
             stmt = stmt.where(WorkflowModel.is_deleted == 0)
         result = await self.db.execute(stmt)

--- a/backend/app/schemas/test_suite.py
+++ b/backend/app/schemas/test_suite.py
@@ -223,7 +223,10 @@ class TestRunInDB(TestRunBase):
 
 
 class TestRun(TestRunInDB):
-    pass
+    # Display metadata of the workflow version the run executed; populated on
+    # read paths, None on the create response.
+    workflow_name: Optional[str] = None
+    workflow_version: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -234,6 +237,30 @@ class BatchRunsRequest(BaseModel):
     ids: List[str] = Field(
         ...,
         description="List of test run UUIDs to fetch.",
+    )
+
+
+class EvaluationRunRequest(BaseModel):
+    """Options for starting a single evaluation run."""
+
+    target_workflow_id: Optional[UUID] = Field(
+        default=None,
+        description=(
+            "Run against this workflow version instead of the evaluation's own. "
+            "Must be a version of the same workflow (same agent)."
+        ),
+    )
+
+
+class RunWorkflowEvaluationsRequest(BaseModel):
+    """Options for the workflow-wide Run all."""
+
+    target_workflow_id: Optional[UUID] = Field(
+        default=None,
+        description=(
+            "Run every evaluation against this workflow version instead of its "
+            "own. Must be a version of the same workflow (same agent)."
+        ),
     )
 
 

--- a/backend/app/schemas/workflow.py
+++ b/backend/app/schemas/workflow.py
@@ -39,6 +39,7 @@ class WorkflowMinimal(BaseModel):
     id: UUID
     name: str
     version: str
+    agent_id: Optional[UUID] = None
 
     model_config = ConfigDict(
         from_attributes=True

--- a/backend/app/services/test_suite.py
+++ b/backend/app/services/test_suite.py
@@ -2146,19 +2146,32 @@ class TestSuiteService:
             return 0.0
         return None
 
-    async def get_runs_by_ids(self, ids: List[str]) -> List[TestRunInDB]:
+    async def _runs_with_workflow_labels(self, rows: List[Any]) -> List[TestRun]:
+        """Attach the executed workflow's name/version to each run for display."""
+        runs = [TestRun.model_validate(r, from_attributes=True) for r in rows]
+        ids = list({run.workflow_id for run in runs if run.workflow_id})
+        workflows = await self.workflow_service.get_minimal_by_ids(ids)
+        by_id = {workflow.id: workflow for workflow in workflows}
+        for run in runs:
+            workflow = by_id.get(run.workflow_id)
+            if workflow:
+                run.workflow_name = workflow.name
+                run.workflow_version = workflow.version
+        return runs
+
+    async def get_runs_by_ids(self, ids: List[str]) -> List[TestRun]:
         rows = await self.run_repo.get_by_ids(ids)
-        return [TestRunInDB.model_validate(r, from_attributes=True) for r in rows]
+        return await self._runs_with_workflow_labels(rows)
 
     async def get_run(self, run_id: UUID) -> TestRun:
         run = await self.run_repo.get_by_id(run_id)
         if not run:
             raise AppException(status_code=404, error_key=ErrorKey.NOT_FOUND)
-        return TestRun.model_validate(run, from_attributes=True)
+        return (await self._runs_with_workflow_labels([run]))[0]
 
-    async def list_runs_for_suite(self, suite_id: UUID) -> List[TestRunInDB]:
+    async def list_runs_for_suite(self, suite_id: UUID) -> List[TestRun]:
         rows = await self.run_repo.get_all_for_suite(suite_id)
-        return [TestRunInDB.model_validate(r, from_attributes=True) for r in rows]
+        return await self._runs_with_workflow_labels(rows)
 
     async def list_results_for_run(self, run_id: UUID) -> List[TestResultInDB]:
         rows = await self.result_repo.get_all_for_run(run_id)
@@ -2280,6 +2293,7 @@ class TestSuiteService:
         dispatch: Callable[
             [TestRunInDB, Optional[Dict[str, Any]], Optional[Dict[str, Any]]], None
         ],
+        target_workflow_id: Optional[UUID] = None,
     ) -> List[StartedEvaluationRun]:
         """Queue and dispatch a run for every evaluation targeting this workflow.
 
@@ -2287,13 +2301,29 @@ class TestSuiteService:
         through its dataset's default workflow. Each evaluation is created and
         dispatched independently: one failure is reported as ``failed_to_start``
         and does not prevent the rest from running.
+
+        ``target_workflow_id`` runs every evaluation against that version
+        instead of its own; it must be a version of ``workflow_id``.
         """
+        if target_workflow_id:
+            await self._ensure_version_of_same_workflow(
+                workflow_id, target_workflow_id
+            )
         targeted = await self._evaluations_for_workflow(workflow_id)
+
+        # Every evaluation in this scope shares ``workflow_id`` as its effective
+        # workflow, so the active version is the same for all of them: resolve it
+        # once instead of per evaluation.
+        batch_target = target_workflow_id
+        if not batch_target and targeted:
+            batch_target = await self.workflow_service.get_active_version_id(
+                workflow_id
+            )
 
         results: List[StartedEvaluationRun] = []
         for ev in targeted:
             try:
-                run = await self._start_evaluation_run(ev, dispatch)
+                run = await self._start_evaluation_run(ev, dispatch, batch_target)
                 results.append(
                     StartedEvaluationRun(
                         evaluation_id=ev.id,
@@ -2314,6 +2344,58 @@ class TestSuiteService:
                     )
                 )
         return results
+
+    async def start_evaluation_run(
+        self,
+        evaluation_id: UUID,
+        dispatch: Callable[
+            [TestRunInDB, Optional[Dict[str, Any]], Optional[Dict[str, Any]]], None
+        ],
+        target_workflow_id: Optional[UUID] = None,
+    ) -> TestRunInDB:
+        """Queue and dispatch one evaluation's run, optionally against another
+        version of its workflow."""
+        ev = await self.evaluation_repo.get_by_id(evaluation_id)
+        if not ev:
+            raise AppException(status_code=404, error_key=ErrorKey.NOT_FOUND)
+        if target_workflow_id:
+            base_workflow_id = await self._effective_workflow_id(
+                ev.workflow_id, ev.suite_id
+            )
+            await self._ensure_version_of_same_workflow(
+                base_workflow_id, target_workflow_id
+            )
+        return await self._start_evaluation_run(ev, dispatch, target_workflow_id)
+
+    async def _ensure_version_of_same_workflow(
+        self, base_workflow_id: Any, target_workflow_id: UUID
+    ) -> None:
+        """Reject a target that is not a saved version of the base workflow.
+
+        Versions of one workflow share its agent; comparing agent ids keeps an
+        evaluation from being pointed at an unrelated workflow by accident.
+        """
+        if not base_workflow_id:
+            raise AppException(
+                status_code=400,
+                error_key=ErrorKey.EVALUATION_TARGET_NOT_A_VERSION,
+                error_detail=(
+                    "The evaluation has no workflow, so a target version "
+                    "cannot be resolved."
+                ),
+            )
+        if str(base_workflow_id) == str(target_workflow_id):
+            return
+        base = await self.workflow_service.get_by_id(UUID(str(base_workflow_id)))
+        target = await self.workflow_service.get_by_id(target_workflow_id)
+        same_agent = (
+            base.agent_id is not None and base.agent_id == target.agent_id
+        )
+        if not same_agent:
+            raise AppException(
+                status_code=400,
+                error_key=ErrorKey.EVALUATION_TARGET_NOT_A_VERSION,
+            )
 
     async def _evaluations_for_workflow(
         self, workflow_id: UUID
@@ -2526,6 +2608,7 @@ class TestSuiteService:
         dispatch: Callable[
             [TestRunInDB, Optional[Dict[str, Any]], Optional[Dict[str, Any]]], None
         ],
+        target_workflow_id: Optional[UUID] = None,
     ) -> TestRunInDB:
         """Create, record and dispatch a single evaluation run.
 
@@ -2538,10 +2621,13 @@ class TestSuiteService:
         # would merge every conversation into a single memory thread.
         input_metadata = dict(ev.input_metadata or {})
         input_metadata.pop("thread_id", None)
+        resolved_workflow_id = (
+            target_workflow_id or await self._default_run_workflow_id(ev)
+        )
         data = TestRunCreate(
             techniques=list(ev.techniques or []),
             technique_configs=ev.technique_configs or None,
-            workflow_id=ev.workflow_id,
+            workflow_id=resolved_workflow_id,
             input_metadata=input_metadata or None,
         )
         run = await self.create_run(ev.suite_id, data)
@@ -2552,6 +2638,21 @@ class TestSuiteService:
             await self._mark_run_failed_to_start(run.id)
             raise
         return run
+
+    async def _default_run_workflow_id(self, ev: TestEvaluationModel) -> Any:
+        """The version a run executes when the caller names none.
+
+        The agent's active version, so an evaluation tests what is live rather
+        than the version it happened to be configured against. Falls back to its
+        own pinned workflow when the workflow has no agent or no active version.
+        """
+        pinned = await self._effective_workflow_id(ev.workflow_id, ev.suite_id)
+        if not pinned:
+            return None
+        active = await self.workflow_service.get_active_version_id(
+            UUID(str(pinned))
+        )
+        return active or pinned
 
     async def _mark_run_failed_to_start(self, run_id: UUID) -> None:
         """Flip a still-queued run to ``failed`` so it is not left dangling."""

--- a/backend/app/services/test_suite.py
+++ b/backend/app/services/test_suite.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import json
+import re
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 from uuid import UUID, uuid4
 
@@ -378,6 +379,319 @@ def _node_matches_selector(node: Dict[str, Any], selector: Any) -> bool:
     return node.get("id") == selector or _names_equal(node.get("label"), selector)
 
 
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
+)
+
+
+def _display_name(value: Any, labels: Dict[str, str], fallback: str = "unknown node") -> str:
+    """Human name for a node/tool reference: its resolved label, the value itself
+    when it already reads as a name, or a neutral fallback instead of a raw id."""
+    text = str(value or "").strip()
+    if not text:
+        return fallback
+    label = labels.get(text)
+    if label:
+        return label
+    # MCP tool ids are "{nodeId}:{toolName}"; the tool name half is readable.
+    prefix, _, suffix = text.partition(":")
+    if suffix and _UUID_RE.match(prefix):
+        return suffix
+    return fallback if _UUID_RE.match(text) else text
+
+
+def _tool_usage_labeler(
+    labels: Dict[str, str], events: Iterable[Dict[str, Any]] | None = None
+) -> Callable[[str], str]:
+    """id → display name for tool-usage comments; event tool names fill any gaps
+    in the catalogue labels."""
+    combined = dict(labels)
+    for event in events or []:
+        tool_id, tool_name = event.get("tool_id"), event.get("tool_name")
+        if tool_id and tool_name:
+            combined.setdefault(tool_id, tool_name)
+    return lambda value: _display_name(value, combined)
+
+
+def _shorten(value: Any, max_length: int) -> str:
+    """Single-line preview of a value, truncated with an ellipsis."""
+    text = value if isinstance(value, str) else json.dumps(value, default=str)
+    text = " ".join(str(text).split())
+    return text if len(text) <= max_length else text[: max_length - 3] + "..."
+
+
+def _describe_run_error(entry: Any, nodes: Dict[str, Any]) -> str:
+    """One readable "node — error" fragment for a run-level error entry."""
+    if isinstance(entry, dict) and "node" in entry:
+        node = nodes.get(entry.get("node")) or {}
+        source = node.get("label") or node.get("type") or "unknown node"
+        message = _shorten(entry.get("error") or "", 120)
+    elif isinstance(entry, dict) and "message" in entry:
+        # The engine's run-level errors are {"message", "type", "timestamp"} dicts;
+        # only the message is worth showing, with node ids swapped for labels.
+        source = "workflow"
+        text = str(entry.get("message") or "")
+        for node_id, node in nodes.items():
+            if node_id in text and node.get("label"):
+                text = text.replace(node_id, node["label"])
+        message = _shorten(text, 120)
+    else:
+        source = "workflow"
+        message = _shorten(entry, 120)
+    return f"'{source}' — {message}" if message else f"'{source}'"
+
+
+def _summarize_run_errors(errors: List[Any], nodes: Dict[str, Any], max_entries: int = 3) -> str:
+    described = [_describe_run_error(entry, nodes) for entry in errors[:max_entries]]
+    suffix = f"; and {len(errors) - max_entries} more" if len(errors) > max_entries else ""
+    return f"{len(errors)} error(s) during run: " + "; ".join(described) + suffix + "."
+
+
+def _json_diff_summary(
+    actual: Dict[str, Any], expected: Dict[str, Any], max_entries: int = 4
+) -> str:
+    """Readable top-level field diff between actual and expected JSON objects."""
+    differences: List[str] = []
+    for key in expected:
+        if key not in actual:
+            differences.append(f"missing field '{key}'")
+        elif actual[key] != expected[key]:
+            differences.append(
+                f"'{key}': expected {_shorten(expected[key], 40)}, got {_shorten(actual[key], 40)}"
+            )
+    for key in actual:
+        if key not in expected:
+            differences.append(f"unexpected field '{key}'")
+    shown = differences[:max_entries]
+    if len(differences) > max_entries:
+        shown.append(f"and {len(differences) - max_entries} more difference(s)")
+    return "; ".join(shown)
+
+
+def _parse_route_rules(config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Route rules from config; a legacy single-rule config becomes a one-item list."""
+    raw_rules = config.get("rules")
+    if isinstance(raw_rules, list):
+        rules = []
+        for raw in raw_rules:
+            if not isinstance(raw, dict):
+                continue
+            expected = _normalize_text(raw.get("expected"))
+            if not expected:
+                continue
+            rules.append({"router": raw.get("router") or raw.get("node"), "expected": expected})
+        return rules
+    expected = _normalize_text(config.get("expected"))
+    if not expected:
+        return []
+    return [{"router": config.get("router") or config.get("node"), "expected": expected}]
+
+
+def _parse_action_rules(config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Action rules from config; a legacy single-rule config becomes a one-item list."""
+
+    def build(raw: Dict[str, Any]) -> Dict[str, Any] | None:
+        selector = raw.get("node")
+        node_type = raw.get("node_type")
+        if not selector and not node_type:
+            return None
+        return {
+            "node": selector,
+            "node_type": node_type,
+            "should_fire": bool(raw.get("should_fire", True)),
+        }
+
+    raw_rules = config.get("rules")
+    if isinstance(raw_rules, list):
+        built = [build(raw) for raw in raw_rules if isinstance(raw, dict)]
+        return [rule for rule in built if rule]
+    rule = build(config)
+    return [rule] if rule else []
+
+
+def _parse_judge_rules(config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Judge rules from config; a legacy single-rubric config becomes a one-item list."""
+
+    def build(raw: Dict[str, Any]) -> Dict[str, Any] | None:
+        rubric = str(raw.get("rubric") or raw.get("instructions") or "").strip()
+        if not rubric:
+            return None
+        try:
+            min_score = float(raw.get("min_score", 0.5))
+        except (TypeError, ValueError):
+            min_score = 0.5
+        return {
+            "rubric": rubric,
+            "min_score": min_score,
+            "label": str(raw.get("label") or "").strip(),
+            "source_type": raw.get("source_type"),
+            "source_field": raw.get("source_field"),
+        }
+
+    raw_rules = config.get("rules")
+    if isinstance(raw_rules, list):
+        built = [build(raw) for raw in raw_rules if isinstance(raw, dict)]
+        return [rule for rule in built if rule]
+    rule = build(config)
+    return [rule] if rule else []
+
+
+def _grade_route_rule(
+    rule: Dict[str, Any],
+    routers: List[Dict[str, Any]],
+    node_labels: Dict[str, str],
+    rule_number: int,
+) -> Dict[str, Any]:
+    """Grade one route rule against the routers seen in the trace."""
+    selector = rule.get("router")
+    expected = rule["expected"]
+    matched = [r for r in routers if _node_matches_selector(r, selector)] if selector else routers
+    routes = [
+        _normalize_text((r.get("output") or {}).get("route"))
+        for r in matched
+        if isinstance(r.get("output"), dict)
+    ]
+    passed = any(_names_equal(route, expected) for route in routes)
+    if selector:
+        trace_label = matched[0].get("label") if matched else None
+        router_name = trace_label or _display_name(selector, node_labels)
+    else:
+        router_name = None
+    routes_taken = [route for route in routes if route]
+    # The stored observed value stays plain (legacy shape); quotes are comment-only.
+    observed = ", ".join(routes_taken) or "none"
+    quoted_routes = ", ".join(f"'{route}'" for route in routes_taken) or "none"
+
+    if passed:
+        comment = (
+            f"Router '{router_name}' took route '{expected}'."
+            if router_name
+            else f"Route '{expected}' was taken."
+        )
+    elif selector and not matched:
+        comment = f"Router '{router_name}' did not run."
+    elif router_name:
+        comment = f"Expected route '{expected}' on router '{router_name}', took {quoted_routes}."
+    else:
+        comment = f"Expected route '{expected}', took {quoted_routes}."
+
+    return {
+        "rule_number": rule_number,
+        "router": {"id": selector, "label": router_name},
+        "expected": expected,
+        "observed": observed,
+        "passed": passed,
+        "comment": comment,
+    }
+
+
+def _grade_action_rule(
+    rule: Dict[str, Any],
+    nodes: Dict[str, Any],
+    node_labels: Dict[str, str],
+    rule_number: int,
+) -> Dict[str, Any]:
+    """Grade one action rule against the executed nodes in the trace."""
+    selector = rule.get("node")
+    node_type = rule.get("node_type")
+    should_fire = rule["should_fire"]
+
+    def is_target(node: Dict[str, Any]) -> bool:
+        if selector and not _node_matches_selector(node, selector):
+            return False
+        if node_type and node.get("type") != node_type:
+            return False
+        return True
+
+    candidates = [node for node in nodes.values() if is_target(node)]
+    fired_node = next(
+        (node for node in candidates if node.get("status") == "success" and not node.get("error")),
+        None,
+    )
+    fired = fired_node is not None
+    errored = any(node.get("error") for node in candidates)
+    passed = fired if should_fire else not fired
+
+    # Name the node that determined the outcome: the one that fired when the rule
+    # hinges on firing, else the first match (all share the not-fired status).
+    named_node = fired_node or (candidates[0] if candidates else None)
+    trace_label = named_node.get("label") if named_node else None
+    target_name = trace_label or _display_name(selector or node_type, node_labels)
+
+    show_comment_on_pass = False
+    if passed:
+        if not candidates:
+            comment = f"'{target_name}' did not run in this evaluation."
+            show_comment_on_pass = True
+        elif fired:
+            comment = f"'{target_name}' completed."
+        else:
+            comment = f"'{target_name}' did not complete."
+    elif should_fire:
+        comment = f"Expected '{target_name}' to fire but it did not."
+    else:
+        comment = f"Expected '{target_name}' not to fire but it did."
+
+    if not candidates:
+        observed = "did not run"
+    elif fired:
+        observed = "completed"
+    elif errored:
+        observed = "ran with an error"
+    else:
+        observed = "did not complete"
+
+    return {
+        "rule_number": rule_number,
+        "node": {"id": selector or node_type, "label": target_name},
+        "expected": "must complete" if should_fire else "must not complete",
+        "observed": observed,
+        "passed": passed,
+        "comment": comment,
+        "show_comment_on_pass": show_comment_on_pass,
+    }
+
+
+def _rules_result(key: str, details: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Roll one or more graded rule details into a single metric result.
+
+    A single rule keeps the legacy shape (bool score, its own comment) so stored
+    configs render exactly as before; multiple rules score the passed fraction.
+    """
+    total = len(details)
+    passed_count = sum(1 for detail in details if detail["passed"])
+    all_passed = passed_count == total
+
+    if total == 1:
+        single = details[0]
+        hide_comment = single["passed"] and not single.get("show_comment_on_pass")
+        return {
+            "key": key,
+            "score": single["passed"],
+            "passed": single["passed"],
+            "expected": single["expected"],
+            "actual": single["observed"],
+            "comment": None if hide_comment else single["comment"],
+            "details": details,
+        }
+
+    failing = [detail["comment"] for detail in details if not detail["passed"]]
+    comment = f"{passed_count} of {total} rule(s) passed."
+    if failing:
+        comment += " " + " ".join(failing[:2])
+        if len(failing) > 2:
+            comment += f" (+{len(failing) - 2} more)"
+    return {
+        "key": key,
+        "score": passed_count / total,
+        "passed": all_passed,
+        "expected": f"{total} rules",
+        "actual": f"{passed_count} of {total} passed",
+        "comment": comment,
+        "details": details,
+    }
+
+
 def _is_empty_retrieval_result(result: Any) -> bool:
     """True when a retrieval result carries no usable content (empty or a no-result sentinel)."""
     return not _tool_result_satisfies({"result": result}, require_not_empty=True, required_text="")
@@ -751,7 +1065,11 @@ class SimpleEvaluatorRegistry:
             "key": "json_match",
             "score": passed,
             "passed": passed,
-            "comment": None if passed else "JSON outputs do not match.",
+            "comment": (
+                None
+                if passed
+                else f"JSON outputs do not match: {_json_diff_summary(outputs, reference_outputs)}."
+            ),
         }
 
     async def _field_equals(
@@ -801,7 +1119,7 @@ class SimpleEvaluatorRegistry:
             "key": "no_errors",
             "score": passed,
             "passed": passed,
-            "comment": None if passed else f"{len(errors)} error(s) during run.",
+            "comment": None if passed else _summarize_run_errors(errors, trace.get("nodes") or {}),
         }
 
     # ---- agent process techniques ----------------------------------------
@@ -824,12 +1142,19 @@ class SimpleEvaluatorRegistry:
             parse_tool_usage_config,
         )
 
+        from app.services.tool_catalog import resolve_agents
+
         trace = payload.get("trace") or {}
         events = trace.get("tool_events") or []
 
+        workflow = payload.get("workflow")
         resolve_tool_id, resolve_agent_id, agent_ids, all_tool_ids = build_tool_usage_resolvers(
-            payload.get("workflow")
+            workflow
         )
+        catalog = resolve_agents(workflow) if workflow is not None else []
+        labels = {agent["id"]: agent["label"] for agent in catalog}
+        labels.update({tool["id"]: tool["label"] for agent in catalog for tool in agent["tools"]})
+        label_of = _tool_usage_labeler(labels, events)
         executed_nodes = set((trace.get("nodes") or {}).keys())
         # Only real agents count as "executed"; other node types can't use tools.
         executed_agent_ids = executed_nodes & agent_ids if agent_ids is not None else executed_nodes
@@ -848,7 +1173,7 @@ class SimpleEvaluatorRegistry:
             return {"key": "tool_used", "score": 0.0, "passed": False,
                     "comment": "No tool usage rules configured."}
 
-        summary = evaluate_rules(parsed.rules, events, executed_agent_ids)
+        summary = evaluate_rules(parsed.rules, events, executed_agent_ids, label_of)
         coverage = summary["coverage"]
         score = summary["score"]
         results = summary["results"]
@@ -877,9 +1202,11 @@ class SimpleEvaluatorRegistry:
         payload: Dict[str, Any],
         config: Dict[str, Any],
     ) -> Dict[str, Any]:
-        """Pass when a router node chose the expected branch."""
-        expected = _normalize_text(config.get("expected"))
-        if not expected:
+        """Pass when every configured router rule saw its expected branch taken."""
+        from app.services.tool_catalog import resolve_node_labels
+
+        rules = _parse_route_rules(config)
+        if not rules:
             return {
                 "key": "route_taken",
                 "score": False,
@@ -888,26 +1215,14 @@ class SimpleEvaluatorRegistry:
             }
 
         routers = (payload.get("trace") or {}).get("nodes_by_type", {}).get("routerNode", [])
-        selector = config.get("router") or config.get("node")
-        if selector:
-            routers = [r for r in routers if _node_matches_selector(r, selector)]
+        workflow = payload.get("workflow")
+        node_labels = resolve_node_labels(workflow) if workflow is not None else {}
 
-        routes = [
-            _normalize_text((r.get("output") or {}).get("route"))
-            for r in routers
-            if isinstance(r.get("output"), dict)
+        details = [
+            _grade_route_rule(rule, routers, node_labels, index)
+            for index, rule in enumerate(rules, start=1)
         ]
-        passed = any(_names_equal(route, expected) for route in routes)
-        observed = ", ".join(route for route in routes if route) or "none"
-
-        return {
-            "key": "route_taken",
-            "score": passed,
-            "passed": passed,
-            "expected": expected,
-            "actual": observed,
-            "comment": None if passed else f"Expected route {expected!r}, took {routes or 'none'}.",
-        }
+        return _rules_result("route_taken", details)
 
     async def _action_taken(
         self,
@@ -918,10 +1233,11 @@ class SimpleEvaluatorRegistry:
         payload: Dict[str, Any],
         config: Dict[str, Any],
     ) -> Dict[str, Any]:
-        """Pass when a configured side-effect node (by id/label/type) ran successfully."""
-        selector = config.get("node")
-        node_type = config.get("node_type")
-        if not selector and not node_type:
+        """Pass when every configured side-effect node rule is satisfied."""
+        from app.services.tool_catalog import resolve_node_labels
+
+        rules = _parse_action_rules(config)
+        if not rules:
             return {
                 "key": "action_taken",
                 "score": False,
@@ -930,44 +1246,14 @@ class SimpleEvaluatorRegistry:
             }
 
         nodes = (payload.get("trace") or {}).get("nodes") or {}
-        should_fire = bool(config.get("should_fire", True))
-        target = selector or node_type
+        workflow = payload.get("workflow")
+        node_labels = resolve_node_labels(workflow) if workflow is not None else {}
 
-        def is_target(node: Dict[str, Any]) -> bool:
-            if selector and not _node_matches_selector(node, selector):
-                return False
-            if node_type and node.get("type") != node_type:
-                return False
-            return True
-
-        candidates = [node for node in nodes.values() if is_target(node)]
-        fired = any(node.get("status") == "success" and not node.get("error") for node in candidates)
-        passed = fired if should_fire else not fired
-        errored = any(node.get("error") for node in candidates)
-
-        if passed:
-            comment = f"{target!r} did not run in this evaluation." if not candidates else None
-        elif should_fire:
-            comment = f"Expected {target!r} to fire but it did not."
-        else:
-            comment = f"Expected {target!r} not to fire but it did."
-
-        if not candidates:
-            observed = "did not run"
-        elif fired:
-            observed = "completed"
-        elif errored:
-            observed = "ran with an error"
-        else:
-            observed = "did not complete"
-        return {
-            "key": "action_taken",
-            "score": passed,
-            "passed": passed,
-            "expected": "must complete" if should_fire else "must not complete",
-            "actual": observed,
-            "comment": comment,
-        }
+        details = [
+            _grade_action_rule(rule, nodes, node_labels, index)
+            for index, rule in enumerate(rules, start=1)
+        ]
+        return _rules_result("action_taken", details)
 
     async def _guardrail_nli(
         self,
@@ -1168,7 +1454,6 @@ class SimpleEvaluatorRegistry:
             config.get("use_llm_judge", False)
             or config.get("provenance_mode") == "llm"
         )
-        use_embeddings = config.get("provenance_mode") == "embeddings"
 
         if use_llm_judge:
             score, reason = await self._run_provenance_judge(
@@ -1179,13 +1464,11 @@ class SimpleEvaluatorRegistry:
             )
             if score is None:
                 raise RuntimeError("Provenance LLM judge did not return a score.")
-        elif use_embeddings:
-            # Real embedding similarity; never silently fall back to word overlap.
+        else:
+            # Embeddings are the default; mode-less legacy configs grade the same
+            # way rather than with the removed word-overlap heuristic.
             score = await self._embedding_provenance_score(answer, context_text, config)
             reason = "Embedding similarity score"
-        else:
-            score = self._naive_provenance_score(answer, context_text)
-            reason = "Word-overlap score"
 
         min_score = float(config.get("min_score", 0.5))
         if not 0.0 <= min_score <= 1.0:
@@ -1261,19 +1544,6 @@ class SimpleEvaluatorRegistry:
         self._embedder_cache[cache_key] = embedder
         return embedder
 
-    def _naive_provenance_score(self, answer: str, context: str) -> float:
-        if not answer or not context:
-            return 0.0
-
-        answer_tokens = {token.lower() for token in answer.split() if len(token) > 3}
-        context_tokens = {token.lower() for token in context.split() if len(token) > 3}
-
-        if not answer_tokens:
-            return 0.0
-
-        overlap = answer_tokens & context_tokens
-        return len(overlap) / float(len(answer_tokens))
-
     async def _run_provenance_judge(
         self,
         *,
@@ -1338,20 +1608,15 @@ class SimpleEvaluatorRegistry:
         payload: Dict[str, Any],
         config: Dict[str, Any],
     ) -> Dict[str, Any]:
-        """Grade the answer against a user-supplied rubric (any criteria)."""
-        rubric = (config.get("rubric") or config.get("instructions") or "").strip()
-        if not rubric:
+        """Grade the answer against one or more user-supplied rubrics."""
+        rules = _parse_judge_rules(config)
+        if not rules:
             return {
                 "key": "llm_judge",
                 "score": False,
                 "passed": False,
                 "comment": "No rubric configured for llm_judge.",
             }
-
-        try:
-            min_score = float(config.get("min_score", 0.5))
-        except (TypeError, ValueError):
-            min_score = 0.5
 
         answer = _resolve_selector_value(config.get("answer_field"), payload=payload, default=outputs)
         # Auto-provide the user's turn as the QUESTION so the wizard only needs a
@@ -1362,12 +1627,47 @@ class SimpleEvaluatorRegistry:
         )
         answer_text = _normalize_text(answer)
         question_text = _normalize_text(question)
+        provider_id = config.get("llm_provider_id")
+
+        details = list(
+            await asyncio.gather(
+                *(
+                    self._grade_judge_rule(
+                        rule,
+                        rule_number=index,
+                        question_text=question_text,
+                        answer_text=answer_text,
+                        payload=payload,
+                        provider_id=provider_id,
+                    )
+                    for index, rule in enumerate(rules, start=1)
+                )
+            )
+        )
+
+        if len(details) == 1:
+            return self._single_judge_result(details[0])
+        return self._multi_judge_result(details)
+
+    async def _grade_judge_rule(
+        self,
+        rule: Dict[str, Any],
+        *,
+        rule_number: int,
+        question_text: str,
+        answer_text: str,
+        payload: Dict[str, Any],
+        provider_id: str | None,
+    ) -> Dict[str, Any]:
+        """Run one rubric through the judge and return its per-rule detail."""
+        label = rule["label"] or f"Rule {rule_number}"
+        min_score = rule["min_score"]
 
         # New configs use a stable source preset. Saved legacy configs keep their
         # dotted source_field; an unresolved selected source skips instead of
         # silently degrading into a rubric-only judgment.
-        source_type = config.get("source_type")
-        source_field = config.get("source_field")
+        source_type = rule.get("source_type")
+        source_field = rule.get("source_field")
         source_required = False
         if isinstance(source_type, str):
             source_required = source_type != "none"
@@ -1380,15 +1680,18 @@ class SimpleEvaluatorRegistry:
 
         if source_required and not source_text:
             return {
-                "key": "llm_judge",
+                "rule_number": rule_number,
+                "label": label,
                 "score": None,
+                "threshold": min_score,
                 "passed": False,
                 "not_evaluated": True,
-                "comment": "Not evaluated: the selected grounding source was unavailable.",
+                "reason": None,
+                "comment": f"{label}: not evaluated — the grounding source was unavailable.",
             }
 
         system_prompt = (
-            f"{rubric}\n\n"
+            f"{rule['rubric']}\n\n"
             "Return ONLY a compact JSON object in this exact format:\n"
             '{"score": 0.0-1.0, "reason": "short explanation"}\n'
             "Do not include any extra text or explanation."
@@ -1403,26 +1706,104 @@ class SimpleEvaluatorRegistry:
         score, reason = await self._invoke_json_judge(
             system_prompt=system_prompt,
             user_content="\n\n".join(user_parts),
-            provider_id=config.get("llm_provider_id"),
+            provider_id=provider_id,
         )
         # A missing score means the judge output was malformed — our evaluator's
         # problem, not the agent's. Report it as an error, not a failing answer.
         if score is None:
             return {
-                "key": "llm_judge",
+                "rule_number": rule_number,
+                "label": label,
                 "score": None,
+                "threshold": min_score,
                 "passed": False,
                 "error": True,
-                "comment": reason or "LLM judge did not return a usable score.",
+                "reason": reason,
+                "comment": f"{label}: {reason or 'LLM judge did not return a usable score.'}",
             }
 
         passed = score >= min_score
         return {
-            "key": "llm_judge",
+            "rule_number": rule_number,
+            "label": label,
             "score": score,
-            "passed": passed,
             "threshold": min_score,
-            "comment": f"{reason or 'no reason'}; threshold={min_score:.2f}",
+            "passed": passed,
+            "reason": reason,
+            "comment": f"{label}: {reason or 'no reason'}; score={score:.2f}; threshold={min_score:.2f}",
+        }
+
+    @staticmethod
+    def _single_judge_result(detail: Dict[str, Any]) -> Dict[str, Any]:
+        """Legacy single-rubric result shape, unchanged for stored configs."""
+        if detail.get("not_evaluated"):
+            return {
+                "key": "llm_judge",
+                "score": None,
+                "passed": False,
+                "not_evaluated": True,
+                "comment": "Not evaluated: the selected grounding source was unavailable.",
+            }
+        if detail.get("error"):
+            return {
+                "key": "llm_judge",
+                "score": None,
+                "passed": False,
+                "error": True,
+                "comment": detail.get("reason") or "LLM judge did not return a usable score.",
+            }
+        return {
+            "key": "llm_judge",
+            "score": detail["score"],
+            "passed": detail["passed"],
+            "threshold": detail["threshold"],
+            "comment": f"{detail.get('reason') or 'no reason'}; threshold={detail['threshold']:.2f}",
+            "details": [detail],
+        }
+
+    @staticmethod
+    def _multi_judge_result(details: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Roll several judge rules into one metric, mirroring Tool Usage semantics:
+        errors surface as an evaluator error, skipped rules are excluded from the
+        score, and the metric passes only when every graded rule passes."""
+        errored = [detail for detail in details if detail.get("error")]
+        if errored:
+            return {
+                "key": "llm_judge",
+                "score": None,
+                "passed": False,
+                "error": True,
+                "comment": f"{len(errored)} judge rule(s) failed to run. {errored[0]['comment']}",
+                "details": details,
+            }
+
+        graded = [d for d in details if not d.get("not_evaluated")]
+        skipped = len(details) - len(graded)
+        if not graded:
+            return {
+                "key": "llm_judge",
+                "score": None,
+                "passed": False,
+                "not_evaluated": True,
+                "comment": "Not evaluated: no judge rule had an available grounding source.",
+                "details": details,
+            }
+
+        passed_count = sum(1 for detail in graded if detail["passed"])
+        comment = f"{passed_count} of {len(graded)} judge rule(s) passed."
+        if skipped:
+            comment += f" {skipped} not evaluated."
+        failing = [detail["comment"] for detail in graded if not detail["passed"]]
+        if failing:
+            comment += " " + " ".join(failing[:2])
+            if len(failing) > 2:
+                comment += f" (+{len(failing) - 2} more)"
+        return {
+            "key": "llm_judge",
+            "score": passed_count / len(graded),
+            "passed": passed_count == len(graded),
+            "comment": comment,
+            "details": details,
         }
 
 
@@ -1802,6 +2183,9 @@ class TestSuiteService:
                         reference_outputs=case.expected_output,
                         execution_trace=execution_trace,
                         technique_configs=technique_configs,
+                        # Evaluators resolve node/tool ids to display labels from
+                        # the graph; without it comments degrade to "unknown node".
+                        workflow=workflow,
                     ),
                     timeout=EVALUATOR_TIMEOUT_SECONDS,
                 )
@@ -2032,20 +2416,22 @@ class TestSuiteService:
         ]
         conversation_groups = [[str(case.id) for case in group] for group in conversations]
 
-        planned = plan_tool_rule_results(
-            parsed.rules, turns, conversation_groups, case_events, case_executed_agents
-        )
-
-        rule_by_id = {rule.id: rule for rule in parsed.rules}
-        # Turn index per case so a per-turn result can name the turn it graded.
-        turn_index_by_case = {turn["id"]: turn["turn_index"] for turn in turns}
-
         # Human-readable snapshot captured at run time, so results stay legible even
         # if a tool or agent is later renamed. Labels come from the resolved catalogue.
         agent_labels = {agent["id"]: agent["label"] for agent in agents}
         tool_labels = {
             tool["id"]: tool["label"] for agent in agents for tool in agent["tools"]
         }
+        all_events = [event for events in case_events.values() for event in events]
+        label_of = _tool_usage_labeler({**agent_labels, **tool_labels}, all_events)
+
+        planned = plan_tool_rule_results(
+            parsed.rules, turns, conversation_groups, case_events, case_executed_agents, label_of
+        )
+
+        rule_by_id = {rule.id: rule for rule in parsed.rules}
+        # Turn index per case so a per-turn result can name the turn it graded.
+        turn_index_by_case = {turn["id"]: turn["turn_index"] for turn in turns}
         rule_snapshot_by_id = {
             rule.id: self._rule_snapshot(rule, index, agent_labels, tool_labels, describe_tool_rule)
             for index, rule in enumerate(parsed.rules)
@@ -2106,7 +2492,10 @@ class TestSuiteService:
         for key in ("observed_tools", "missing_tools", "failed_tools", "forbidden_tools"):
             ids.update(result.get(key) or [])
         ids.update((result.get("call_counts") or {}).keys())
-        return {tool_id: {"label": tool_labels.get(tool_id, tool_id)} for tool_id in ids}
+        return {
+            tool_id: {"label": _display_name(tool_id, tool_labels, fallback="unknown tool")}
+            for tool_id in ids
+        }
 
     @staticmethod
     def _conversation_index(conversations: List[List[TestCaseInDB]]):

--- a/backend/app/services/tool_catalog.py
+++ b/backend/app/services/tool_catalog.py
@@ -160,6 +160,11 @@ def resolve_action_nodes(workflow: Any, workflow_path: Optional[List[str]] = Non
     ]
 
 
+def resolve_node_labels(workflow: Any) -> Dict[str, str]:
+    """Display label for every node id in the workflow graph."""
+    return {node.get("id"): _node_label(node) for node in _nodes(workflow) if node.get("id")}
+
+
 def nested_workflow_refs(workflow: Any) -> List[Dict[str, Any]]:
     """Executor nodes that run another workflow, for the caller to expand recursively."""
     refs = []

--- a/backend/app/services/tool_usage_rules.py
+++ b/backend/app/services/tool_usage_rules.py
@@ -20,7 +20,7 @@ Each rule result is one of three states so incomplete runs never look healthy:
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Iterable, List, Optional, Set
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -245,13 +245,23 @@ def _count_calls(scoped: List[Dict[str, Any]]) -> "tuple[Dict[str, int], Dict[st
     return call_counts, successful
 
 
+def _named(ids: Iterable[str], label_of: Callable[[str], str]) -> str:
+    return ", ".join(f"'{label_of(item)}'" for item in ids)
+
+
 def evaluate_rule(
     rule: ToolUsageRule,
     events: Iterable[Dict[str, Any]],
     executed_agent_ids: Optional[Set[str]] = None,
+    label_of: Optional[Callable[[str], str]] = None,
 ) -> Dict[str, Any]:
-    """Grade one rule against a scoped set of tool events. Returns a three-state result."""
+    """Grade one rule against a scoped set of tool events. Returns a three-state result.
+
+    ``label_of`` renders tool/agent ids as display names in comments; ids are kept
+    as-is in the structured result fields.
+    """
     executed_agent_ids = executed_agent_ids or set()
+    label_of = label_of or (lambda value: value)
     scoped = _events_for_rule(rule, events)
     target_set: Set[str] = set(rule.tool_ids)
 
@@ -277,7 +287,7 @@ def evaluate_rule(
         violated = sorted(t for t in (target_set & attempted) if t)
         if violated:
             return done(_result(rule, RULE_FAILED, forbidden=violated,
-                                comment=f"Forbidden tool(s) attempted: {violated}."))
+                                comment=f"Forbidden tool(s) attempted: {_named(violated, label_of)}."))
         if not agent_ran:
             return done(_result(rule, RULE_NOT_EVALUATED,
                                 comment="Agent did not run; forbidden-tool rule could not be checked."))
@@ -287,7 +297,7 @@ def evaluate_rule(
         outside = sorted(t for t in (attempted - target_set) if t)
         if outside:
             return done(_result(rule, RULE_FAILED, forbidden=outside,
-                                comment=f"Tool(s) outside the allowed set were used: {outside}."))
+                                comment=f"Tool(s) outside the allowed set were used: {_named(outside, label_of)}."))
         if not agent_ran:
             return done(_result(rule, RULE_NOT_EVALUATED,
                                 comment="Agent did not run; allowed-only rule could not be checked."))
@@ -324,14 +334,16 @@ def evaluate_rule(
         return done(_result(rule, RULE_PASSED, observed=observed,
                             comment="Required tool usage satisfied."))
 
-    scope = f" by node {rule.agent_id}" if rule.agent_id else ""
+    scope = f" by agent '{label_of(rule.agent_id)}'" if rule.agent_id else ""
     parts: List[str] = []
     if not_called:
-        parts.append(f"not called: {not_called}")
+        parts.append(f"not called: {_named(not_called, label_of)}")
     if called_but_failed:
-        parts.append(f"called but did not succeed: {called_but_failed}")
+        parts.append(f"called but did not succeed: {_named(called_but_failed, label_of)}")
     if per_tool_reasons:
-        reasons = "; ".join(f"{tool_id}: {reason}" for tool_id, reason in sorted(per_tool_reasons.items()))
+        reasons = "; ".join(
+            f"{label_of(tool_id)}: {reason}" for tool_id, reason in sorted(per_tool_reasons.items())
+        )
         parts.append(f"result/argument checks failed — {reasons}")
     comment = f"Required tool usage not satisfied{scope}: " + "; ".join(parts) + "."
     return done(_result(rule, RULE_FAILED, observed=observed, missing=not_called,
@@ -387,10 +399,11 @@ def evaluate_rules(
     rules: Iterable[ToolUsageRule],
     events: Iterable[Dict[str, Any]],
     executed_agent_ids: Optional[Set[str]] = None,
+    label_of: Optional[Callable[[str], str]] = None,
 ) -> Dict[str, Any]:
     """Grade every rule and summarize with pass/fail/coverage. ``events`` is one scope slice."""
     events = list(events)
-    results = [evaluate_rule(rule, events, executed_agent_ids) for rule in rules]
+    results = [evaluate_rule(rule, events, executed_agent_ids, label_of) for rule in rules]
 
     passed = sum(1 for r in results if r["status"] == RULE_PASSED)
     failed = sum(1 for r in results if r["status"] == RULE_FAILED)
@@ -431,6 +444,7 @@ def plan_tool_rule_results(
     conversation_groups: List[List[str]],
     events_by_turn: Dict[str, List[Dict[str, Any]]],
     executed_by_turn: Dict[str, Set[str]],
+    label_of: Optional[Callable[[str], str]] = None,
 ) -> List[Dict[str, Any]]:
     """Grade every rule over its scope and return placed results (no DB, no ORM).
 
@@ -464,13 +478,17 @@ def plan_tool_rule_results(
             if target_id is None:
                 planned.append(place(rule, _not_evaluated_result(rule, "Target turn not found in this run.")))
                 continue
-            result = evaluate_rule(rule, events_by_turn.get(target_id, []), executed_by_turn.get(target_id, set()))
+            result = evaluate_rule(
+                rule, events_by_turn.get(target_id, []), executed_by_turn.get(target_id, set()), label_of
+            )
             planned.append(place(rule, result, case_id=target_id))
 
         elif rule.scope == "every_turn":
             for turn in turns:
                 tid = turn["id"]
-                result = evaluate_rule(rule, events_by_turn.get(tid, []), executed_by_turn.get(tid, set()))
+                result = evaluate_rule(
+                    rule, events_by_turn.get(tid, []), executed_by_turn.get(tid, set()), label_of
+                )
                 planned.append(place(rule, result, case_id=tid))
 
         else:  # conversation: merge every turn's events and grade once
@@ -482,7 +500,7 @@ def plan_tool_rule_results(
                     merged_executed |= executed_by_turn.get(tid, set())
                 representative = group[0] if group else None
                 conversation_id = turns_by_id.get(representative, {}).get("source_conversation_id")
-                result = evaluate_rule(rule, merged_events, merged_executed)
+                result = evaluate_rule(rule, merged_events, merged_executed, label_of)
                 planned.append(place(
                     rule, result,
                     case_id=None if conversation_id is not None else representative,

--- a/backend/app/services/workflow.py
+++ b/backend/app/services/workflow.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Optional
 from uuid import UUID
 
 from injector import inject
@@ -41,6 +41,10 @@ class WorkflowService:
     # ---------- READ ----------
     async def get_all_minimal(self) -> List[WorkflowMinimal]:
         rows = await self.repository.get_all_minimal()
+        return [WorkflowMinimal.model_validate(r, from_attributes=True) for r in rows]
+
+    async def get_minimal_by_ids(self, ids: List[UUID]) -> List[WorkflowMinimal]:
+        rows = await self.repository.get_minimal_by_ids(ids)
         return [WorkflowMinimal.model_validate(r, from_attributes=True) for r in rows]
 
     async def get_summaries_by_agent(self, agent_id: UUID) -> List[WorkflowSummary]:
@@ -88,6 +92,26 @@ class WorkflowService:
             .execution_options(**{GROUP_SCOPE_BYPASS_FLAG: True})
         )
         return {row.id: row.username for row in rows}
+
+    async def get_active_version_id(self, workflow_id: UUID) -> Optional[UUID]:
+        """The live version of the workflow's agent — what the builder marks Active.
+
+        ``None`` when the workflow has no agent or the agent points nowhere, so
+        callers can fall back to the version they already hold.
+
+        Agents are group-scoped but workflows are not; the scope filter is
+        bypassed so this pointer resolves to the same version for every caller
+        instead of silently falling back for some. Only the id is read.
+        """
+        workflow = await self.repository.get_by_id(workflow_id)
+        if not workflow or not workflow.agent_id:
+            return None
+        rows = await self.repository.db.execute(
+            select(AgentModel.workflow_id)
+            .where(AgentModel.id == workflow.agent_id)
+            .execution_options(**{GROUP_SCOPE_BYPASS_FLAG: True})
+        )
+        return rows.scalar_one_or_none()
 
     async def get_by_id(self, workflow_id: UUID) -> WorkflowInDB:
         orm_obj = await self.repository.get_by_id(workflow_id)

--- a/backend/tests/unit/test_eval_version_targeting.py
+++ b/backend/tests/unit/test_eval_version_targeting.py
@@ -1,0 +1,261 @@
+"""Unit tests for version-targeted evaluation runs: the same-workflow guard and
+how a run resolves which workflow version to execute."""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from app.core.exceptions.exception_classes import AppException
+from app.schemas.test_suite import TestRunInDB
+from app.services.test_suite import TestSuiteService as EvalService
+
+
+def _service() -> EvalService:
+    return EvalService(
+        suite_repo=AsyncMock(),
+        case_repo=AsyncMock(),
+        run_repo=AsyncMock(),
+        result_repo=AsyncMock(),
+        evaluation_repo=AsyncMock(),
+        tool_rule_result_repo=AsyncMock(),
+        workflow_service=AsyncMock(),
+        conversation_repo=AsyncMock(),
+    )
+
+
+def _eval(*, suite_id=None, workflow_id=None, technique_configs=None):
+    return SimpleNamespace(
+        id=uuid4(),
+        workflow_id=workflow_id,
+        suite_id=suite_id or uuid4(),
+        input_metadata=None,
+        techniques=["no_errors"],
+        technique_configs=technique_configs,
+    )
+
+
+def _workflow(*, workflow_id=None, agent_id=None):
+    return SimpleNamespace(id=workflow_id or uuid4(), agent_id=agent_id)
+
+
+class TestSameWorkflowGuard:
+    @pytest.mark.asyncio
+    async def test_same_id_passes_without_lookups(self):
+        service = _service()
+        workflow_id = uuid4()
+
+        await service._ensure_version_of_same_workflow(workflow_id, workflow_id)
+
+        service.workflow_service.get_by_id.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_same_agent_passes(self):
+        service = _service()
+        agent_id = uuid4()
+        base, target = uuid4(), uuid4()
+        service.workflow_service.get_by_id = AsyncMock(
+            side_effect=[
+                _workflow(workflow_id=base, agent_id=agent_id),
+                _workflow(workflow_id=target, agent_id=agent_id),
+            ]
+        )
+
+        await service._ensure_version_of_same_workflow(base, target)
+
+    @pytest.mark.asyncio
+    async def test_different_agent_is_rejected(self):
+        service = _service()
+        base, target = uuid4(), uuid4()
+        service.workflow_service.get_by_id = AsyncMock(
+            side_effect=[
+                _workflow(workflow_id=base, agent_id=uuid4()),
+                _workflow(workflow_id=target, agent_id=uuid4()),
+            ]
+        )
+
+        with pytest.raises(AppException) as excinfo:
+            await service._ensure_version_of_same_workflow(base, target)
+        assert excinfo.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_missing_agent_is_rejected(self):
+        """Workflows without an agent cannot be proven related — refuse."""
+        service = _service()
+        base, target = uuid4(), uuid4()
+        service.workflow_service.get_by_id = AsyncMock(
+            side_effect=[
+                _workflow(workflow_id=base, agent_id=None),
+                _workflow(workflow_id=target, agent_id=None),
+            ]
+        )
+
+        with pytest.raises(AppException):
+            await service._ensure_version_of_same_workflow(base, target)
+
+    @pytest.mark.asyncio
+    async def test_no_base_workflow_is_rejected(self):
+        service = _service()
+
+        with pytest.raises(AppException) as excinfo:
+            await service._ensure_version_of_same_workflow(None, uuid4())
+        assert excinfo.value.status_code == 400
+
+
+class TestVersionTargetedRuns:
+    def _run_in_db(self, *, suite_id, workflow_id):
+        from datetime import datetime
+
+        return TestRunInDB(
+            id=uuid4(),
+            suite_id=suite_id,
+            workflow_id=workflow_id,
+            status="queued",
+            techniques=["no_errors"],
+            summary_metrics=None,
+            created_at=datetime(2026, 1, 1),
+            updated_at=datetime(2026, 1, 1),
+        )
+
+    @pytest.mark.asyncio
+    async def test_single_run_uses_target_version(self):
+        service = _service()
+        target = uuid4()
+        ev = _eval(workflow_id=uuid4())
+        service.evaluation_repo.get_by_id = AsyncMock(return_value=ev)
+        service._ensure_version_of_same_workflow = AsyncMock()
+        service.create_run = AsyncMock(
+            return_value=self._run_in_db(suite_id=ev.suite_id, workflow_id=target)
+        )
+        service.append_run_to_evaluation = AsyncMock()
+
+        await service.start_evaluation_run(ev.id, lambda *args: None, target)
+
+        data = service.create_run.await_args.args[1]
+        assert data.workflow_id == target
+        service._ensure_version_of_same_workflow.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_single_run_defaults_to_the_active_version(self):
+        """No explicit target runs what is live, not the pinned version."""
+        service = _service()
+        active = uuid4()
+        ev = _eval(workflow_id=uuid4())
+        service.evaluation_repo.get_by_id = AsyncMock(return_value=ev)
+        service._ensure_version_of_same_workflow = AsyncMock()
+        service.workflow_service.get_active_version_id = AsyncMock(return_value=active)
+        service.create_run = AsyncMock(
+            return_value=self._run_in_db(suite_id=ev.suite_id, workflow_id=active)
+        )
+        service.append_run_to_evaluation = AsyncMock()
+
+        await service.start_evaluation_run(ev.id, lambda *args: None)
+
+        data = service.create_run.await_args.args[1]
+        assert data.workflow_id == active
+        service._ensure_version_of_same_workflow.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_single_run_falls_back_to_pinned_without_an_active_version(self):
+        service = _service()
+        ev = _eval(workflow_id=uuid4())
+        service.evaluation_repo.get_by_id = AsyncMock(return_value=ev)
+        service.workflow_service.get_active_version_id = AsyncMock(return_value=None)
+        service.create_run = AsyncMock(
+            return_value=self._run_in_db(suite_id=ev.suite_id, workflow_id=ev.workflow_id)
+        )
+        service.append_run_to_evaluation = AsyncMock()
+
+        await service.start_evaluation_run(ev.id, lambda *args: None)
+
+        data = service.create_run.await_args.args[1]
+        assert data.workflow_id == ev.workflow_id
+
+    @pytest.mark.asyncio
+    async def test_explicit_target_wins_over_the_active_version(self):
+        service = _service()
+        target = uuid4()
+        ev = _eval(workflow_id=uuid4())
+        service.evaluation_repo.get_by_id = AsyncMock(return_value=ev)
+        service._ensure_version_of_same_workflow = AsyncMock()
+        service.workflow_service.get_active_version_id = AsyncMock(return_value=uuid4())
+        service.create_run = AsyncMock(
+            return_value=self._run_in_db(suite_id=ev.suite_id, workflow_id=target)
+        )
+        service.append_run_to_evaluation = AsyncMock()
+
+        await service.start_evaluation_run(ev.id, lambda *args: None, target)
+
+        data = service.create_run.await_args.args[1]
+        assert data.workflow_id == target
+        service.workflow_service.get_active_version_id.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_default_uses_the_dataset_workflow_when_evaluation_has_none(self):
+        """An evaluation with no workflow resolves through its dataset, then to active."""
+        service = _service()
+        suite_workflow, active = uuid4(), uuid4()
+        ev = _eval(workflow_id=None)
+        service.suite_repo.get_by_id = AsyncMock(
+            return_value=SimpleNamespace(id=ev.suite_id, workflow_id=suite_workflow)
+        )
+        service.workflow_service.get_active_version_id = AsyncMock(return_value=active)
+
+        resolved = await service._default_run_workflow_id(ev)
+
+        assert resolved == active
+        service.workflow_service.get_active_version_id.assert_awaited_once_with(
+            suite_workflow
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_all_resolves_the_active_version_once_for_the_batch(self):
+        """Every evaluation in the scope shares the workflow, so the lookup must
+        not repeat per evaluation."""
+        service = _service()
+        workflow_id, active = uuid4(), uuid4()
+        rows = [_eval(workflow_id=workflow_id) for _ in range(4)]
+        service.evaluation_repo.get_all_for_workflow = AsyncMock(return_value=rows)
+        service.workflow_service.get_active_version_id = AsyncMock(return_value=active)
+        service._start_evaluation_run = AsyncMock(
+            return_value=self._run_in_db(suite_id=rows[0].suite_id, workflow_id=active)
+        )
+
+        await service.start_workflow_evaluations(workflow_id, lambda *args: None)
+
+        service.workflow_service.get_active_version_id.assert_awaited_once_with(
+            workflow_id
+        )
+        for call in service._start_evaluation_run.await_args_list:
+            assert call.args[2] == active
+
+    @pytest.mark.asyncio
+    async def test_run_all_skips_the_lookup_when_no_evaluations_match(self):
+        service = _service()
+        service.evaluation_repo.get_all_for_workflow = AsyncMock(return_value=[])
+        service.workflow_service.get_active_version_id = AsyncMock()
+
+        results = await service.start_workflow_evaluations(uuid4(), lambda *args: None)
+
+        assert results == []
+        service.workflow_service.get_active_version_id.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_run_all_passes_target_to_every_evaluation(self):
+        service = _service()
+        workflow_id, target = uuid4(), uuid4()
+        rows = [_eval(workflow_id=workflow_id) for _ in range(2)]
+        service.evaluation_repo.get_all_for_workflow = AsyncMock(return_value=rows)
+        service._ensure_version_of_same_workflow = AsyncMock()
+        service._start_evaluation_run = AsyncMock(
+            return_value=self._run_in_db(suite_id=rows[0].suite_id, workflow_id=target)
+        )
+
+        dispatch = lambda *args: None  # noqa: E731
+        await service.start_workflow_evaluations(workflow_id, dispatch, target)
+
+        service._ensure_version_of_same_workflow.assert_awaited_once_with(
+            workflow_id, target
+        )
+        for call in service._start_evaluation_run.await_args_list:
+            assert call.args[2] == target

--- a/backend/tests/unit/test_evaluation_run_reliability.py
+++ b/backend/tests/unit/test_evaluation_run_reliability.py
@@ -124,6 +124,86 @@ class TestPausedToolEvent:
         assert recorded["error"] is None
 
 
+class TestToolResultRecording:
+    @pytest.mark.asyncio
+    async def test_recorded_tool_result_feeds_result_checks_and_retrievals(self):
+        """End-to-end over the real recording chain: a tool invoked through
+        BaseTool on a real WorkflowState must surface its result to the
+        result-content checks and the retrieved-context collector."""
+        from app.modules.workflow.agents.base_tool import BaseTool
+        from app.modules.workflow.engine.workflow_state import WorkflowState
+        from app.services.test_suite import SimpleEvaluatorRegistry, _build_grading_context
+
+        workflow = {
+            "id": "wf1",
+            "nodes": [
+                {"id": "agent1", "type": "agentNode", "data": {"name": "HR Agent"}},
+                {"id": "kb1", "type": "knowledgeToolNode", "data": {"name": "Search Handbook"}},
+            ],
+            "edges": [{"source": "kb1", "target": "agent1", "targetHandle": "tools"}],
+        }
+        state = WorkflowState(workflow=workflow)
+        handbook_text = "Employees receive 25 vacation days per year."
+
+        # The tool's function is the node's execute, which tracks node status
+        # around the actual work — mirrored here without a full engine run.
+        async def _node_execute(_payload):
+            state.start_node_execution("kb1")
+            state.complete_node_execution("kb1", output=handbook_text)
+            return handbook_text
+
+        tool = BaseTool(
+            node_id="kb1",
+            name="search_handbook",
+            description="",
+            parameters={},
+            function=_node_execute,
+            agent_id="agent1",
+            state=state,
+        )
+        # The agent node executes as a workflow step and calls the tool mid-run.
+        state.start_node_execution("agent1")
+        result = await tool.invoke(topic="vacation days")
+        state.complete_node_execution("agent1", output={"message": "answered"})
+        assert result == handbook_text
+
+        trace = state.format_state_as_response()
+        events = trace.get("tool_events") or []
+        assert events and events[0]["result"] == handbook_text
+
+        context = _build_grading_context(trace)
+        assert any(
+            handbook_text in str(retrieval.get("results")) for retrieval in context["retrievals"]
+        )
+
+        registry = SimpleEvaluatorRegistry()
+        metrics = await registry.evaluate(
+            ["tool_used"],
+            inputs={"message": "How many vacation days do I get?"},
+            outputs="You get 25 vacation days per year.",
+            reference_outputs=None,
+            execution_trace=trace,
+            technique_configs={
+                "tool_used": {"tool": "search_handbook", "result_contains": "25 vacation days"}
+            },
+            workflow=workflow,
+        )
+        assert metrics["tool_used"]["passed"] is True
+
+        failing = await registry.evaluate(
+            ["tool_used"],
+            inputs={},
+            outputs="",
+            reference_outputs=None,
+            execution_trace=trace,
+            technique_configs={
+                "tool_used": {"tool": "search_handbook", "result_contains": "unlimited holidays"}
+            },
+            workflow=workflow,
+        )
+        assert failing["tool_used"]["passed"] is False
+
+
 class TestMetricResultContract:
     def test_accepts_not_evaluated_without_a_score(self):
         from app.schemas.test_suite import TestResultMetrics
@@ -232,6 +312,63 @@ class TestCoverageAggregation:
         assert metric["cases"] == 2
         assert metric["evaluated"] == 2
         assert metric["accuracy"] == 0.5
+
+
+class TestRunPathLabelResolution:
+    @pytest.mark.asyncio
+    async def test_run_loop_passes_workflow_so_comments_use_node_labels(self):
+        """The run loop must hand the workflow graph to the evaluators — without
+        it, route/action comments degrade to 'unknown node' for real runs."""
+        service = _service()
+        now = datetime(2026, 1, 1)
+        router_id = str(uuid4())
+        case = SimpleNamespace(
+            id=uuid4(),
+            suite_id=uuid4(),
+            source_conversation_id=None,
+            turn_index=None,
+            input_data={"message": "hi"},
+            expected_output={"value": "ok"},
+            tags=["imported"],
+            weight=None,
+            created_at=now,
+            updated_at=now,
+        )
+        service.case_repo.get_all_for_suite.return_value = [case]
+
+        suite = SimpleNamespace(id=uuid4(), default_input_metadata=None)
+        workflow = SimpleNamespace(
+            id=uuid4(),
+            nodes=[{"id": router_id, "type": "routerNode", "data": {"name": "Escalation Router"}}],
+            edges=[],
+        )
+        run = SimpleNamespace(
+            id=uuid4(), techniques=["route_taken"], status="queued", summary_metrics=None
+        )
+        engine = MagicMock()
+        engine.execute_from_node = AsyncMock(
+            return_value=SimpleNamespace(
+                output="out",
+                status="ok",
+                # The router never ran, so only the workflow graph can name it.
+                format_state_as_response=lambda: {"state": {"nodeExecutionStatus": {}}},
+            )
+        )
+        with patch("app.services.test_suite.WorkflowEngine", return_value=engine):
+            await service._execute_run(
+                suite,
+                workflow,
+                run,
+                technique_configs={
+                    "route_taken": {"rules": [{"router": router_id, "expected": "true"}]}
+                },
+            )
+
+        persisted = service.result_repo.create.call_args[0][0]
+        comment = persisted.metrics["route_taken"]["comment"]
+        assert "Escalation Router" in comment
+        assert router_id not in comment
+        assert "unknown node" not in comment
 
 
 class TestPausedConversationExecution:

--- a/backend/tests/unit/test_evaluators.py
+++ b/backend/tests/unit/test_evaluators.py
@@ -295,6 +295,88 @@ class TestTraceAwareEvaluators:
         )
         assert metrics["contains"]["passed"] is True
 
+    @pytest.mark.asyncio
+    async def test_no_errors_comment_names_failing_node(self):
+        trace = _sample_trace(node_error="ThreadScopedRAG: NoneType has no len()")
+        metrics = await self.registry.evaluate(
+            ["no_errors"],
+            inputs={},
+            outputs="ok",
+            reference_outputs=None,
+            execution_trace=trace,
+        )
+        m = metrics["no_errors"]
+        assert m["passed"] is False
+        assert "Knowledge Query" in m["comment"]
+        assert "NoneType has no len()" in m["comment"]
+
+    @pytest.mark.asyncio
+    async def test_no_errors_comment_includes_state_level_errors(self):
+        trace = _sample_trace()
+        trace["state"]["errors"] = ["upstream provider unavailable"]
+        metrics = await self.registry.evaluate(
+            ["no_errors"],
+            inputs={},
+            outputs="ok",
+            reference_outputs=None,
+            execution_trace=trace,
+        )
+        m = metrics["no_errors"]
+        assert m["passed"] is False
+        assert "upstream provider unavailable" in m["comment"]
+
+    @pytest.mark.asyncio
+    async def test_no_errors_renders_engine_error_dicts_readably(self):
+        """The engine's canonical {'message','type','timestamp'} error dicts show
+        only the message, with node ids swapped for their display labels."""
+        trace = _sample_trace()
+        trace["state"]["errors"] = [
+            {
+                "message": "Node n2: retrieval failed",
+                "type": "node_execution",
+                "timestamp": "2026-01-01T00:00:00+00:00",
+            }
+        ]
+        metrics = await self.registry.evaluate(
+            ["no_errors"],
+            inputs={},
+            outputs="ok",
+            reference_outputs=None,
+            execution_trace=trace,
+        )
+        m = metrics["no_errors"]
+        assert m["passed"] is False
+        assert "Node Knowledge Query: retrieval failed" in m["comment"]
+        assert "timestamp" not in m["comment"]
+        assert "{" not in m["comment"]
+
+    @pytest.mark.asyncio
+    async def test_json_match_failure_names_differing_fields(self):
+        metrics = await self.registry.evaluate(
+            ["json_match"],
+            inputs={},
+            outputs={"amount": 450, "notes": "extra"},
+            reference_outputs={"amount": 500, "currency": "EUR"},
+        )
+        m = metrics["json_match"]
+        assert m["passed"] is False
+        comment = m["comment"]
+        assert "'amount'" in comment
+        assert "500" in comment and "450" in comment
+        assert "missing field 'currency'" in comment
+        assert "unexpected field 'notes'" in comment
+
+    @pytest.mark.asyncio
+    async def test_json_match_pass_has_no_comment(self):
+        metrics = await self.registry.evaluate(
+            ["json_match"],
+            inputs={},
+            outputs={"amount": 500},
+            reference_outputs={"amount": 500},
+        )
+        assert metrics["json_match"]["passed"] is True
+        assert metrics["json_match"]["comment"] is None
+
 
 class TestHumanInputPauseEvaluation:
     @pytest.mark.asyncio
@@ -650,6 +732,38 @@ def _agent_workflow():
     }
 
 
+def _two_router_trace(*, first_route="true", second_route="support"):
+    """Trace with two routers, for multi-rule route_taken assertions."""
+    return {
+        "output": "Sample response.",
+        "state": {
+            "input": {"message": "Sample user question?"},
+            "errors": [],
+            "nodeExecutionStatus": {
+                "router1": {
+                    "name": "Sample Router",
+                    "type": "routerNode",
+                    "input": {},
+                    "output": {"route": first_route, "next_nodes": []},
+                    "status": "success",
+                    "error": None,
+                },
+                "router2": {
+                    "name": "Second Router",
+                    "type": "routerNode",
+                    "input": {},
+                    "output": {"route": second_route, "next_nodes": []},
+                    "status": "success",
+                    "error": None,
+                },
+            },
+        },
+        "tool_events": [],
+        "token_usage": {},
+        "cost_usd": None,
+    }
+
+
 def _multi_agent_trace():
     """Two agents, each calling a different tool — for agent-scoped assertions."""
     return {
@@ -905,7 +1019,8 @@ class TestProcessCheckEvaluators:
 
     @pytest.mark.asyncio
     async def test_tool_used_scoped_required_tool_not_used_fails(self):
-        # other_tool is available to agent1 but never called; the scoped failure names the node.
+        # other_tool is available to agent1 but never called; the scoped failure
+        # names the agent by its display label, not its node id.
         metrics = await self.registry.evaluate(
             ["tool_used"],
             inputs={},
@@ -916,7 +1031,9 @@ class TestProcessCheckEvaluators:
             workflow=_agent_workflow(),
         )
         assert metrics["tool_used"]["passed"] is False
-        assert "by node" in (metrics["tool_used"]["comment"] or "")
+        comment = metrics["tool_used"]["comment"] or ""
+        assert "by agent 'Sample Agent'" in comment
+        assert "agent1" not in comment
 
     @pytest.mark.asyncio
     async def test_tool_used_must_not_use_uncalled_tool_passes(self):
@@ -1099,6 +1216,233 @@ class TestProcessCheckEvaluators:
         assert metrics["action_taken"]["passed"] is False
         assert "configured" in metrics["action_taken"]["comment"].lower()
 
+    @pytest.mark.asyncio
+    async def test_route_taken_multiple_rules_reports_each(self):
+        trace = _two_router_trace(first_route="true", second_route="billing")
+        metrics = await self.registry.evaluate(
+            ["route_taken"],
+            inputs={},
+            outputs="",
+            reference_outputs=None,
+            execution_trace=trace,
+            technique_configs={
+                "route_taken": {
+                    "rules": [
+                        {"router": "router1", "expected": "true"},
+                        {"router": "router2", "expected": "support"},
+                    ]
+                }
+            },
+        )
+        m = metrics["route_taken"]
+        assert m["passed"] is False
+        assert m["score"] == 0.5
+        assert len(m["details"]) == 2
+        assert m["details"][0]["passed"] is True
+        assert m["details"][1]["passed"] is False
+        assert "1 of 2" in m["comment"]
+        assert "Second Router" in m["comment"]
+
+    @pytest.mark.asyncio
+    async def test_route_taken_multiple_rules_all_pass(self):
+        trace = _two_router_trace(first_route="true", second_route="support")
+        metrics = await self.registry.evaluate(
+            ["route_taken"],
+            inputs={},
+            outputs="",
+            reference_outputs=None,
+            execution_trace=trace,
+            technique_configs={
+                "route_taken": {
+                    "rules": [
+                        {"router": "router1", "expected": "true"},
+                        {"router": "router2", "expected": "support"},
+                    ]
+                }
+            },
+        )
+        m = metrics["route_taken"]
+        assert m["passed"] is True
+        assert m["score"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_route_taken_missing_router_names_it_from_workflow(self):
+        """A rule whose router never ran resolves its display name from the graph,
+        never showing the raw node id."""
+        metrics = await self.registry.evaluate(
+            ["route_taken"],
+            inputs={},
+            outputs="",
+            reference_outputs=None,
+            execution_trace=_agent_trace(route="true"),
+            technique_configs={
+                "route_taken": {
+                    "rules": [
+                        {
+                            "router": "8f2a4b6c-1d2e-4f5a-9b8c-7d6e5f4a3b2c",
+                            "expected": "true",
+                        }
+                    ]
+                }
+            },
+            workflow={
+                "id": "wf1",
+                "nodes": [
+                    {
+                        "id": "8f2a4b6c-1d2e-4f5a-9b8c-7d6e5f4a3b2c",
+                        "type": "routerNode",
+                        "data": {"name": "Escalation Router"},
+                    }
+                ],
+                "edges": [],
+            },
+        )
+        m = metrics["route_taken"]
+        assert m["passed"] is False
+        assert "Escalation Router" in m["comment"]
+        assert "8f2a4b6c" not in m["comment"]
+
+    @pytest.mark.asyncio
+    async def test_route_taken_unknown_router_id_never_prints_uuid(self):
+        metrics = await self.registry.evaluate(
+            ["route_taken"],
+            inputs={},
+            outputs="",
+            reference_outputs=None,
+            execution_trace=_agent_trace(route="true"),
+            technique_configs={
+                "route_taken": {
+                    "rules": [
+                        {
+                            "router": "8f2a4b6c-1d2e-4f5a-9b8c-7d6e5f4a3b2c",
+                            "expected": "true",
+                        }
+                    ]
+                }
+            },
+        )
+        m = metrics["route_taken"]
+        assert m["passed"] is False
+        assert "8f2a4b6c" not in m["comment"]
+        assert "unknown node" in m["comment"]
+
+    @pytest.mark.asyncio
+    async def test_action_taken_multiple_rules(self):
+        """One node must fire (it did) and another must not (it did) — half pass."""
+        metrics = await self.registry.evaluate(
+            ["action_taken"],
+            inputs={},
+            outputs="",
+            reference_outputs=None,
+            execution_trace=_agent_trace(action_status="success"),
+            technique_configs={
+                "action_taken": {
+                    "rules": [
+                        {"node": "action1", "should_fire": True},
+                        {"node": "action1", "should_fire": False},
+                    ]
+                }
+            },
+        )
+        m = metrics["action_taken"]
+        assert m["passed"] is False
+        assert m["score"] == 0.5
+        assert len(m["details"]) == 2
+        assert "Sample Action Node" in m["comment"]
+
+    @pytest.mark.asyncio
+    async def test_action_taken_comment_uses_label_not_id(self):
+        metrics = await self.registry.evaluate(
+            ["action_taken"],
+            inputs={},
+            outputs="",
+            reference_outputs=None,
+            execution_trace=_agent_trace(action_status="failed"),
+            technique_configs={"action_taken": {"node": "action1"}},
+        )
+        m = metrics["action_taken"]
+        assert m["passed"] is False
+        assert "Sample Action Node" in m["comment"]
+        assert "'action1'" not in m["comment"]
+
+    @pytest.mark.asyncio
+    async def test_action_taken_names_the_node_that_fired(self):
+        """A node_type rule matching several nodes must blame the node that actually
+        completed, not whichever candidate happens to come first in the trace."""
+        trace = {
+            "output": "out",
+            "state": {
+                "input": {},
+                "errors": [],
+                "nodeExecutionStatus": {
+                    "mail_a": {
+                        "name": "Mail A",
+                        "type": "emailNode",
+                        "output": {},
+                        "status": "failed",
+                        "error": "smtp down",
+                    },
+                    "mail_b": {
+                        "name": "Mail B",
+                        "type": "emailNode",
+                        "output": {},
+                        "status": "success",
+                        "error": None,
+                    },
+                },
+            },
+            "tool_events": [],
+        }
+        metrics = await self.registry.evaluate(
+            ["action_taken"],
+            inputs={},
+            outputs="",
+            reference_outputs=None,
+            execution_trace=trace,
+            technique_configs={"action_taken": {"node_type": "emailNode", "should_fire": False}},
+        )
+        m = metrics["action_taken"]
+        assert m["passed"] is False
+        assert "Mail B" in m["comment"]
+        assert "Mail A" not in m["comment"]
+
+    @pytest.mark.asyncio
+    async def test_route_taken_actual_value_stays_plain(self):
+        metrics = await self.registry.evaluate(
+            ["route_taken"],
+            inputs={},
+            outputs="",
+            reference_outputs=None,
+            execution_trace=_agent_trace(route="false"),
+            technique_configs={"route_taken": {"expected": "true"}},
+        )
+        m = metrics["route_taken"]
+        assert m["passed"] is False
+        assert m["actual"] == "false"
+        assert "'false'" in m["comment"]
+
+    @pytest.mark.asyncio
+    async def test_tool_used_forbidden_comment_uses_labels(self):
+        metrics = await self.registry.evaluate(
+            ["tool_used"],
+            inputs={},
+            outputs="",
+            reference_outputs=None,
+            execution_trace=_agent_trace(tool_name="lookup_tool"),
+            technique_configs={
+                "tool_used": {
+                    "rules": [
+                        {"id": "r1", "tool_ids": ["node_lookup_tool"], "operator": "none"}
+                    ]
+                }
+            },
+            workflow=_agent_workflow(),
+        )
+        m = metrics["tool_used"]
+        assert m["passed"] is False
+        assert "Lookup Tool" in m["comment"]
+        assert "node_lookup_tool" not in m["comment"]
+
 
 class TestLlmJudge:
     def setup_method(self):
@@ -1145,6 +1489,99 @@ class TestLlmJudge:
             technique_configs={"llm_judge": {"rubric": "Is the reply professional?", "min_score": 0.5}},
         )
         assert metrics["llm_judge"]["passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_multiple_rules_report_each(self):
+        """Two rubrics grade independently; the metric passes only when all do."""
+        async def fake_judge(*, system_prompt, user_content, provider_id=None):
+            if "polite" in system_prompt.lower():
+                return 0.9, "courteous"
+            return 0.2, "misses half the question"
+
+        self.registry._invoke_json_judge = fake_judge
+        metrics = await self.registry.evaluate(
+            ["llm_judge"],
+            inputs={"message": "How do I reset my password and my email?"},
+            outputs="Click reset.",
+            reference_outputs=None,
+            technique_configs={
+                "llm_judge": {
+                    "rules": [
+                        {"label": "Politeness", "rubric": "Is the reply polite?", "min_score": 0.5},
+                        {"label": "Completeness", "rubric": "Does it answer everything?", "min_score": 0.5},
+                    ]
+                }
+            },
+        )
+        m = metrics["llm_judge"]
+        assert m["passed"] is False
+        assert m["score"] == 0.5
+        assert len(m["details"]) == 2
+        assert "1 of 2" in m["comment"]
+        assert "Completeness" in m["comment"]
+        assert m["details"][0]["passed"] is True
+        assert m["details"][1]["passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_multiple_rules_skip_rule_with_unavailable_source(self):
+        """A rule whose grounding source is missing is excluded, not failed."""
+        async def fake_judge(*, system_prompt, user_content, provider_id=None):
+            return 0.8, "fine"
+
+        self.registry._invoke_json_judge = fake_judge
+        metrics = await self.registry.evaluate(
+            ["llm_judge"],
+            inputs={},
+            outputs="Some answer.",
+            reference_outputs=None,
+            execution_trace={},
+            technique_configs={
+                "llm_judge": {
+                    "rules": [
+                        {"label": "Tone", "rubric": "Polite?", "min_score": 0.5, "source_type": "none"},
+                        {
+                            "label": "Relevance",
+                            "rubric": "Sources relevant?",
+                            "min_score": 0.5,
+                            "source_type": "kb_retrievals",
+                        },
+                    ]
+                }
+            },
+        )
+        m = metrics["llm_judge"]
+        assert m["passed"] is True
+        assert m["score"] == 1.0
+        assert "1 not evaluated" in m["comment"]
+        assert m["details"][1]["not_evaluated"] is True
+
+    @pytest.mark.asyncio
+    async def test_multiple_rules_error_surfaces_as_evaluator_error(self):
+        async def fake_judge(*, system_prompt, user_content, provider_id=None):
+            if "polite" in system_prompt.lower():
+                return 0.9, "fine"
+            return None, "malformed judge output"
+
+        self.registry._invoke_json_judge = fake_judge
+        metrics = await self.registry.evaluate(
+            ["llm_judge"],
+            inputs={},
+            outputs="Answer.",
+            reference_outputs=None,
+            technique_configs={
+                "llm_judge": {
+                    "rules": [
+                        {"label": "Tone", "rubric": "Is it polite?", "min_score": 0.5},
+                        {"label": "Broken", "rubric": "Whatever.", "min_score": 0.5},
+                    ]
+                }
+            },
+        )
+        m = metrics["llm_judge"]
+        assert m.get("error") is True
+        assert m["passed"] is False
+        assert m["score"] is None
+        assert "Broken" in m["comment"]
 
     @pytest.mark.asyncio
     async def test_source_field_feeds_kb_content_to_judge(self):
@@ -1851,7 +2288,13 @@ class TestSemanticEvaluators:
         assert metrics["provenance_eval"].get("not_evaluated") is True
 
     @pytest.mark.asyncio
-    async def test_provenance_overlap_default(self):
+    async def test_provenance_mode_less_config_defaults_to_embeddings(self):
+        """A config saved before the mode field existed grades with embeddings,
+        never the removed word-overlap heuristic."""
+        async def fake_embed(answer, context, config):
+            return 0.9
+
+        self.registry._embedding_provenance_score = fake_embed
         metrics = await self.registry.evaluate(
             ["provenance_eval"],
             inputs={},
@@ -1865,10 +2308,14 @@ class TestSemanticEvaluators:
         m = metrics["provenance_eval"]
         assert m.get("not_evaluated") is not True
         assert m["passed"] is True
-        assert "overlap" in m["comment"].lower()
+        assert "embedding" in m["comment"].lower()
 
     @pytest.mark.asyncio
     async def test_provenance_legacy_config_without_source_uses_expected_output(self):
+        async def fake_embed(answer, context, config):
+            return 0.9
+
+        self.registry._embedding_provenance_score = fake_embed
         metrics = await self.registry.evaluate(
             ["provenance_eval"],
             inputs={},

--- a/backend/tests/unit/test_workflow_evaluations_batch.py
+++ b/backend/tests/unit/test_workflow_evaluations_batch.py
@@ -245,7 +245,7 @@ class TestStartWorkflowEvaluations:
         service = _service()
         service._evaluations_for_workflow = AsyncMock(return_value=evals)
 
-        async def fake_start(ev, dispatch):
+        async def fake_start(ev, dispatch, target_workflow_id=None):
             if ev is evals[1]:
                 raise RuntimeError("boom - secret internals")
             return SimpleNamespace(id=uuid4(), suite_id=ev.suite_id, status="queued")
@@ -274,6 +274,8 @@ class TestStartEvaluationRunOrphanCleanup:
         run = SimpleNamespace(id=uuid4(), suite_id=suite, status="queued")
         service.create_run = AsyncMock(return_value=run)
         service.append_run_to_evaluation = AsyncMock()
+        # Runs default to the agent's active version; this workflow has none.
+        service.workflow_service.get_active_version_id = AsyncMock(return_value=None)
 
         # the persisted row the cleanup path fetches and flips
         row = SimpleNamespace(id=run.id, status="queued", summary_metrics=None)

--- a/backend/tests/unit/workflow/test_workflow_active_version.py
+++ b/backend/tests/unit/workflow/test_workflow_active_version.py
@@ -1,0 +1,65 @@
+"""Resolving a workflow's active version — the pointer evaluation runs default to."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.db.events.group_scope import GROUP_SCOPE_BYPASS_FLAG
+from app.services.workflow import WorkflowService
+
+
+def _service(*, workflow, agent_workflow_id=None):
+    """A service whose repository returns ``workflow`` and whose session returns
+    ``agent_workflow_id`` for the agent lookup."""
+    repository = MagicMock()
+    repository.get_by_id = AsyncMock(return_value=workflow)
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=agent_workflow_id)
+    repository.db = MagicMock()
+    repository.db.execute = AsyncMock(return_value=result)
+    return WorkflowService(repository=repository)
+
+
+@pytest.mark.asyncio
+async def test_returns_the_agents_workflow_id():
+    active = uuid4()
+    service = _service(
+        workflow=SimpleNamespace(id=uuid4(), agent_id=uuid4()),
+        agent_workflow_id=active,
+    )
+
+    assert await service.get_active_version_id(uuid4()) == active
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_the_workflow_has_no_agent():
+    service = _service(workflow=SimpleNamespace(id=uuid4(), agent_id=None))
+
+    assert await service.get_active_version_id(uuid4()) is None
+    service.repository.db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_the_workflow_is_missing():
+    service = _service(workflow=None)
+
+    assert await service.get_active_version_id(uuid4()) is None
+    service.repository.db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_bypasses_group_scope_so_every_caller_resolves_the_same_version():
+    """Agents are group-scoped and workflows are not; without the bypass the
+    lookup would silently return nothing for users outside the agent's group,
+    and their runs would target a different version."""
+    service = _service(
+        workflow=SimpleNamespace(id=uuid4(), agent_id=uuid4()),
+        agent_workflow_id=uuid4(),
+    )
+
+    await service.get_active_version_id(uuid4())
+
+    statement = service.repository.db.execute.await_args.args[0]
+    assert statement.get_execution_options().get(GROUP_SCOPE_BYPASS_FLAG) is True

--- a/frontend/src/interfaces/testEvaluation.interface.ts
+++ b/frontend/src/interfaces/testEvaluation.interface.ts
@@ -83,6 +83,35 @@ export interface EvaluationToolCatalog {
 export type ToolUsageOperator = "all" | "any" | "none" | "only";
 export type ToolUsageScope = "specific_turn" | "every_turn" | "conversation";
 
+// ---- Route / Action multi-rule builder drafts ----
+
+export interface RouteRuleDraft {
+  router: string;
+  expected: string;
+}
+
+export interface ActionRuleDraft {
+  node: string;
+  nodeType: string;
+  shouldFire: boolean;
+}
+
+export type JudgeRuleSource =
+  | "expected_output"
+  | "kb_retrievals"
+  | "conversation_context"
+  | "tool_events"
+  | "none"
+  | "legacy";
+
+export interface JudgeRuleDraft {
+  label: string;
+  rubric: string;
+  minScore: string;
+  sourceType: JudgeRuleSource;
+  sourceField: string;
+}
+
 // Extra per-tool assertions (result/argument checks). Not edited in the builder yet,
 // but preserved verbatim so editing a rule never drops them.
 export interface ToolUsagePerToolCheck {

--- a/frontend/src/interfaces/testSuite.interface.ts
+++ b/frontend/src/interfaces/testSuite.interface.ts
@@ -38,6 +38,14 @@ export interface TestRun {
   updated_at?: string;
 }
 
+export interface MetricRuleDetail {
+  rule_number?: number;
+  passed: boolean;
+  comment?: string | null;
+  expected?: string | null;
+  observed?: string | null;
+}
+
 export interface TestResultMetric {
   score: number | boolean | null;
   passed: boolean;
@@ -47,6 +55,7 @@ export interface TestResultMetric {
   expected?: string | null;
   actual?: string | null;
   threshold?: number | null;
+  details?: MetricRuleDetail[] | null;
 }
 
 export interface TestResult {

--- a/frontend/src/interfaces/testSuite.interface.ts
+++ b/frontend/src/interfaces/testSuite.interface.ts
@@ -32,6 +32,8 @@ export interface TestRun {
   status: string;
   techniques: string[];
   summary_metrics?: Record<string, unknown>;
+  workflow_name?: string | null;
+  workflow_version?: string | null;
   created_at?: string;
   updated_at?: string;
 }
@@ -73,11 +75,4 @@ export interface CreateTestCasePayload {
   expected_output?: Record<string, unknown>;
   tags?: string[];
   weight?: number;
-}
-
-export interface StartTestRunPayload {
-  techniques: string[];
-  technique_configs?: Record<string, Record<string, unknown>>;
-  workflow_id?: string;
-  input_metadata?: Record<string, unknown>;
 }

--- a/frontend/src/interfaces/workflow.interface.ts
+++ b/frontend/src/interfaces/workflow.interface.ts
@@ -35,11 +35,12 @@ export interface Workflow {
   settings?: WorkflowSettings;
 }
 
-// Lightweight workflow data (id, name, version only)
+// Lightweight workflow data (id, name, version, agent only)
 export interface WorkflowMinimal {
   id: string;
   name: string;
   version: string;
+  agent_id?: string | null;
 }
 
 export interface WorkflowSummary {

--- a/frontend/src/services/testEvaluations.ts
+++ b/frontend/src/services/testEvaluations.ts
@@ -7,6 +7,7 @@ import {
   TestToolRuleResult,
   WorkflowEvaluationSummary,
 } from "@/interfaces/testEvaluation.interface";
+import { TestRun } from "@/interfaces/testSuite.interface";
 
 export type {
   PaginatedEvaluations,
@@ -51,16 +52,24 @@ export const updateTestEvaluation = (
 export const deleteTestEvaluation = (id: string) =>
   apiRequest<void>("DELETE", `${BASE}/evaluations/${id}`);
 
-export const appendRunToEvaluation = (evaluationId: string, runId: string) =>
-  apiRequest<TestEvaluationConfig>(
+export const runTestEvaluation = (
+  evaluationId: string,
+  targetWorkflowId?: string,
+) =>
+  apiRequest<TestRun>(
     "POST",
-    `${BASE}/evaluations/${evaluationId}/runs/${runId}`,
+    `${BASE}/evaluations/${evaluationId}/run`,
+    targetWorkflowId ? { target_workflow_id: targetWorkflowId } : {},
   );
 
-export const runWorkflowEvaluations = (workflowId: string) =>
+export const runWorkflowEvaluations = (
+  workflowId: string,
+  targetWorkflowId?: string,
+) =>
   apiRequest<StartedEvaluationRun[]>(
     "POST",
     `${BASE}/workflows/${workflowId}/evaluations/run`,
+    targetWorkflowId ? { target_workflow_id: targetWorkflowId } : undefined,
   );
 
 export const getWorkflowEvaluationSummaries = () =>

--- a/frontend/src/services/testSuites.ts
+++ b/frontend/src/services/testSuites.ts
@@ -2,7 +2,6 @@ import { apiRequest } from "@/config/api";
 import type {
   CreateTestCasePayload,
   CreateTestSuitePayload,
-  StartTestRunPayload,
   TestCase,
   TestResult,
   TestRun,
@@ -68,13 +67,6 @@ export const removeConversationFromSuite = (suiteId: string, conversationId: str
   apiRequest<void>(
     "DELETE",
     `${BASE}/suites/${suiteId}/conversations/${conversationId}`,
-  );
-
-export const startTestRun = (suiteId: string, payload: StartTestRunPayload) =>
-  apiRequest<TestRun>(
-    "POST",
-    `${BASE}/suites/${suiteId}/runs`,
-    payload as unknown as Record<string, unknown>,
   );
 
 export const listTestRunsForSuite = (suiteId: string) =>

--- a/frontend/src/views/TestSuites/components/ActionRulesBuilder.tsx
+++ b/frontend/src/views/TestSuites/components/ActionRulesBuilder.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+import { Button } from "@/components/button";
+import { Label } from "@/components/label";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/select";
+import { Plus, Trash2 } from "lucide-react";
+import type {
+  ActionRuleDraft,
+  EvaluationActionNodeInfo,
+} from "@/interfaces/testEvaluation.interface";
+
+export const newActionRule = (): ActionRuleDraft => ({
+  node: "",
+  nodeType: "",
+  shouldFire: true,
+});
+
+interface ActionRuleRowProps {
+  rule: ActionRuleDraft;
+  index: number;
+  nodes: EvaluationActionNodeInfo[];
+  onChange: (patch: Partial<ActionRuleDraft>) => void;
+  onRemove: () => void;
+  canRemove: boolean;
+}
+
+const ActionRuleRow: React.FC<ActionRuleRowProps> = ({
+  rule,
+  index,
+  nodes,
+  onChange,
+  onRemove,
+  canRemove,
+}) => {
+  const nodeInCatalog = nodes.some((node) => node.id === rule.node);
+  // Free text is only for a config the catalogue can't match: a saved node id
+  // that is gone, or a legacy node_type-based config.
+  const isLegacyValue =
+    (Boolean(rule.node) && nodes.length > 0 && !nodeInCatalog) || Boolean(rule.nodeType);
+  const useDropdown = nodes.length > 0 && !isLegacyValue;
+
+  return (
+    <div className="rounded-lg border p-3 space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground">Rule {index + 1}</span>
+        {canRemove && (
+          <Button variant="ghost" size="sm" className="h-7 px-2" onClick={onRemove}>
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+      {useDropdown ? (
+        <div>
+          <Label className="text-xs">Node *</Label>
+          <Select
+            value={rule.node}
+            onValueChange={(next) => onChange({ node: next, nodeType: "" })}
+          >
+            <SelectTrigger className="mt-1">
+              <SelectValue placeholder="Select a node" />
+            </SelectTrigger>
+            <SelectContent>
+              {nodes.map((node) => (
+                <SelectItem key={node.id} value={node.id}>
+                  {node.label} ({node.type})
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      ) : (
+        <>
+          <div>
+            <Label className="text-xs">Node (id or label)</Label>
+            <Input
+              value={rule.node}
+              onChange={(e) => onChange({ node: e.target.value })}
+              placeholder="e.g. Create Zendesk Ticket"
+              className="mt-1"
+            />
+          </div>
+          <div>
+            <Label className="text-xs">Node Type</Label>
+            <Input
+              value={rule.nodeType}
+              onChange={(e) => onChange({ nodeType: e.target.value })}
+              placeholder="e.g. zendeskTicketNode"
+              className="mt-1"
+            />
+          </div>
+        </>
+      )}
+      <div className="flex items-center justify-between rounded-lg border px-3 py-2">
+        <div>
+          <div className="text-xs font-medium">Must complete</div>
+          <div className="text-xs text-muted-foreground">
+            Turn off to require that the node does not complete successfully
+          </div>
+        </div>
+        <Switch
+          checked={rule.shouldFire}
+          onCheckedChange={(checked) => onChange({ shouldFire: checked })}
+        />
+      </div>
+    </div>
+  );
+};
+
+interface ActionRulesBuilderProps {
+  rules: ActionRuleDraft[];
+  nodes: EvaluationActionNodeInfo[];
+  onChange: (rules: ActionRuleDraft[]) => void;
+}
+
+export const ActionRulesBuilder: React.FC<ActionRulesBuilderProps> = ({
+  rules,
+  nodes,
+  onChange,
+}) => {
+  const updateRule = (index: number, patch: Partial<ActionRuleDraft>) => {
+    onChange(rules.map((rule, i) => (i === index ? { ...rule, ...patch } : rule)));
+  };
+
+  const removeRule = (index: number) => {
+    onChange(rules.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="space-y-3">
+      {rules.map((rule, index) => (
+        <ActionRuleRow
+          key={index}
+          rule={rule}
+          index={index}
+          nodes={nodes}
+          onChange={(patch) => updateRule(index, patch)}
+          onRemove={() => removeRule(index)}
+          canRemove={rules.length > 1}
+        />
+      ))}
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => onChange([...rules, newActionRule()])}
+      >
+        <Plus className="mr-1 h-3.5 w-3.5" />
+        Add rule
+      </Button>
+    </div>
+  );
+};

--- a/frontend/src/views/TestSuites/components/CompareRunsDialog.tsx
+++ b/frontend/src/views/TestSuites/components/CompareRunsDialog.tsx
@@ -1,0 +1,388 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  AlertCircle,
+  ArrowDownRight,
+  ArrowUpRight,
+  CheckCircle2,
+  Loader2,
+  Minus,
+  XCircle,
+} from "lucide-react";
+
+import { Badge } from "@/components/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/select";
+import { listResultsForRun } from "@/services/testSuites";
+import { getToolRuleResults } from "@/services/testEvaluations";
+import { TestResult, TestRun } from "@/interfaces/testSuite.interface";
+import type { TestToolRuleResult } from "@/interfaces/testEvaluation.interface";
+import { cn } from "@/helpers/utils";
+import { methodLabel } from "../helpers/methodLabels";
+import { CaseStatus, caseStatusFor } from "../helpers/runResults";
+
+interface CompareRunsDialogProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** All runs of the evaluation, newest first. */
+  runs: TestRun[];
+}
+
+type CaseChange = "regression" | "improvement" | "unchanged" | "other";
+
+interface CaseComparison {
+  caseId: string;
+  baseline: CaseStatus | null;
+  candidate: CaseStatus | null;
+  change: CaseChange;
+}
+
+interface RunData {
+  results: TestResult[];
+  toolResults: TestToolRuleResult[];
+}
+
+/** Summary metric shape stored per technique on a run. */
+type TechniqueSummary = { accuracy?: number };
+
+const RUN_TOTALS_KEY = "_totals";
+
+const runLabel = (run: TestRun): string => {
+  const version = run.workflow_version ? ` · v${run.workflow_version}` : "";
+  const date = run.created_at
+    ? ` · ${new Date(run.created_at).toLocaleString()}`
+    : "";
+  return `Run #${run.id?.slice(-4)}${version}${date}`;
+};
+
+const classifyChange = (
+  baseline: CaseStatus | null,
+  candidate: CaseStatus | null,
+): CaseChange => {
+  if (baseline === "passed" && candidate === "failed") return "regression";
+  if (baseline === "failed" && candidate === "passed") return "improvement";
+  if (baseline === candidate) return "unchanged";
+  return "other";
+};
+
+const CHANGE_ORDER: Record<CaseChange, number> = {
+  regression: 0,
+  improvement: 1,
+  other: 2,
+  unchanged: 3,
+};
+
+const StatusIcon: React.FC<{ status: CaseStatus | null }> = ({ status }) => {
+  if (status === "passed") {
+    return <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />;
+  }
+  if (status === "failed") {
+    return <XCircle className="h-4 w-4 text-red-600 dark:text-red-400" />;
+  }
+  if (status === "not_scored") {
+    return <AlertCircle className="h-4 w-4 text-amber-600 dark:text-amber-400" />;
+  }
+  return <Minus className="h-4 w-4 text-muted-foreground/50" />;
+};
+
+const ChangeBadge: React.FC<{ change: CaseChange }> = ({ change }) => {
+  if (change === "regression") {
+    return (
+      <Badge className="bg-red-50 text-red-700 border border-red-200 dark:bg-red-500/15 dark:text-red-400 dark:border-red-500/30">
+        <ArrowDownRight className="mr-1 h-3 w-3" />
+        Regression
+      </Badge>
+    );
+  }
+  if (change === "improvement") {
+    return (
+      <Badge className="bg-green-50 text-green-700 border border-green-200 dark:bg-green-500/15 dark:text-green-400 dark:border-green-500/30">
+        <ArrowUpRight className="mr-1 h-3 w-3" />
+        Improved
+      </Badge>
+    );
+  }
+  return null;
+};
+
+const TechniqueDelta: React.FC<{
+  technique: string;
+  baseline: number | null;
+  candidate: number | null;
+}> = ({ technique, baseline, candidate }) => {
+  const hasBoth = baseline !== null && candidate !== null;
+  const delta = hasBoth ? candidate - baseline : null;
+  const deltaClass =
+    delta === null || Math.abs(delta) < 0.005
+      ? "text-muted-foreground"
+      : delta > 0
+        ? "text-green-600 dark:text-green-400"
+        : "text-red-600 dark:text-red-400";
+  const percent = (value: number | null) =>
+    value === null ? "–" : `${Math.round(value * 100)}%`;
+
+  return (
+    <div className="flex items-center justify-between gap-2 text-xs">
+      <span className="truncate text-muted-foreground">{methodLabel(technique)}</span>
+      <span className="shrink-0 tabular-nums">
+        {percent(baseline)} → {percent(candidate)}{" "}
+        {delta !== null && (
+          <span className={cn("font-medium", deltaClass)}>
+            ({delta > 0 ? "+" : ""}
+            {Math.round(delta * 100)}%)
+          </span>
+        )}
+      </span>
+    </div>
+  );
+};
+
+export const CompareRunsDialog: React.FC<CompareRunsDialogProps> = ({
+  isOpen,
+  onOpenChange,
+  runs,
+}) => {
+  const [baselineRunId, setBaselineRunId] = useState<string>("");
+  const [candidateRunId, setCandidateRunId] = useState<string>("");
+  const [dataByRunId, setDataByRunId] = useState<Record<string, RunData>>({});
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Only finished runs have stable results worth comparing.
+  const comparableRuns = useMemo(
+    () => runs.filter((run) => run.id && (run.status === "completed" || run.status === "failed")),
+    [runs],
+  );
+
+  // Default to the two most recent finished runs: newest as candidate.
+  useEffect(() => {
+    if (!isOpen) return;
+    setCandidateRunId(comparableRuns[0]?.id ?? "");
+    setBaselineRunId(comparableRuns[1]?.id ?? "");
+  }, [isOpen, comparableRuns]);
+
+  useEffect(() => {
+    const idsToLoad = [baselineRunId, candidateRunId].filter(
+      (id) => id && !dataByRunId[id],
+    );
+    if (!isOpen || idsToLoad.length === 0) return;
+    let isStale = false;
+    const load = async () => {
+      setIsLoading(true);
+      try {
+        const loaded = await Promise.all(
+          idsToLoad.map(async (runId) => {
+            const [results, toolResults] = await Promise.all([
+              listResultsForRun(runId),
+              getToolRuleResults(runId).catch(() => []),
+            ]);
+            return [runId, { results: results ?? [], toolResults: toolResults ?? [] }] as const;
+          }),
+        );
+        if (isStale) return;
+        setDataByRunId((prev) => ({ ...prev, ...Object.fromEntries(loaded) }));
+      } finally {
+        if (!isStale) setIsLoading(false);
+      }
+    };
+    void load();
+    return () => {
+      isStale = true;
+    };
+  }, [isOpen, baselineRunId, candidateRunId, dataByRunId]);
+
+  const statusByCase = (runId: string): Map<string, CaseStatus> => {
+    const data = dataByRunId[runId];
+    const map = new Map<string, CaseStatus>();
+    if (!data) return map;
+    const toolsByCase = new Map<string, TestToolRuleResult[]>();
+    for (const toolResult of data.toolResults) {
+      const isTurnScope =
+        toolResult.scope === "every_turn" || toolResult.scope === "specific_turn";
+      if (isTurnScope && toolResult.case_id) {
+        const existing = toolsByCase.get(toolResult.case_id) ?? [];
+        existing.push(toolResult);
+        toolsByCase.set(toolResult.case_id, existing);
+      }
+    }
+    for (const result of data.results) {
+      if (!result.case_id) continue;
+      map.set(result.case_id, caseStatusFor(result, toolsByCase.get(result.case_id) ?? []));
+    }
+    return map;
+  };
+
+  const comparisons: CaseComparison[] = useMemo(() => {
+    if (!baselineRunId || !candidateRunId) return [];
+    const baselineStatuses = statusByCase(baselineRunId);
+    const candidateStatuses = statusByCase(candidateRunId);
+    const caseIds = new Set([...baselineStatuses.keys(), ...candidateStatuses.keys()]);
+    const rows = [...caseIds].map((caseId) => {
+      const baseline = baselineStatuses.get(caseId) ?? null;
+      const candidate = candidateStatuses.get(caseId) ?? null;
+      return { caseId, baseline, candidate, change: classifyChange(baseline, candidate) };
+    });
+    return rows.sort((a, b) => CHANGE_ORDER[a.change] - CHANGE_ORDER[b.change]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [baselineRunId, candidateRunId, dataByRunId]);
+
+  const regressionCount = comparisons.filter((c) => c.change === "regression").length;
+  const improvementCount = comparisons.filter((c) => c.change === "improvement").length;
+
+  const baselineRun = comparableRuns.find((run) => run.id === baselineRunId);
+  const candidateRun = comparableRuns.find((run) => run.id === candidateRunId);
+
+  // Per-technique accuracy across both runs, keyed by technique.
+  const techniqueRows = useMemo(() => {
+    const accuracyOf = (run: TestRun | undefined, technique: string): number | null => {
+      const summary = run?.summary_metrics?.[technique] as TechniqueSummary | undefined;
+      return typeof summary?.accuracy === "number" ? summary.accuracy : null;
+    };
+    const techniques = new Set<string>();
+    [baselineRun, candidateRun].forEach((run) => {
+      Object.keys(run?.summary_metrics ?? {})
+        .filter((key) => key !== RUN_TOTALS_KEY)
+        .forEach((key) => techniques.add(key));
+    });
+    return [...techniques].map((technique) => ({
+      technique,
+      baseline: accuracyOf(baselineRun, technique),
+      candidate: accuracyOf(candidateRun, technique),
+    }));
+  }, [baselineRun, candidateRun]);
+
+  const verdict =
+    regressionCount > 0
+      ? `${regressionCount} regression${regressionCount !== 1 ? "s" : ""}`
+      : "No regressions";
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[85vh] w-[95vw] max-w-3xl flex-col gap-0 overflow-hidden p-0">
+        <DialogHeader className="shrink-0 border-b px-5 py-3">
+          <DialogTitle>Compare Runs</DialogTitle>
+        </DialogHeader>
+
+        <div className="shrink-0 space-y-3 border-b px-5 py-4">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <div className="mb-1 text-xs font-medium text-muted-foreground">Baseline</div>
+              <Select value={baselineRunId} onValueChange={setBaselineRunId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Choose a run" />
+                </SelectTrigger>
+                <SelectContent>
+                  {comparableRuns.map((run) => (
+                    <SelectItem key={run.id} value={run.id!}>
+                      {runLabel(run)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <div className="mb-1 text-xs font-medium text-muted-foreground">Candidate</div>
+              <Select value={candidateRunId} onValueChange={setCandidateRunId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Choose a run" />
+                </SelectTrigger>
+                <SelectContent>
+                  {comparableRuns.map((run) => (
+                    <SelectItem key={run.id} value={run.id!}>
+                      {runLabel(run)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {baselineRun && candidateRun && (
+            <>
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    regressionCount > 0
+                      ? "border-red-200 text-red-700 dark:border-red-500/30 dark:text-red-400"
+                      : "border-green-200 text-green-700 dark:border-green-500/30 dark:text-green-400",
+                  )}
+                >
+                  {verdict}
+                </Badge>
+                {improvementCount > 0 && (
+                  <Badge variant="outline" className="border-green-200 text-green-700 dark:border-green-500/30 dark:text-green-400">
+                    {improvementCount} improved
+                  </Badge>
+                )}
+              </div>
+              {techniqueRows.length > 0 && (
+                <div className="space-y-1 rounded border p-3">
+                  {techniqueRows.map((row) => (
+                    <TechniqueDelta
+                      key={row.technique}
+                      technique={row.technique}
+                      baseline={row.baseline}
+                      candidate={row.candidate}
+                    />
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-3">
+          {isLoading ? (
+            <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading results…
+            </div>
+          ) : !baselineRunId || !candidateRunId ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              Choose two finished runs to compare.
+            </div>
+          ) : comparisons.length === 0 ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              These runs share no scored test cases.
+            </div>
+          ) : (
+            <div className="divide-y divide-border">
+              <div className="flex items-center gap-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                <span className="flex-1">Case</span>
+                <span className="w-16 text-center">Baseline</span>
+                <span className="w-16 text-center">Candidate</span>
+                <span className="w-28" />
+              </div>
+              {comparisons.map((row) => (
+                <div key={row.caseId} className="flex items-center gap-3 py-2">
+                  <span className="flex-1 truncate text-sm">
+                    Case #{row.caseId.slice(-4)}
+                  </span>
+                  <span className="flex w-16 justify-center">
+                    <StatusIcon status={row.baseline} />
+                  </span>
+                  <span className="flex w-16 justify-center">
+                    <StatusIcon status={row.candidate} />
+                  </span>
+                  <span className="flex w-28 justify-end">
+                    <ChangeBadge change={row.change} />
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/views/TestSuites/components/EvaluationListRow.tsx
+++ b/frontend/src/views/TestSuites/components/EvaluationListRow.tsx
@@ -101,7 +101,7 @@ export const EvaluationListRow: React.FC<EvaluationListRowProps> = ({
           <DropdownMenuContent align="end">
             <DropdownMenuItem
               disabled={isRunning}
-              onClick={onEdit}
+              onSelect={onEdit}
               title={isRunning ? "Can't edit while this evaluation is running" : undefined}
             >
               <Pencil className="h-4 w-4 mr-2" />
@@ -109,7 +109,7 @@ export const EvaluationListRow: React.FC<EvaluationListRowProps> = ({
             </DropdownMenuItem>
             <DropdownMenuItem
               disabled={isRunning}
-              onClick={onDelete}
+              onSelect={onDelete}
               className="text-red-600 focus:text-red-600 dark:text-red-400 dark:focus:text-red-400"
               title={isRunning ? "Can't delete while this evaluation is running" : undefined}
             >

--- a/frontend/src/views/TestSuites/components/EvaluationWizard.tsx
+++ b/frontend/src/views/TestSuites/components/EvaluationWizard.tsx
@@ -26,9 +26,12 @@ import type { TestSuite } from "@/interfaces/testSuite.interface";
 import type { WorkflowMinimal } from "@/interfaces/workflow.interface";
 import type { LLMProviderMinimal } from "@/interfaces/llmProvider.interface";
 import type {
+  ActionRuleDraft,
   EvaluationActionNodeInfo,
   EvaluationAgentInfo,
   EvaluationRouterInfo,
+  JudgeRuleDraft,
+  RouteRuleDraft,
   ToolUsagePerToolCheck,
   ToolUsageRule,
 } from "@/interfaces/testEvaluation.interface";
@@ -36,6 +39,9 @@ import { getEvaluationToolCatalog } from "@/services/testEvaluations";
 import { listTestCases } from "@/services/testSuites";
 import type { TestCase } from "@/interfaces/testSuite.interface";
 import { ToolUsageRuleBuilder, type RuleConversation } from "./ToolUsageRuleBuilder";
+import { RouteRulesBuilder, newRouteRule } from "./RouteRulesBuilder";
+import { ActionRulesBuilder, newActionRule } from "./ActionRulesBuilder";
+import { JudgeRulesBuilder, newJudgeRule } from "./JudgeRulesBuilder";
 
 // Group imported multi-turn cases into conversations for specific-turn targeting.
 const deriveConversations = (cases: TestCase[]): RuleConversation[] => {
@@ -182,6 +188,60 @@ const GRADING_SOURCE_OPTIONS: {
   { value: "expected_output", label: "Expected answer" },
 ];
 
+// Ready-made rubrics: one click fills the rubric text and picks the matching
+// grading source. The user can still edit the text afterwards.
+// Anchors put "partial" at 0.4 so it lands under the default 0.5 threshold — a
+// partially satisfied criterion should not pass unless the user lowers the bar.
+const RUBRIC_PRESETS: {
+  key: string;
+  label: string;
+  rubric: string;
+  sourceType: GradingSourceSelection;
+}[] = [
+  {
+    key: "retrieval_relevance",
+    label: "Retrieval relevance",
+    rubric:
+      "Judge whether the SOURCE passages are relevant to answering the QUESTION. " +
+      "Ignore the answer itself. Score 1.0 when the passages contain the " +
+      "information needed to answer the question, 0.4 when they are only " +
+      "partially relevant, and 0.0 when they are unrelated to the question. " +
+      "Intermediate scores are allowed.",
+    sourceType: "kb_retrievals",
+  },
+  {
+    key: "completeness",
+    label: "Completeness",
+    rubric:
+      "Judge whether the ANSWER fully addresses every part of the QUESTION. " +
+      "Ignore style and tone. Score 1.0 when every part is answered, 0.4 when " +
+      "only some parts are answered, and 0.0 when the answer misses the point " +
+      "of the question. Intermediate scores are allowed.",
+    sourceType: "none",
+  },
+  {
+    key: "helpfulness",
+    label: "Helpfulness",
+    rubric:
+      "Judge whether the ANSWER moves the user toward resolving their request. " +
+      "Ignore length and formatting. Score 1.0 when it resolves the request or " +
+      "gives a clear, correct next step, 0.4 when it is on topic but leaves the " +
+      "user without a usable way forward, and 0.0 when it is unhelpful or " +
+      "off-topic. Intermediate scores are allowed.",
+    sourceType: "none",
+  },
+  {
+    key: "politeness",
+    label: "Politeness & tone",
+    rubric:
+      "Judge whether the ANSWER is polite, professional and helpful in tone. " +
+      "Ignore factual correctness. Score 1.0 when it is courteous and " +
+      "constructive, 0.4 when it is neutral or curt, and 0.0 when it is rude, " +
+      "dismissive or inappropriate. Intermediate scores are allowed.",
+    sourceType: "none",
+  },
+];
+
 const GradingSourceSelect: React.FC<{
   value: GradingSourceSelection;
   onChange: (value: GradingSourceSelection) => void;
@@ -284,16 +344,10 @@ export interface EvaluationWizardData {
   notContainsText: string;
   fieldEqualsField: string;
   fieldEqualsExpected: string;
-  routeExpected: string;
-  routeNode: string;
-  actionNode: string;
-  actionNodeType: string;
-  actionShouldFire: boolean;
-  judgeRubric: string;
-  judgeMinScore: string;
+  routeRules: RouteRuleDraft[];
+  actionRules: ActionRuleDraft[];
+  judgeRules: JudgeRuleDraft[];
   judgeProviderId: string;
-  judgeSourceType: GradingSourceSelection;
-  judgeSourceField: string;
 }
 
 interface EvaluationWizardProps {
@@ -505,25 +559,23 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
     initialData?.fieldEqualsExpected ?? ""
   );
 
-  // Route Taken config
-  const [routeExpected, setRouteExpected] = useState(initialData?.routeExpected ?? "");
-  const [routeNode, setRouteNode] = useState(initialData?.routeNode ?? "");
+  // Route Taken config — always at least one rule row to fill in.
+  const [routeRules, setRouteRules] = useState<RouteRuleDraft[]>(
+    initialData?.routeRules?.length ? initialData.routeRules : [newRouteRule()],
+  );
 
-  // Action Taken config
-  const [actionNode, setActionNode] = useState(initialData?.actionNode ?? "");
-  const [actionNodeType, setActionNodeType] = useState(initialData?.actionNodeType ?? "");
-  const [actionShouldFire, setActionShouldFire] = useState(initialData?.actionShouldFire ?? true);
+  // Action Taken config — always at least one rule row to fill in.
+  const [actionRules, setActionRules] = useState<ActionRuleDraft[]>(
+    initialData?.actionRules?.length ? initialData.actionRules : [newActionRule()],
+  );
 
-  // LLM Judge config
-  const [judgeRubric, setJudgeRubric] = useState(initialData?.judgeRubric ?? "");
-  const [judgeMinScore, setJudgeMinScore] = useState(initialData?.judgeMinScore ?? "0.5");
+  // LLM Judge config — always at least one rule row to fill in.
+  const [judgeRules, setJudgeRules] = useState<JudgeRuleDraft[]>(
+    initialData?.judgeRules?.length ? initialData.judgeRules : [newJudgeRule()],
+  );
   const [judgeProviderId, setJudgeProviderId] = useState(
     initialData?.judgeProviderId ?? providers[0]?.id ?? ""
   );
-  const [judgeSourceType, setJudgeSourceType] = useState<GradingSourceSelection>(
-    initialData?.judgeSourceType ?? "none"
-  );
-  const [judgeSourceField] = useState(initialData?.judgeSourceField ?? "");
 
   const currentStepIndex = STEPS.findIndex((s) => s.key === step);
 
@@ -554,32 +606,36 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
       ));
   const nliScoreInvalid = metrics.includes("nli_eval") && !isValidScore(nliMinEntailScore);
   const provScoreInvalid = metrics.includes("provenance_eval") && !isValidScore(provMinScore);
-  const judgeScoreInvalid = metrics.includes("llm_judge") && !isValidScore(judgeMinScore);
+  const judgeRulesInvalid =
+    metrics.includes("llm_judge") &&
+    (judgeRules.length === 0 ||
+      judgeRules.some((rule) => !rule.rubric.trim() || !isValidScore(rule.minScore)));
 
-  // Route/Action dropdowns use the catalogue; fall back to free text only when the
-  // catalogue is unavailable or a saved value predates it (an unmatched legacy id).
-  const selectedRouter = catalogRouters.find((r) => r.id === routeNode);
-  // Free text is only for a config the catalogue can't match: a saved router id that
-  // is gone, or an old "any router" config (expected set with no router chosen).
-  const routeLegacyValue =
-    catalogRouters.length > 0 &&
-    ((Boolean(routeNode) && !selectedRouter) || (!routeNode && Boolean(routeExpected)));
-  const useRouteDropdowns = catalogRouters.length > 0 && !routeLegacyValue;
-  const actionNodeInCatalog = catalogActionNodes.some((n) => n.id === actionNode);
-  const actionLegacyValue =
-    (Boolean(actionNode) && catalogActionNodes.length > 0 && !actionNodeInCatalog) ||
-    Boolean(actionNodeType);
-  const useActionDropdown = catalogActionNodes.length > 0 && !actionLegacyValue;
+  // Per-rule validity mirrors the builders' dropdown/free-text split: with a
+  // catalogue, a fresh rule must pick a router; legacy free-text rules only
+  // need the expected route.
+  const routeRuleInvalid = (rule: RouteRuleDraft): boolean => {
+    const inCatalog = catalogRouters.some((router) => router.id === rule.router);
+    const isLegacyValue =
+      catalogRouters.length > 0 &&
+      ((Boolean(rule.router) && !inCatalog) || (!rule.router && Boolean(rule.expected)));
+    const usesDropdowns = catalogRouters.length > 0 && !isLegacyValue;
+    if (usesDropdowns && !rule.router.trim()) return true;
+    return !rule.expected.trim();
+  };
+
+  const actionRuleInvalid = (rule: ActionRuleDraft): boolean =>
+    !rule.node.trim() && !rule.nodeType.trim();
 
   const isConfigureStepValid = (): boolean => {
-    if (metrics.includes("llm_judge") && !judgeRubric.trim()) return false;
     if (metrics.includes("not_contains") && !notContainsText.trim()) return false;
     if (metrics.includes("route_taken")) {
-      if (useRouteDropdowns && !routeNode.trim()) return false;
-      if (!routeExpected.trim()) return false;
+      if (routeRules.length === 0 || routeRules.some(routeRuleInvalid)) return false;
     }
-    if (metrics.includes("action_taken") && !actionNode.trim() && !actionNodeType.trim()) return false;
-    if (toolRulesInvalid || nliScoreInvalid || provScoreInvalid || judgeScoreInvalid) return false;
+    if (metrics.includes("action_taken")) {
+      if (actionRules.length === 0 || actionRules.some(actionRuleInvalid)) return false;
+    }
+    if (toolRulesInvalid || nliScoreInvalid || provScoreInvalid || judgeRulesInvalid) return false;
     return true;
   };
 
@@ -641,16 +697,10 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
         notContainsText,
         fieldEqualsField,
         fieldEqualsExpected,
-        routeExpected,
-        routeNode,
-        actionNode,
-        actionNodeType,
-        actionShouldFire,
-        judgeRubric,
-        judgeMinScore,
+        routeRules,
+        actionRules,
+        judgeRules,
         judgeProviderId,
-        judgeSourceType,
-        judgeSourceField,
       });
       // Reset form on successful create
       if (mode === "create") {
@@ -688,15 +738,10 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
     setNotContainsText("");
     setFieldEqualsField("");
     setFieldEqualsExpected("");
-    setRouteExpected("");
-    setRouteNode("");
-    setActionNode("");
-    setActionNodeType("");
-    setActionShouldFire(true);
-    setJudgeRubric("");
-    setJudgeMinScore("0.5");
+    setRouteRules([newRouteRule()]);
+    setActionRules([newActionRule()]);
+    setJudgeRules([newJudgeRule()]);
     setJudgeProviderId(providers[0]?.id ?? "");
-    setJudgeSourceType("none");
   };
 
   const handleOpenChange = (open: boolean) => {
@@ -1192,84 +1237,14 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
                   Route Taken Config
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  Checks that a router node selected the expected branch.
+                  Checks that router nodes selected the expected branches. All rules must
+                  pass.
                 </p>
-                {useRouteDropdowns ? (
-                  <>
-                    <div>
-                      <Label className="text-xs">Router *</Label>
-                      <Select
-                        value={routeNode}
-                        onValueChange={(next) => {
-                          setRouteNode(next);
-                          setRouteExpected("");
-                        }}
-                      >
-                        <SelectTrigger className="mt-1">
-                          <SelectValue placeholder="Select a router" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {catalogRouters.map((router) => (
-                            <SelectItem key={router.id} value={router.id}>
-                              {router.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    {selectedRouter && selectedRouter.branches.length > 0 && (
-                      <div>
-                        <Label className="text-xs">Expected Branch *</Label>
-                        <Select value={routeExpected} onValueChange={setRouteExpected}>
-                          <SelectTrigger className="mt-1">
-                            <SelectValue placeholder="Select a branch" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {selectedRouter.branches.map((branch) => (
-                              <SelectItem key={branch.value} value={branch.value}>
-                                {branch.destination
-                                  ? `${branch.value} → ${branch.destination}`
-                                  : branch.value}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                    )}
-                    {selectedRouter && selectedRouter.branches.length === 0 && (
-                      <div>
-                        <Label className="text-xs">Expected Route *</Label>
-                        <Input
-                          value={routeExpected}
-                          onChange={(e) => setRouteExpected(e.target.value)}
-                          placeholder="e.g. escalate"
-                          className="mt-1"
-                        />
-                      </div>
-                    )}
-                  </>
-                ) : (
-                  <>
-                    <div>
-                      <Label className="text-xs">Expected Route *</Label>
-                      <Input
-                        value={routeExpected}
-                        onChange={(e) => setRouteExpected(e.target.value)}
-                        placeholder="e.g. escalate"
-                        className="mt-1"
-                      />
-                    </div>
-                    <div>
-                      <Label className="text-xs">Router Node (id or label, optional)</Label>
-                      <Input
-                        value={routeNode}
-                        onChange={(e) => setRouteNode(e.target.value)}
-                        placeholder="Leave empty to match any router node"
-                        className="mt-1"
-                      />
-                    </div>
-                  </>
-                )}
+                <RouteRulesBuilder
+                  rules={routeRules}
+                  routers={catalogRouters}
+                  onChange={setRouteRules}
+                />
               </div>
             )}
 
@@ -1280,61 +1255,14 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
                   Action Taken Config
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  Checks whether a specific workflow node ran successfully.
+                  Checks whether specific workflow nodes ran successfully. All rules must
+                  pass.
                 </p>
-                {useActionDropdown ? (
-                  <div>
-                    <Label className="text-xs">Node *</Label>
-                    <Select
-                      value={actionNode}
-                      onValueChange={(next) => {
-                        setActionNode(next);
-                        setActionNodeType("");
-                      }}
-                    >
-                      <SelectTrigger className="mt-1">
-                        <SelectValue placeholder="Select a node" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {catalogActionNodes.map((node) => (
-                          <SelectItem key={node.id} value={node.id}>
-                            {node.label} ({node.type})
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                ) : (
-                  <>
-                    <div>
-                      <Label className="text-xs">Node (id or label)</Label>
-                      <Input
-                        value={actionNode}
-                        onChange={(e) => setActionNode(e.target.value)}
-                        placeholder="e.g. Create Zendesk Ticket"
-                        className="mt-1"
-                      />
-                    </div>
-                    <div>
-                      <Label className="text-xs">Node Type</Label>
-                      <Input
-                        value={actionNodeType}
-                        onChange={(e) => setActionNodeType(e.target.value)}
-                        placeholder="e.g. zendeskTicketNode"
-                        className="mt-1"
-                      />
-                    </div>
-                  </>
-                )}
-                <div className="flex items-center justify-between rounded-lg border px-3 py-2">
-                  <div>
-                    <div className="text-xs font-medium">Must complete</div>
-                    <div className="text-xs text-muted-foreground">
-                      Turn off to require that the node does not complete successfully
-                    </div>
-                  </div>
-                  <Switch checked={actionShouldFire} onCheckedChange={setActionShouldFire} />
-                </div>
+                <ActionRulesBuilder
+                  rules={actionRules}
+                  nodes={catalogActionNodes}
+                  onChange={setActionRules}
+                />
               </div>
             )}
 
@@ -1345,18 +1273,9 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
                   LLM Judge Config
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  Grades the answer against a rubric you write. One criterion per judge works best.
+                  Grades the answer against rubrics you write. One criterion per rule works
+                  best; all rules must pass.
                 </p>
-                <div>
-                  <Label className="text-xs">Rubric *</Label>
-                  <Textarea
-                    value={judgeRubric}
-                    onChange={(e) => setJudgeRubric(e.target.value)}
-                    placeholder="e.g. Score 1.0 if the answer is polite and offers a next step, 0.0 otherwise."
-                    rows={4}
-                    className="mt-1"
-                  />
-                </div>
                 <div>
                   <Label className="text-xs">LLM Provider</Label>
                   <Select value={judgeProviderId} onValueChange={setJudgeProviderId}>
@@ -1372,33 +1291,11 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
                     </SelectContent>
                   </Select>
                 </div>
-                <div>
-                  <Label className="text-xs">Min Score (0-1)</Label>
-                  <Input
-                    value={judgeMinScore}
-                    onChange={(e) => setJudgeMinScore(e.target.value)}
-                    className="mt-1"
-                    placeholder="0.5"
-                  />
-                  {judgeScoreInvalid && (
-                    <p className="text-xs text-red-500 mt-1">Enter a number between 0 and 1.</p>
-                  )}
-                </div>
-                <div className="flex items-center justify-between rounded-md border p-3">
-                  <div>
-                    <Label className="text-xs">Give the judge the retrieved context</Label>
-                    <p className="text-xs text-muted-foreground mt-1">
-                      Off = rubric only (style or behavior checks). On = the judge also
-                      sees the KB passages the agent retrieved during the run.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={judgeSourceType === "kb_retrievals"}
-                    onCheckedChange={(checked) =>
-                      setJudgeSourceType(checked ? "kb_retrievals" : "none")
-                    }
-                  />
-                </div>
+                <JudgeRulesBuilder
+                  rules={judgeRules}
+                  presets={RUBRIC_PRESETS}
+                  onChange={setJudgeRules}
+                />
               </div>
             )}
           </div>

--- a/frontend/src/views/TestSuites/components/JudgeRulesBuilder.tsx
+++ b/frontend/src/views/TestSuites/components/JudgeRulesBuilder.tsx
@@ -1,0 +1,157 @@
+import React from "react";
+import { Button } from "@/components/button";
+import { Label } from "@/components/label";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/switch";
+import { Plus, Trash2 } from "lucide-react";
+import type { JudgeRuleDraft, JudgeRuleSource } from "@/interfaces/testEvaluation.interface";
+
+export interface JudgeRubricPreset {
+  key: string;
+  label: string;
+  rubric: string;
+  sourceType: JudgeRuleSource;
+}
+
+export const newJudgeRule = (): JudgeRuleDraft => ({
+  label: "",
+  rubric: "",
+  minScore: "0.5",
+  sourceType: "none",
+  sourceField: "",
+});
+
+// A score field is valid when empty (a default applies) or a number in [0, 1].
+const isValidScore = (text: string): boolean => {
+  if (text.trim() === "") return true;
+  const value = Number(text);
+  return Number.isFinite(value) && value >= 0 && value <= 1;
+};
+
+interface JudgeRuleRowProps {
+  rule: JudgeRuleDraft;
+  index: number;
+  presets: JudgeRubricPreset[];
+  onChange: (patch: Partial<JudgeRuleDraft>) => void;
+  onRemove: () => void;
+  canRemove: boolean;
+}
+
+const JudgeRuleRow: React.FC<JudgeRuleRowProps> = ({
+  rule,
+  index,
+  presets,
+  onChange,
+  onRemove,
+  canRemove,
+}) => (
+  <div className="rounded-lg border p-3 space-y-3">
+    <div className="flex items-center justify-between">
+      <span className="text-xs font-medium text-muted-foreground">
+        {rule.label.trim() ? rule.label : `Rule ${index + 1}`}
+      </span>
+      {canRemove && (
+        <Button variant="ghost" size="sm" className="h-7 px-2" onClick={onRemove}>
+          <Trash2 className="h-3.5 w-3.5" />
+        </Button>
+      )}
+    </div>
+    <div>
+      <Label className="text-xs">Rubric *</Label>
+      <div className="mt-1 flex flex-wrap gap-1.5">
+        {presets.map((preset) => (
+          <Button
+            key={preset.key}
+            variant="outline"
+            size="sm"
+            className="h-6 px-2 text-xs"
+            onClick={() =>
+              onChange({
+                label: preset.label,
+                rubric: preset.rubric,
+                sourceType: preset.sourceType,
+              })
+            }
+          >
+            {preset.label}
+          </Button>
+        ))}
+      </div>
+      <Textarea
+        value={rule.rubric}
+        onChange={(e) => onChange({ rubric: e.target.value })}
+        placeholder="e.g. Score 1.0 if the answer is polite and offers a next step, 0.0 otherwise."
+        rows={4}
+        className="mt-1"
+      />
+    </div>
+    <div>
+      <Label className="text-xs">Min Score (0-1)</Label>
+      <Input
+        value={rule.minScore}
+        onChange={(e) => onChange({ minScore: e.target.value })}
+        className="mt-1"
+        placeholder="0.5"
+      />
+      {!isValidScore(rule.minScore) && (
+        <p className="text-xs text-red-500 mt-1">Enter a number between 0 and 1.</p>
+      )}
+    </div>
+    <div className="flex items-center justify-between rounded-md border p-3">
+      <div>
+        <Label className="text-xs">Give the judge the retrieved context</Label>
+        <p className="text-xs text-muted-foreground mt-1">
+          Off = rubric only (style or behavior checks). On = the judge also sees the
+          KB passages the agent retrieved during the run.
+        </p>
+      </div>
+      <Switch
+        checked={rule.sourceType === "kb_retrievals"}
+        onCheckedChange={(checked) =>
+          onChange({ sourceType: checked ? "kb_retrievals" : "none" })
+        }
+      />
+    </div>
+  </div>
+);
+
+interface JudgeRulesBuilderProps {
+  rules: JudgeRuleDraft[];
+  presets: JudgeRubricPreset[];
+  onChange: (rules: JudgeRuleDraft[]) => void;
+}
+
+export const JudgeRulesBuilder: React.FC<JudgeRulesBuilderProps> = ({
+  rules,
+  presets,
+  onChange,
+}) => {
+  const updateRule = (index: number, patch: Partial<JudgeRuleDraft>) => {
+    onChange(rules.map((rule, i) => (i === index ? { ...rule, ...patch } : rule)));
+  };
+
+  const removeRule = (index: number) => {
+    onChange(rules.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="space-y-3">
+      {rules.map((rule, index) => (
+        <JudgeRuleRow
+          key={index}
+          rule={rule}
+          index={index}
+          presets={presets}
+          onChange={(patch) => updateRule(index, patch)}
+          onRemove={() => removeRule(index)}
+          canRemove={rules.length > 1}
+        />
+      ))}
+      <Button variant="outline" size="sm" onClick={() => onChange([...rules, newJudgeRule()])}>
+        <Plus className="mr-1 h-3.5 w-3.5" />
+        Add rule
+      </Button>
+    </div>
+  );
+};

--- a/frontend/src/views/TestSuites/components/MetricRuleBreakdown.tsx
+++ b/frontend/src/views/TestSuites/components/MetricRuleBreakdown.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { CheckCircle2, XCircle } from "lucide-react";
+import type { MetricRuleDetail } from "@/interfaces/testSuite.interface";
+
+interface MetricRuleBreakdownProps {
+  details: MetricRuleDetail[];
+}
+
+// Per-rule pass/fail lines under a multi-rule metric (Route Taken / Action Taken).
+export const MetricRuleBreakdown: React.FC<MetricRuleBreakdownProps> = ({ details }) => (
+  <div className="mt-1 space-y-0.5 pl-4">
+    {details.map((detail, index) => (
+      <div key={detail.rule_number ?? index} className="flex items-start gap-1.5 text-xs">
+        {detail.passed ? (
+          <CheckCircle2 className="mt-0.5 h-3 w-3 shrink-0 text-green-600 dark:text-green-400" />
+        ) : (
+          <XCircle className="mt-0.5 h-3 w-3 shrink-0 text-red-600 dark:text-red-400" />
+        )}
+        <span className="text-muted-foreground">{detail.comment}</span>
+      </div>
+    ))}
+  </div>
+);

--- a/frontend/src/views/TestSuites/components/RouteRulesBuilder.tsx
+++ b/frontend/src/views/TestSuites/components/RouteRulesBuilder.tsx
@@ -1,0 +1,177 @@
+import React from "react";
+import { Button } from "@/components/button";
+import { Label } from "@/components/label";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/select";
+import { Plus, Trash2 } from "lucide-react";
+import type {
+  EvaluationRouterInfo,
+  RouteRuleDraft,
+} from "@/interfaces/testEvaluation.interface";
+
+export const newRouteRule = (): RouteRuleDraft => ({ router: "", expected: "" });
+
+interface RouteRuleRowProps {
+  rule: RouteRuleDraft;
+  index: number;
+  routers: EvaluationRouterInfo[];
+  onChange: (patch: Partial<RouteRuleDraft>) => void;
+  onRemove: () => void;
+  canRemove: boolean;
+}
+
+const RouteRuleRow: React.FC<RouteRuleRowProps> = ({
+  rule,
+  index,
+  routers,
+  onChange,
+  onRemove,
+  canRemove,
+}) => {
+  const selectedRouter = routers.find((router) => router.id === rule.router);
+  // Free text is only for a config the catalogue can't match: a saved router id
+  // that is gone, or an old "any router" config (expected set with no router).
+  const isLegacyValue =
+    routers.length > 0 &&
+    ((Boolean(rule.router) && !selectedRouter) || (!rule.router && Boolean(rule.expected)));
+  const useDropdowns = routers.length > 0 && !isLegacyValue;
+
+  return (
+    <div className="rounded-lg border p-3 space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground">Rule {index + 1}</span>
+        {canRemove && (
+          <Button variant="ghost" size="sm" className="h-7 px-2" onClick={onRemove}>
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+      {useDropdowns ? (
+        <>
+          <div>
+            <Label className="text-xs">Router *</Label>
+            <Select
+              value={rule.router}
+              onValueChange={(next) => onChange({ router: next, expected: "" })}
+            >
+              <SelectTrigger className="mt-1">
+                <SelectValue placeholder="Select a router" />
+              </SelectTrigger>
+              <SelectContent>
+                {routers.map((router) => (
+                  <SelectItem key={router.id} value={router.id}>
+                    {router.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          {selectedRouter && selectedRouter.branches.length > 0 && (
+            <div>
+              <Label className="text-xs">Expected Branch *</Label>
+              <Select
+                value={rule.expected}
+                onValueChange={(next) => onChange({ expected: next })}
+              >
+                <SelectTrigger className="mt-1">
+                  <SelectValue placeholder="Select a branch" />
+                </SelectTrigger>
+                <SelectContent>
+                  {selectedRouter.branches.map((branch) => (
+                    <SelectItem key={branch.value} value={branch.value}>
+                      {branch.destination
+                        ? `${branch.value} → ${branch.destination}`
+                        : branch.value}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+          {selectedRouter && selectedRouter.branches.length === 0 && (
+            <div>
+              <Label className="text-xs">Expected Route *</Label>
+              <Input
+                value={rule.expected}
+                onChange={(e) => onChange({ expected: e.target.value })}
+                placeholder="e.g. escalate"
+                className="mt-1"
+              />
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          <div>
+            <Label className="text-xs">Expected Route *</Label>
+            <Input
+              value={rule.expected}
+              onChange={(e) => onChange({ expected: e.target.value })}
+              placeholder="e.g. escalate"
+              className="mt-1"
+            />
+          </div>
+          <div>
+            <Label className="text-xs">Router Node (id or label, optional)</Label>
+            <Input
+              value={rule.router}
+              onChange={(e) => onChange({ router: e.target.value })}
+              placeholder="Leave empty to match any router node"
+              className="mt-1"
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+interface RouteRulesBuilderProps {
+  rules: RouteRuleDraft[];
+  routers: EvaluationRouterInfo[];
+  onChange: (rules: RouteRuleDraft[]) => void;
+}
+
+export const RouteRulesBuilder: React.FC<RouteRulesBuilderProps> = ({
+  rules,
+  routers,
+  onChange,
+}) => {
+  const updateRule = (index: number, patch: Partial<RouteRuleDraft>) => {
+    onChange(rules.map((rule, i) => (i === index ? { ...rule, ...patch } : rule)));
+  };
+
+  const removeRule = (index: number) => {
+    onChange(rules.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="space-y-3">
+      {rules.map((rule, index) => (
+        <RouteRuleRow
+          key={index}
+          rule={rule}
+          index={index}
+          routers={routers}
+          onChange={(patch) => updateRule(index, patch)}
+          onRemove={() => removeRule(index)}
+          canRemove={rules.length > 1}
+        />
+      ))}
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => onChange([...rules, newRouteRule()])}
+      >
+        <Plus className="mr-1 h-3.5 w-3.5" />
+        Add rule
+      </Button>
+    </div>
+  );
+};

--- a/frontend/src/views/TestSuites/components/RunAgainstVersionDialog.tsx
+++ b/frontend/src/views/TestSuites/components/RunAgainstVersionDialog.tsx
@@ -1,0 +1,182 @@
+import React, { useEffect, useState } from "react";
+import { Loader2, Play } from "lucide-react";
+
+import { Button } from "@/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/select";
+import { getWorkflowSummaries } from "@/services/workflows";
+import { getAgentConfig } from "@/services/api";
+import { WorkflowSummary } from "@/interfaces/workflow.interface";
+
+interface RunAgainstVersionDialogProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Groups the saved versions to choose from. */
+  agentId: string;
+  /** The version the evaluation runs against by default. */
+  currentWorkflowId?: string;
+  /** Named once in the description instead of repeated per option. */
+  workflowName?: string;
+  /** Confirm label, e.g. "Run" or "Run all". */
+  confirmLabel?: string;
+  isStarting?: boolean;
+  onRun: (targetWorkflowId: string) => void;
+}
+
+export const RunAgainstVersionDialog: React.FC<RunAgainstVersionDialogProps> = ({
+  isOpen,
+  onOpenChange,
+  agentId,
+  currentWorkflowId,
+  workflowName,
+  confirmLabel = "Run",
+  isStarting = false,
+  onRun,
+}) => {
+  const [versions, setVersions] = useState<WorkflowSummary[]>([]);
+  const [isLoadingVersions, setIsLoadingVersions] = useState(false);
+  const [hasLoadFailed, setHasLoadFailed] = useState(false);
+  const [selectedWorkflowId, setSelectedWorkflowId] = useState<string>("");
+  // The agent's live version — the pointer the builder marks Active, and what a
+  // plain Run executes.
+  const [activeWorkflowId, setActiveWorkflowId] = useState<string | null>(null);
+  // Bumped to refetch on retry.
+  const [loadAttempt, setLoadAttempt] = useState(0);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    // A response from a previous open (or another agent) must never overwrite
+    // the current one.
+    let isStale = false;
+    const loadVersions = async () => {
+      setIsLoadingVersions(true);
+      setHasLoadFailed(false);
+      try {
+        // A missing agent must not hide the version list; it only costs the marker.
+        const [rows, agent] = await Promise.all([
+          getWorkflowSummaries(agentId),
+          getAgentConfig(agentId).catch(() => null),
+        ]);
+        if (isStale) return;
+        setVersions(rows ?? []);
+        setActiveWorkflowId(agent?.workflow_id ?? null);
+        // Preselect what a plain Run would execute: the active version, or the
+        // evaluation's own when the workflow has no active version.
+        setSelectedWorkflowId(agent?.workflow_id ?? currentWorkflowId ?? "");
+      } catch {
+        // Distinct from an empty list: the versions are unknown, not absent.
+        if (!isStale) {
+          setVersions([]);
+          setHasLoadFailed(true);
+        }
+      } finally {
+        if (!isStale) setIsLoadingVersions(false);
+      }
+    };
+    void loadVersions();
+    return () => {
+      isStale = true;
+    };
+  }, [isOpen, agentId, currentWorkflowId, loadAttempt]);
+
+  // Each saved version carries its own name, so it is what tells two versions
+  // apart once a workflow has many of them. "current" marks the agent's live
+  // version, matching the wording of the wizard's workflow picker.
+  const versionLabel = (version: WorkflowSummary): string => {
+    const suffix = version.id === activeWorkflowId ? " (current)" : "";
+    if (!version.name?.trim()) return `v${version.version}${suffix}`;
+    return `v${version.version} · ${version.name}${suffix}`;
+  };
+
+  const hasOtherVersions = versions.length > 1;
+  const canRun = Boolean(selectedWorkflowId) && hasOtherVersions && !isStarting;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Run against a version</DialogTitle>
+        </DialogHeader>
+        <div className="mt-2 space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Execute against another saved version of{" "}
+            {workflowName ?? "this workflow"} — for example a draft you are
+            still working on.
+          </p>
+          <div className="space-y-1.5">
+            <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Version
+            </div>
+            {isLoadingVersions ? (
+              <div className="flex h-10 items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading versions…
+              </div>
+            ) : hasLoadFailed ? (
+              <div className="flex items-center gap-3">
+                <p className="flex-1 text-xs text-destructive">
+                  Couldn't load this workflow's versions.
+                </p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setLoadAttempt((attempt) => attempt + 1)}
+                >
+                  Retry
+                </Button>
+              </div>
+            ) : (
+              <Select
+                value={selectedWorkflowId}
+                onValueChange={setSelectedWorkflowId}
+                disabled={!hasOtherVersions}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Choose a version" />
+                </SelectTrigger>
+                <SelectContent>
+                  {versions.map((version) => (
+                    <SelectItem key={version.id} value={version.id}>
+                      {versionLabel(version)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+            {!isLoadingVersions && !hasLoadFailed && !hasOtherVersions && (
+              <p className="text-xs text-muted-foreground">
+                This workflow has only one saved version. Save another version in
+                the workflow builder to run against it here.
+              </p>
+            )}
+          </div>
+        </div>
+        <DialogFooter className="mt-6 gap-2 border-t pt-4">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button disabled={!canRun} onClick={() => onRun(selectedWorkflowId)}>
+            {isStarting ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Play className="mr-2 h-4 w-4" />
+            )}
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/views/TestSuites/helpers/evaluationForm.test.ts
+++ b/frontend/src/views/TestSuites/helpers/evaluationForm.test.ts
@@ -43,6 +43,14 @@ describe("parseToolRules legacy shapes", () => {
     const rules = parseRules({ tool: "search", result_contains: "ok" });
     expect(rules[0].per_tool?.search?.result_contains).toBe("ok");
   });
+
+  it("skips non-object rule entries instead of crashing the edit wizard", () => {
+    const rules = parseRules({
+      rules: [null, { id: "r1", tool_ids: ["t1"], operator: "all", scope: "every_turn" }],
+    });
+    expect(rules).toHaveLength(1);
+    expect(rules[0].id).toBe("r1");
+  });
 });
 
 describe("serializeToolRule round-trips per_tool", () => {
@@ -86,17 +94,23 @@ describe("grading source configs", () => {
       provEmbeddingModelName: "all-MiniLM-L6-v2",
       provLlmProviderId: "",
       provLlmJudgeSystemPromptSuffix: "",
-      judgeRubric: "The answer should be helpful.",
-      judgeMinScore: "0.5",
+      judgeRules: [
+        {
+          label: "",
+          rubric: "The answer should be helpful.",
+          minScore: "0.5",
+          sourceType: "none",
+          sourceField: "",
+        },
+      ],
       judgeProviderId: "",
-      judgeSourceType: "none",
-      judgeSourceField: "",
     } as unknown as EvaluationWizardData;
 
     const configs = buildTechniqueConfigs(data);
     expect(configs.nli_eval.evidence_source).toBe("expected_output");
     expect(configs.provenance_eval.context_source).toBe("kb_retrievals");
-    expect(configs.llm_judge.source_type).toBe("none");
+    const judgeRules = configs.llm_judge.rules as Record<string, unknown>[];
+    expect(judgeRules[0].source_type).toBe("none");
   });
 
   it("keeps unknown legacy source fields when an evaluation is edited", () => {
@@ -124,7 +138,8 @@ describe("grading source configs", () => {
 
     expect(configs.nli_eval.evidence_field).toBe("trace.nodes.custom.output");
     expect(configs.provenance_eval.context_field).toBe("trace.nodes.legacy.output");
-    expect(configs.llm_judge.source_field).toBe("trace.session.custom");
+    const judgeRules = configs.llm_judge.rules as Record<string, unknown>[];
+    expect(judgeRules[0].source_field).toBe("trace.session.custom");
   });
 
   it("preserves the old expected-output default for saved semantic evaluations", () => {
@@ -146,7 +161,56 @@ describe("grading source configs", () => {
     const initial = getEditInitialData(evaluation, []);
     expect(initial.nliEvidenceSource).toBe("expected_output");
     expect(initial.provContextSource).toBe("expected_output");
-    expect(initial.judgeSourceType).toBe("none");
+    expect(initial.judgeRules?.[0]?.sourceType).toBe("none");
+  });
+
+  it("round-trips a multi-rule judge config through the wizard", () => {
+    const evaluation = {
+      id: "e4",
+      name: "multi judge",
+      suite_id: "s1",
+      techniques: ["llm_judge"],
+      technique_configs: {
+        llm_judge: {
+          llm_provider_id: "p1",
+          rules: [
+            { label: "Tone", rubric: "Polite?", min_score: 0.5, source_type: "none" },
+            {
+              label: "Relevance",
+              rubric: "Sources relevant?",
+              min_score: 0.7,
+              source_type: "kb_retrievals",
+            },
+          ],
+        },
+      },
+      run_ids: [],
+      created_at: "",
+      updated_at: "",
+    } as TestEvaluationConfig;
+
+    const initial = getEditInitialData(evaluation, []);
+    expect(initial.judgeRules).toHaveLength(2);
+    expect(initial.judgeRules?.[1]?.sourceType).toBe("kb_retrievals");
+
+    const data = {
+      metrics: ["llm_judge"],
+      judgeRules: initial.judgeRules,
+      judgeProviderId: initial.judgeProviderId,
+    } as unknown as EvaluationWizardData;
+    const configs = buildTechniqueConfigs(data);
+    expect(configs.llm_judge).toEqual({
+      llm_provider_id: "p1",
+      rules: [
+        { label: "Tone", rubric: "Polite?", min_score: 0.5, source_type: "none" },
+        {
+          label: "Relevance",
+          rubric: "Sources relevant?",
+          min_score: 0.7,
+          source_type: "kb_retrievals",
+        },
+      ],
+    });
   });
 });
 
@@ -189,5 +253,88 @@ describe("field_equals config", () => {
     const initial = getEditInitialData(evaluation, []);
     expect(initial.fieldEqualsField).toBe("outputs.status");
     expect(initial.fieldEqualsExpected).toBe("resolved");
+  });
+});
+
+describe("route_taken and action_taken multi-rule configs", () => {
+  const evalWithConfigs = (
+    configs: Record<string, Record<string, unknown>>,
+  ): TestEvaluationConfig =>
+    ({
+      id: "ra1",
+      name: "route/action",
+      suite_id: "s1",
+      techniques: Object.keys(configs),
+      technique_configs: configs,
+      run_ids: [],
+      created_at: "",
+      updated_at: "",
+    }) as TestEvaluationConfig;
+
+  it("parses a legacy single-rule route config into one draft rule", () => {
+    const initial = getEditInitialData(
+      evalWithConfigs({ route_taken: { expected: "true", node: "router1" } }),
+      [],
+    );
+    expect(initial.routeRules).toEqual([{ router: "router1", expected: "true" }]);
+  });
+
+  it("parses a legacy single-rule action config into one draft rule", () => {
+    const initial = getEditInitialData(
+      evalWithConfigs({ action_taken: { node: "action1", should_fire: false } }),
+      [],
+    );
+    expect(initial.actionRules).toEqual([
+      { node: "action1", nodeType: "", shouldFire: false },
+    ]);
+  });
+
+  it("serializes route rules as a rules list", () => {
+    const data = {
+      metrics: ["route_taken"],
+      routeRules: [
+        { router: "r1", expected: "true" },
+        { router: "", expected: "support" },
+      ],
+    } as unknown as EvaluationWizardData;
+
+    expect(buildTechniqueConfigs(data).route_taken).toEqual({
+      rules: [{ router: "r1", expected: "true" }, { expected: "support" }],
+    });
+  });
+
+  it("skips non-object rule entries the backend tolerates instead of crashing", () => {
+    const initial = getEditInitialData(
+      evalWithConfigs({
+        route_taken: { rules: [null, { router: "r1", expected: "true" }, "junk"] },
+        action_taken: { rules: [42, { node: "a1" }] },
+      }),
+      [],
+    );
+    expect(initial.routeRules).toEqual([{ router: "r1", expected: "true" }]);
+    expect(initial.actionRules).toEqual([{ node: "a1", nodeType: "", shouldFire: true }]);
+  });
+
+  it("round-trips a stored multi-rule action config through the wizard", () => {
+    const stored = {
+      action_taken: {
+        rules: [
+          { node: "a1", should_fire: true },
+          { node_type: "zendeskTicketNode", should_fire: false },
+        ],
+      },
+    };
+    const initial = getEditInitialData(evalWithConfigs(stored), []);
+    const data = {
+      metrics: ["action_taken"],
+      actionRules: initial.actionRules,
+    } as unknown as EvaluationWizardData;
+
+    expect(buildTechniqueConfigs(data).action_taken).toEqual({
+      rules: [
+        { node: "a1", should_fire: true },
+        { node_type: "zendeskTicketNode", should_fire: false },
+      ],
+    });
   });
 });

--- a/frontend/src/views/TestSuites/helpers/evaluationForm.ts
+++ b/frontend/src/views/TestSuites/helpers/evaluationForm.ts
@@ -3,6 +3,9 @@ import {
   GradingSourceSelection,
 } from "../components/EvaluationWizard";
 import {
+  ActionRuleDraft,
+  JudgeRuleDraft,
+  RouteRuleDraft,
   TestEvaluationConfig,
   ToolUsageOperator,
   ToolUsagePerToolCheck,
@@ -79,13 +82,21 @@ const legacyPerTool = (cfg: Record<string, unknown>): Record<string, ToolUsagePe
   };
 };
 
+// Keep only plain-object rule entries; the backend tolerates junk entries, so
+// the wizard must too instead of crashing the page render.
+const objectRules = (rules: unknown[]): Record<string, unknown>[] =>
+  rules.filter(
+    (rule): rule is Record<string, unknown> =>
+      Boolean(rule) && typeof rule === "object" && !Array.isArray(rule),
+  );
+
 // Parse a stored tool_used config into builder rules, converting the legacy shape.
 const parseToolRules = (
   cfg: Record<string, unknown> | undefined,
 ): ToolUsageRule[] => {
   if (!cfg) return [];
   if (Array.isArray(cfg.rules)) {
-    return (cfg.rules as Record<string, unknown>[]).map((rule, index) => ({
+    return objectRules(cfg.rules).map((rule, index) => ({
       id: (rule.id as string) ?? `rule-${index}`,
       agent_id: (rule.agent_id as string) ?? null,
       tool_ids: Array.isArray(rule.tool_ids) ? (rule.tool_ids as string[]) : [],
@@ -143,6 +154,72 @@ const serializeToolRule = (rule: ToolUsageRule): Record<string, unknown> => ({
   ...(rule.max_calls != null ? { max_calls: rule.max_calls } : {}),
   ...(rule.per_tool && Object.keys(rule.per_tool).length ? { per_tool: rule.per_tool } : {}),
 });
+
+// Parse a stored llm_judge config into builder rules; a legacy single-rubric
+// config becomes a one-item list.
+const parseJudgeRules = (cfg: Record<string, unknown> | undefined): JudgeRuleDraft[] => {
+  if (!cfg) return [];
+
+  const toDraft = (rule: Record<string, unknown>): JudgeRuleDraft | null => {
+    const rubric = ((rule.rubric ?? rule.instructions) as string) ?? "";
+    if (!rubric.trim()) return null;
+    const source = parseGradingSource(rule, "source_type", "source_field", "none");
+    return {
+      label: (rule.label as string) ?? "",
+      rubric,
+      minScore: String(rule.min_score ?? "0.5"),
+      sourceType: source.selection,
+      sourceField: source.legacyField,
+    };
+  };
+
+  if (Array.isArray(cfg.rules)) {
+    return objectRules(cfg.rules)
+      .map(toDraft)
+      .filter((rule): rule is JudgeRuleDraft => rule !== null);
+  }
+  const single = toDraft(cfg);
+  return single ? [single] : [];
+};
+
+// Parse a stored route_taken config into builder rules; a legacy single-rule
+// config becomes a one-item list.
+const parseRouteRules = (cfg: Record<string, unknown> | undefined): RouteRuleDraft[] => {
+  if (!cfg) return [];
+  if (Array.isArray(cfg.rules)) {
+    return objectRules(cfg.rules).map((rule) => ({
+      router: ((rule.router ?? rule.node) as string) ?? "",
+      expected: (rule.expected as string) ?? "",
+    }));
+  }
+  if (cfg.expected) {
+    return [
+      {
+        router: ((cfg.router ?? cfg.node) as string) ?? "",
+        expected: cfg.expected as string,
+      },
+    ];
+  }
+  return [];
+};
+
+// Parse a stored action_taken config into builder rules; a legacy single-rule
+// config becomes a one-item list.
+const parseActionRules = (cfg: Record<string, unknown> | undefined): ActionRuleDraft[] => {
+  if (!cfg) return [];
+  const toDraft = (rule: Record<string, unknown>): ActionRuleDraft => ({
+    node: (rule.node as string) ?? "",
+    nodeType: (rule.node_type as string) ?? "",
+    shouldFire: rule.should_fire === undefined ? true : Boolean(rule.should_fire),
+  });
+  if (Array.isArray(cfg.rules)) {
+    return objectRules(cfg.rules).map(toDraft);
+  }
+  if (cfg.node || cfg.node_type) {
+    return [toDraft(cfg)];
+  }
+  return [];
+};
 
 const parseJsonObject = (
   text: string,
@@ -254,27 +331,34 @@ export const buildTechniqueConfigs = (
 
   if (data.metrics.includes("route_taken")) {
     configs.route_taken = {
-      expected: data.routeExpected.trim(),
-      ...(data.routeNode.trim() ? { node: data.routeNode.trim() } : {}),
+      rules: data.routeRules.map((rule) => ({
+        expected: rule.expected.trim(),
+        ...(rule.router.trim() ? { router: rule.router.trim() } : {}),
+      })),
     };
   }
 
   if (data.metrics.includes("action_taken")) {
     configs.action_taken = {
-      should_fire: data.actionShouldFire,
-      ...(data.actionNode.trim() ? { node: data.actionNode.trim() } : {}),
-      ...(data.actionNodeType.trim() ? { node_type: data.actionNodeType.trim() } : {}),
+      rules: data.actionRules.map((rule) => ({
+        should_fire: rule.shouldFire,
+        ...(rule.node.trim() ? { node: rule.node.trim() } : {}),
+        ...(rule.nodeType.trim() ? { node_type: rule.nodeType.trim() } : {}),
+      })),
     };
   }
 
   if (data.metrics.includes("llm_judge")) {
     configs.llm_judge = {
-      rubric: data.judgeRubric.trim(),
-      min_score: Number(data.judgeMinScore || "0.5"),
       ...(data.judgeProviderId.trim() ? { llm_provider_id: data.judgeProviderId.trim() } : {}),
-      ...(data.judgeSourceType === "legacy" && data.judgeSourceField
-        ? { source_field: data.judgeSourceField }
-        : { source_type: data.judgeSourceType }),
+      rules: data.judgeRules.map((rule) => ({
+        rubric: rule.rubric.trim(),
+        min_score: Number(rule.minScore || "0.5"),
+        ...(rule.label.trim() ? { label: rule.label.trim() } : {}),
+        ...(rule.sourceType === "legacy" && rule.sourceField
+          ? { source_field: rule.sourceField }
+          : { source_type: rule.sourceType }),
+      })),
     };
   }
 
@@ -305,7 +389,6 @@ export const getEditInitialData = (
     "context_field",
     "expected_output",
   );
-  const judgeSource = parseGradingSource(judgeCfg, "source_type", "source_field", "none");
   const metaWithoutMemory = evaluation.input_metadata
     ? Object.fromEntries(Object.entries(evaluation.input_metadata).filter(([k]) => k !== "use_memory"))
     : {};
@@ -336,15 +419,9 @@ export const getEditInitialData = (
     fieldEqualsField: (fieldEqualsCfg?.field as string) ?? "",
     fieldEqualsExpected:
       fieldEqualsCfg?.expected != null ? String(fieldEqualsCfg.expected) : "",
-    routeExpected: (routeCfg?.expected as string) ?? "",
-    routeNode: (routeCfg?.node as string) ?? "",
-    actionNode: (actionCfg?.node as string) ?? "",
-    actionNodeType: (actionCfg?.node_type as string) ?? "",
-    actionShouldFire: actionCfg?.should_fire === undefined ? true : Boolean(actionCfg.should_fire),
-    judgeRubric: (judgeCfg?.rubric as string) ?? "",
-    judgeMinScore: String(judgeCfg?.min_score ?? "0.5"),
+    routeRules: parseRouteRules(routeCfg),
+    actionRules: parseActionRules(actionCfg),
+    judgeRules: parseJudgeRules(judgeCfg),
     judgeProviderId: (judgeCfg?.llm_provider_id as string) ?? providers[0]?.id ?? "",
-    judgeSourceType: judgeSource.selection,
-    judgeSourceField: judgeSource.legacyField,
   };
 };

--- a/frontend/src/views/TestSuites/helpers/runResults.ts
+++ b/frontend/src/views/TestSuites/helpers/runResults.ts
@@ -1,0 +1,52 @@
+import { TestResult, TestRun } from "@/interfaces/testSuite.interface";
+import type { TestToolRuleResult } from "@/interfaces/testEvaluation.interface";
+
+export type CaseStatus = "passed" | "failed" | "not_scored";
+
+export const hasMetrics = (result: TestResult): boolean =>
+  !!result.metrics && Object.keys(result.metrics).length > 0;
+
+// No metrics means no score, whatever the stored status claims.
+export const isResultNotScored = (result: TestResult): boolean =>
+  !hasMetrics(result) || (!!result.status && result.status !== "scored");
+
+export const isResultPassed = (result: TestResult): boolean =>
+  hasMetrics(result) &&
+  !isResultNotScored(result) &&
+  Object.values(result.metrics!).every((m) => m.passed);
+
+export const isResultFailed = (result: TestResult): boolean =>
+  !isResultPassed(result) && !isResultNotScored(result);
+
+export const notScoredLabel = (result: TestResult): string => {
+  if (result.status === "skipped") return "Skipped";
+  if (result.status === "scoring_failed") return "Scoring failed";
+  if (result.status === "execution_failed") return "Execution failed";
+  return "Not scored";
+};
+
+// A case's status reflects its turn-level Tool Usage results too: a tool failure
+// fails the case, and a tool pass can score an otherwise-unscored case.
+export const caseStatusFor = (
+  result: TestResult,
+  toolResults: TestToolRuleResult[],
+): CaseStatus => {
+  const toolFailed = toolResults.some((t) => t.status === "failed");
+  const toolPassed = toolResults.some((t) => t.status === "passed");
+  if (toolFailed) return "failed";
+  const passed = isResultPassed(result) || (isResultNotScored(result) && toolPassed);
+  if (passed) return "passed";
+  if (isResultFailed(result)) return "failed";
+  return "not_scored";
+};
+
+export const runAvgAccuracy = (run: TestRun): number | null => {
+  const summaryMetrics = run.summary_metrics as
+    | Record<string, { accuracy?: number }>
+    | undefined;
+  const scored = Object.values(summaryMetrics ?? {}).filter(
+    (m) => typeof m.accuracy === "number",
+  );
+  if (!scored.length) return null;
+  return scored.reduce((sum, m, _, arr) => sum + (m.accuracy ?? 0) / arr.length, 0);
+};

--- a/frontend/src/views/TestSuites/pages/EvaluationDetailPage.tsx
+++ b/frontend/src/views/TestSuites/pages/EvaluationDetailPage.tsx
@@ -53,6 +53,7 @@ import { ToolUsageResults } from "../components/ToolUsageResults";
 import { ToolUsageResultCard } from "../components/ToolUsageResultCard";
 import { RunAgainstVersionDialog } from "../components/RunAgainstVersionDialog";
 import { CompareRunsDialog } from "../components/CompareRunsDialog";
+import { MetricRuleBreakdown } from "../components/MetricRuleBreakdown";
 import { methodLabel } from "../helpers/methodLabels";
 import {
   isResultFailed,
@@ -505,18 +506,23 @@ const EvaluationDetailPage: React.FC = () => {
                   tech,
                   evaluation?.technique_configs?.[tech],
                 );
-                if (!metricValue.comment && !sourceLabel) return null;
+                const ruleDetails =
+                  Array.isArray(metricValue.details) && metricValue.details.length > 1
+                    ? metricValue.details
+                    : null;
+                if (!metricValue.comment && !sourceLabel && !ruleDetails) return null;
                 return (
                   <div key={`${result.id}-${tech}-comment`} className="text-xs">
                     <span className="font-semibold text-muted-foreground">{methodLabel(tech)}:</span>{" "}
-                    {metricValue.comment && (
+                    {metricValue.comment && !ruleDetails && (
                       <span className="text-muted-foreground">{metricValue.comment}</span>
                     )}
                     {sourceLabel && (
                       <span className="text-muted-foreground">
-                        {metricValue.comment ? " — " : ""}checked against: {sourceLabel}
+                        {metricValue.comment && !ruleDetails ? " — " : ""}checked against: {sourceLabel}
                       </span>
                     )}
+                    {ruleDetails && <MetricRuleBreakdown details={ruleDetails} />}
                   </div>
                 );
               })}

--- a/frontend/src/views/TestSuites/pages/EvaluationDetailPage.tsx
+++ b/frontend/src/views/TestSuites/pages/EvaluationDetailPage.tsx
@@ -1,23 +1,32 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import toast from "react-hot-toast";
 import { PageLayout } from "@/components/PageLayout";
 import JsonViewer from "@/components/JsonViewer";
 import { Button } from "@/components/button";
 import { Badge } from "@/components/badge";
-import { ChevronLeft, Play, CheckCircle2, XCircle, AlertCircle, Loader2 } from "lucide-react";
+import {
+  ChevronLeft,
+  GitBranch,
+  GitCompareArrows,
+  Play,
+  CheckCircle2,
+  XCircle,
+  AlertCircle,
+  Loader2,
+} from "lucide-react";
 import {
   getTestRun,
   getTestRunsBatch,
   listTestCases,
   listResultsForRun,
   listTestSuites,
-  startTestRun,
 } from "@/services/testSuites";
 import { getWorkflowsMinimal } from "@/services/workflows";
 import {
   getTestEvaluationById,
-  appendRunToEvaluation,
   getToolRuleResults,
+  runTestEvaluation,
 } from "@/services/testEvaluations";
 import { TestResult, TestRun, TestSuite } from "@/interfaces/testSuite.interface";
 import type { TestToolRuleResult } from "@/interfaces/testEvaluation.interface";
@@ -37,10 +46,21 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Skeleton } from "@/components/skeleton";
 import { Progress } from "@/components/progress";
 import { PaginationBar } from "@/components/PaginationBar";
+import { TooltipProvider } from "@/components/RadixTooltip";
+import { TooltipButton } from "@/components/tooltip-button";
 import { cn } from "@/helpers/utils";
 import { ToolUsageResults } from "../components/ToolUsageResults";
 import { ToolUsageResultCard } from "../components/ToolUsageResultCard";
+import { RunAgainstVersionDialog } from "../components/RunAgainstVersionDialog";
+import { CompareRunsDialog } from "../components/CompareRunsDialog";
 import { methodLabel } from "../helpers/methodLabels";
+import {
+  isResultFailed,
+  isResultNotScored,
+  isResultPassed,
+  notScoredLabel,
+  runAvgAccuracy,
+} from "../helpers/runResults";
 
 type ResultFilter = "all" | "passed" | "failed" | "not_scored";
 
@@ -117,28 +137,6 @@ const usesExpectedOutput = (
   }
 };
 
-const hasMetrics = (result: TestResult): boolean =>
-  !!result.metrics && Object.keys(result.metrics).length > 0;
-
-// No metrics means no score, whatever the stored status claims.
-const isResultNotScored = (result: TestResult): boolean =>
-  !hasMetrics(result) || (!!result.status && result.status !== "scored");
-
-const isResultPassed = (result: TestResult): boolean =>
-  hasMetrics(result) &&
-  !isResultNotScored(result) &&
-  Object.values(result.metrics!).every((m) => m.passed);
-
-const isResultFailed = (result: TestResult): boolean =>
-  !isResultPassed(result) && !isResultNotScored(result);
-
-const notScoredLabel = (result: TestResult): string => {
-  if (result.status === "skipped") return "Skipped";
-  if (result.status === "scoring_failed") return "Scoring failed";
-  if (result.status === "execution_failed") return "Execution failed";
-  return "Not scored";
-};
-
 const accuracyTextClass = (acc: number): string =>
   acc >= 0.9
     ? "text-green-600 dark:text-green-400"
@@ -172,6 +170,9 @@ const EvaluationDetailPage: React.FC = () => {
   const [toolResultsByRun, setToolResultsByRun] = useState<Record<string, TestToolRuleResult[]>>({});
   const [suite, setSuite] = useState<TestSuite | null>(null);
   const [workflowName, setWorkflowName] = useState<string>("Dataset default");
+  const [workflowAgentId, setWorkflowAgentId] = useState<string | null>(null);
+  const [isVersionDialogOpen, setIsVersionDialogOpen] = useState(false);
+  const [isCompareOpen, setIsCompareOpen] = useState(false);
   const [expectedOutputByCaseId, setExpectedOutputByCaseId] = useState<
     Record<string, Record<string, unknown> | undefined>
   >({});
@@ -205,6 +206,7 @@ const EvaluationDetailPage: React.FC = () => {
         (item: WorkflowMinimal) => item.id === evaluation.workflow_id,
       );
       setWorkflowName(workflowData?.name ?? "Dataset default");
+      setWorkflowAgentId(workflowData?.agent_id ?? null);
     };
     loadContext();
   }, [evaluation]);
@@ -275,20 +277,12 @@ const EvaluationDetailPage: React.FC = () => {
     loadSelectedRunResults();
   }, [selectedRunId]);
 
-  const handleRunEvaluation = async () => {
+  const handleRunEvaluation = async (targetWorkflowId?: string) => {
     if (!evaluation || !evaluationId) return;
     setIsRunning(true);
     try {
-      // Memory threads are generated per conversation by the backend at run time.
-      const runMetadata = evaluation.input_metadata ?? undefined;
-      const created = await startTestRun(evaluation.suite_id, {
-        techniques: evaluation.techniques,
-        technique_configs: evaluation.technique_configs,
-        workflow_id: evaluation.workflow_id,
-        input_metadata: runMetadata,
-      });
+      const created = await runTestEvaluation(evaluationId, targetWorkflowId);
       if (created?.id) {
-        await appendRunToEvaluation(evaluationId, created.id);
         setRuns((prev) => [created, ...prev]);
         setRunsPage(1); // jump back to the first page so the new run is visible
 
@@ -313,8 +307,16 @@ const EvaluationDetailPage: React.FC = () => {
         // Return early — setIsRunning(false) is handled by the interval above.
         return;
       }
-    } catch {
-      // fall through to finally
+    } catch (error) {
+      const status = (error as { response?: { status?: number } })?.response
+        ?.status;
+      if (status === 409) {
+        toast.error("This evaluation is already running.");
+      } else if (status === 400) {
+        toast.error("That version does not belong to this workflow.");
+      } else {
+        toast.error("Failed to start the evaluation.");
+      }
     }
     setIsRunning(false);
   };
@@ -387,13 +389,6 @@ const EvaluationDetailPage: React.FC = () => {
     RUN_TOTALS_KEY
   ] as RunTotals | undefined;
 
-  const runAvgAccuracy = (run: TestRun): number | null => {
-    const summaryMetrics = run.summary_metrics as Record<string, { accuracy?: number }> | undefined;
-    const scored = Object.values(summaryMetrics ?? {}).filter((m) => typeof m.accuracy === "number");
-    if (!scored.length) return null;
-    return scored.reduce((sum, m, _, arr) => sum + (m.accuracy ?? 0) / arr.length, 0);
-  };
-
   // Client-side pagination for the runs list (runs are all loaded up front).
   const runsTotalPages = Math.max(1, Math.ceil(runs.length / RUNS_PAGE_SIZE));
   const runsSafePage = Math.min(runsPage, runsTotalPages);
@@ -401,6 +396,13 @@ const EvaluationDetailPage: React.FC = () => {
     (runsSafePage - 1) * RUNS_PAGE_SIZE,
     runsSafePage * RUNS_PAGE_SIZE,
   );
+
+  // Offered whenever the evaluation targets a workflow; the dialog handles a
+  // workflow that has no second version to choose.
+  const canRunAgainstVersion = Boolean(workflowAgentId && evaluation?.workflow_id);
+  const finishedRunCount = runs.filter(
+    (run) => run.status === "completed" || run.status === "failed",
+  ).length;
 
   // Runs are sorted newest-first, so the most recent is the summary for the header.
   const lastRun = runs[0];
@@ -624,19 +626,38 @@ const EvaluationDetailPage: React.FC = () => {
             <p className="truncate text-sm text-muted-foreground">{evaluation.description}</p>
           )}
         </div>
-        <Button
-          onClick={handleRunEvaluation}
-          disabled={isRunning}
-          className="shrink-0"
-          aria-label="Run evaluation"
-        >
-          {isRunning ? (
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-          ) : (
-            <Play className="mr-2 h-4 w-4" />
+        <div className="flex shrink-0 items-center gap-2">
+          {canRunAgainstVersion && (
+            <TooltipProvider delayDuration={200}>
+              <TooltipButton
+                button={
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    disabled={isRunning}
+                    onClick={() => setIsVersionDialogOpen(true)}
+                    aria-label="Run against a version"
+                  >
+                    <GitBranch className="h-4 w-4" />
+                  </Button>
+                }
+                tooltipContent={{ children: <p>Run against a version</p> }}
+              />
+            </TooltipProvider>
           )}
-          {isRunning ? "Running..." : "Run"}
-        </Button>
+          <Button
+            onClick={() => handleRunEvaluation()}
+            disabled={isRunning}
+            aria-label="Run evaluation"
+          >
+            {isRunning ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Play className="mr-2 h-4 w-4" />
+            )}
+            {isRunning ? "Running..." : "Run"}
+          </Button>
+        </div>
       </div>
 
       {/* Configuration + Last Run summary */}
@@ -701,6 +722,11 @@ const EvaluationDetailPage: React.FC = () => {
               <div>
                 <div className="flex flex-wrap items-center gap-2">
                   <span className="font-medium">Run #{lastRun.id?.slice(-4)}</span>
+                  {lastRun.workflow_version && (
+                    <Badge variant="outline" className="text-[10px]">
+                      v{lastRun.workflow_version}
+                    </Badge>
+                  )}
                   <RunStatusBadge status={lastRun.status} />
                 </div>
                 <div className="mt-0.5 text-xs text-muted-foreground">
@@ -745,9 +771,17 @@ const EvaluationDetailPage: React.FC = () => {
       <div className="rounded-lg border bg-card p-4 dark:bg-zinc-900">
         <div className="mb-3 flex items-center justify-between">
           <h2 className="text-lg font-semibold">Previous Executions</h2>
-          <Badge variant="secondary" className="text-xs">
-            {runs.length} run{runs.length !== 1 ? "s" : ""}
-          </Badge>
+          <div className="flex items-center gap-2">
+            {finishedRunCount >= 2 && (
+              <Button variant="outline" size="sm" onClick={() => setIsCompareOpen(true)}>
+                <GitCompareArrows className="mr-1.5 h-3.5 w-3.5" />
+                Compare
+              </Button>
+            )}
+            <Badge variant="secondary" className="text-xs">
+              {runs.length} run{runs.length !== 1 ? "s" : ""}
+            </Badge>
+          </div>
         </div>
 
         {isLoadingRuns ? (
@@ -791,6 +825,11 @@ const EvaluationDetailPage: React.FC = () => {
                   <div className="flex items-center justify-between gap-2">
                     <div className="flex items-center gap-2">
                       <span className="font-medium">Run #{run.id?.slice(-4)}</span>
+                      {run.workflow_version && (
+                        <Badge variant="outline" className="text-[10px]">
+                          v{run.workflow_version}
+                        </Badge>
+                      )}
                       {avgAccuracy !== null && (
                         <div className="flex items-center gap-1">
                           <Progress
@@ -877,7 +916,14 @@ const EvaluationDetailPage: React.FC = () => {
         <DialogContent className="flex h-[90vh] max-h-[90vh] w-[95vw] max-w-[1400px] flex-col gap-0 overflow-hidden p-0">
           <DialogHeader className="shrink-0 border-b px-5 py-3">
             <div className="flex items-center justify-between gap-3">
-              <DialogTitle>Run Details #{selectedRun?.id?.slice(-4)}</DialogTitle>
+              <div className="flex items-center gap-2">
+                <DialogTitle>Run Details #{selectedRun?.id?.slice(-4)}</DialogTitle>
+                {selectedRun?.workflow_version && (
+                  <Badge variant="outline" className="text-[10px]">
+                    v{selectedRun.workflow_version}
+                  </Badge>
+                )}
+              </div>
               {selectedRun && <RunStatusBadge status={selectedRun.status} />}
             </div>
             {selectedRun?.created_at && (
@@ -1077,6 +1123,27 @@ const EvaluationDetailPage: React.FC = () => {
           </div>
         </DialogContent>
       </Dialog>
+
+      {canRunAgainstVersion && workflowAgentId && (
+        <RunAgainstVersionDialog
+          isOpen={isVersionDialogOpen}
+          onOpenChange={setIsVersionDialogOpen}
+          agentId={workflowAgentId}
+          currentWorkflowId={evaluation.workflow_id}
+          workflowName={workflowName}
+          isStarting={isRunning}
+          onRun={(targetWorkflowId) => {
+            setIsVersionDialogOpen(false);
+            void handleRunEvaluation(targetWorkflowId);
+          }}
+        />
+      )}
+
+      <CompareRunsDialog
+        isOpen={isCompareOpen}
+        onOpenChange={setIsCompareOpen}
+        runs={runs}
+      />
     </PageLayout>
   );
 };

--- a/frontend/src/views/TestSuites/pages/WorkflowEvaluationsPage.tsx
+++ b/frontend/src/views/TestSuites/pages/WorkflowEvaluationsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronLeft, ListChecks, Loader2, Play, Search } from "lucide-react";
+import { ChevronLeft, GitBranch, ListChecks, Loader2, Play, Search } from "lucide-react";
 import toast from "react-hot-toast";
 
 import { PageLayout } from "@/components/PageLayout";
@@ -16,14 +16,16 @@ import {
 } from "@/components/dialog";
 import { PaginationBar } from "@/components/PaginationBar";
 import { PageListSkeleton } from "@/components/skeletons";
+import { TooltipProvider } from "@/components/RadixTooltip";
+import { TooltipButton } from "@/components/tooltip-button";
 
 import { getWorkflowsMinimal } from "@/services/workflows";
-import { getTestRunsBatch, listTestSuites, startTestRun } from "@/services/testSuites";
+import { getTestRunsBatch, listTestSuites } from "@/services/testSuites";
 import { getLLMProvidersMinimal } from "@/services/llmProviders";
 import {
-  appendRunToEvaluation,
   deleteTestEvaluation,
   getWorkflowEvaluationsPage,
+  runTestEvaluation,
   runWorkflowEvaluations,
   updateTestEvaluation,
 } from "@/services/testEvaluations";
@@ -33,6 +35,7 @@ import { TestRun, TestSuite } from "@/interfaces/testSuite.interface";
 import { LLMProviderMinimal } from "@/interfaces/llmProvider.interface";
 import { EvaluationWizard, EvaluationWizardData } from "../components/EvaluationWizard";
 import { EvaluationListRow } from "../components/EvaluationListRow";
+import { RunAgainstVersionDialog } from "../components/RunAgainstVersionDialog";
 import { buildTechniqueConfigs, getEditInitialData, wizardMetadata } from "../helpers/evaluationForm";
 
 const PAGE_SIZE = 20;
@@ -94,6 +97,7 @@ const WorkflowEvaluationsPage: React.FC = () => {
 
   const [editingEvaluation, setEditingEvaluation] = useState<TestEvaluationConfig | null>(null);
   const [deletingEvaluationId, setDeletingEvaluationId] = useState<string | null>(null);
+  const [isRunAllVersionDialogOpen, setIsRunAllVersionDialogOpen] = useState(false);
 
   // staleTime 0 makes react-query refetch this when the tab regains focus. The
   // interval is the page's only poll: it runs when a batch is active that this
@@ -120,9 +124,13 @@ const WorkflowEvaluationsPage: React.FC = () => {
   const evaluations = pageData?.items ?? [];
   const total = pageData?.total ?? 0;
   const totalUnfiltered = pageData?.total_unfiltered ?? 0;
+  const currentWorkflow = workflows.find((w) => w.id === workflowId);
   const workflowName = isUnassigned
     ? "Unassigned evaluations"
-    : workflows.find((w) => w.id === workflowId)?.name ?? "Workflow";
+    : currentWorkflow?.name ?? "Workflow";
+  const workflowAgentId = isUnassigned ? null : currentWorkflow?.agent_id ?? null;
+  // Offered on every workflow; the dialog handles one with no second version.
+  const canRunAgainstVersion = Boolean(workflowAgentId);
 
   useEffect(() => {
     const load = async () => {
@@ -201,22 +209,19 @@ const WorkflowEvaluationsPage: React.FC = () => {
     if (!evaluation.id || isEvaluationRunning(evaluation)) return;
     setRunningEvalIds((prev) => new Set(prev).add(evaluation.id));
     try {
-      // Memory threads are generated per conversation by the backend at run time.
-      const runMetadata = evaluation.input_metadata ?? undefined;
-      const created = await startTestRun(evaluation.suite_id, {
-        techniques: evaluation.techniques,
-        technique_configs: evaluation.technique_configs,
-        workflow_id: evaluation.workflow_id,
-        input_metadata: runMetadata,
-      });
+      const created = await runTestEvaluation(evaluation.id);
       if (created?.id) {
-        await appendRunToEvaluation(evaluation.id, created.id);
         setLastRunsByEvaluationId((prev) => ({ ...prev, [evaluation.id as string]: created }));
         toast.success("Evaluation started");
         void refetchPage(); // any_running turns on, which starts the status poll
       }
-    } catch {
-      toast.error("Failed to start evaluation");
+    } catch (error) {
+      if (isRunningConflict(error)) {
+        toast.error("This evaluation is already running");
+        void refetchPage();
+      } else {
+        toast.error("Failed to start evaluation");
+      }
     } finally {
       setRunningEvalIds((prev) => {
         const next = new Set(prev);
@@ -226,7 +231,7 @@ const WorkflowEvaluationsPage: React.FC = () => {
     }
   };
 
-  const handleRunAll = async () => {
+  const handleRunAll = async (targetWorkflowId?: string) => {
     if (isUnassigned || isRunAllInFlight.current || isWorkflowRunning || pageData?.any_running) {
       return;
     }
@@ -243,7 +248,7 @@ const WorkflowEvaluationsPage: React.FC = () => {
     };
 
     try {
-      const started = await runWorkflowEvaluations(workflowId);
+      const started = await runWorkflowEvaluations(workflowId, targetWorkflowId);
       if (isStale()) return; // navigated away before the POST resolved
       const startedRuns = (started ?? []).filter(
         (s): s is typeof s & { run_id: string } => Boolean(s.run_id),
@@ -404,33 +409,53 @@ const WorkflowEvaluationsPage: React.FC = () => {
             />
           </div>
           {!isUnassigned && (
-            <Button
-              variant="outline"
-              disabled={isWorkflowRunning || Boolean(pageData?.any_running)}
-              onClick={handleRunAll}
-            >
-              {isWorkflowRunning && workflowProgress ? (
-                <>
-                  <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-                  {workflowProgress.done}/{workflowProgress.total}
-                </>
-              ) : isWorkflowRunning ? (
-                <>
-                  <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-                  Starting…
-                </>
-              ) : pageData?.any_running ? (
-                <>
-                  <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-                  Running…
-                </>
-              ) : (
-                <>
-                  <Play className="h-3.5 w-3.5 mr-1" />
-                  Run all
-                </>
+            <div className="flex items-center gap-2">
+              {canRunAgainstVersion && (
+                <TooltipProvider delayDuration={200}>
+                  <TooltipButton
+                    button={
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        disabled={isWorkflowRunning || Boolean(pageData?.any_running)}
+                        onClick={() => setIsRunAllVersionDialogOpen(true)}
+                        aria-label="Run all against a version"
+                      >
+                        <GitBranch className="h-4 w-4" />
+                      </Button>
+                    }
+                    tooltipContent={{ children: <p>Run all against a version</p> }}
+                  />
+                </TooltipProvider>
               )}
-            </Button>
+              <Button
+                variant="outline"
+                disabled={isWorkflowRunning || Boolean(pageData?.any_running)}
+                onClick={() => handleRunAll()}
+              >
+                {isWorkflowRunning && workflowProgress ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                    {workflowProgress.done}/{workflowProgress.total}
+                  </>
+                ) : isWorkflowRunning ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                    Starting…
+                  </>
+                ) : pageData?.any_running ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                    Running…
+                  </>
+                ) : (
+                  <>
+                    <Play className="h-3.5 w-3.5 mr-1" />
+                    Run all
+                  </>
+                )}
+              </Button>
+            </div>
           )}
         </div>
       </div>
@@ -485,6 +510,22 @@ const WorkflowEvaluationsPage: React.FC = () => {
           pageItemCount={evaluations.length}
           onPageChange={setPage}
           className="mt-4"
+        />
+      )}
+
+      {canRunAgainstVersion && workflowAgentId && (
+        <RunAgainstVersionDialog
+          isOpen={isRunAllVersionDialogOpen}
+          onOpenChange={setIsRunAllVersionDialogOpen}
+          agentId={workflowAgentId}
+          currentWorkflowId={workflowId}
+          workflowName={workflowName}
+          confirmLabel="Run all"
+          isStarting={isWorkflowRunning}
+          onRun={(targetWorkflowId) => {
+            setIsRunAllVersionDialogOpen(false);
+            void handleRunAll(targetWorkflowId);
+          }}
         />
       )}
 


### PR DESCRIPTION
## Description
Adds multi-rule support to Route Taken, Action Taken and LLM Judge, and makes evaluation results easier to read.

- Route/Action/Judge configs accept a `rules` list — legacy single-rule configs work unchanged, no migration; results show a per-rule pass/fail breakdown
- LLM Judge: per-rule rubric, threshold and grounding source, rules judged in parallel; rubric presets in the wizard (Retrieval relevance, Completeness, Helpfulness, Politeness & tone)
- Evaluator comments show node/tool display names instead of raw ids; the run loop now passes the workflow graph so labels resolve in real runs
- No Errors names the failing nodes; JSON Match lists mismatched/missing/unexpected fields
- Provenance: mode-less legacy configs grade with embeddings; word-overlap heuristic removed (workflow guardrail node untouched)
- Fix: Edit/Delete in the evaluation row menu were clickable while a run was active

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
