### PR TITLE
feat: export and import evaluations across environments

### DIFF
--- a/backend/app/api/v1/routes/test_evaluations.py
+++ b/backend/app/api/v1/routes/test_evaluations.py
@@ -10,6 +10,13 @@ from app.core.permissions.constants import Permissions as P
 from app.core.tenant_scope import get_tenant_context
 from app.dependencies.dependency_injection import RedisString
 from app.dependencies.injector import injector
+from app.schemas.eval_bundle import (
+    EvaluationBundle,
+    EvaluationImportPreview,
+    EvaluationImportPreviewRequest,
+    EvaluationImportRequest,
+    EvaluationImportResult,
+)
 from app.schemas.test_suite import (
     EvaluationRunRequest,
     EvaluationToolCatalog,
@@ -22,6 +29,7 @@ from app.schemas.test_suite import (
     TestRun,
     WorkflowEvaluationSummary,
 )
+from app.services.eval_bundle import EvalBundleService
 from app.services.test_suite import TestSuiteService
 from app.tasks.test_suite_tasks import execute_test_suite_run_task
 
@@ -78,6 +86,37 @@ async def create_evaluation(
     return await service.create_evaluation(data)
 
 
+@router.post(
+    "/evaluations/import/preview",
+    response_model=EvaluationImportPreview,
+    dependencies=[Depends(auth), Depends(permissions(P.Evaluation.READ))],
+)
+async def preview_evaluation_import(
+    data: EvaluationImportPreviewRequest,
+    service: EvalBundleService = Injected(EvalBundleService),
+):
+    """Resolve a bundle's references against a target workflow without importing."""
+    return await service.preview_import(data)
+
+
+@router.post(
+    "/evaluations/import",
+    response_model=EvaluationImportResult,
+    status_code=status.HTTP_201_CREATED,
+    # Evaluation.UPDATE, matching every other evaluation and dataset route.
+    # Note: test_cases.py gates case reads/writes behind Workflow.* instead, so
+    # a supervisor can own datasets but not their cases — an inconsistency in
+    # that router, not something to resolve by locking supervisors out here.
+    dependencies=[Depends(auth), Depends(permissions(P.Evaluation.UPDATE))],
+)
+async def import_evaluation(
+    data: EvaluationImportRequest,
+    service: EvalBundleService = Injected(EvalBundleService),
+):
+    """Create the bundle's dataset, cases and evaluation against a target workflow."""
+    return await service.import_bundle(data)
+
+
 @router.get(
     "/evaluations/{evaluation_id}",
     response_model=TestEvaluation,
@@ -88,6 +127,19 @@ async def get_evaluation(
     service: TestSuiteService = Injected(TestSuiteService),
 ):
     return await service.get_evaluation(evaluation_id)
+
+
+@router.get(
+    "/evaluations/{evaluation_id}/export",
+    response_model=EvaluationBundle,
+    dependencies=[Depends(auth), Depends(permissions(P.Evaluation.READ))],
+)
+async def export_evaluation(
+    evaluation_id: UUID,
+    service: EvalBundleService = Injected(EvalBundleService),
+):
+    """The evaluation, its dataset and reference labels as a portable bundle."""
+    return await service.export_evaluation(evaluation_id)
 
 
 @router.patch(
@@ -204,7 +256,23 @@ async def run_workflow_evaluations(
         detail="This workflow already has running evaluations.",
     )
     redis = injector.get(RedisString)
-    lock_key = f"tenant:{get_tenant_context()}:eval-run-all:{workflow_id}"
+    # The batch spans every version of the workflow, so the lock must key on the
+    # workflow rather than whichever version the URL names — two callers holding
+    # different version ids would otherwise both start runs for the same set.
+    # A failed lookup falls back to the requested id: a narrower lock is worse
+    # than none at all, and must not turn a valid request into a 500.
+    try:
+        canonical_id = (
+            await service.workflow_service.get_active_version_id(workflow_id)
+        ) or workflow_id
+    except Exception:  # pylint: disable=broad-except
+        logger.warning(
+            "Could not resolve the live version of workflow %s for the Run-all "
+            "lock; locking on the requested version.",
+            workflow_id,
+        )
+        canonical_id = workflow_id
+    lock_key = f"tenant:{get_tenant_context()}:eval-run-all:{canonical_id}"
     lock_token = uuid4().hex
     acquired = await redis.set(
         lock_key, lock_token, nx=True, ex=RUN_ALL_LOCK_TTL_SECONDS

--- a/backend/app/core/exceptions/error_messages.py
+++ b/backend/app/core/exceptions/error_messages.py
@@ -12,6 +12,7 @@ class ErrorKey(Enum):
     INTERNAL_ERROR = "error_500"
     TOOL_USAGE_CONFIG_INVALID = "tool_usage_config_invalid"
     EVALUATION_TARGET_NOT_A_VERSION = "evaluation_target_not_a_version"
+    EVALUATION_BUNDLE_INVALID = "evaluation_bundle_invalid"
     NOT_FOUND = "not_found"
     AUDIT_LOG_NOT_FOUND = "audit_log_not_found"
     SENTIMENT_OBJECT_STRUCTURE = "sentiment_object_structure"
@@ -182,6 +183,7 @@ ERROR_MESSAGES = {
         ErrorKey.INTERNAL_ERROR: "An internal server error occurred. Please try again later.",
         ErrorKey.TOOL_USAGE_CONFIG_INVALID: "The tool usage configuration could not be resolved to canonical tool ids.",
         ErrorKey.EVALUATION_TARGET_NOT_A_VERSION: "The target workflow is not a version of the evaluation's workflow.",
+        ErrorKey.EVALUATION_BUNDLE_INVALID: "The evaluation bundle is invalid or could not be imported.",
         ErrorKey.NOT_FOUND: "The requested resource was not found.",
         ErrorKey.AUDIT_LOG_NOT_FOUND: "The requested log was not found.",
         ErrorKey.SENTIMENT_OBJECT_STRUCTURE: "Sentiment object must have 'positive', 'neutral', and 'negative' fields.",

--- a/backend/app/core/exceptions/exception_handler.py
+++ b/backend/app/core/exceptions/exception_handler.py
@@ -13,13 +13,18 @@ from app.core.exceptions.exception_classes import AppException, UpstreamServiceE
 
 logger = logging.getLogger(__name__)
 
-_SSO_CLIENT_ERROR_KEYS = frozenset(
+# Errors whose detail is written for the end user and carries no internal
+# information, so it is returned outside dev too.
+_CLIENT_SAFE_DETAIL_KEYS = frozenset(
     {
         ErrorKey.SSO_MICROSOFT_OAUTH_ERROR,
         ErrorKey.SSO_MICROSOFT_USER_DENIED,
         ErrorKey.SSO_MICROSOFT_REDIRECT_NOT_ALLOWED,
         ErrorKey.SSO_MICROSOFT_NOT_CONFIGURED,
         ErrorKey.SSO_MICROSOFT_DISABLED,
+        # Says which reference could not be re-linked, or why the import was
+        # refused — the whole point is telling the user what to change.
+        ErrorKey.EVALUATION_BUNDLE_INVALID,
     }
 )
 
@@ -47,7 +52,7 @@ def _response_error_detail(error: AppException) -> str | None:
         return None
     if os.getenv("ENV") == "dev":
         return sanitized
-    if error.error_key in _SSO_CLIENT_ERROR_KEYS:
+    if error.error_key in _CLIENT_SAFE_DETAIL_KEYS:
         return sanitized
     return None
 

--- a/backend/app/repositories/test_suite.py
+++ b/backend/app/repositories/test_suite.py
@@ -6,6 +6,8 @@ from injector import inject
 from sqlalchemy import and_, delete, exists, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.db.events.group_scope import GROUP_SCOPE_BYPASS_FLAG
+from app.db.models.agent import AgentModel
 from app.db.models.test_suite import (
     TestSuiteModel,
     TestCaseModel,
@@ -14,6 +16,7 @@ from app.db.models.test_suite import (
     TestEvaluationModel,
     TestToolRuleResultModel,
 )
+from app.db.models.workflow import WorkflowModel
 from app.repositories.db_repository import DbRepository
 
 
@@ -201,9 +204,39 @@ class TestEvaluationRepository(DbRepository[TestEvaluationModel]):
         result = await self.db.execute(stmt)
         return result.scalars().all()
 
+    @staticmethod
+    def _version_ids_of(workflow_id: UUID):
+        """Every live version of the workflow ``workflow_id`` belongs to.
+
+        Versions are separate ``workflows`` rows sharing an ``agent_id``, and an
+        evaluation is pinned to one of them. Users think in workflows, not
+        versions, so the overview and its drill-down span all of them. A
+        workflow with no agent matches only itself (comparing against a NULL
+        agent yields NULL, never true).
+        """
+        target_agent = (
+            select(WorkflowModel.agent_id)
+            .where(WorkflowModel.id == str(workflow_id))
+            .scalar_subquery()
+        )
+        return select(WorkflowModel.id).where(
+            WorkflowModel.is_deleted == 0,
+            or_(
+                WorkflowModel.id == str(workflow_id),
+                and_(
+                    WorkflowModel.agent_id.is_not(None),
+                    WorkflowModel.agent_id == target_agent,
+                ),
+            ),
+        )
+
     def _workflow_condition(self, workflow_id: Optional[UUID]):
         """Match evaluations by effective workflow: own ``workflow_id`` or, when
         absent, their dataset's default. ``workflow_id=None`` = unassigned.
+
+        A workflow id matches every version of that workflow, so evaluations
+        pinned to different versions appear under one row rather than splitting
+        into look-alike duplicates.
 
         An evaluation is unassigned when it has no ``workflow_id`` and its suite
         does not resolve to a live workflow — including evals whose suite was
@@ -225,13 +258,13 @@ class TestEvaluationRepository(DbRepository[TestEvaluationModel]):
                 )
             )
         else:
-            workflow = str(workflow_id)
+            version_ids = self._version_ids_of(workflow_id)
             workflow_suites = select(suite.id).where(
-                suite.workflow_id == workflow, suite.is_deleted == 0
+                suite.workflow_id.in_(version_ids), suite.is_deleted == 0
             )
             conditions.append(
                 or_(
-                    evaluation.workflow_id == workflow,
+                    evaluation.workflow_id.in_(version_ids),
                     and_(
                         evaluation.workflow_id.is_(None),
                         evaluation.suite_id.in_(workflow_suites),
@@ -239,6 +272,36 @@ class TestEvaluationRepository(DbRepository[TestEvaluationModel]):
                 )
             )
         return and_(*conditions)
+
+    def _grouped_effective_workflow(self):
+        """(group key expression, joins) collapsing versions onto one workflow.
+
+        The key is the agent's live version, so every evaluation of a workflow
+        lands in the same bucket whichever version it is pinned to; workflows
+        without an agent keep their own id. Agents are group-scoped while
+        workflows are not, so the scope filter is bypassed for the join —
+        otherwise the same workflow would bucket differently per caller.
+        """
+        evaluation = TestEvaluationModel
+        suite = TestSuiteModel
+        effective = func.coalesce(evaluation.workflow_id, suite.workflow_id)
+        return func.coalesce(AgentModel.workflow_id, effective), effective
+
+    def _grouped_select(self, *columns):
+        evaluation = TestEvaluationModel
+        suite = TestSuiteModel
+        _, effective = self._grouped_effective_workflow()
+        return (
+            select(*columns)
+            .select_from(evaluation)
+            .outerjoin(
+                suite, and_(suite.id == evaluation.suite_id, suite.is_deleted == 0)
+            )
+            .outerjoin(WorkflowModel, WorkflowModel.id == effective)
+            .outerjoin(AgentModel, AgentModel.id == WorkflowModel.agent_id)
+            .where(evaluation.is_deleted == 0)
+            .execution_options(**{GROUP_SCOPE_BYPASS_FLAG: True})
+        )
 
     def _search_condition(self, search: Optional[str]):
         if not search or not search.strip():
@@ -296,42 +359,30 @@ class TestEvaluationRepository(DbRepository[TestEvaluationModel]):
         return result.scalars().all()
 
     async def count_by_effective_workflow(self) -> List[Tuple[Optional[UUID], int]]:
-        """(effective_workflow_id, count) per workflow; ``None`` = unassigned bucket."""
-        evaluation = TestEvaluationModel
-        suite = TestSuiteModel
-        effective = func.coalesce(evaluation.workflow_id, suite.workflow_id)
-        stmt = (
-            select(effective.label("workflow_id"), func.count().label("count"))
-            .select_from(evaluation)
-            .outerjoin(
-                suite,
-                and_(suite.id == evaluation.suite_id, suite.is_deleted == 0),
-            )
-            .where(evaluation.is_deleted == 0)
-            .group_by(effective)
-        )
+        """(workflow_id, count) per workflow; ``None`` = unassigned bucket.
+
+        Versions collapse onto one row, so a workflow never appears twice.
+        """
+        group_key, _ = self._grouped_effective_workflow()
+        stmt = self._grouped_select(
+            group_key.label("workflow_id"), func.count().label("count")
+        ).group_by(group_key)
         result = await self.db.execute(stmt)
         return [(row.workflow_id, int(row.count)) for row in result.all()]
 
     async def get_latest_run_pointers(
         self,
     ) -> List[Tuple[Optional[UUID], List[str]]]:
-        """(effective_workflow_id, run_ids) for every live evaluation.
+        """(workflow_id, run_ids) for every live evaluation.
 
         Used to compute per-workflow health: ``run_ids[0]`` is each evaluation's
-        latest run. Only the pointer lists are loaded here — not the runs.
+        latest run. Only the pointer lists are loaded here — not the runs. Keyed
+        the same way as ``count_by_effective_workflow`` so health lines up with
+        the row it is shown on.
         """
-        evaluation = TestEvaluationModel
-        suite = TestSuiteModel
-        effective = func.coalesce(evaluation.workflow_id, suite.workflow_id)
-        stmt = (
-            select(effective.label("workflow_id"), evaluation.run_ids)
-            .select_from(evaluation)
-            .outerjoin(
-                suite,
-                and_(suite.id == evaluation.suite_id, suite.is_deleted == 0),
-            )
-            .where(evaluation.is_deleted == 0)
+        group_key, _ = self._grouped_effective_workflow()
+        stmt = self._grouped_select(
+            group_key.label("workflow_id"), TestEvaluationModel.run_ids
         )
         result = await self.db.execute(stmt)
         return [(row.workflow_id, list(row.run_ids or [])) for row in result.all()]

--- a/backend/app/repositories/workflow.py
+++ b/backend/app/repositories/workflow.py
@@ -2,8 +2,10 @@ from typing import List
 from uuid import UUID
 
 from injector import inject
-from sqlalchemy import select
+from sqlalchemy import case, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from app.db.events.group_scope import GROUP_SCOPE_BYPASS_FLAG
+from app.db.models.agent import AgentModel
 from app.db.models.workflow import WorkflowModel
 from app.repositories.db_repository import DbRepository
 
@@ -12,29 +14,36 @@ class WorkflowRepository(DbRepository[WorkflowModel]):
     def __init__(self, db: AsyncSession):
         super().__init__(WorkflowModel, db)
 
-    async def get_all_minimal(self) -> List[WorkflowModel]:
+    def _minimal_select(self):
+        """Minimal workflow columns plus whether this row is its agent's live
+        version — the one the builder marks Active.
+
+        Agents are group-scoped but workflows are not, so the scope filter is
+        bypassed for the join; otherwise the same version would look active to
+        some callers and not to others. Only the pointer is read.
+        """
+        is_active_version = case(
+            (AgentModel.workflow_id == WorkflowModel.id, True), else_=False
+        ).label("is_active_version")
         stmt = select(
             WorkflowModel.id,
             WorkflowModel.name,
             WorkflowModel.version,
             WorkflowModel.agent_id,
-        )
+            is_active_version,
+        ).outerjoin(AgentModel, AgentModel.id == WorkflowModel.agent_id)
         if hasattr(WorkflowModel, "is_deleted"):
             stmt = stmt.where(WorkflowModel.is_deleted == 0)
-        result = await self.db.execute(stmt)
+        return stmt.execution_options(**{GROUP_SCOPE_BYPASS_FLAG: True})
+
+    async def get_all_minimal(self) -> List[WorkflowModel]:
+        result = await self.db.execute(self._minimal_select())
         return result.all()
 
     async def get_minimal_by_ids(self, ids: List[UUID]) -> List:
         if not ids:
             return []
-        stmt = select(
-            WorkflowModel.id,
-            WorkflowModel.name,
-            WorkflowModel.version,
-            WorkflowModel.agent_id,
-        ).where(WorkflowModel.id.in_(ids))
-        if hasattr(WorkflowModel, "is_deleted"):
-            stmt = stmt.where(WorkflowModel.is_deleted == 0)
+        stmt = self._minimal_select().where(WorkflowModel.id.in_(ids))
         result = await self.db.execute(stmt)
         return result.all()
 

--- a/backend/app/schemas/eval_bundle.py
+++ b/backend/app/schemas/eval_bundle.py
@@ -1,0 +1,210 @@
+"""Portable evaluation bundle: the export/import file format and its API shapes.
+
+A bundle carries one evaluation, its dataset (cases included) and the display
+labels of every environment-specific reference embedded in the technique
+configs, so an importer can re-link the config to the target environment's
+workflow by name instead of by id.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+EVALUATION_BUNDLE_KIND = "genassist.evaluation-bundle"
+EVALUATION_BUNDLE_SCHEMA_VERSION = 1
+
+# Reference kinds a technique config can point at in the workflow graph.
+REF_KIND_TOOL = "tool"
+REF_KIND_AGENT = "agent"
+REF_KIND_ROUTER = "router"
+REF_KIND_ACTION = "action"
+
+REF_STATUS_RESOLVED = "resolved"
+REF_STATUS_AMBIGUOUS = "ambiguous"
+REF_STATUS_MISSING = "missing"
+
+
+class BundleNodeRef(BaseModel):
+    """Label and node type recorded for one graph-node reference at export time.
+
+    ``node_type`` lets import refuse to bind a name match onto a node of a
+    different type. Absent on bundles exported before it was recorded.
+    """
+
+    label: Optional[str] = None
+    kind: str
+    node_type: Optional[str] = None
+
+
+class BundleProviderRef(BaseModel):
+    """Display metadata recorded for one LLM provider reference at export time."""
+
+    name: Optional[str] = None
+    provider: Optional[str] = None
+    model: Optional[str] = None
+
+
+class BundleReferences(BaseModel):
+    """Label maps for every environment-specific id embedded in the configs.
+
+    ``cases`` maps an exported test case id to its ``local_id`` inside the
+    bundle, so turn-targeted rules can be re-pointed at the recreated cases.
+    """
+
+    nodes: Dict[str, BundleNodeRef] = Field(default_factory=dict)
+    llm_providers: Dict[str, BundleProviderRef] = Field(default_factory=dict)
+    cases: Dict[str, int] = Field(default_factory=dict)
+
+
+class BundleCase(BaseModel):
+    local_id: int
+    input_data: Dict[str, Any]
+    expected_output: Optional[Dict[str, Any]] = None
+    tags: Optional[List[str]] = None
+    weight: Optional[float] = None
+    source_conversation_id: Optional[UUID] = None
+    turn_index: Optional[int] = None
+
+
+# Ceiling on an INBOUND bundle: the whole payload is parsed into memory before
+# anything is written. Enforced on the import paths rather than on the model,
+# which is also the export response — capping that would make a large dataset
+# impossible to export.
+MAX_BUNDLE_CASES = 5000
+MAX_BUNDLE_RESOLUTIONS = 1000
+
+
+class BundleDataset(BaseModel):
+    # Length limits match the DB columns so a bad bundle fails at parse time,
+    # not halfway through an import.
+    name: str = Field(max_length=200)
+    description: Optional[str] = None
+    default_input_metadata: Optional[Dict[str, Any]] = None
+    cases: List[BundleCase] = Field(default_factory=list)
+
+
+class BundleEvaluation(BaseModel):
+    name: str = Field(max_length=200)
+    description: Optional[str] = None
+    techniques: List[str] = Field(default_factory=list)
+    technique_configs: Optional[Dict[str, Any]] = None
+    input_metadata: Optional[Dict[str, Any]] = None
+
+
+class BundleSource(BaseModel):
+    """Where the bundle came from — display-only, never used for linking."""
+
+    workflow_id: Optional[UUID] = None
+    workflow_name: Optional[str] = None
+    workflow_version: Optional[str] = None
+
+
+class EvaluationBundle(BaseModel):
+    # Plain str, not a Literal: the runtime check in _validate_bundle_header
+    # gives a readable 400 ("this file is not an evaluation bundle") where a
+    # Literal would fail in Pydantic with a raw 422.
+    kind: str = EVALUATION_BUNDLE_KIND
+    schema_version: int = EVALUATION_BUNDLE_SCHEMA_VERSION
+    source: BundleSource = Field(default_factory=BundleSource)
+    evaluation: BundleEvaluation
+    dataset: BundleDataset
+    references: BundleReferences = Field(default_factory=BundleReferences)
+    # Human-readable notes recorded at export time (e.g. stripped secret fields).
+    notes: List[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Import preview / commit
+# ---------------------------------------------------------------------------
+
+
+class BundleRefCandidate(BaseModel):
+    id: str
+    label: str
+
+
+class BundleNodeResolution(BaseModel):
+    """How one graph-node reference resolved against the target workflow."""
+
+    ref: str
+    kind: str
+    label: Optional[str] = None
+    status: str
+    resolved_id: Optional[str] = None
+    resolved_label: Optional[str] = None
+    candidates: List[BundleRefCandidate] = Field(default_factory=list)
+    # Why the status is not a plain match, shown next to the row.
+    note: Optional[str] = None
+    # The node type this reference had in the source workflow, so a manual pick
+    # can be narrowed to nodes that could actually play the same role.
+    original_type: Optional[str] = None
+
+
+class BundleProviderResolution(BaseModel):
+    """How one LLM provider reference resolved against the target environment."""
+
+    ref: str
+    name: Optional[str] = None
+    model: Optional[str] = None
+    status: str
+    resolved_id: Optional[str] = None
+    resolved_name: Optional[str] = None
+
+
+class EvaluationImportPreviewRequest(BaseModel):
+    bundle: EvaluationBundle
+    target_workflow_id: UUID
+
+
+class BundleExistingDataset(BaseModel):
+    """A dataset in the target environment already using the bundle's name, so
+    the import can attach to it instead of creating a duplicate."""
+
+    id: UUID
+    name: str
+    case_count: int
+
+
+class EvaluationImportPreview(BaseModel):
+    evaluation_name: str
+    dataset_name: str
+    case_count: int
+    existing_dataset: Optional[BundleExistingDataset] = None
+    workflow_name_matches: bool
+    node_refs: List[BundleNodeResolution] = Field(default_factory=list)
+    provider_refs: List[BundleProviderResolution] = Field(default_factory=list)
+    warnings: List[str] = Field(default_factory=list)
+    # True when every node reference resolved without a manual pick.
+    can_import: bool
+    # Dropping the unmatched rules would leave the evaluation with no checks at
+    # all, which import refuses — so the UI must not offer that route.
+    dropping_all_would_empty: bool = False
+
+
+class EvaluationImportRequest(BaseModel):
+    bundle: EvaluationBundle
+    target_workflow_id: UUID
+    # Attach to this existing dataset instead of creating one; its cases are
+    # kept as they are and the bundle's cases are not re-created.
+    existing_suite_id: Optional[UUID] = None
+    # Manual picks for ambiguous/missing references, keyed "<kind>:<ref>"
+    # (a ref value can appear under two kinds) -> target node id.
+    resolutions: Dict[str, str] = Field(
+        default_factory=dict, max_length=MAX_BUNDLE_RESOLUTIONS
+    )
+    # Drop rules whose references stayed unresolved instead of failing the import.
+    drop_unresolved_rules: bool = False
+
+
+class EvaluationImportResult(BaseModel):
+    evaluation_id: UUID
+    suite_id: UUID
+    case_count: int
+    # True when the evaluation was attached to an existing dataset rather than
+    # a newly created one.
+    reused_dataset: bool = False
+    dropped_rules: List[str] = Field(default_factory=list)
+    warnings: List[str] = Field(default_factory=list)

--- a/backend/app/schemas/workflow.py
+++ b/backend/app/schemas/workflow.py
@@ -40,6 +40,9 @@ class WorkflowMinimal(BaseModel):
     name: str
     version: str
     agent_id: Optional[UUID] = None
+    # True for the version its agent currently points at — what the builder
+    # marks Active and what a plain evaluation run executes.
+    is_active_version: bool = False
 
     model_config = ConfigDict(
         from_attributes=True

--- a/backend/app/services/eval_bundle.py
+++ b/backend/app/services/eval_bundle.py
@@ -1,0 +1,1308 @@
+"""Export/import of evaluations as portable bundles.
+
+Technique configs embed ids that only exist in the source environment's
+database (graph node ids, LLM provider ids, test case ids). Export records a
+display label next to every such id; import resolves the labels against the
+target workflow's catalog and rewrites the config before creating anything.
+
+The same walk is used to collect references and to rewrite them (the resolver
+is swapped), so the two can never disagree about where references live.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import re
+from typing import Any, Callable, Dict, List, Optional, Tuple
+from uuid import UUID
+
+from injector import inject
+
+from app.core.exceptions.error_messages import ErrorKey
+from app.core.exceptions.exception_classes import AppException
+from app.schemas.eval_bundle import (
+    EVALUATION_BUNDLE_KIND,
+    MAX_BUNDLE_CASES,
+    EVALUATION_BUNDLE_SCHEMA_VERSION,
+    REF_KIND_ACTION,
+    REF_KIND_AGENT,
+    REF_KIND_ROUTER,
+    REF_KIND_TOOL,
+    REF_STATUS_AMBIGUOUS,
+    REF_STATUS_MISSING,
+    REF_STATUS_RESOLVED,
+    BundleCase,
+    BundleDataset,
+    BundleEvaluation,
+    BundleExistingDataset,
+    BundleNodeRef,
+    BundleNodeResolution,
+    BundleProviderRef,
+    BundleProviderResolution,
+    BundleRefCandidate,
+    BundleReferences,
+    BundleSource,
+    EvaluationBundle,
+    EvaluationImportPreview,
+    EvaluationImportPreviewRequest,
+    EvaluationImportRequest,
+    EvaluationImportResult,
+)
+from app.db.models.test_suite import TestCaseModel
+from app.repositories.test_suite import TestCaseRepository
+from app.schemas.test_suite import (
+    TestCaseInDB,
+    TestEvaluationCreate,
+    TestSuiteCreate,
+)
+from app.services.llm_providers import LlmProviderService
+from app.services.test_suite import TestSuiteService, resolvers_from_agents
+from app.services.tool_usage_rules import canonicalize_tool_usage_config
+from app.services.workflow import WorkflowService
+
+logger = logging.getLogger(__name__)
+
+TOOL_USED = "tool_used"
+ROUTE_TAKEN = "route_taken"
+ACTION_TAKEN = "action_taken"
+LLM_JUDGE = "llm_judge"
+PROVENANCE_EVAL = "provenance_eval"
+NLI_EVAL = "nli_eval"
+
+# Techniques whose configs carry an llm_provider_id.
+_PROVIDER_TECHNIQUES = (LLM_JUDGE, PROVENANCE_EVAL)
+
+_TECHNIQUE_LABELS = {
+    TOOL_USED: "Tool Usage",
+    ROUTE_TAKEN: "Route Taken",
+    ACTION_TAKEN: "Action Taken",
+}
+
+# Credential-bearing key names for bundle payloads. Tuned differently from
+# template_sanitizer's list, which matches a bare "token" — correct for workflow
+# node.data, but here it would eat ordinary settings like ``max_tokens``.
+_SECRET_KEY_SUBSTRINGS = (
+    "api_key",
+    "apikey",
+    "api_token",
+    "apitoken",
+    "auth_token",
+    "authtoken",
+    "access_token",
+    "accesstoken",
+    "refresh_token",
+    "refreshtoken",
+    "session_token",
+    "sessiontoken",
+    "id_token",
+    "secret",
+    "password",
+    "passwd",
+    "credential",
+    "private_key",
+    "privatekey",
+    "access_key",
+    "accesskey",
+    "bearer",
+)
+
+# A key that IS the credential rather than merely mentioning one, so "token"
+# is stripped while "max_tokens" and "token_budget" are kept.
+_SECRET_KEY_EXACT = frozenset({"token", "authorization", "auth"})
+
+# Maps whose keys are identifiers, not field names — a tool id can contain
+# "secret" without the entry being a credential. Their values are still walked.
+_IDENTIFIER_KEYED_FIELDS = frozenset({"per_tool"})
+
+_URL_PATTERN = re.compile(r"https?://", re.IGNORECASE)
+_UUID_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+_MAX_METADATA_WARNINGS = 10
+
+
+def _normalize_name(value: Any) -> str:
+    return str(value).strip().lower()
+
+
+class UnresolvedRefError(ValueError):
+    """A config reference that has no usable mapping in the target environment."""
+
+    def __init__(self, ref: str, kind: str, reason: Optional[str] = None):
+        self.ref = ref
+        self.kind = kind
+        self.reason = reason or (
+            f"no match for {kind} '{ref}' in the target workflow"
+        )
+        super().__init__(self.reason)
+
+
+def ref_key(ref: str, kind: str) -> str:
+    """Key for resolution maps. A ref value can appear under two kinds (an agent
+    node id is also an action node), so maps are keyed by kind + ref."""
+    return f"{kind}:{ref}"
+
+
+# ---------------------------------------------------------------------------
+# Sanitization (secrets never travel inside a bundle)
+# ---------------------------------------------------------------------------
+
+
+def _is_bundle_secret_key(key: Any) -> bool:
+    """Whether a bundle payload key names a credential."""
+    if not isinstance(key, str):
+        return False
+    lowered = key.strip().lower()
+    if lowered in _SECRET_KEY_EXACT:
+        return True
+    return any(substring in lowered for substring in _SECRET_KEY_SUBSTRINGS)
+
+
+def sanitize_secret_keys(
+    mapping: Optional[Dict[str, Any]], context: str
+) -> Tuple[Optional[Dict[str, Any]], List[str]]:
+    """Copy of ``mapping`` without credential-bearing keys, at any depth.
+
+    Keys are only treated as field names where they are one: inside an
+    identifier-keyed map such as ``per_tool`` a key is a tool id, and dropping
+    it because the tool is called "get_api_key" would silently delete a check.
+    """
+    if not isinstance(mapping, dict):
+        return mapping, []
+    notes: List[str] = []
+
+    def clean(value: Any, parent_key: Optional[str] = None) -> Any:
+        if isinstance(value, dict):
+            keys_are_identifiers = parent_key in _IDENTIFIER_KEYED_FIELDS
+            result = {}
+            for key, nested in value.items():
+                if not keys_are_identifiers and _is_bundle_secret_key(key):
+                    notes.append(f"Removed secret field '{key}' from {context}.")
+                    continue
+                result[key] = clean(nested, key)
+            return result
+        if isinstance(value, list):
+            return [clean(item, parent_key) for item in value]
+        return copy.deepcopy(value)
+
+    # One note per distinct field: a rule repeated across cases should not
+    # produce a wall of identical lines.
+    return clean(mapping), list(dict.fromkeys(notes))
+
+
+def sanitize_technique_configs(
+    configs: Optional[Dict[str, Any]],
+) -> Tuple[Dict[str, Any], List[str]]:
+    """Strip secret-looking keys from the top level of every technique config."""
+    clean: Dict[str, Any] = {}
+    notes: List[str] = []
+    for technique, config in (configs or {}).items():
+        if not isinstance(config, dict):
+            clean[technique] = config
+            continue
+        safe, config_notes = sanitize_secret_keys(
+            config, f"the {technique} configuration"
+        )
+        clean[technique] = safe
+        notes.extend(config_notes)
+    return clean, notes
+
+
+# ---------------------------------------------------------------------------
+# Reference walk (collection and rewriting share it)
+# ---------------------------------------------------------------------------
+
+Resolver = Callable[[str, str], str]
+
+
+def _rewrite_tool_rule(rule: Dict[str, Any], resolve: Resolver) -> Dict[str, Any]:
+    """Rewrite one tool rule (rules shape or the legacy single-tool config)."""
+    updated = dict(rule)
+    if isinstance(updated.get("tool_ids"), list):
+        mapped_ids = [
+            resolve(str(tool_id), REF_KIND_TOOL)
+            for tool_id in updated["tool_ids"]
+            if tool_id
+        ]
+        # Two source refs (e.g. a tool's id and its display name) may map to
+        # one target tool; a duplicate entry would be redundant, not wrong.
+        updated["tool_ids"] = list(dict.fromkeys(mapped_ids))
+    if updated.get("agent_id"):
+        updated["agent_id"] = resolve(str(updated["agent_id"]), REF_KIND_AGENT)
+    if isinstance(updated.get("per_tool"), dict):
+        updated["per_tool"] = _rewrite_per_tool(updated["per_tool"], resolve)
+    # Legacy keys: "tool" is a tool reference, "node" is the agent.
+    if updated.get("tool"):
+        updated["tool"] = resolve(str(updated["tool"]), REF_KIND_TOOL)
+    if updated.get("node"):
+        updated["node"] = resolve(str(updated["node"]), REF_KIND_AGENT)
+    return updated
+
+
+def _rewrite_per_tool(per_tool: Dict[str, Any], resolve: Resolver) -> Dict[str, Any]:
+    """Re-key per-tool checks. Unlike tool_ids, two checks collapsing onto one
+    target tool would silently drop one of them — refuse instead."""
+    rewritten: Dict[str, Any] = {}
+    for tool_id, check in per_tool.items():
+        mapped = resolve(str(tool_id), REF_KIND_TOOL)
+        if mapped in rewritten:
+            raise UnresolvedRefError(
+                str(tool_id),
+                REF_KIND_TOOL,
+                reason=(
+                    f"per-tool checks for '{tool_id}' and another entry both "
+                    "map to the same target tool"
+                ),
+            )
+        rewritten[mapped] = check
+    return rewritten
+
+
+def _rewrite_route_rule(rule: Dict[str, Any], resolve: Resolver) -> Dict[str, Any]:
+    updated = dict(rule)
+    selector_key = "router" if updated.get("router") else "node"
+    if updated.get(selector_key):
+        updated[selector_key] = resolve(str(updated[selector_key]), REF_KIND_ROUTER)
+    return updated
+
+
+def _rewrite_action_rule(rule: Dict[str, Any], resolve: Resolver) -> Dict[str, Any]:
+    updated = dict(rule)
+    if updated.get("node"):
+        updated["node"] = resolve(str(updated["node"]), REF_KIND_ACTION)
+    return updated
+
+
+_RULE_REWRITERS: Dict[str, Callable[[Dict[str, Any], Resolver], Dict[str, Any]]] = {
+    TOOL_USED: _rewrite_tool_rule,
+    ROUTE_TAKEN: _rewrite_route_rule,
+    ACTION_TAKEN: _rewrite_action_rule,
+}
+
+
+def _drop_message(technique: str, rule_number: int, error: UnresolvedRefError) -> str:
+    label = _TECHNIQUE_LABELS.get(technique, technique)
+    return f"{label} rule {rule_number} was dropped: {error.reason}."
+
+
+def _rewrite_technique_config(
+    technique: str,
+    config: Dict[str, Any],
+    resolve: Resolver,
+    drop_log: Optional[List[str]],
+) -> Optional[Dict[str, Any]]:
+    """Rewrite one technique config; None when every rule was dropped.
+
+    With ``drop_log`` set, a rule whose reference cannot be resolved is dropped
+    and logged; without it the ``UnresolvedRefError`` propagates.
+    """
+    rule_rewriter = _RULE_REWRITERS[technique]
+    raw_rules = config.get("rules")
+    if not isinstance(raw_rules, list):
+        # Legacy single-rule shape: the config itself is the rule.
+        try:
+            return rule_rewriter(config, resolve)
+        except UnresolvedRefError as error:
+            if drop_log is None:
+                raise
+            drop_log.append(_drop_message(technique, 1, error))
+            return None
+
+    rewritten: List[Dict[str, Any]] = []
+    for number, rule in enumerate(raw_rules, start=1):
+        if not isinstance(rule, dict):
+            continue
+        try:
+            rewritten.append(rule_rewriter(rule, resolve))
+        except UnresolvedRefError as error:
+            if drop_log is None:
+                raise
+            drop_log.append(_drop_message(technique, number, error))
+    if not rewritten:
+        return None
+    return {**config, "rules": rewritten}
+
+
+def rewrite_node_refs(
+    configs: Dict[str, Any],
+    resolve: Resolver,
+    drop_log: Optional[List[str]] = None,
+) -> Tuple[Dict[str, Any], List[str]]:
+    """Rewrite every graph-node reference. Returns (configs, dropped techniques)."""
+    new_configs: Dict[str, Any] = {}
+    dropped_techniques: List[str] = []
+    for technique, config in configs.items():
+        no_node_refs = technique not in _RULE_REWRITERS or not isinstance(config, dict)
+        if no_node_refs:
+            new_configs[technique] = config
+            continue
+        rewritten = _rewrite_technique_config(technique, config, resolve, drop_log)
+        if rewritten is None:
+            dropped_techniques.append(technique)
+            continue
+        new_configs[technique] = rewritten
+    return new_configs, dropped_techniques
+
+
+def collect_node_refs(configs: Optional[Dict[str, Any]]) -> List[Tuple[str, str]]:
+    """Every (ref value, kind) a config embeds, in first-seen order."""
+    seen: Dict[Tuple[str, str], None] = {}
+
+    def record(value: str, kind: str) -> str:
+        seen.setdefault((value, kind), None)
+        return value
+
+    rewrite_node_refs(configs or {}, record, drop_log=[])
+    return list(seen.keys())
+
+
+def collect_provider_ids(configs: Optional[Dict[str, Any]]) -> List[str]:
+    ids: Dict[str, None] = {}
+    for technique in _PROVIDER_TECHNIQUES:
+        config = (configs or {}).get(technique)
+        if isinstance(config, dict) and config.get("llm_provider_id"):
+            ids.setdefault(str(config["llm_provider_id"]), None)
+    return list(ids.keys())
+
+
+def collect_case_ids(configs: Optional[Dict[str, Any]]) -> List[str]:
+    """Test case ids referenced by turn-targeted tool rules."""
+    config = (configs or {}).get(TOOL_USED)
+    if not isinstance(config, dict) or not isinstance(config.get("rules"), list):
+        return []
+    ids: Dict[str, None] = {}
+    for rule in config["rules"]:
+        if isinstance(rule, dict) and rule.get("target_case_id"):
+            ids.setdefault(str(rule["target_case_id"]), None)
+    return list(ids.keys())
+
+
+# ---------------------------------------------------------------------------
+# Resolution against a target workflow catalog
+# ---------------------------------------------------------------------------
+
+
+def build_node_indexes(catalog: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Per-kind lookup tables: id -> label, id -> node type, and normalized
+    name -> matching nodes."""
+    indexes: Dict[str, Dict[str, Any]] = {
+        kind: {"labels_by_id": {}, "types_by_id": {}, "ids_by_name": {}}
+        for kind in (REF_KIND_TOOL, REF_KIND_AGENT, REF_KIND_ROUTER, REF_KIND_ACTION)
+    }
+
+    def add(
+        kind: str, node_id: Any, label: Any, node_type: Any = None, *names: Any
+    ) -> None:
+        if not node_id:
+            return
+        node_id = str(node_id)
+        label = str(label or node_id)
+        index = indexes[kind]
+        index["labels_by_id"][node_id] = label
+        if node_type:
+            index["types_by_id"][node_id] = str(node_type)
+        for name in (label, *names):
+            if not name:
+                continue
+            index["ids_by_name"].setdefault(_normalize_name(name), {})[node_id] = label
+
+    for agent in catalog.get("agents", []):
+        add(REF_KIND_AGENT, agent.get("id"), agent.get("label"), agent.get("type"))
+        for tool in agent.get("tools", []):
+            add(
+                REF_KIND_TOOL,
+                tool.get("id"),
+                tool.get("label"),
+                tool.get("type"),
+                tool.get("name"),
+            )
+    for router in catalog.get("routers", []):
+        # Every router is a routerNode, so a type mismatch cannot arise here.
+        add(REF_KIND_ROUTER, router.get("id"), router.get("label"))
+    for node in catalog.get("action_nodes", []):
+        add(REF_KIND_ACTION, node.get("id"), node.get("label"), node.get("type"))
+    return indexes
+
+
+def resolve_node_ref(
+    ref: str,
+    kind: str,
+    bundle_label: Optional[str],
+    indexes: Dict[str, Dict[str, Any]],
+    bundle_node_type: Optional[str] = None,
+) -> BundleNodeResolution:
+    """Match one reference: same id first, then by name/label, then the export label.
+
+    An id match is authoritative — it is the same node, whatever it is now called
+    or typed. A name match is not: the same name can belong to a different kind of
+    node in a rebuilt workflow, so a differing ``node_type`` downgrades the match
+    to a confirmation rather than binding the check to the wrong node.
+    """
+    index = indexes[kind]
+
+    def outcome(**fields: Any) -> BundleNodeResolution:
+        return BundleNodeResolution(
+            ref=ref,
+            kind=kind,
+            label=bundle_label,
+            original_type=bundle_node_type,
+            **fields,
+        )
+
+    if ref in index["labels_by_id"]:
+        return outcome(
+            status=REF_STATUS_RESOLVED,
+            resolved_id=ref,
+            resolved_label=index["labels_by_id"][ref],
+        )
+
+    matches: Dict[str, str] = index["ids_by_name"].get(_normalize_name(ref), {})
+    if not matches and bundle_label:
+        matches = index["ids_by_name"].get(_normalize_name(bundle_label), {})
+
+    candidates = [
+        BundleRefCandidate(id=node_id, label=label)
+        for node_id, label in sorted(matches.items())
+    ]
+    if len(candidates) == 1:
+        matched_type = index["types_by_id"].get(candidates[0].id)
+        mismatch = _type_mismatch_note(bundle_node_type, matched_type)
+        if mismatch:
+            return outcome(
+                status=REF_STATUS_AMBIGUOUS, candidates=candidates, note=mismatch
+            )
+        return outcome(
+            status=REF_STATUS_RESOLVED,
+            resolved_id=candidates[0].id,
+            resolved_label=candidates[0].label,
+        )
+    status = REF_STATUS_AMBIGUOUS if candidates else REF_STATUS_MISSING
+    return outcome(status=status, candidates=candidates)
+
+
+def _type_mismatch_note(
+    bundle_node_type: Optional[str], matched_type: Optional[str]
+) -> Optional[str]:
+    """Why a name match must be confirmed, or None when the types agree.
+
+    Either type being unknown means no judgement is possible — a bundle exported
+    before types were recorded must keep resolving as it always did.
+    """
+    if not bundle_node_type or not matched_type:
+        return None
+    if bundle_node_type == matched_type:
+        return None
+    return (
+        f"The name matches, but this node is a {matched_type} and the original "
+        f"was a {bundle_node_type}."
+    )
+
+
+def resolve_provider_ref(
+    provider_id: str,
+    meta: Optional[BundleProviderRef],
+    providers: List[Any],
+) -> BundleProviderResolution:
+    """Match a provider by id, then model name, then display name."""
+    name = meta.name if meta else None
+    model = meta.model if meta else None
+
+    def resolved(provider: Any) -> BundleProviderResolution:
+        return BundleProviderResolution(
+            ref=provider_id,
+            name=name,
+            model=model,
+            status=REF_STATUS_RESOLVED,
+            resolved_id=str(provider.id),
+            resolved_name=provider.name,
+        )
+
+    # An exact id is honoured whatever its state; a match found by name must be
+    # usable, and the wizard only offers active providers.
+    for provider in providers:
+        if str(provider.id) == provider_id:
+            return resolved(provider)
+    providers = [p for p in providers if getattr(p, "is_active", 1) == 1]
+
+    matches = [
+        p
+        for p in providers
+        if model and p.llm_model and _normalize_name(p.llm_model) == _normalize_name(model)
+    ]
+    if len(matches) > 1 and name:
+        narrowed = [p for p in matches if _normalize_name(p.name or "") == _normalize_name(name)]
+        matches = narrowed or matches
+    if not matches and name:
+        matches = [
+            p for p in providers if _normalize_name(p.name or "") == _normalize_name(name)
+        ]
+    if matches:
+        return resolved(matches[0])
+    return BundleProviderResolution(
+        ref=provider_id, name=name, model=model, status=REF_STATUS_MISSING
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider / case reference rewriting
+# ---------------------------------------------------------------------------
+
+
+def rewrite_provider_refs(
+    configs: Dict[str, Any],
+    provider_map: Dict[str, Optional[str]],
+) -> Tuple[Dict[str, Any], List[str]]:
+    """Re-point llm_provider_id fields; an unmatched provider falls back to the
+    target environment's default provider (the field is removed)."""
+    new_configs = dict(configs)
+    warnings: List[str] = []
+    for technique in _PROVIDER_TECHNIQUES:
+        config = new_configs.get(technique)
+        if not isinstance(config, dict) or not config.get("llm_provider_id"):
+            continue
+        updated = dict(config)
+        mapped = provider_map.get(str(updated["llm_provider_id"]))
+        if mapped:
+            updated["llm_provider_id"] = mapped
+        else:
+            updated.pop("llm_provider_id")
+            warnings.append(
+                f"No matching LLM provider for {technique}; "
+                "the default provider will be used."
+            )
+        new_configs[technique] = updated
+    return new_configs, warnings
+
+
+def rewrite_case_refs(
+    configs: Dict[str, Any],
+    case_map: Dict[str, str],
+) -> Tuple[Dict[str, Any], List[str]]:
+    """Re-point tool rules' target_case_id at the recreated cases.
+
+    A rule that also targets by (conversation, turn) just loses the stale id —
+    the portable pair keeps working. A rule with neither mapping is kept but
+    will grade as "target turn not found", so it is reported.
+    """
+    config = configs.get(TOOL_USED)
+    if not isinstance(config, dict) or not isinstance(config.get("rules"), list):
+        return configs, []
+
+    warnings: List[str] = []
+    rules: List[Any] = []
+    for rule in config["rules"]:
+        if not isinstance(rule, dict) or not rule.get("target_case_id"):
+            rules.append(rule)
+            continue
+        updated = dict(rule)
+        mapped = case_map.get(str(updated["target_case_id"]))
+        has_conversation_target = (
+            updated.get("target_source_conversation_id") is not None
+            and updated.get("target_turn_index") is not None
+        )
+        if mapped:
+            updated["target_case_id"] = mapped
+        elif has_conversation_target:
+            updated.pop("target_case_id")
+        else:
+            warnings.append(
+                f"Tool Usage rule '{updated.get('id')}' targets a test case that "
+                "is not part of the bundle; it will grade as not evaluated."
+            )
+        rules.append(updated)
+    return {**configs, TOOL_USED: {**config, "rules": rules}}, warnings
+
+
+# ---------------------------------------------------------------------------
+# Warnings for values that may not make sense in another environment
+# ---------------------------------------------------------------------------
+
+
+def scan_metadata_warnings(context: str, metadata: Optional[Dict[str, Any]]) -> List[str]:
+    """Flag URL- and UUID-looking values so the user reviews them after import."""
+    warnings: List[str] = []
+    if not isinstance(metadata, dict):
+        return warnings
+    for key, value in metadata.items():
+        if len(warnings) >= _MAX_METADATA_WARNINGS:
+            break
+        if not isinstance(value, str):
+            continue
+        if _URL_PATTERN.search(value) or _UUID_PATTERN.match(value.strip()):
+            warnings.append(
+                f"{context} field '{key}' looks environment-specific; "
+                "review it after import."
+            )
+    return warnings
+
+
+def environment_warnings(configs: Dict[str, Any]) -> List[str]:
+    """Notes about config values that must exist in the target environment."""
+    # NLI needs no warning: the model can only be one of the platform's curated
+    # options (anything else falls back to the default at run time), so the
+    # choice carries nothing environment-specific.
+    warnings: List[str] = []
+    provenance_config = configs.get(PROVENANCE_EVAL)
+    if isinstance(provenance_config, dict):
+        embedding_type = provenance_config.get("embedding_type")
+        if embedding_type in ("openai", "bedrock"):
+            warnings.append(
+                "Provenance embeddings use the target environment's "
+                f"{embedding_type} credentials and endpoint settings."
+            )
+    return warnings
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+@inject
+class EvalBundleService:
+    """Builds bundles from stored evaluations and imports them elsewhere."""
+
+    def __init__(
+        self,
+        suite_service: TestSuiteService,
+        workflow_service: WorkflowService,
+        llm_provider_service: LlmProviderService,
+        case_repo: TestCaseRepository,
+    ) -> None:
+        self.suites = suite_service
+        self.workflows = workflow_service
+        self.providers = llm_provider_service
+        self.case_repo = case_repo
+
+    # ---- Export -----------------------------------------------------------
+
+    async def export_evaluation(self, evaluation_id: UUID) -> EvaluationBundle:
+        evaluation = await self.suites.get_evaluation(evaluation_id)
+        suite = await self.suites.get_suite(evaluation.suite_id)
+        cases = await self.suites.list_cases_for_suite(evaluation.suite_id)
+        workflow_id = evaluation.workflow_id or suite.workflow_id
+
+        configs, notes = sanitize_technique_configs(evaluation.technique_configs)
+        input_metadata, metadata_notes = sanitize_secret_keys(
+            evaluation.input_metadata, "the evaluation input metadata"
+        )
+        default_metadata, default_notes = sanitize_secret_keys(
+            suite.default_input_metadata, "the dataset input metadata"
+        )
+        notes.extend(metadata_notes + default_notes)
+
+        # Case inputs merge into the same run payload as the metadata above, so
+        # they get the same secret stripping.
+        bundle_cases: List[BundleCase] = []
+        for index, case in enumerate(cases, 1):
+            input_data, case_notes = sanitize_secret_keys(
+                case.input_data, f"test case {index} input"
+            )
+            expected_output, expected_notes = sanitize_secret_keys(
+                case.expected_output, f"test case {index} expected output"
+            )
+            notes.extend(case_notes + expected_notes)
+            bundle_cases.append(
+                _bundle_case(case, index, input_data or {}, expected_output)
+            )
+
+        return EvaluationBundle(
+            source=await self._bundle_source(workflow_id),
+            evaluation=BundleEvaluation(
+                name=evaluation.name,
+                description=evaluation.description,
+                techniques=list(evaluation.techniques or []),
+                technique_configs=configs or None,
+                input_metadata=input_metadata,
+            ),
+            dataset=BundleDataset(
+                name=suite.name,
+                description=suite.description,
+                default_input_metadata=default_metadata,
+                cases=bundle_cases,
+            ),
+            references=await self._bundle_references(workflow_id, configs, cases),
+            notes=notes,
+        )
+
+    async def _bundle_source(self, workflow_id: Optional[UUID]) -> BundleSource:
+        if not workflow_id:
+            return BundleSource()
+        try:
+            workflow = await self.workflows.get_by_id(UUID(str(workflow_id)))
+        except Exception:  # pylint: disable=broad-except
+            return BundleSource(workflow_id=workflow_id)
+        return BundleSource(
+            workflow_id=workflow_id,
+            workflow_name=workflow.name,
+            workflow_version=workflow.version,
+        )
+
+    async def _bundle_references(
+        self,
+        workflow_id: Optional[UUID],
+        configs: Dict[str, Any],
+        cases: List[TestCaseInDB],
+    ) -> BundleReferences:
+        indexes = build_node_indexes(await self._workflow_catalog(workflow_id))
+        nodes: Dict[str, BundleNodeRef] = {}
+        for ref, kind in collect_node_refs(configs):
+            nodes[ref] = BundleNodeRef(
+                label=indexes[kind]["labels_by_id"].get(ref),
+                kind=kind,
+                node_type=indexes[kind]["types_by_id"].get(ref),
+            )
+
+        providers: Dict[str, BundleProviderRef] = {}
+        if collect_provider_ids(configs):
+            known = {str(p.id): p for p in await self.providers.get_all_minimal()}
+            for provider_id in collect_provider_ids(configs):
+                provider = known.get(provider_id)
+                providers[provider_id] = BundleProviderRef(
+                    name=provider.name if provider else None,
+                    provider=provider.llm_model_provider if provider else None,
+                    model=provider.llm_model if provider else None,
+                )
+
+        local_ids = {str(case.id): index for index, case in enumerate(cases, 1)}
+        case_refs = {
+            case_id: local_ids[case_id]
+            for case_id in collect_case_ids(configs)
+            if case_id in local_ids
+        }
+        return BundleReferences(nodes=nodes, llm_providers=providers, cases=case_refs)
+
+    async def _workflow_catalog(self, workflow_id: Optional[UUID]) -> Dict[str, Any]:
+        if not workflow_id:
+            return {}
+        try:
+            catalog = await self.suites.get_evaluation_tool_catalog(
+                UUID(str(workflow_id))
+            )
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        return catalog.model_dump()
+
+    # ---- Import -----------------------------------------------------------
+
+    async def preview_import(
+        self, request: EvaluationImportPreviewRequest
+    ) -> EvaluationImportPreview:
+        bundle = request.bundle
+        _validate_bundle_header(bundle)
+        target_workflow = await self.workflows.get_by_id(request.target_workflow_id)
+        resolution = await self._resolve_against_target(
+            bundle, request.target_workflow_id
+        )
+
+        existing_dataset = await self._find_existing_dataset(
+            bundle.dataset.name, request.target_workflow_id
+        )
+        workflow_name_matches = bool(
+            bundle.source.workflow_name
+            and _normalize_name(bundle.source.workflow_name)
+            == _normalize_name(target_workflow.name)
+        )
+        can_import = all(
+            ref.status == REF_STATUS_RESOLVED for ref in resolution["node_refs"]
+        )
+        return EvaluationImportPreview(
+            dropping_all_would_empty=self._dropping_all_would_empty(
+                bundle, resolution
+            ),
+            evaluation_name=bundle.evaluation.name,
+            dataset_name=bundle.dataset.name,
+            case_count=len(bundle.dataset.cases),
+            existing_dataset=existing_dataset,
+            workflow_name_matches=workflow_name_matches,
+            node_refs=resolution["node_refs"],
+            provider_refs=resolution["provider_refs"],
+            warnings=self._preview_warnings(bundle, resolution),
+            can_import=can_import,
+        )
+
+    async def _workflow_version_ids(self, workflow_id: UUID) -> set:
+        """Every version of this workflow, as id strings.
+
+        Datasets are attached to whichever version was current when they were
+        made, so scoping to a single version would keep re-creating duplicates
+        the moment an import targets a different one.
+        """
+        workflows = await self.workflows.get_all_minimal()
+        target = next((w for w in workflows if str(w.id) == str(workflow_id)), None)
+        if not target or not target.agent_id:
+            return {str(workflow_id)}
+        return {
+            str(w.id)
+            for w in workflows
+            if w.agent_id and str(w.agent_id) == str(target.agent_id)
+        }
+
+    async def _find_existing_dataset(
+        self, name: str, target_workflow_id: UUID
+    ) -> Optional[BundleExistingDataset]:
+        """A dataset on the target workflow already using this name.
+
+        Scoped to the workflow: two workflows can each own a "Regression set",
+        and reusing the other one's would grade the wrong cases.
+        """
+        version_ids = await self._workflow_version_ids(target_workflow_id)
+        suites = await self.suites.list_suites()
+        match = next(
+            (
+                s
+                for s in suites
+                if _normalize_name(s.name) == _normalize_name(name)
+                and str(s.workflow_id) in version_ids
+            ),
+            None,
+        )
+        if not match:
+            return None
+        cases = await self.suites.list_cases_for_suite(match.id)
+        return BundleExistingDataset(
+            id=match.id, name=match.name, case_count=len(cases)
+        )
+
+    def _dropping_all_would_empty(
+        self, bundle: EvaluationBundle, resolution: Dict[str, Any]
+    ) -> bool:
+        """Whether dropping the unmatched rules would leave nothing to grade.
+
+        Import refuses that outcome, so the dialog needs to know before it
+        offers dropping as the way forward.
+        """
+        if not bundle.evaluation.techniques:
+            return False
+        configs, _ = sanitize_technique_configs(bundle.evaluation.technique_configs)
+        node_map = {
+            ref_key(ref.ref, ref.kind): ref.resolved_id
+            for ref in resolution["node_refs"]
+            if ref.status == REF_STATUS_RESOLVED and ref.resolved_id
+        }
+        _, dropped = rewrite_node_refs(configs, _map_resolver(node_map), [])
+        return all(
+            technique in dropped for technique in bundle.evaluation.techniques
+        )
+
+    async def import_bundle(
+        self, request: EvaluationImportRequest
+    ) -> EvaluationImportResult:
+        bundle = request.bundle
+        _validate_bundle_header(bundle)
+        await self.workflows.get_by_id(request.target_workflow_id)
+        resolution = await self._resolve_against_target(
+            bundle, request.target_workflow_id
+        )
+
+        node_map = self._node_map(resolution, request)
+        configs, _ = sanitize_technique_configs(
+            bundle.evaluation.technique_configs
+        )
+        dropped_rules: List[str] = []
+        drop_log = dropped_rules if request.drop_unresolved_rules else None
+        try:
+            configs, dropped_techniques = rewrite_node_refs(
+                configs, _map_resolver(node_map), drop_log
+            )
+        except UnresolvedRefError as error:
+            raise AppException(
+                status_code=400,
+                error_key=ErrorKey.EVALUATION_BUNDLE_INVALID,
+                error_detail=(
+                    f"{error.reason.capitalize()}. Resolve it manually or "
+                    "allow dropping the rule."
+                ),
+            ) from error
+
+        provider_map = {
+            ref.ref: ref.resolved_id for ref in resolution["provider_refs"]
+        }
+        configs, provider_warnings = rewrite_provider_refs(configs, provider_map)
+        techniques = [
+            technique
+            for technique in bundle.evaluation.techniques
+            if technique not in dropped_techniques
+        ]
+        if bundle.evaluation.techniques and not techniques:
+            # An empty technique list does NOT mean "grade nothing": the run loop
+            # falls back to the platform defaults, so this would silently score
+            # the evaluation with checks nobody chose. Refuse instead.
+            raise AppException(
+                status_code=400,
+                error_key=ErrorKey.EVALUATION_BUNDLE_INVALID,
+                error_detail=(
+                    "Every check was dropped, so the imported evaluation would "
+                    "grade nothing. Map the references to this workflow, or "
+                    "choose a different target workflow."
+                ),
+            )
+        self._validate_tool_config(configs, resolution["catalog"])
+
+        reuse_suite_id = request.existing_suite_id
+        if reuse_suite_id:
+            suite_id, case_map, case_count, reuse_warnings = await self._reuse_dataset(
+                reuse_suite_id, bundle, request.target_workflow_id
+            )
+        else:
+            suite_id, case_map, case_count, reuse_warnings = await self._new_dataset(
+                request.target_workflow_id, bundle
+            )
+
+        configs, case_warnings = rewrite_case_refs(configs, case_map)
+        try:
+            evaluation = await self.suites.create_evaluation(
+                TestEvaluationCreate(
+                    name=bundle.evaluation.name,
+                    description=bundle.evaluation.description,
+                    suite_id=suite_id,
+                    workflow_id=request.target_workflow_id,
+                    techniques=techniques,
+                    technique_configs=configs or None,
+                    input_metadata=bundle.evaluation.input_metadata,
+                )
+            )
+        except Exception:
+            # Only a dataset this import created may be cleaned up; an existing
+            # one belongs to other evaluations.
+            if not reuse_suite_id:
+                await self._cleanup_suite(suite_id)
+            raise
+        return EvaluationImportResult(
+            evaluation_id=evaluation.id,
+            suite_id=suite_id,
+            case_count=case_count,
+            reused_dataset=bool(reuse_suite_id),
+            dropped_rules=dropped_rules,
+            warnings=provider_warnings + case_warnings + reuse_warnings,
+        )
+
+    async def _new_dataset(
+        self, target_workflow_id: UUID, bundle: EvaluationBundle
+    ) -> Tuple[UUID, Dict[str, str], int, List[str]]:
+        """Create the bundle's dataset and its cases."""
+        suite = await self.suites.create_suite(
+            TestSuiteCreate(
+                name=bundle.dataset.name,
+                description=bundle.dataset.description,
+                workflow_id=target_workflow_id,
+                default_input_metadata=bundle.dataset.default_input_metadata,
+            )
+        )
+        # Repos commit per call, so a later failure can't roll the suite back —
+        # clean it up explicitly instead of leaving an orphan dataset behind.
+        try:
+            case_map = await self._create_cases(suite.id, bundle)
+        except Exception:
+            await self._cleanup_suite(suite.id)
+            raise
+        return suite.id, case_map, len(bundle.dataset.cases), []
+
+    async def _reuse_dataset(
+        self, suite_id: UUID, bundle: EvaluationBundle, target_workflow_id: UUID
+    ) -> Tuple[UUID, Dict[str, str], int, List[str]]:
+        """Attach to an existing dataset, leaving its cases untouched.
+
+        Turn-targeted rules are re-pointed at the existing cases by
+        (conversation, turn), the only pairing stable across environments.
+        """
+        try:
+            suite = await self.suites.get_suite(suite_id)
+        except AppException as error:
+            raise AppException(
+                status_code=400,
+                error_key=ErrorKey.EVALUATION_BUNDLE_INVALID,
+                error_detail="The dataset to reuse no longer exists.",
+            ) from error
+        version_ids = await self._workflow_version_ids(target_workflow_id)
+        if str(suite.workflow_id) not in version_ids:
+            raise AppException(
+                status_code=400,
+                error_key=ErrorKey.EVALUATION_BUNDLE_INVALID,
+                error_detail=(
+                    "The dataset to reuse belongs to a different workflow."
+                ),
+            )
+
+        existing = await self.suites.list_cases_for_suite(suite.id)
+        case_map = _case_map_for_existing(bundle, existing)
+        warnings: List[str] = []
+        if len(existing) != len(bundle.dataset.cases):
+            warnings.append(
+                f"Reused dataset '{suite.name}' has {len(existing)} case(s) while "
+                f"the bundle has {len(bundle.dataset.cases)}; the evaluation grades "
+                "the existing cases."
+            )
+        return suite.id, case_map, len(existing), warnings
+
+    async def _resolve_against_target(
+        self, bundle: EvaluationBundle, target_workflow_id: UUID
+    ) -> Dict[str, Any]:
+        catalog = await self._workflow_catalog(target_workflow_id)
+        indexes = build_node_indexes(catalog)
+        configs = bundle.evaluation.technique_configs or {}
+
+        node_refs = [
+            resolve_node_ref(
+                ref,
+                kind,
+                _bundle_label(bundle, ref),
+                indexes,
+                _bundle_node_type(bundle, ref),
+            )
+            for ref, kind in collect_node_refs(configs)
+        ]
+        provider_refs: List[BundleProviderResolution] = []
+        provider_ids = collect_provider_ids(configs)
+        if provider_ids:
+            providers = await self.providers.get_all_minimal()
+            provider_refs = [
+                resolve_provider_ref(
+                    provider_id,
+                    bundle.references.llm_providers.get(provider_id),
+                    providers,
+                )
+                for provider_id in provider_ids
+            ]
+        return {
+            "catalog": catalog,
+            "node_refs": node_refs,
+            "provider_refs": provider_refs,
+        }
+
+    def _node_map(
+        self,
+        resolution: Dict[str, Any],
+        request: EvaluationImportRequest,
+    ) -> Dict[str, str]:
+        """Auto-resolved references plus the caller's manual picks (validated).
+
+        Keyed by ``ref_key(ref, kind)``: one value may appear under two kinds
+        (an agent node id is also an action node), and each needs its own
+        resolution against its own kind's catalog.
+        """
+        indexes = build_node_indexes(resolution["catalog"])
+        node_map: Dict[str, str] = {
+            ref_key(ref.ref, ref.kind): ref.resolved_id
+            for ref in resolution["node_refs"]
+            if ref.status == REF_STATUS_RESOLVED and ref.resolved_id
+        }
+        kind_by_key = {
+            ref_key(ref.ref, ref.kind): ref.kind for ref in resolution["node_refs"]
+        }
+        for key, chosen_id in request.resolutions.items():
+            kind = kind_by_key.get(key)
+            if not kind:
+                continue
+            if chosen_id not in indexes[kind]["labels_by_id"]:
+                raise AppException(
+                    status_code=400,
+                    error_key=ErrorKey.EVALUATION_BUNDLE_INVALID,
+                    error_detail=(
+                        f"Resolution for '{key}' points at unknown {kind} "
+                        f"'{chosen_id}' in the target workflow."
+                    ),
+                )
+            node_map[key] = chosen_id
+        return node_map
+
+    def _validate_tool_config(
+        self, configs: Dict[str, Any], catalog: Dict[str, Any]
+    ) -> None:
+        """Fail before anything is created if the tool config cannot canonicalize."""
+        if TOOL_USED not in configs or not isinstance(configs.get(TOOL_USED), dict):
+            return
+        resolve_tool_id, resolve_agent_id, _, all_tool_ids = resolvers_from_agents(
+            catalog.get("agents", [])
+        )
+        try:
+            canonicalize_tool_usage_config(
+                configs[TOOL_USED],
+                resolve_tool_id=resolve_tool_id,
+                resolve_agent_id=resolve_agent_id,
+                all_tool_ids=all_tool_ids,
+            )
+        except ValueError as error:
+            # str(error) here can be a raw pydantic ValidationError over
+            # caller-supplied JSON, and this error key's detail is returned to
+            # clients — log the specifics, return a fixed sentence.
+            logger.warning(
+                "Tool usage config in an imported bundle could not be "
+                "canonicalized: %s",
+                error,
+            )
+            raise AppException(
+                status_code=400,
+                error_key=ErrorKey.EVALUATION_BUNDLE_INVALID,
+                error_detail=(
+                    "The Tool Usage configuration could not be matched to this "
+                    "workflow. Check its rules against the target workflow's tools."
+                ),
+            ) from error
+
+    async def _cleanup_suite(self, suite_id: UUID) -> None:
+        """Best-effort removal of a half-imported dataset; never masks the cause."""
+        try:
+            await self.suites.delete_suite(suite_id)
+        except Exception:  # pylint: disable=broad-except
+            logger.warning(
+                "Failed to clean up suite %s after a failed import", suite_id,
+                exc_info=True,
+            )
+
+    async def _create_cases(
+        self, suite_id: UUID, bundle: EvaluationBundle
+    ) -> Dict[str, str]:
+        """Create the dataset's cases; map exported case ids to the new ids."""
+        models = [
+            TestCaseModel(
+                suite_id=suite_id,
+                input_data=case.input_data,
+                expected_output=case.expected_output,
+                tags=case.tags,
+                weight=case.weight,
+                source_conversation_id=case.source_conversation_id,
+                turn_index=case.turn_index,
+            )
+            for case in bundle.dataset.cases
+        ]
+        created = await self.case_repo.create_many(models) if models else []
+        new_id_by_local = {
+            case.local_id: str(model.id)
+            for case, model in zip(bundle.dataset.cases, created)
+        }
+        return {
+            case_id: new_id_by_local[local_id]
+            for case_id, local_id in bundle.references.cases.items()
+            if local_id in new_id_by_local
+        }
+
+    def _preview_warnings(
+        self, bundle: EvaluationBundle, resolution: Dict[str, Any]
+    ) -> List[str]:
+        configs = bundle.evaluation.technique_configs or {}
+        warnings = list(bundle.notes)
+        warnings.extend(environment_warnings(configs))
+        warnings.extend(
+            scan_metadata_warnings(
+                "Evaluation input metadata", bundle.evaluation.input_metadata
+            )
+        )
+        warnings.extend(
+            scan_metadata_warnings(
+                "Dataset input metadata", bundle.dataset.default_input_metadata
+            )
+        )
+        for provider_ref in resolution["provider_refs"]:
+            if provider_ref.status == REF_STATUS_MISSING:
+                warnings.append(
+                    "No matching LLM provider was found; the default provider "
+                    "will be used for judged checks."
+                )
+        unmapped_cases = [
+            case_id
+            for case_id in collect_case_ids(configs)
+            if case_id not in bundle.references.cases
+        ]
+        if unmapped_cases:
+            warnings.append(
+                "Some turn-targeted rules reference test cases that are not part "
+                "of the bundle and will grade as not evaluated."
+            )
+        return warnings
+
+
+def _bundle_case(
+    case: TestCaseInDB,
+    local_id: int,
+    input_data: Dict[str, Any],
+    expected_output: Optional[Dict[str, Any]],
+) -> BundleCase:
+    return BundleCase(
+        local_id=local_id,
+        input_data=input_data,
+        expected_output=expected_output,
+        tags=case.tags,
+        weight=case.weight,
+        source_conversation_id=case.source_conversation_id,
+        turn_index=case.turn_index,
+    )
+
+
+def _case_map_for_existing(
+    bundle: EvaluationBundle, existing: List[TestCaseInDB]
+) -> Dict[str, str]:
+    """Map the bundle's referenced case ids onto an existing dataset's cases.
+
+    Matching is by (conversation, turn), which survives across environments;
+    a manually created case has no such pairing and stays unmapped, which
+    ``rewrite_case_refs`` reports rather than mis-pointing the rule.
+    """
+    existing_by_turn = {
+        (str(case.source_conversation_id), case.turn_index): str(case.id)
+        for case in existing
+        if case.source_conversation_id is not None and case.turn_index is not None
+    }
+    new_id_by_local: Dict[int, str] = {}
+    for case in bundle.dataset.cases:
+        if case.source_conversation_id is None or case.turn_index is None:
+            continue
+        matched = existing_by_turn.get(
+            (str(case.source_conversation_id), case.turn_index)
+        )
+        if matched:
+            new_id_by_local[case.local_id] = matched
+    return {
+        case_id: new_id_by_local[local_id]
+        for case_id, local_id in bundle.references.cases.items()
+        if local_id in new_id_by_local
+    }
+
+
+def _bundle_label(bundle: EvaluationBundle, ref: str) -> Optional[str]:
+    node = bundle.references.nodes.get(ref)
+    return node.label if node else None
+
+
+def _bundle_node_type(bundle: EvaluationBundle, ref: str) -> Optional[str]:
+    node = bundle.references.nodes.get(ref)
+    return node.node_type if node else None
+
+
+def _map_resolver(node_map: Dict[str, str]) -> Resolver:
+    def resolve(value: str, kind: str) -> str:
+        mapped = node_map.get(ref_key(value, kind))
+        if not mapped:
+            raise UnresolvedRefError(value, kind)
+        return mapped
+
+    return resolve
+
+
+def _validate_bundle_header(bundle: EvaluationBundle) -> None:
+    if len(bundle.dataset.cases) > MAX_BUNDLE_CASES:
+        raise AppException(
+            status_code=400,
+            error_key=ErrorKey.EVALUATION_BUNDLE_INVALID,
+            error_detail=(
+                f"This bundle has {len(bundle.dataset.cases)} test cases; "
+                f"the import limit is {MAX_BUNDLE_CASES}."
+            ),
+        )
+    if bundle.kind != EVALUATION_BUNDLE_KIND:
+        raise AppException(
+            status_code=400,
+            error_key=ErrorKey.EVALUATION_BUNDLE_INVALID,
+            error_detail="The file is not an evaluation bundle.",
+        )
+    if bundle.schema_version > EVALUATION_BUNDLE_SCHEMA_VERSION:
+        raise AppException(
+            status_code=400,
+            error_key=ErrorKey.EVALUATION_BUNDLE_INVALID,
+            error_detail=(
+                "The bundle was exported by a newer version of the platform "
+                "and cannot be imported here."
+            ),
+        )

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -19264,6 +19264,108 @@
         ]
       }
     },
+    "/api/genagent/eval/evaluations/import/preview": {
+      "post": {
+        "tags": [
+          "v1",
+          "Test Evaluations"
+        ],
+        "summary": "Preview Evaluation Import",
+        "description": "Resolve a bundle's references against a target workflow without importing.",
+        "operationId": "preview_evaluation_import_api_genagent_eval_evaluations_import_preview_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvaluationImportPreviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluationImportPreview"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/genagent/eval/evaluations/import": {
+      "post": {
+        "tags": [
+          "v1",
+          "Test Evaluations"
+        ],
+        "summary": "Import Evaluation",
+        "description": "Create the bundle's dataset, cases and evaluation against a target workflow.",
+        "operationId": "import_evaluation_api_genagent_eval_evaluations_import_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvaluationImportRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluationImportResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
     "/api/genagent/eval/evaluations/{evaluation_id}": {
       "get": {
         "tags": [
@@ -19407,6 +19509,59 @@
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/genagent/eval/evaluations/{evaluation_id}/export": {
+      "get": {
+        "tags": [
+          "v1",
+          "Test Evaluations"
+        ],
+        "summary": "Export Evaluation",
+        "description": "The evaluation, its dataset and reference labels as a portable bundle.",
+        "operationId": "export_evaluation_api_genagent_eval_evaluations__evaluation_id__export_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "evaluation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Evaluation Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluationBundle-Output"
+                }
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
@@ -29600,6 +29755,522 @@
         ],
         "title": "Body_upload_welcome_image_api_genagent_agents_configs__agent_id__welcome_image_post"
       },
+      "BundleCase": {
+        "properties": {
+          "local_id": {
+            "type": "integer",
+            "title": "Local Id"
+          },
+          "input_data": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Input Data"
+          },
+          "expected_output": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Output"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags"
+          },
+          "weight": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weight"
+          },
+          "source_conversation_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Conversation Id"
+          },
+          "turn_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Turn Index"
+          }
+        },
+        "type": "object",
+        "required": [
+          "local_id",
+          "input_data"
+        ],
+        "title": "BundleCase"
+      },
+      "BundleDataset": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 200,
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "default_input_metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Input Metadata"
+          },
+          "cases": {
+            "items": {
+              "$ref": "#/components/schemas/BundleCase"
+            },
+            "type": "array",
+            "title": "Cases"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "BundleDataset"
+      },
+      "BundleEvaluation": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 200,
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "techniques": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Techniques"
+          },
+          "technique_configs": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Technique Configs"
+          },
+          "input_metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "BundleEvaluation"
+      },
+      "BundleExistingDataset": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "case_count": {
+            "type": "integer",
+            "title": "Case Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "case_count"
+        ],
+        "title": "BundleExistingDataset",
+        "description": "A dataset in the target environment already using the bundle's name, so\nthe import can attach to it instead of creating a duplicate."
+      },
+      "BundleNodeRef": {
+        "properties": {
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "node_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Node Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "kind"
+        ],
+        "title": "BundleNodeRef",
+        "description": "Label and node type recorded for one graph-node reference at export time.\n\n``node_type`` lets import refuse to bind a name match onto a node of a\ndifferent type. Absent on bundles exported before it was recorded."
+      },
+      "BundleNodeResolution": {
+        "properties": {
+          "ref": {
+            "type": "string",
+            "title": "Ref"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "resolved_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolved Id"
+          },
+          "resolved_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolved Label"
+          },
+          "candidates": {
+            "items": {
+              "$ref": "#/components/schemas/BundleRefCandidate"
+            },
+            "type": "array",
+            "title": "Candidates"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "original_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Original Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ref",
+          "kind",
+          "status"
+        ],
+        "title": "BundleNodeResolution",
+        "description": "How one graph-node reference resolved against the target workflow."
+      },
+      "BundleProviderRef": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          }
+        },
+        "type": "object",
+        "title": "BundleProviderRef",
+        "description": "Display metadata recorded for one LLM provider reference at export time."
+      },
+      "BundleProviderResolution": {
+        "properties": {
+          "ref": {
+            "type": "string",
+            "title": "Ref"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "resolved_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolved Id"
+          },
+          "resolved_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolved Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ref",
+          "status"
+        ],
+        "title": "BundleProviderResolution",
+        "description": "How one LLM provider reference resolved against the target environment."
+      },
+      "BundleRefCandidate": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "label"
+        ],
+        "title": "BundleRefCandidate"
+      },
+      "BundleReferences": {
+        "properties": {
+          "nodes": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/BundleNodeRef"
+            },
+            "type": "object",
+            "title": "Nodes"
+          },
+          "llm_providers": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/BundleProviderRef"
+            },
+            "type": "object",
+            "title": "Llm Providers"
+          },
+          "cases": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Cases"
+          }
+        },
+        "type": "object",
+        "title": "BundleReferences",
+        "description": "Label maps for every environment-specific id embedded in the configs.\n\n``cases`` maps an exported test case id to its ``local_id`` inside the\nbundle, so turn-targeted rules can be re-pointed at the recreated cases."
+      },
+      "BundleSource": {
+        "properties": {
+          "workflow_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workflow Id"
+          },
+          "workflow_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workflow Name"
+          },
+          "workflow_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workflow Version"
+          }
+        },
+        "type": "object",
+        "title": "BundleSource",
+        "description": "Where the bundle came from \u2014 display-only, never used for linking."
+      },
       "ConnectionStatus": {
         "properties": {
           "status": {
@@ -31318,6 +31989,258 @@
           "type"
         ],
         "title": "EvaluationAgentInfo"
+      },
+      "EvaluationBundle-Input": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "title": "Kind",
+            "default": "genassist.evaluation-bundle"
+          },
+          "schema_version": {
+            "type": "integer",
+            "title": "Schema Version",
+            "default": 1
+          },
+          "source": {
+            "$ref": "#/components/schemas/BundleSource"
+          },
+          "evaluation": {
+            "$ref": "#/components/schemas/BundleEvaluation"
+          },
+          "dataset": {
+            "$ref": "#/components/schemas/BundleDataset"
+          },
+          "references": {
+            "$ref": "#/components/schemas/BundleReferences"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "evaluation",
+          "dataset"
+        ],
+        "title": "EvaluationBundle"
+      },
+      "EvaluationBundle-Output": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "title": "Kind",
+            "default": "genassist.evaluation-bundle"
+          },
+          "schema_version": {
+            "type": "integer",
+            "title": "Schema Version",
+            "default": 1
+          },
+          "source": {
+            "$ref": "#/components/schemas/BundleSource"
+          },
+          "evaluation": {
+            "$ref": "#/components/schemas/BundleEvaluation"
+          },
+          "dataset": {
+            "$ref": "#/components/schemas/BundleDataset"
+          },
+          "references": {
+            "$ref": "#/components/schemas/BundleReferences"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "evaluation",
+          "dataset"
+        ],
+        "title": "EvaluationBundle"
+      },
+      "EvaluationImportPreview": {
+        "properties": {
+          "evaluation_name": {
+            "type": "string",
+            "title": "Evaluation Name"
+          },
+          "dataset_name": {
+            "type": "string",
+            "title": "Dataset Name"
+          },
+          "case_count": {
+            "type": "integer",
+            "title": "Case Count"
+          },
+          "existing_dataset": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BundleExistingDataset"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "workflow_name_matches": {
+            "type": "boolean",
+            "title": "Workflow Name Matches"
+          },
+          "node_refs": {
+            "items": {
+              "$ref": "#/components/schemas/BundleNodeResolution"
+            },
+            "type": "array",
+            "title": "Node Refs"
+          },
+          "provider_refs": {
+            "items": {
+              "$ref": "#/components/schemas/BundleProviderResolution"
+            },
+            "type": "array",
+            "title": "Provider Refs"
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Warnings"
+          },
+          "can_import": {
+            "type": "boolean",
+            "title": "Can Import"
+          },
+          "dropping_all_would_empty": {
+            "type": "boolean",
+            "title": "Dropping All Would Empty",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "evaluation_name",
+          "dataset_name",
+          "case_count",
+          "workflow_name_matches",
+          "can_import"
+        ],
+        "title": "EvaluationImportPreview"
+      },
+      "EvaluationImportPreviewRequest": {
+        "properties": {
+          "bundle": {
+            "$ref": "#/components/schemas/EvaluationBundle-Input"
+          },
+          "target_workflow_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Target Workflow Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "bundle",
+          "target_workflow_id"
+        ],
+        "title": "EvaluationImportPreviewRequest"
+      },
+      "EvaluationImportRequest": {
+        "properties": {
+          "bundle": {
+            "$ref": "#/components/schemas/EvaluationBundle-Input"
+          },
+          "target_workflow_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Target Workflow Id"
+          },
+          "existing_suite_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Existing Suite Id"
+          },
+          "resolutions": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "maxProperties": 1000,
+            "title": "Resolutions"
+          },
+          "drop_unresolved_rules": {
+            "type": "boolean",
+            "title": "Drop Unresolved Rules",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "bundle",
+          "target_workflow_id"
+        ],
+        "title": "EvaluationImportRequest"
+      },
+      "EvaluationImportResult": {
+        "properties": {
+          "evaluation_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Evaluation Id"
+          },
+          "suite_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Suite Id"
+          },
+          "case_count": {
+            "type": "integer",
+            "title": "Case Count"
+          },
+          "reused_dataset": {
+            "type": "boolean",
+            "title": "Reused Dataset",
+            "default": false
+          },
+          "dropped_rules": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Dropped Rules"
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Warnings"
+          }
+        },
+        "type": "object",
+        "required": [
+          "evaluation_id",
+          "suite_id",
+          "case_count"
+        ],
+        "title": "EvaluationImportResult"
       },
       "EvaluationRouterBranch": {
         "properties": {
@@ -43862,6 +44785,11 @@
               }
             ],
             "title": "Agent Id"
+          },
+          "is_active_version": {
+            "type": "boolean",
+            "title": "Is Active Version",
+            "default": false
           }
         },
         "type": "object",

--- a/backend/tests/unit/test_eval_bundle.py
+++ b/backend/tests/unit/test_eval_bundle.py
@@ -1,0 +1,1279 @@
+"""Unit tests for evaluation export/import bundles: reference collection,
+sanitization, resolution against a target workflow and config rewriting."""
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from app.core.exceptions.error_messages import ErrorKey
+from app.core.exceptions.exception_classes import AppException
+from app.schemas.eval_bundle import (
+    EVALUATION_BUNDLE_SCHEMA_VERSION,
+    REF_KIND_ACTION,
+    REF_KIND_AGENT,
+    REF_KIND_ROUTER,
+    REF_KIND_TOOL,
+    REF_STATUS_AMBIGUOUS,
+    REF_STATUS_MISSING,
+    REF_STATUS_RESOLVED,
+    BundleCase,
+    BundleDataset,
+    BundleEvaluation,
+    BundleNodeRef,
+    BundleProviderRef,
+    BundleReferences,
+    BundleSource,
+    EvaluationBundle,
+    EvaluationImportPreviewRequest,
+    EvaluationImportRequest,
+)
+from app.schemas.test_suite import (
+    EvaluationToolCatalog,
+    TestCaseInDB,
+    TestEvaluation,
+    TestSuiteInDB,
+)
+from app.services.eval_bundle import (
+    EvalBundleService,
+    UnresolvedRefError,
+    build_node_indexes,
+    collect_case_ids,
+    collect_node_refs,
+    collect_provider_ids,
+    resolve_node_ref,
+    resolve_provider_ref,
+    rewrite_case_refs,
+    rewrite_node_refs,
+    rewrite_provider_refs,
+    sanitize_technique_configs,
+)
+
+
+NOW = datetime(2026, 1, 1)
+
+
+def _catalog(prefix: str) -> dict:
+    """A one-agent catalog whose node ids are unique per environment."""
+    return {
+        "workflow_id": uuid4(),
+        "agents": [
+            {
+                "id": f"{prefix}-agent",
+                "label": "HR Agent",
+                "type": "reactAgentNode",
+                "workflow_path": [],
+                "tools": [
+                    {
+                        "id": f"{prefix}-tool-search",
+                        "name": "search_handbook",
+                        "label": "Search Handbook",
+                        "type": "knowledgeBaseNode",
+                    },
+                    {
+                        "id": f"{prefix}-tool-escalate",
+                        "name": "escalate_to_hr",
+                        "label": "Escalate To HR",
+                        "type": "pythonNode",
+                    },
+                ],
+            }
+        ],
+        "routers": [
+            {
+                "id": f"{prefix}-router",
+                "label": "Intent Router",
+                "workflow_path": [],
+                "branches": [],
+            }
+        ],
+        "action_nodes": [
+            {
+                "id": f"{prefix}-agent",
+                "label": "HR Agent",
+                "type": "reactAgentNode",
+                "workflow_path": [],
+            },
+            {
+                "id": f"{prefix}-escalation",
+                "label": "Escalation Message",
+                "type": "pythonNode",
+                "workflow_path": [],
+            },
+        ],
+    }
+
+
+def _configs(case_id: str, provider_id: str) -> dict:
+    return {
+        "tool_used": {
+            "rules": [
+                {
+                    "id": "rule-1",
+                    "tool_ids": ["src-tool-search"],
+                    "operator": "all",
+                    "agent_id": "src-agent",
+                    "scope": "specific_turn",
+                    "target_case_id": case_id,
+                    "per_tool": {"src-tool-search": {"result_not_empty": True}},
+                }
+            ]
+        },
+        "route_taken": {"rules": [{"router": "src-router", "expected": "hr"}]},
+        "action_taken": {"rules": [{"node": "src-escalation", "should_fire": True}]},
+        "llm_judge": {
+            "rules": [{"rubric": "Grade politeness", "min_score": 0.7}],
+            "llm_provider_id": provider_id,
+        },
+        "provenance_eval": {
+            "min_score": 0.5,
+            "embedding_type": "openai",
+            "embedding_api_key": "sk-secret",
+            "llm_provider_id": provider_id,
+        },
+    }
+
+
+class TestSanitization:
+    def test_secret_keys_are_stripped_with_notes(self):
+        configs, notes = sanitize_technique_configs(_configs("c1", "p1"))
+
+        assert "embedding_api_key" not in configs["provenance_eval"]
+        assert any("embedding_api_key" in note for note in notes)
+
+    def test_non_secret_keys_survive(self):
+        configs, _ = sanitize_technique_configs(_configs("c1", "p1"))
+
+        assert configs["provenance_eval"]["embedding_type"] == "openai"
+        assert configs["llm_judge"]["llm_provider_id"] == "p1"
+
+
+class TestSecretHeuristic:
+    """Credentials must go; ordinary settings that merely contain "token" stay."""
+
+    def test_ordinary_settings_survive(self):
+        configs, notes = sanitize_technique_configs(
+            {"llm_judge": {"max_tokens": 512, "token_budget": 10, "min_score": 0.5}}
+        )
+
+        assert configs["llm_judge"] == {
+            "max_tokens": 512,
+            "token_budget": 10,
+            "min_score": 0.5,
+        }
+        assert notes == []
+
+    def test_credentials_are_stripped_at_any_depth(self):
+        configs, notes = sanitize_technique_configs(
+            {
+                "tool_used": {
+                    "rules": [
+                        {"id": "r", "per_tool": {"t": {"expected_args": {"api_key": "sk-x"}}}}
+                    ]
+                }
+            }
+        )
+
+        rule = configs["tool_used"]["rules"][0]
+        assert rule["per_tool"]["t"]["expected_args"] == {}
+        assert len(notes) == 1
+
+    def test_auth_bearing_tokens_are_still_stripped(self):
+        configs, _ = sanitize_technique_configs(
+            {"provenance_eval": {"auth_token": "x", "access_token": "y", "min_score": 0.5}}
+        )
+
+        assert configs["provenance_eval"] == {"min_score": 0.5}
+
+    def test_a_bare_token_key_is_a_credential(self):
+        """template_sanitizer strips these from shared artifacts; case inputs
+        are merged into the run payload the same way, so they must go too."""
+        configs, _ = sanitize_technique_configs(
+            {
+                "provenance_eval": {
+                    "token": "sk-live",
+                    "api_token": "x",
+                    "refresh_token": "y",
+                    "session_token": "z",
+                    "id_token": "w",
+                    "authorization": "Bearer v",
+                    "min_score": 0.5,
+                }
+            }
+        )
+
+        assert configs["provenance_eval"] == {"min_score": 0.5}
+
+    def test_per_tool_keys_are_tool_ids_not_field_names(self):
+        """per_tool is keyed by tool id — an MCP tool called get_api_key must
+        not have its whole check deleted as if the key were a credential."""
+        configs, notes = sanitize_technique_configs(
+            {
+                "tool_used": {
+                    "rules": [
+                        {
+                            "id": "r",
+                            "tool_ids": ["mcp_1:get_api_key", "toolNode_4"],
+                            "per_tool": {
+                                "mcp_1:get_api_key": {"min_calls": 1},
+                                "toolNode_4": {"result_not_empty": True},
+                            },
+                        }
+                    ]
+                }
+            }
+        )
+
+        per_tool = configs["tool_used"]["rules"][0]["per_tool"]
+        assert set(per_tool) == {"mcp_1:get_api_key", "toolNode_4"}
+        assert notes == []
+
+    def test_notes_do_not_repeat_per_occurrence(self):
+        configs, notes = sanitize_technique_configs(
+            {
+                "tool_used": {
+                    "rules": [
+                        {"id": "a", "expected_args": {"api_key": "x"}},
+                        {"id": "b", "expected_args": {"api_key": "y"}},
+                    ]
+                }
+            }
+        )
+
+        assert notes == ["Removed secret field 'api_key' from the tool_used configuration."]
+        assert configs["tool_used"]["rules"][0]["expected_args"] == {}
+
+
+class TestReferenceCollection:
+    def test_collects_every_node_ref_kind(self):
+        refs = dict(collect_node_refs(_configs("c1", "p1")))
+
+        assert refs["src-tool-search"] == REF_KIND_TOOL
+        assert refs["src-agent"] == REF_KIND_AGENT
+        assert refs["src-router"] == REF_KIND_ROUTER
+        assert refs["src-escalation"] == "action"
+
+    def test_collects_legacy_shapes(self):
+        configs = {
+            "tool_used": {"tool": "search_handbook", "node": "HR Agent"},
+            "route_taken": {"node": "src-router", "expected": "hr"},
+        }
+        refs = dict(collect_node_refs(configs))
+
+        assert refs["search_handbook"] == REF_KIND_TOOL
+        assert refs["HR Agent"] == REF_KIND_AGENT
+        assert refs["src-router"] == REF_KIND_ROUTER
+
+    def test_collects_provider_and_case_ids(self):
+        configs = _configs("case-9", "provider-7")
+
+        assert collect_provider_ids(configs) == ["provider-7"]
+        assert collect_case_ids(configs) == ["case-9"]
+
+
+class TestNodeResolution:
+    def test_same_id_resolves_directly(self):
+        indexes = build_node_indexes(_catalog("tgt"))
+
+        result = resolve_node_ref("tgt-tool-search", REF_KIND_TOOL, None, indexes)
+
+        assert result.status == REF_STATUS_RESOLVED
+        assert result.resolved_id == "tgt-tool-search"
+
+    def test_label_from_bundle_resolves_new_id(self):
+        indexes = build_node_indexes(_catalog("tgt"))
+
+        result = resolve_node_ref(
+            "src-tool-search", REF_KIND_TOOL, "Search Handbook", indexes
+        )
+
+        assert result.status == REF_STATUS_RESOLVED
+        assert result.resolved_id == "tgt-tool-search"
+
+    def test_unknown_ref_is_missing(self):
+        indexes = build_node_indexes(_catalog("tgt"))
+
+        result = resolve_node_ref("nope", REF_KIND_ROUTER, "No Router", indexes)
+
+        assert result.status == REF_STATUS_MISSING
+        assert result.candidates == []
+
+    def test_duplicate_labels_are_ambiguous(self):
+        catalog = _catalog("tgt")
+        catalog["routers"].append(
+            {"id": "tgt-router-2", "label": "Intent Router", "workflow_path": [], "branches": []}
+        )
+        indexes = build_node_indexes(catalog)
+
+        result = resolve_node_ref("src-router", REF_KIND_ROUTER, "Intent Router", indexes)
+
+        assert result.status == REF_STATUS_AMBIGUOUS
+        assert {c.id for c in result.candidates} == {"tgt-router", "tgt-router-2"}
+
+
+class TestNodeTypeGuard:
+    """A name match must not bind a check to a differently-typed node."""
+
+    def test_same_type_name_match_resolves(self):
+        indexes = build_node_indexes(_catalog("tgt"))
+
+        result = resolve_node_ref(
+            "src-escalation", REF_KIND_ACTION, "Escalation Message", indexes, "pythonNode"
+        )
+
+        assert result.status == REF_STATUS_RESOLVED
+        assert result.resolved_id == "tgt-escalation"
+        assert result.note is None
+
+    def test_differing_type_needs_confirmation(self):
+        indexes = build_node_indexes(_catalog("tgt"))
+
+        result = resolve_node_ref(
+            "src-escalation", REF_KIND_ACTION, "Escalation Message", indexes, "routerNode"
+        )
+
+        assert result.status == REF_STATUS_AMBIGUOUS
+        assert result.resolved_id is None
+        assert [c.id for c in result.candidates] == ["tgt-escalation"]
+        assert "pythonNode" in result.note and "routerNode" in result.note
+
+    def test_id_match_wins_over_a_differing_type(self):
+        """The id proves it is the same node; a type change there is the user's edit."""
+        indexes = build_node_indexes(_catalog("tgt"))
+
+        result = resolve_node_ref(
+            "tgt-escalation", REF_KIND_ACTION, "Escalation Message", indexes, "routerNode"
+        )
+
+        assert result.status == REF_STATUS_RESOLVED
+        assert result.resolved_id == "tgt-escalation"
+        assert result.note is None
+
+    def test_bundle_without_a_recorded_type_resolves_unchanged(self):
+        indexes = build_node_indexes(_catalog("tgt"))
+
+        result = resolve_node_ref(
+            "src-escalation", REF_KIND_ACTION, "Escalation Message", indexes, None
+        )
+
+        assert result.status == REF_STATUS_RESOLVED
+        assert result.resolved_id == "tgt-escalation"
+
+    def test_router_refs_are_unaffected(self):
+        """Routers are all routerNode, so no type is indexed and none is compared."""
+        indexes = build_node_indexes(_catalog("tgt"))
+
+        result = resolve_node_ref(
+            "src-router", REF_KIND_ROUTER, "Intent Router", indexes, "routerNode"
+        )
+
+        assert result.status == REF_STATUS_RESOLVED
+        assert result.resolved_id == "tgt-router"
+
+    def test_tool_refs_compare_types_too(self):
+        indexes = build_node_indexes(_catalog("tgt"))
+
+        result = resolve_node_ref(
+            "src-tool-search", REF_KIND_TOOL, "Search Handbook", indexes, "httpNode"
+        )
+
+        assert result.status == REF_STATUS_AMBIGUOUS
+        assert "knowledgeBaseNode" in result.note
+
+
+class TestProviderResolution:
+    def test_matches_by_model_then_name(self):
+        providers = [
+            SimpleNamespace(id=uuid4(), name="Azure GPT", llm_model="gpt-4o"),
+            SimpleNamespace(id=uuid4(), name="OpenAI GPT", llm_model="gpt-4o"),
+        ]
+        meta = BundleProviderRef(name="OpenAI GPT", provider="openai", model="gpt-4o")
+
+        result = resolve_provider_ref("old-id", meta, providers)
+
+        assert result.status == REF_STATUS_RESOLVED
+        assert result.resolved_id == str(providers[1].id)
+
+    def test_inactive_providers_are_not_matched_by_name(self):
+        """The wizard only offers active providers, so a name match must not
+        bind the judge to a retired one it cannot later be edited to."""
+        retired = SimpleNamespace(
+            id=uuid4(), name="Old GPT", llm_model="gpt-4o", is_active=0
+        )
+        live = SimpleNamespace(
+            id=uuid4(), name="New GPT", llm_model="gpt-4o", is_active=1
+        )
+        meta = BundleProviderRef(name="Old GPT", provider="openai", model="gpt-4o")
+
+        result = resolve_provider_ref("old-id", meta, [retired, live])
+
+        assert result.resolved_id == str(live.id)
+
+    def test_an_exact_provider_id_is_honoured_even_when_inactive(self):
+        retired = SimpleNamespace(
+            id=uuid4(), name="Old GPT", llm_model="gpt-4o", is_active=0
+        )
+
+        result = resolve_provider_ref(str(retired.id), None, [retired])
+
+        assert result.status == REF_STATUS_RESOLVED
+        assert result.resolved_id == str(retired.id)
+
+    def test_unmatched_provider_is_missing(self):
+        providers = [SimpleNamespace(id=uuid4(), name="Claude", llm_model="claude-sonnet-5")]
+        meta = BundleProviderRef(name="Mistral", provider=None, model="mistral-large")
+
+        result = resolve_provider_ref("old-id", meta, providers)
+
+        assert result.status == REF_STATUS_MISSING
+
+
+class TestRewriting:
+    def test_rewrites_every_node_ref(self):
+        node_map = {
+            "src-tool-search": "tgt-tool-search",
+            "src-agent": "tgt-agent",
+            "src-router": "tgt-router",
+            "src-escalation": "tgt-escalation",
+        }
+        configs, dropped = rewrite_node_refs(
+            _configs("c1", "p1"), lambda ref, kind: node_map[ref]
+        )
+
+        rule = configs["tool_used"]["rules"][0]
+        assert rule["tool_ids"] == ["tgt-tool-search"]
+        assert rule["agent_id"] == "tgt-agent"
+        assert list(rule["per_tool"]) == ["tgt-tool-search"]
+        assert configs["route_taken"]["rules"][0]["router"] == "tgt-router"
+        assert configs["action_taken"]["rules"][0]["node"] == "tgt-escalation"
+        assert dropped == []
+
+    def test_unresolved_ref_raises_without_drop_log(self):
+        def resolve(ref, kind):
+            raise UnresolvedRefError(ref, kind)
+
+        with pytest.raises(UnresolvedRefError):
+            rewrite_node_refs({"route_taken": {"rules": [{"router": "x", "expected": "a"}]}}, resolve)
+
+    def test_drop_mode_drops_rule_and_technique(self):
+        def resolve(ref, kind):
+            raise UnresolvedRefError(ref, kind)
+
+        drop_log = []
+        configs, dropped = rewrite_node_refs(
+            {"route_taken": {"rules": [{"router": "x", "expected": "a"}]}},
+            resolve,
+            drop_log,
+        )
+
+        assert dropped == ["route_taken"]
+        assert "route_taken" not in configs
+        assert len(drop_log) == 1
+
+    def test_provider_fallback_removes_field_with_warning(self):
+        configs = {"llm_judge": {"rules": [], "llm_provider_id": "old"}}
+
+        rewritten, warnings = rewrite_provider_refs(configs, {"old": None})
+
+        assert "llm_provider_id" not in rewritten["llm_judge"]
+        assert len(warnings) == 1
+
+    def test_case_refs_remap_or_fall_back_to_conversation_target(self):
+        conversation_id = str(uuid4())
+        configs = {
+            "tool_used": {
+                "rules": [
+                    {"id": "r1", "target_case_id": "old-1"},
+                    {
+                        "id": "r2",
+                        "target_case_id": "old-2",
+                        "target_source_conversation_id": conversation_id,
+                        "target_turn_index": 1,
+                    },
+                    {"id": "r3", "target_case_id": "old-3"},
+                ]
+            }
+        }
+
+        rewritten, warnings = rewrite_case_refs(configs, {"old-1": "new-1"})
+
+        rules = rewritten["tool_used"]["rules"]
+        assert rules[0]["target_case_id"] == "new-1"
+        assert "target_case_id" not in rules[1]
+        assert rules[2]["target_case_id"] == "old-3"
+        assert len(warnings) == 1
+
+
+def _service(**overrides) -> EvalBundleService:
+    service = EvalBundleService(
+        suite_service=AsyncMock(),
+        workflow_service=AsyncMock(),
+        llm_provider_service=AsyncMock(),
+        case_repo=AsyncMock(),
+    )
+    for name, value in overrides.items():
+        setattr(service, name, value)
+    return service
+
+
+def _provider(provider_id):
+    return SimpleNamespace(
+        id=provider_id, name="OpenAI GPT", llm_model_provider="openai", llm_model="gpt-4o"
+    )
+
+
+def _export_fixture():
+    suite_id, workflow_id, case_id, provider_id = uuid4(), uuid4(), uuid4(), uuid4()
+    evaluation = TestEvaluation(
+        id=uuid4(),
+        name="HR checks",
+        description="desc",
+        suite_id=suite_id,
+        workflow_id=workflow_id,
+        techniques=["tool_used", "route_taken", "llm_judge"],
+        technique_configs=_configs(str(case_id), str(provider_id)),
+        input_metadata={"channel": "web", "api_key": "leak-me"},
+        run_ids=["11111111-1111-1111-1111-111111111111"],
+        created_at=NOW,
+        updated_at=NOW,
+    )
+    suite = TestSuiteInDB(
+        id=suite_id,
+        name="HR dataset",
+        description=None,
+        workflow_id=workflow_id,
+        default_input_metadata=None,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+    case = TestCaseInDB(
+        id=case_id,
+        suite_id=suite_id,
+        input_data={"message": "hi"},
+        expected_output={"value": "hello"},
+        created_at=NOW,
+        updated_at=NOW,
+    )
+    service = _service()
+    service.suites.get_evaluation.return_value = evaluation
+    service.suites.get_suite.return_value = suite
+    service.suites.list_cases_for_suite.return_value = [case]
+    service.suites.get_evaluation_tool_catalog.return_value = EvaluationToolCatalog(
+        **_catalog("src")
+    )
+    service.workflows.get_by_id.return_value = SimpleNamespace(
+        id=workflow_id, name="HR Assistant", version="1.0"
+    )
+    service.providers.get_all_minimal.return_value = [_provider(provider_id)]
+    return service, evaluation, case_id, provider_id
+
+
+class TestExport:
+    @pytest.mark.asyncio
+    async def test_bundle_records_labels_providers_and_case_refs(self):
+        service, _, case_id, provider_id = _export_fixture()
+
+        bundle = await service.export_evaluation(uuid4())
+
+        assert bundle.source.workflow_name == "HR Assistant"
+        assert bundle.references.nodes["src-tool-search"].label == "Search Handbook"
+        assert bundle.references.nodes["src-router"].kind == REF_KIND_ROUTER
+        # Types travel so import can refuse a name match onto a different type.
+        assert bundle.references.nodes["src-tool-search"].node_type == "knowledgeBaseNode"
+        assert bundle.references.nodes["src-agent"].node_type == "reactAgentNode"
+        assert bundle.references.nodes["src-escalation"].node_type == "pythonNode"
+        assert bundle.references.llm_providers[str(provider_id)].model == "gpt-4o"
+        assert bundle.references.cases[str(case_id)] == 1
+        assert bundle.dataset.cases[0].local_id == 1
+
+    @pytest.mark.asyncio
+    async def test_bundle_never_contains_secrets_or_run_history(self):
+        service, _, _, _ = _export_fixture()
+
+        bundle = await service.export_evaluation(uuid4())
+
+        assert "embedding_api_key" not in bundle.evaluation.technique_configs["provenance_eval"]
+        assert "api_key" not in bundle.evaluation.input_metadata
+        assert "run_ids" not in bundle.evaluation.model_dump()
+        assert any("api_key" in note for note in bundle.notes)
+
+
+def _bundle(case_id: str, provider_id: str) -> EvaluationBundle:
+    configs, _ = sanitize_technique_configs(_configs(case_id, provider_id))
+    return EvaluationBundle(
+        source=BundleSource(workflow_name="HR Assistant", workflow_version="1.0"),
+        evaluation=BundleEvaluation(
+            name="HR checks",
+            techniques=["tool_used", "route_taken", "action_taken", "llm_judge"],
+            technique_configs=configs,
+        ),
+        dataset=BundleDataset(
+            name="HR dataset",
+            cases=[
+                BundleCase(local_id=1, input_data={"message": "hi"}),
+                BundleCase(local_id=2, input_data={"message": "bye"}),
+            ],
+        ),
+        references=BundleReferences(
+            nodes={
+                "src-tool-search": BundleNodeRef(label="Search Handbook", kind=REF_KIND_TOOL),
+                "src-agent": BundleNodeRef(label="HR Agent", kind=REF_KIND_AGENT),
+                "src-router": BundleNodeRef(label="Intent Router", kind=REF_KIND_ROUTER),
+                "src-escalation": BundleNodeRef(label="Escalation Message", kind="action"),
+            },
+            llm_providers={
+                provider_id: BundleProviderRef(name="OpenAI GPT", provider="openai", model="gpt-4o")
+            },
+            cases={case_id: 1},
+        ),
+    )
+
+
+def _import_service(target_provider_id):
+    service = _service()
+    service.suites.get_evaluation_tool_catalog.return_value = EvaluationToolCatalog(
+        **_catalog("tgt")
+    )
+    service.workflows.get_by_id.return_value = SimpleNamespace(
+        id=uuid4(), name="HR Assistant", version="2.0"
+    )
+    service.providers.get_all_minimal.return_value = [_provider(target_provider_id)]
+    service.suites.list_suites.return_value = []
+    service.workflows.get_all_minimal.return_value = []
+    new_suite_id = uuid4()
+    service.suites.create_suite.return_value = SimpleNamespace(id=new_suite_id)
+    service.suites.create_evaluation.return_value = SimpleNamespace(id=uuid4())
+
+    def assign_ids(models):
+        for model in models:
+            model.id = uuid4()
+        return models
+
+    service.case_repo.create_many.side_effect = assign_ids
+    return service
+
+
+class TestPreview:
+    @pytest.mark.asyncio
+    async def test_labels_resolve_against_target_catalog(self):
+        provider_id = str(uuid4())
+        service = _import_service(uuid4())
+
+        preview = await service.preview_import(
+            EvaluationImportPreviewRequest(
+                bundle=_bundle(str(uuid4()), provider_id),
+                target_workflow_id=uuid4(),
+            )
+        )
+
+        assert preview.can_import is True
+        assert preview.workflow_name_matches is True
+        by_ref = {r.ref: r for r in preview.node_refs}
+        assert by_ref["src-tool-search"].resolved_id == "tgt-tool-search"
+        assert by_ref["src-router"].resolved_id == "tgt-router"
+
+    @pytest.mark.asyncio
+    async def test_missing_node_blocks_import(self):
+        provider_id = str(uuid4())
+        service = _import_service(uuid4())
+        bundle = _bundle(str(uuid4()), provider_id)
+        bundle.references.nodes["src-router"].label = "Renamed Router"
+        bundle.evaluation.technique_configs["route_taken"]["rules"][0]["router"] = "unknown"
+
+        preview = await service.preview_import(
+            EvaluationImportPreviewRequest(bundle=bundle, target_workflow_id=uuid4())
+        )
+
+        assert preview.can_import is False
+
+    @pytest.mark.asyncio
+    async def test_newer_schema_version_is_rejected(self):
+        service = _import_service(uuid4())
+        bundle = _bundle(str(uuid4()), str(uuid4()))
+        bundle.schema_version = EVALUATION_BUNDLE_SCHEMA_VERSION + 1
+
+        with pytest.raises(AppException) as excinfo:
+            await service.preview_import(
+                EvaluationImportPreviewRequest(bundle=bundle, target_workflow_id=uuid4())
+            )
+        assert excinfo.value.status_code == 400
+
+
+class TestImport:
+    @pytest.mark.asyncio
+    async def test_import_rewrites_configs_to_target_ids(self):
+        old_case_id = str(uuid4())
+        target_provider_id = uuid4()
+        service = _import_service(target_provider_id)
+
+        result = await service.import_bundle(
+            EvaluationImportRequest(
+                bundle=_bundle(old_case_id, str(uuid4())),
+                target_workflow_id=uuid4(),
+            )
+        )
+
+        created = service.suites.create_evaluation.await_args.args[0]
+        configs = created.technique_configs
+        rule = configs["tool_used"]["rules"][0]
+        assert rule["tool_ids"] == ["tgt-tool-search"]
+        assert rule["agent_id"] == "tgt-agent"
+        assert configs["route_taken"]["rules"][0]["router"] == "tgt-router"
+        assert configs["action_taken"]["rules"][0]["node"] == "tgt-escalation"
+        assert rule["target_case_id"] not in (old_case_id, None)
+        assert result.case_count == 2
+
+    @pytest.mark.asyncio
+    async def test_judge_provider_is_matched_by_model(self):
+        target_provider_id = uuid4()
+        service = _import_service(target_provider_id)
+
+        await service.import_bundle(
+            EvaluationImportRequest(
+                bundle=_bundle(str(uuid4()), str(uuid4())),
+                target_workflow_id=uuid4(),
+            )
+        )
+
+        created = service.suites.create_evaluation.await_args.args[0]
+        assert created.technique_configs["llm_judge"]["llm_provider_id"] == str(
+            target_provider_id
+        )
+
+    @pytest.mark.asyncio
+    async def test_unresolved_ref_fails_before_creating_anything(self):
+        service = _import_service(uuid4())
+        bundle = _bundle(str(uuid4()), str(uuid4()))
+        bundle.references.nodes["src-router"].label = "Renamed Router"
+        bundle.evaluation.technique_configs["route_taken"]["rules"][0]["router"] = "unknown"
+
+        with pytest.raises(AppException) as excinfo:
+            await service.import_bundle(
+                EvaluationImportRequest(bundle=bundle, target_workflow_id=uuid4())
+            )
+
+        assert excinfo.value.status_code == 400
+        service.suites.create_suite.assert_not_awaited()
+        service.suites.create_evaluation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_import_is_refused_when_every_check_would_be_dropped(self):
+        """An empty technique list makes the run fall back to platform defaults,
+        so it would grade with checks nobody chose rather than grade nothing."""
+        service = _import_service(uuid4())
+        bundle = _bundle(str(uuid4()), str(uuid4()))
+        bundle.evaluation.techniques = ["route_taken"]
+        bundle.evaluation.technique_configs = {
+            "route_taken": {"rules": [{"router": "unknown", "expected": "a"}]}
+        }
+        bundle.references.nodes = {}
+
+        with pytest.raises(AppException) as excinfo:
+            await service.import_bundle(
+                EvaluationImportRequest(
+                    bundle=bundle,
+                    target_workflow_id=uuid4(),
+                    drop_unresolved_rules=True,
+                )
+            )
+
+        assert excinfo.value.status_code == 400
+        service.suites.create_suite.assert_not_awaited()
+        service.suites.create_evaluation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_preview_flags_when_dropping_would_leave_no_checks(self):
+        """Import refuses that outcome, so the dialog must not offer dropping."""
+        service = _import_service(uuid4())
+        bundle = _bundle(str(uuid4()), str(uuid4()))
+        bundle.evaluation.techniques = ["route_taken"]
+        bundle.evaluation.technique_configs = {
+            "route_taken": {"rules": [{"router": "unknown", "expected": "a"}]}
+        }
+        bundle.references.nodes = {}
+
+        preview = await service.preview_import(
+            EvaluationImportPreviewRequest(bundle=bundle, target_workflow_id=uuid4())
+        )
+
+        assert preview.dropping_all_would_empty is True
+
+    @pytest.mark.asyncio
+    async def test_preview_allows_dropping_when_other_checks_survive(self):
+        service = _import_service(uuid4())
+        bundle = _bundle(str(uuid4()), str(uuid4()))
+
+        preview = await service.preview_import(
+            EvaluationImportPreviewRequest(bundle=bundle, target_workflow_id=uuid4())
+        )
+
+        assert preview.dropping_all_would_empty is False
+
+    @pytest.mark.asyncio
+    async def test_an_oversized_bundle_is_refused_on_import(self):
+        from app.schemas.eval_bundle import MAX_BUNDLE_CASES
+
+        service = _import_service(uuid4())
+        bundle = _bundle(str(uuid4()), str(uuid4()))
+        bundle.dataset.cases = [
+            BundleCase(local_id=i, input_data={"message": "x"})
+            for i in range(MAX_BUNDLE_CASES + 1)
+        ]
+
+        with pytest.raises(AppException) as excinfo:
+            await service.import_bundle(
+                EvaluationImportRequest(bundle=bundle, target_workflow_id=uuid4())
+            )
+        assert excinfo.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_export_is_not_capped_by_the_import_limit(self):
+        """The cap guards inbound payloads; a big dataset must still export."""
+        from app.schemas.eval_bundle import MAX_BUNDLE_CASES
+
+        service, _, _, _ = _export_fixture()
+        suite_id = service.suites.get_suite.return_value.id
+        service.suites.list_cases_for_suite.return_value = [
+            TestCaseInDB(
+                id=uuid4(),
+                suite_id=suite_id,
+                input_data={"message": str(i)},
+                created_at=NOW,
+                updated_at=NOW,
+            )
+            for i in range(MAX_BUNDLE_CASES + 10)
+        ]
+
+        bundle = await service.export_evaluation(uuid4())
+
+        assert len(bundle.dataset.cases) == MAX_BUNDLE_CASES + 10
+
+    @pytest.mark.asyncio
+    async def test_drop_unresolved_rules_drops_and_reports(self):
+        service = _import_service(uuid4())
+        bundle = _bundle(str(uuid4()), str(uuid4()))
+        bundle.references.nodes["src-router"].label = "Renamed Router"
+        bundle.evaluation.technique_configs["route_taken"]["rules"][0]["router"] = "unknown"
+
+        result = await service.import_bundle(
+            EvaluationImportRequest(
+                bundle=bundle,
+                target_workflow_id=uuid4(),
+                drop_unresolved_rules=True,
+            )
+        )
+
+        assert len(result.dropped_rules) == 1
+        created = service.suites.create_evaluation.await_args.args[0]
+        assert "route_taken" not in created.techniques
+        assert "route_taken" not in created.technique_configs
+
+    @pytest.mark.asyncio
+    async def test_manual_resolution_overrides_missing_ref(self):
+        service = _import_service(uuid4())
+        bundle = _bundle(str(uuid4()), str(uuid4()))
+        bundle.references.nodes["src-router"].label = "Renamed Router"
+        bundle.evaluation.technique_configs["route_taken"]["rules"][0]["router"] = "src-router"
+
+        await service.import_bundle(
+            EvaluationImportRequest(
+                bundle=bundle,
+                target_workflow_id=uuid4(),
+                resolutions={"router:src-router": "tgt-router"},
+            )
+        )
+
+        created = service.suites.create_evaluation.await_args.args[0]
+        assert created.technique_configs["route_taken"]["rules"][0]["router"] == "tgt-router"
+
+    @pytest.mark.asyncio
+    async def test_manual_resolution_to_unknown_node_is_rejected(self):
+        service = _import_service(uuid4())
+        bundle = _bundle(str(uuid4()), str(uuid4()))
+
+        with pytest.raises(AppException) as excinfo:
+            await service.import_bundle(
+                EvaluationImportRequest(
+                    bundle=bundle,
+                    target_workflow_id=uuid4(),
+                    resolutions={"router:src-router": "not-a-node"},
+                )
+            )
+        assert excinfo.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_wrong_kind_is_rejected(self):
+        service = _import_service(uuid4())
+        bundle = _bundle(str(uuid4()), str(uuid4())).model_dump()
+        bundle["kind"] = "genassist.evaluation-bundle"
+        request = EvaluationImportRequest(
+            bundle=bundle, target_workflow_id=uuid4()
+        )
+        request.bundle.kind = "something-else"
+
+        with pytest.raises(AppException):
+            await service.import_bundle(request)
+
+
+class TestEnvironmentWarnings:
+    def test_nli_model_choice_is_never_flagged(self):
+        """Both curated models resolve everywhere, so neither is a portability risk."""
+        from app.constants.nli_models import NLI_MODELS
+        from app.services.eval_bundle import environment_warnings
+
+        for model in NLI_MODELS:
+            warnings = environment_warnings(
+                {"nli_eval": {"nli_model_name": model["value"], "min_entail_score": 0.6}}
+            )
+            assert warnings == []
+
+    def test_hosted_embeddings_are_flagged(self):
+        """Unlike NLI, these reach an external service with per-environment credentials."""
+        from app.services.eval_bundle import environment_warnings
+
+        for embedding_type in ("openai", "bedrock"):
+            warnings = environment_warnings(
+                {"provenance_eval": {"embedding_type": embedding_type}}
+            )
+            assert len(warnings) == 1
+
+    def test_local_embeddings_are_not_flagged(self):
+        from app.services.eval_bundle import environment_warnings
+
+        warnings = environment_warnings(
+            {"provenance_eval": {"embedding_type": "huggingface"}}
+        )
+
+        assert warnings == []
+
+
+class TestReviewRegressions:
+    def test_service_resolves_through_the_injector(self):
+        from injector import Injector
+
+        from app.repositories.test_suite import TestCaseRepository
+        from app.services.llm_providers import LlmProviderService
+        from app.services.test_suite import TestSuiteService
+        from app.services.workflow import WorkflowService
+
+        container = Injector()
+        container.binder.bind(TestSuiteService, to=AsyncMock())
+        container.binder.bind(WorkflowService, to=AsyncMock())
+        container.binder.bind(LlmProviderService, to=AsyncMock())
+        container.binder.bind(TestCaseRepository, to=AsyncMock())
+
+        assert isinstance(container.get(EvalBundleService), EvalBundleService)
+
+    @pytest.mark.asyncio
+    async def test_same_ref_under_two_kinds_resolves_independently(self):
+        service = _import_service(uuid4())
+        catalog = _catalog("tgt")
+        catalog["action_nodes"].append(
+            {"id": "tgt-agent-2", "label": "HR Agent", "type": "pythonNode", "workflow_path": []}
+        )
+        service.suites.get_evaluation_tool_catalog.return_value = EvaluationToolCatalog(
+            **catalog
+        )
+        bundle = _bundle(str(uuid4()), str(uuid4()))
+        bundle.evaluation.technique_configs["action_taken"]["rules"][0]["node"] = "src-agent"
+
+        result = await service.import_bundle(
+            EvaluationImportRequest(
+                bundle=bundle,
+                target_workflow_id=uuid4(),
+                resolutions={"action:src-agent": "tgt-agent-2"},
+            )
+        )
+
+        created = service.suites.create_evaluation.await_args.args[0]
+        tool_rule = created.technique_configs["tool_used"]["rules"][0]
+        action_rule = created.technique_configs["action_taken"]["rules"][0]
+        assert tool_rule["agent_id"] == "tgt-agent"
+        assert action_rule["node"] == "tgt-agent-2"
+        assert result.dropped_rules == []
+
+    @pytest.mark.asyncio
+    async def test_ambiguity_in_one_kind_is_not_bypassed_by_the_other(self):
+        service = _import_service(uuid4())
+        catalog = _catalog("tgt")
+        catalog["action_nodes"].append(
+            {"id": "tgt-agent-2", "label": "HR Agent", "type": "pythonNode", "workflow_path": []}
+        )
+        service.suites.get_evaluation_tool_catalog.return_value = EvaluationToolCatalog(
+            **catalog
+        )
+        bundle = _bundle(str(uuid4()), str(uuid4()))
+        bundle.evaluation.technique_configs["action_taken"]["rules"][0]["node"] = "src-agent"
+
+        with pytest.raises(AppException) as excinfo:
+            await service.import_bundle(
+                EvaluationImportRequest(bundle=bundle, target_workflow_id=uuid4())
+            )
+        assert excinfo.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_export_strips_secret_keys_from_case_inputs(self):
+        service, _, _, _ = _export_fixture()
+        case = service.suites.list_cases_for_suite.return_value[0]
+        case.input_data = {"message": "hi", "auth_token": "leak-me"}
+
+        bundle = await service.export_evaluation(uuid4())
+
+        assert "auth_token" not in bundle.dataset.cases[0].input_data
+        assert bundle.dataset.cases[0].input_data["message"] == "hi"
+        assert any("auth_token" in note for note in bundle.notes)
+
+    @pytest.mark.asyncio
+    async def test_per_tool_checks_collapsing_onto_one_tool_are_refused(self):
+        service = _import_service(uuid4())
+        bundle = _bundle(str(uuid4()), str(uuid4()))
+        rule = bundle.evaluation.technique_configs["tool_used"]["rules"][0]
+        rule["per_tool"] = {
+            "src-tool-search": {"result_not_empty": True},
+            "Search Handbook": {"result_contains": "policy"},
+        }
+
+        with pytest.raises(AppException) as excinfo:
+            await service.import_bundle(
+                EvaluationImportRequest(bundle=bundle, target_workflow_id=uuid4())
+            )
+        assert excinfo.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_failed_evaluation_create_cleans_up_the_new_suite(self):
+        service = _import_service(uuid4())
+        service.suites.create_evaluation.side_effect = RuntimeError("db down")
+
+        with pytest.raises(RuntimeError):
+            await service.import_bundle(
+                EvaluationImportRequest(
+                    bundle=_bundle(str(uuid4()), str(uuid4())),
+                    target_workflow_id=uuid4(),
+                )
+            )
+
+        created_suite = service.suites.create_suite.return_value
+        service.suites.delete_suite.assert_awaited_once_with(created_suite.id)
+
+
+class TestDatasetReuse:
+    def _existing_case(self, suite_id, conversation_id, turn_index):
+        return TestCaseInDB(
+            id=uuid4(),
+            suite_id=suite_id,
+            input_data={"message": f"turn {turn_index}"},
+            source_conversation_id=conversation_id,
+            turn_index=turn_index,
+            created_at=NOW,
+            updated_at=NOW,
+        )
+
+    @pytest.mark.asyncio
+    async def test_preview_reports_an_existing_dataset_by_name(self):
+        service = _import_service(uuid4())
+        suite_id, target = uuid4(), uuid4()
+        service.suites.list_suites.return_value = [
+            SimpleNamespace(id=uuid4(), name="Unrelated", workflow_id=target),
+            # Same name but another workflow's — must not be offered.
+            SimpleNamespace(id=uuid4(), name="hr dataset", workflow_id=uuid4()),
+            SimpleNamespace(id=suite_id, name="hr dataset", workflow_id=target),
+        ]
+        service.suites.list_cases_for_suite.return_value = [
+            self._existing_case(suite_id, uuid4(), 0)
+        ]
+
+        preview = await service.preview_import(
+            EvaluationImportPreviewRequest(
+                bundle=_bundle(str(uuid4()), str(uuid4())),
+                target_workflow_id=target,
+            )
+        )
+
+        assert preview.existing_dataset is not None
+        assert preview.existing_dataset.id == suite_id
+        assert preview.existing_dataset.case_count == 1
+
+    @pytest.mark.asyncio
+    async def test_reuse_attaches_without_creating_a_dataset_or_cases(self):
+        service = _import_service(uuid4())
+        suite_id, target = uuid4(), uuid4()
+        service.suites.get_suite.return_value = SimpleNamespace(
+            id=suite_id, name="HR dataset", workflow_id=target
+        )
+        service.suites.list_cases_for_suite.return_value = [
+            self._existing_case(suite_id, uuid4(), 0),
+            self._existing_case(suite_id, uuid4(), 1),
+        ]
+
+        result = await service.import_bundle(
+            EvaluationImportRequest(
+                bundle=_bundle(str(uuid4()), str(uuid4())),
+                target_workflow_id=target,
+                existing_suite_id=suite_id,
+            )
+        )
+
+        assert result.reused_dataset is True
+        assert result.suite_id == suite_id
+        service.suites.create_suite.assert_not_awaited()
+        service.case_repo.create_many.assert_not_awaited()
+        created = service.suites.create_evaluation.await_args.args[0]
+        assert created.suite_id == suite_id
+
+    @pytest.mark.asyncio
+    async def test_reuse_repoints_turn_targets_at_the_existing_cases(self):
+        service = _import_service(uuid4())
+        suite_id, conversation_id, old_case_id = uuid4(), uuid4(), str(uuid4())
+        target = uuid4()
+        existing = self._existing_case(suite_id, conversation_id, 0)
+        service.suites.get_suite.return_value = SimpleNamespace(
+            id=suite_id, name="HR dataset", workflow_id=target
+        )
+        service.suites.list_cases_for_suite.return_value = [existing]
+
+        bundle = _bundle(old_case_id, str(uuid4()))
+        bundle.dataset.cases = [
+            BundleCase(
+                local_id=1,
+                input_data={"message": "hi"},
+                source_conversation_id=conversation_id,
+                turn_index=0,
+            )
+        ]
+
+        await service.import_bundle(
+            EvaluationImportRequest(
+                bundle=bundle,
+                target_workflow_id=target,
+                existing_suite_id=suite_id,
+            )
+        )
+
+        created = service.suites.create_evaluation.await_args.args[0]
+        rule = created.technique_configs["tool_used"]["rules"][0]
+        assert rule["target_case_id"] == str(existing.id)
+
+    @pytest.mark.asyncio
+    async def test_reuse_warns_when_case_counts_differ(self):
+        service = _import_service(uuid4())
+        suite_id, target = uuid4(), uuid4()
+        service.suites.get_suite.return_value = SimpleNamespace(
+            id=suite_id, name="HR dataset", workflow_id=target
+        )
+        service.suites.list_cases_for_suite.return_value = [
+            self._existing_case(suite_id, uuid4(), 0)
+        ]
+
+        result = await service.import_bundle(
+            EvaluationImportRequest(
+                bundle=_bundle(str(uuid4()), str(uuid4())),
+                target_workflow_id=target,
+                existing_suite_id=suite_id,
+            )
+        )
+
+        assert any("1 case(s)" in w and "bundle has 2" in w for w in result.warnings)
+
+    @pytest.mark.asyncio
+    async def test_reuse_of_a_deleted_dataset_is_rejected(self):
+        service = _import_service(uuid4())
+        service.suites.get_suite.side_effect = AppException(
+            status_code=404, error_key=ErrorKey.NOT_FOUND
+        )
+
+        with pytest.raises(AppException) as excinfo:
+            await service.import_bundle(
+                EvaluationImportRequest(
+                    bundle=_bundle(str(uuid4()), str(uuid4())),
+                    target_workflow_id=uuid4(),
+                    existing_suite_id=uuid4(),
+                )
+            )
+        assert excinfo.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_a_reused_dataset_is_never_cleaned_up_on_failure(self):
+        service = _import_service(uuid4())
+        suite_id, target = uuid4(), uuid4()
+        service.suites.get_suite.return_value = SimpleNamespace(
+            id=suite_id, name="HR dataset", workflow_id=target
+        )
+        service.suites.list_cases_for_suite.return_value = []
+        service.suites.create_evaluation.side_effect = RuntimeError("db down")
+
+        with pytest.raises(RuntimeError):
+            await service.import_bundle(
+                EvaluationImportRequest(
+                    bundle=_bundle(str(uuid4()), str(uuid4())),
+                    target_workflow_id=target,
+                    existing_suite_id=suite_id,
+                )
+            )
+
+        service.suites.delete_suite.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_dataset_on_another_version_of_the_same_workflow_is_offered(self):
+        """Datasets stay attached to the version current when they were made, so
+        scoping to one version would keep creating the duplicates we removed."""
+        service = _import_service(uuid4())
+        agent_id, suite_id = uuid4(), uuid4()
+        v1, v2 = uuid4(), uuid4()
+        service.workflows.get_all_minimal.return_value = [
+            SimpleNamespace(id=v1, agent_id=agent_id),
+            SimpleNamespace(id=v2, agent_id=agent_id),
+        ]
+        service.suites.list_suites.return_value = [
+            SimpleNamespace(id=suite_id, name="hr dataset", workflow_id=v1)
+        ]
+        service.suites.list_cases_for_suite.return_value = [
+            self._existing_case(suite_id, uuid4(), 0)
+        ]
+
+        preview = await service.preview_import(
+            EvaluationImportPreviewRequest(
+                bundle=_bundle(str(uuid4()), str(uuid4())),
+                target_workflow_id=v2,
+            )
+        )
+
+        assert preview.existing_dataset is not None
+        assert preview.existing_dataset.id == suite_id
+
+    @pytest.mark.asyncio
+    async def test_reusing_another_workflows_dataset_is_rejected(self):
+        service = _import_service(uuid4())
+        suite_id = uuid4()
+        service.suites.get_suite.return_value = SimpleNamespace(
+            id=suite_id, name="HR dataset", workflow_id=uuid4()
+        )
+
+        with pytest.raises(AppException) as excinfo:
+            await service.import_bundle(
+                EvaluationImportRequest(
+                    bundle=_bundle(str(uuid4()), str(uuid4())),
+                    target_workflow_id=uuid4(),
+                    existing_suite_id=suite_id,
+                )
+            )
+        assert excinfo.value.status_code == 400
+        service.suites.create_evaluation.assert_not_awaited()
+
+
+class TestRoundTrip:
+    @pytest.mark.asyncio
+    async def test_exported_bundle_imports_with_target_ids(self):
+        export_service, _, _, _ = _export_fixture()
+        bundle = await export_service.export_evaluation(uuid4())
+
+        import_service = _import_service(uuid4())
+        result = await import_service.import_bundle(
+            EvaluationImportRequest(bundle=bundle, target_workflow_id=uuid4())
+        )
+
+        created = import_service.suites.create_evaluation.await_args.args[0]
+        rule = created.technique_configs["tool_used"]["rules"][0]
+        assert rule["tool_ids"] == ["tgt-tool-search"]
+        assert created.technique_configs["route_taken"]["rules"][0]["router"] == "tgt-router"
+        assert result.case_count == 1

--- a/frontend/src/interfaces/evalBundle.interface.ts
+++ b/frontend/src/interfaces/evalBundle.interface.ts
@@ -1,0 +1,106 @@
+export const EVALUATION_BUNDLE_KIND = "genassist.evaluation-bundle";
+
+export interface BundleNodeRef {
+  label?: string | null;
+  kind: string;
+  node_type?: string | null;
+}
+
+export interface BundleProviderRef {
+  name?: string | null;
+  provider?: string | null;
+  model?: string | null;
+}
+
+export interface BundleCase {
+  local_id: number;
+  input_data: Record<string, unknown>;
+  expected_output?: Record<string, unknown> | null;
+  tags?: string[] | null;
+  weight?: number | null;
+  source_conversation_id?: string | null;
+  turn_index?: number | null;
+}
+
+export interface EvaluationBundle {
+  kind: string;
+  schema_version: number;
+  source: {
+    workflow_id?: string | null;
+    workflow_name?: string | null;
+    workflow_version?: string | null;
+  };
+  evaluation: {
+    name: string;
+    description?: string | null;
+    techniques: string[];
+    technique_configs?: Record<string, unknown> | null;
+    input_metadata?: Record<string, unknown> | null;
+  };
+  dataset: {
+    name: string;
+    description?: string | null;
+    default_input_metadata?: Record<string, unknown> | null;
+    cases: BundleCase[];
+  };
+  references: {
+    nodes: Record<string, BundleNodeRef>;
+    llm_providers: Record<string, BundleProviderRef>;
+    cases: Record<string, number>;
+  };
+  notes: string[];
+}
+
+export interface BundleRefCandidate {
+  id: string;
+  label: string;
+}
+
+export interface BundleNodeResolution {
+  ref: string;
+  kind: string;
+  label?: string | null;
+  status: "resolved" | "ambiguous" | "missing";
+  resolved_id?: string | null;
+  resolved_label?: string | null;
+  candidates: BundleRefCandidate[];
+  note?: string | null;
+  original_type?: string | null;
+}
+
+export interface BundleProviderResolution {
+  ref: string;
+  name?: string | null;
+  model?: string | null;
+  status: "resolved" | "missing";
+  resolved_id?: string | null;
+  resolved_name?: string | null;
+}
+
+export interface BundleExistingDataset {
+  id: string;
+  name: string;
+  case_count: number;
+}
+
+export interface EvaluationImportPreview {
+  evaluation_name: string;
+  dataset_name: string;
+  case_count: number;
+  existing_dataset?: BundleExistingDataset | null;
+  workflow_name_matches: boolean;
+  node_refs: BundleNodeResolution[];
+  provider_refs: BundleProviderResolution[];
+  warnings: string[];
+  can_import: boolean;
+  dropping_all_would_empty?: boolean;
+}
+
+export interface EvaluationImportResult {
+  evaluation_id: string;
+  suite_id: string;
+  case_count: number;
+  reused_dataset: boolean;
+  dropped_rules: string[];
+  warnings: string[];
+}

--- a/frontend/src/interfaces/workflow.interface.ts
+++ b/frontend/src/interfaces/workflow.interface.ts
@@ -41,6 +41,8 @@ export interface WorkflowMinimal {
   name: string;
   version: string;
   agent_id?: string | null;
+  /** True for the version its agent points at — what the builder marks Active. */
+  is_active_version?: boolean;
 }
 
 export interface WorkflowSummary {

--- a/frontend/src/services/testEvaluations.ts
+++ b/frontend/src/services/testEvaluations.ts
@@ -1,5 +1,10 @@
 import { apiRequest } from "@/config/api";
 import {
+  EvaluationBundle,
+  EvaluationImportPreview,
+  EvaluationImportResult,
+} from "@/interfaces/evalBundle.interface";
+import {
   EvaluationToolCatalog,
   PaginatedEvaluations,
   StartedEvaluationRun,
@@ -103,4 +108,31 @@ export const getToolRuleResults = (runId: string) =>
   apiRequest<TestToolRuleResult[]>(
     "GET",
     `${BASE}/runs/${runId}/tool-rule-results`,
+  );
+
+export const exportTestEvaluation = (id: string) =>
+  apiRequest<EvaluationBundle>("GET", `${BASE}/evaluations/${id}/export`);
+
+export interface EvaluationImportPayload {
+  bundle: EvaluationBundle;
+  target_workflow_id: string;
+  existing_suite_id?: string;
+  resolutions?: Record<string, string>;
+  drop_unresolved_rules?: boolean;
+}
+
+export const previewEvaluationImport = (
+  payload: Pick<EvaluationImportPayload, "bundle" | "target_workflow_id">,
+) =>
+  apiRequest<EvaluationImportPreview>(
+    "POST",
+    `${BASE}/evaluations/import/preview`,
+    payload as unknown as Record<string, unknown>,
+  );
+
+export const importEvaluation = (payload: EvaluationImportPayload) =>
+  apiRequest<EvaluationImportResult>(
+    "POST",
+    `${BASE}/evaluations/import`,
+    payload as unknown as Record<string, unknown>,
   );

--- a/frontend/src/views/TestSuites/components/EvaluationListRow.tsx
+++ b/frontend/src/views/TestSuites/components/EvaluationListRow.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Loader2, MoreVertical, Pencil, Play, Trash2 } from "lucide-react";
+import { Download, Loader2, MoreVertical, Pencil, Play, Trash2 } from "lucide-react";
 import { Button } from "@/components/button";
 import { Badge } from "@/components/badge";
 import { Progress } from "@/components/progress";
@@ -22,6 +22,7 @@ interface EvaluationListRowProps {
   lastRunStatus?: string;
   onOpen: () => void;
   onEdit: () => void;
+  onExport: () => void;
   onDelete: () => void;
   onRun: (e: React.MouseEvent) => void;
 }
@@ -33,6 +34,7 @@ export const EvaluationListRow: React.FC<EvaluationListRowProps> = ({
   lastRunStatus,
   onOpen,
   onEdit,
+  onExport,
   onDelete,
   onRun,
 }) => (
@@ -106,6 +108,10 @@ export const EvaluationListRow: React.FC<EvaluationListRowProps> = ({
             >
               <Pencil className="h-4 w-4 mr-2" />
               Edit
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={onExport}>
+              <Download className="h-4 w-4 mr-2" />
+              Export
             </DropdownMenuItem>
             <DropdownMenuItem
               disabled={isRunning}

--- a/frontend/src/views/TestSuites/components/EvaluationWizard.tsx
+++ b/frontend/src/views/TestSuites/components/EvaluationWizard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Button } from "@/components/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -35,6 +35,7 @@ import type {
   ToolUsagePerToolCheck,
   ToolUsageRule,
 } from "@/interfaces/testEvaluation.interface";
+import { WorkflowVersionPicker } from "./WorkflowVersionPicker";
 import { getEvaluationToolCatalog } from "@/services/testEvaluations";
 import { listTestCases } from "@/services/testSuites";
 import type { TestCase } from "@/interfaces/testSuite.interface";
@@ -276,19 +277,6 @@ const STEPS: { key: WizardStep; label: string; icon: React.ElementType }[] = [
   { key: "configure", label: "Configure", icon: SlidersHorizontal },
 ];
 
-// Compare two workflow version strings numerically (e.g. "10" > "9", "1.2" > "1.1").
-// Returns a - b, so the highest version sorts last with a plain ascending sort.
-const compareVersions = (a: string, b: string): number => {
-  const parse = (v: string) => v.split(".").map((part) => parseInt(part.replace(/\D/g, ""), 10) || 0);
-  const pa = parse(a);
-  const pb = parse(b);
-  const len = Math.max(pa.length, pb.length);
-  for (let i = 0; i < len; i++) {
-    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
-    if (diff !== 0) return diff;
-  }
-  return 0;
-};
 
 const MetricOption: React.FC<{
   metric: MetricDef;
@@ -381,25 +369,6 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   // Which workflow group's version list is expanded (only one at a time; collapsed
   // by default so the list stays short).
-  const [expandedWorkflowName, setExpandedWorkflowName] = useState<string | null>(null);
-
-  // Group workflows by name, newest version first, so each name shows its current
-  // version with older versions nested beneath it.
-  const workflowGroups = useMemo(() => {
-    const byName = new Map<string, WorkflowMinimal[]>();
-    for (const wf of workflows) {
-      if (!wf.id) continue;
-      const existing = byName.get(wf.name) ?? [];
-      existing.push(wf);
-      byName.set(wf.name, existing);
-    }
-    return Array.from(byName.entries())
-      .map(([wfName, versions]) => ({
-        name: wfName,
-        versions: [...versions].sort((a, b) => compareVersions(b.version, a.version)),
-      }))
-      .sort((a, b) => a.name.localeCompare(b.name));
-  }, [workflows]);
 
   // Form state
   const [name, setName] = useState(initialData?.name ?? "");
@@ -717,7 +686,6 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
     setDescription("");
     setSuiteId("none");
     setWorkflowId(lockedWorkflowId ?? "none");
-    setExpandedWorkflowName(null);
     setMetrics(["exact_match"]);
     setInputMetadataText("{}");
     setIsMetadataValid(true);
@@ -761,8 +729,8 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
             <div>
               <Label className="text-sm font-medium">Select Workflow *</Label>
               <p className="text-xs text-muted-foreground">
-                Pick the workflow this evaluation runs against. The current version is shown
-                first, with older versions nested below it.
+                Pick the workflow this evaluation runs against. Expand a workflow to
+                choose a version; the one marked Current is what a plain run executes.
               </p>
             </div>
 
@@ -771,97 +739,27 @@ export const EvaluationWizard: React.FC<EvaluationWizardProps> = ({
                 {workflows.find((wf) => wf.id === lockedWorkflowId)?.name ?? "This workflow"}
               </div>
             ) : (
-              <div className="rounded-lg border p-2 space-y-0.5">
-                <button
-                  type="button"
-                  onClick={() => setWorkflowId("none")}
-                  className={cn(
-                    "flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm transition-colors",
-                    workflowId === "none"
-                      ? "bg-primary/10 font-semibold text-primary"
-                      : "font-medium text-muted-foreground hover:bg-muted hover:text-foreground",
-                  )}
-                >
-                  <Database className="h-4 w-4 shrink-0 text-muted-foreground" />
-                  <span className="truncate">Use dataset's default workflow</span>
-                  {workflowId === "none" && <Check className="ml-auto h-4 w-4 shrink-0" />}
-                </button>
-
-                {workflowGroups.map((group) => {
-                  const isExpanded = expandedWorkflowName === group.name;
-                  const selectedInGroup = group.versions.find((wf) => wf.id === workflowId);
-                  return (
-                    <div key={group.name}>
-                      {/* Workflow name = collapsible header; opening it selects the current
-                          version (collapsed by default to keep the list short). */}
-                      <button
-                        type="button"
-                        onClick={() => {
-                          if (isExpanded) {
-                            setExpandedWorkflowName(null);
-                          } else {
-                            setExpandedWorkflowName(group.name);
-                            setWorkflowId(group.versions[0].id);
-                          }
-                        }}
-                        className={cn(
-                          "flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left transition-colors",
-                          selectedInGroup ? "bg-primary/10" : "hover:bg-muted",
-                        )}
-                      >
-                        <ChevronRight
-                          className={cn(
-                            "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
-                            isExpanded && "rotate-90",
-                          )}
-                        />
-                        <span
-                          className={cn(
-                            "truncate text-sm font-semibold",
-                            selectedInGroup ? "text-primary" : "text-foreground",
-                          )}
-                        >
-                          {group.name}
-                        </span>
-                        {!isExpanded && selectedInGroup && (
-                          <span className="ml-auto shrink-0 text-xs font-medium text-primary">
-                            v{selectedInGroup.version}
-                          </span>
-                        )}
-                      </button>
-                      {isExpanded && (
-                        <div className="relative py-0.5 pl-[30px]">
-                          <div className="absolute bottom-0 left-[18px] top-0 w-px bg-border" />
-                          {group.versions.map((wf, idx) => {
-                            const selected = workflowId === wf.id;
-                            return (
-                              <button
-                                key={wf.id}
-                                type="button"
-                                onClick={() => setWorkflowId(wf.id)}
-                                className={cn(
-                                  "flex w-full items-center gap-2 rounded-md px-2.5 py-[6px] text-sm transition-colors",
-                                  selected
-                                    ? "bg-primary/10 font-semibold text-primary"
-                                    : "font-medium text-muted-foreground hover:bg-muted hover:text-foreground",
-                                )}
-                              >
-                                <span className="truncate">v{wf.version}</span>
-                                {idx === 0 && (
-                                  <span className="rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold text-primary-foreground">
-                                    Current
-                                  </span>
-                                )}
-                                {selected && <Check className="ml-auto h-4 w-4 shrink-0" />}
-                              </button>
-                            );
-                          })}
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
+              <WorkflowVersionPicker
+                workflows={workflows}
+                selectedWorkflowId={workflowId}
+                onSelect={setWorkflowId}
+                leadingOption={
+                  <button
+                    type="button"
+                    onClick={() => setWorkflowId("none")}
+                    className={cn(
+                      "flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm transition-colors",
+                      workflowId === "none"
+                        ? "bg-primary/10 font-semibold text-primary"
+                        : "font-medium text-muted-foreground hover:bg-muted hover:text-foreground",
+                    )}
+                  >
+                    <Database className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <span className="truncate">Use dataset's default workflow</span>
+                    {workflowId === "none" && <Check className="ml-auto h-4 w-4 shrink-0" />}
+                  </button>
+                }
+              />
             )}
           </div>
         );

--- a/frontend/src/views/TestSuites/components/ImportEvaluationDialog.tsx
+++ b/frontend/src/views/TestSuites/components/ImportEvaluationDialog.tsx
@@ -1,0 +1,484 @@
+import React, { useMemo, useRef, useState } from "react";
+import { AlertTriangle, ChevronLeft, FileJson, Loader2, Upload } from "lucide-react";
+import toast from "react-hot-toast";
+
+import { Button } from "@/components/button";
+import { Checkbox } from "@/components/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/select";
+import {
+  EvaluationBundle,
+  EvaluationImportPreview,
+  EvaluationImportResult,
+} from "@/interfaces/evalBundle.interface";
+import { EvaluationToolCatalog } from "@/interfaces/testEvaluation.interface";
+import { WorkflowMinimal } from "@/interfaces/workflow.interface";
+import {
+  getEvaluationToolCatalog,
+  importEvaluation,
+  previewEvaluationImport,
+} from "@/services/testEvaluations";
+import { nodeRefKey, parseBundleFile } from "../helpers/evalBundle";
+import { groupWorkflowVersions } from "../helpers/workflowVersions";
+import { ImportMappingTable } from "./ImportMappingTable";
+import { WorkflowVersionPicker } from "./WorkflowVersionPicker";
+
+type ImportStep = "file" | "workflow" | "review";
+
+interface ImportEvaluationDialogProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  workflows: WorkflowMinimal[];
+  onImported: (result: EvaluationImportResult) => void;
+}
+
+/** Prefer the specific reason over the generic message: import errors name the
+ * reference that could not be re-linked, which is what the user must act on. */
+const apiErrorDetail = (error: unknown): string | undefined => {
+  const data = (
+    error as { response?: { data?: { error?: unknown; error_detail?: unknown } } }
+  )?.response?.data;
+  for (const candidate of [data?.error_detail, data?.error]) {
+    if (typeof candidate === "string" && candidate.trim()) return candidate;
+  }
+  return undefined;
+};
+
+export const ImportEvaluationDialog: React.FC<ImportEvaluationDialogProps> = ({
+  isOpen,
+  onOpenChange,
+  workflows,
+  onImported,
+}) => {
+  const [step, setStep] = useState<ImportStep>("file");
+  const [bundle, setBundle] = useState<EvaluationBundle | null>(null);
+  const [fileName, setFileName] = useState("");
+  const [fileError, setFileError] = useState("");
+  const [targetWorkflowId, setTargetWorkflowId] = useState("");
+  const [preview, setPreview] = useState<EvaluationImportPreview | null>(null);
+  const [catalog, setCatalog] = useState<EvaluationToolCatalog | null>(null);
+  const [catalogFailed, setCatalogFailed] = useState(false);
+  const [picks, setPicks] = useState<Record<string, string>>({});
+  const [dropUnresolved, setDropUnresolved] = useState(false);
+  const [reuseDataset, setReuseDataset] = useState(true);
+  const [isPreviewLoading, setIsPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState("");
+  const [isImporting, setIsImporting] = useState(false);
+  // Bumped per preview request (and on reset) so a slow response for a
+  // previously chosen workflow can never overwrite the current one.
+  const previewRequestRef = useRef(0);
+
+  const reset = () => {
+    previewRequestRef.current += 1;
+    setStep("file");
+    setBundle(null);
+    setFileName("");
+    setFileError("");
+    setTargetWorkflowId("");
+    setPreview(null);
+    setCatalog(null);
+    setCatalogFailed(false);
+    setPicks({});
+    setDropUnresolved(false);
+    setReuseDataset(true);
+    setIsPreviewLoading(false);
+    setPreviewError("");
+    setIsImporting(false);
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) reset();
+    onOpenChange(open);
+  };
+
+  const workflowGroups = useMemo(() => groupWorkflowVersions(workflows), [workflows]);
+
+  const handleFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (loadEvent) => {
+      try {
+        const parsed = parseBundleFile(String(loadEvent.target?.result ?? ""));
+        setBundle(parsed);
+        setFileName(file.name);
+        setFileError("");
+        preselectWorkflow(parsed);
+      } catch (error) {
+        setBundle(null);
+        setFileName(file.name);
+        setFileError(error instanceof Error ? error.message : "Could not read the file.");
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const preselectWorkflow = (parsed: EvaluationBundle) => {
+    const sourceName = parsed.source?.workflow_name?.trim().toLowerCase();
+    const group = sourceName
+      ? workflowGroups.find((g) => g.name.trim().toLowerCase() === sourceName)
+      : undefined;
+    // Land on the live version, which is what a plain run would execute; always
+    // overwrite so a selection from a previously chosen file cannot survive.
+    setTargetWorkflowId(group?.activeVersionId ?? group?.versions[0].id ?? "");
+  };
+
+  const loadPreview = async () => {
+    if (!bundle || !targetWorkflowId) return;
+    const requestId = ++previewRequestRef.current;
+    setStep("review");
+    setIsPreviewLoading(true);
+    setPreviewError("");
+    setPreview(null);
+    setPicks({});
+    setDropUnresolved(false);
+    setReuseDataset(true);
+    try {
+      const [previewData, catalogData] = await Promise.all([
+        previewEvaluationImport({ bundle, target_workflow_id: targetWorkflowId }),
+        getEvaluationToolCatalog(targetWorkflowId).catch(() => null),
+      ]);
+      if (requestId !== previewRequestRef.current) return;
+      setPreview(previewData);
+      setCatalog(catalogData);
+      // Without the catalog we cannot offer manual picks; say that rather than
+      // letting each row claim the workflow is empty.
+      setCatalogFailed(catalogData === null);
+      // When nothing matched, importing without those checks is the sane
+      // default — unless that would leave no checks at all, which import
+      // refuses, so offering it would be a dead end.
+      const nothingResolved =
+        (previewData?.node_refs.length ?? 0) > 0 &&
+        previewData!.node_refs.every((nodeRef) => nodeRef.status !== "resolved");
+      setDropUnresolved(
+        nothingResolved && !previewData?.dropping_all_would_empty,
+      );
+      if (!previewData) setPreviewError("Could not preview the import.");
+    } catch (error) {
+      if (requestId !== previewRequestRef.current) return;
+      setPreviewError(apiErrorDetail(error) ?? "Could not preview the import.");
+    } finally {
+      if (requestId === previewRequestRef.current) setIsPreviewLoading(false);
+    }
+  };
+
+  const unresolvedRefs = useMemo(() => {
+    if (!preview) return [];
+    return preview.node_refs.filter(
+      (nodeRef) => nodeRef.status !== "resolved" && !picks[nodeRefKey(nodeRef)],
+    );
+  }, [preview, picks]);
+
+  // Nothing at all matching means this is almost certainly the wrong workflow,
+  // not a mapping exercise — say so rather than posing a row of unanswerable
+  // questions.
+  const looksLikeWrongWorkflow = Boolean(
+    preview &&
+      preview.node_refs.length > 0 &&
+      preview.node_refs.every((nodeRef) => nodeRef.status !== "resolved"),
+  );
+
+  // Import refuses an evaluation with no checks left, so dropping is not a way
+  // forward here and the checkbox must not pretend otherwise.
+  const dropWouldEmpty = Boolean(preview?.dropping_all_would_empty);
+
+  const canImport =
+    Boolean(preview) &&
+    !isImporting &&
+    (unresolvedRefs.length === 0 || dropUnresolved);
+
+  const handleImport = async () => {
+    if (!bundle || !targetWorkflowId) return;
+    setIsImporting(true);
+    try {
+      const existingDatasetId = preview?.existing_dataset?.id;
+      const result = await importEvaluation({
+        bundle,
+        target_workflow_id: targetWorkflowId,
+        existing_suite_id:
+          reuseDataset && existingDatasetId ? existingDatasetId : undefined,
+        resolutions: picks,
+        drop_unresolved_rules: dropUnresolved,
+      });
+      if (!result) {
+        toast.error("You don't have permission to import evaluations.");
+        return;
+      }
+      const notes = [
+        result.reused_dataset ? "reusing the existing dataset" : null,
+        result.dropped_rules.length > 0
+          ? `${result.dropped_rules.length} rule${
+              result.dropped_rules.length !== 1 ? "s" : ""
+            } dropped`
+          : null,
+      ].filter(Boolean);
+      const suffix = notes.length > 0 ? ` (${notes.join(", ")})` : "";
+      toast.success(`Evaluation imported${suffix}`);
+      // These say what the import silently decided — e.g. that a reused dataset
+      // has a different number of cases than the file — so they must not be
+      // dropped just because the dialog is closing.
+      for (const warning of result.warnings) {
+        toast(warning, { icon: "⚠️", duration: 8000 });
+      }
+      handleOpenChange(false);
+      onImported(result);
+    } catch (error) {
+      toast.error(apiErrorDetail(error) ?? "Failed to import evaluation");
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
+  const renderFileStep = () => (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Upload an evaluation bundle exported from another environment. The
+        evaluation, its dataset and its checks are recreated here; run history
+        does not travel.
+      </p>
+      <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed py-8">
+        <FileJson className="h-8 w-8 text-muted-foreground" />
+        <Button variant="outline" className="relative">
+          <Upload className="mr-2 h-4 w-4" />
+          Choose bundle file
+          <Input
+            type="file"
+            accept=".json,application/json"
+            className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+            onChange={handleFile}
+          />
+        </Button>
+        {fileName && !fileError && (
+          <span className="text-xs text-muted-foreground">{fileName}</span>
+        )}
+        {fileError && <span className="text-xs text-destructive">{fileError}</span>}
+      </div>
+      {bundle && (
+        <div className="rounded-lg border bg-muted/40 p-4 text-sm space-y-1">
+          <div className="font-medium">{bundle.evaluation.name}</div>
+          <div className="text-muted-foreground">
+            Dataset "{bundle.dataset.name}" · {bundle.dataset.cases.length} case
+            {bundle.dataset.cases.length !== 1 ? "s" : ""} ·{" "}
+            {bundle.evaluation.techniques.length} metric
+            {bundle.evaluation.techniques.length !== 1 ? "s" : ""}
+          </div>
+          {bundle.source?.workflow_name && (
+            <div className="text-muted-foreground">
+              Exported from workflow "{bundle.source.workflow_name}"
+              {bundle.source.workflow_version ? ` v${bundle.source.workflow_version}` : ""}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  const renderWorkflowStep = () => (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Choose the workflow this evaluation should test. References in the
+        bundle's checks are matched against it by name.
+      </p>
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Target workflow
+        </Label>
+        <WorkflowVersionPicker
+          workflows={workflows}
+          selectedWorkflowId={targetWorkflowId}
+          onSelect={setTargetWorkflowId}
+        />
+        {bundle?.source?.workflow_name && targetWorkflowId && (
+          <p className="text-xs text-muted-foreground">
+            Pre-selected by matching the exported workflow's name.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+
+  const renderReviewStep = () => {
+    if (isPreviewLoading) {
+      return (
+        <div className="flex items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Checking the bundle against the target workflow…
+        </div>
+      );
+    }
+    if (previewError || !preview) {
+      return (
+        <div className="py-8 text-center text-sm text-destructive">
+          {previewError || "Could not preview the import."}
+        </div>
+      );
+    }
+    return (
+      <div className="space-y-4">
+        <div className="rounded-lg border bg-muted/40 p-4 text-sm space-y-2">
+          <div className="font-medium">{preview.evaluation_name}</div>
+          {preview.existing_dataset ? (
+            <div className="space-y-2">
+              <div className="text-muted-foreground">
+                A dataset named "{preview.existing_dataset.name}" already exists here.
+              </div>
+              <Select
+                value={reuseDataset ? "reuse" : "create"}
+                onValueChange={(value) => setReuseDataset(value === "reuse")}
+              >
+                <SelectTrigger className="h-8 w-full max-w-md">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="reuse">
+                    Use the existing dataset ({preview.existing_dataset.case_count} case
+                    {preview.existing_dataset.case_count !== 1 ? "s" : ""})
+                  </SelectItem>
+                  <SelectItem value="create">
+                    Create a second dataset from the file ({preview.case_count} case
+                    {preview.case_count !== 1 ? "s" : ""})
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          ) : (
+            <div className="text-muted-foreground">
+              Creates dataset "{preview.dataset_name}" with {preview.case_count} case
+              {preview.case_count !== 1 ? "s" : ""}.
+            </div>
+          )}
+        </div>
+
+        {looksLikeWrongWorkflow && (
+          <div className="rounded-lg border border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/40 p-3">
+            <div className="flex items-start gap-2 text-sm text-amber-900 dark:text-amber-200">
+              <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+              <div>
+                <p>No references match this workflow.</p>
+                <p className="mt-0.5 text-xs text-amber-800 dark:text-amber-300">
+                  {bundle?.source?.workflow_name
+                    ? `Exported from "${bundle.source.workflow_name}". `
+                    : ""}
+                  Go back to change the target, or import without these checks.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {preview.node_refs.length > 0 && (
+          <ImportMappingTable
+            nodeRefs={preview.node_refs}
+            catalog={catalog}
+            catalogUnavailable={catalogFailed}
+            picks={picks}
+            onPick={(pickKey, targetId) =>
+              setPicks((current) => ({ ...current, [pickKey]: targetId }))
+            }
+          />
+        )}
+
+        {preview.warnings.length > 0 && (
+          <div className="rounded-lg border border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/40 p-3 space-y-1">
+            {preview.warnings.map((warning) => (
+              <div
+                key={warning}
+                className="flex items-start gap-2 text-xs text-amber-800 dark:text-amber-300"
+              >
+                <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                {warning}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {unresolvedRefs.length > 0 && dropWouldEmpty && (
+          <p className="text-sm text-muted-foreground">
+            Dropping the unmatched references would leave this evaluation with no
+            checks, so it can't be imported against this workflow. Map them
+            above, or go back and choose a different workflow.
+          </p>
+        )}
+
+        {unresolvedRefs.length > 0 && !dropWouldEmpty && (
+          <label className="flex items-start gap-2 text-sm">
+            <Checkbox
+              checked={dropUnresolved}
+              onCheckedChange={(checked) => setDropUnresolved(checked === true)}
+              className="mt-0.5"
+            />
+            <span>
+              Drop the checks that use the {unresolvedRefs.length} reference
+              {unresolvedRefs.length !== 1 ? "s" : ""} I haven't matched. The
+              imported evaluation will check less than the original.
+            </span>
+          </label>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Import evaluation</DialogTitle>
+        </DialogHeader>
+
+        <div className="max-h-[60vh] overflow-y-auto pr-1">
+          {step === "file" && renderFileStep()}
+          {step === "workflow" && renderWorkflowStep()}
+          {step === "review" && renderReviewStep()}
+        </div>
+
+        <DialogFooter className="mt-2 gap-2 border-t pt-4">
+          {step !== "file" && (
+            <Button
+              variant="ghost"
+              className="mr-auto"
+              onClick={() => setStep(step === "review" ? "workflow" : "file")}
+              disabled={isImporting}
+            >
+              <ChevronLeft className="mr-1 h-4 w-4" />
+              Back
+            </Button>
+          )}
+          <Button variant="outline" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          {step === "file" && (
+            <Button disabled={!bundle} onClick={() => setStep("workflow")}>
+              Next
+            </Button>
+          )}
+          {step === "workflow" && (
+            <Button disabled={!targetWorkflowId} onClick={() => void loadPreview()}>
+              Next
+            </Button>
+          )}
+          {step === "review" && (
+            <Button disabled={!canImport} onClick={() => void handleImport()}>
+              {isImporting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Import
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/views/TestSuites/components/ImportMappingTable.tsx
+++ b/frontend/src/views/TestSuites/components/ImportMappingTable.tsx
@@ -1,0 +1,225 @@
+import React, { useState } from "react";
+import { AlertTriangle, CheckCircle2 } from "lucide-react";
+
+import { Badge } from "@/components/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/select";
+import { BundleNodeResolution } from "@/interfaces/evalBundle.interface";
+import { EvaluationToolCatalog } from "@/interfaces/testEvaluation.interface";
+import {
+  buildNodeTypeIndex,
+  catalogOptionsForKind,
+  narrowToOriginalType,
+  nodeRefKey,
+} from "../helpers/evalBundle";
+
+const KIND_LABELS: Record<string, string> = {
+  tool: "Tool",
+  agent: "Agent",
+  router: "Router",
+  action: "Node",
+};
+
+// Plural nouns for the "this workflow has none of these" message.
+const KIND_PLURALS: Record<string, string> = {
+  tool: "tools",
+  agent: "agents",
+  router: "routers",
+  action: "nodes",
+};
+
+interface ImportMappingTableProps {
+  nodeRefs: BundleNodeResolution[];
+  catalog: EvaluationToolCatalog | null;
+  /** The target workflow's nodes could not be loaded, so manual picks are impossible. */
+  catalogUnavailable?: boolean;
+  /** Manual picks keyed by nodeRefKey (kind + ref, since a ref can appear under two kinds). */
+  picks: Record<string, string>;
+  onPick: (pickKey: string, targetId: string) => void;
+}
+
+/** One row per reference the bundle's checks point at, with a manual pick for
+ * anything that did not resolve against the target workflow. */
+const countLabels = (labels: string[]): Map<string, number> => {
+  const counts = new Map<string, number>();
+  for (const label of labels) counts.set(label, (counts.get(label) ?? 0) + 1);
+  return counts;
+};
+
+/** A label shared by several nodes (a workflow can hold many "Set State" nodes)
+ * makes entries indistinguishable — append a short id to those. */
+const disambiguate = (label: string, id: string, counts: Map<string, number>) =>
+  (counts.get(label) ?? 0) > 1 ? `${label} (${id.slice(0, 6)})` : label;
+
+const buildDisplayNames = (
+  nodeRefs: BundleNodeResolution[],
+): Record<string, string> => {
+  const counts = countLabels(nodeRefs.map((r) => r.label || r.ref));
+  const names: Record<string, string> = {};
+  for (const nodeRef of nodeRefs) {
+    const label = nodeRef.label || nodeRef.ref;
+    names[nodeRefKey(nodeRef)] = disambiguate(label, nodeRef.ref, counts);
+  }
+  return names;
+};
+
+export const ImportMappingTable: React.FC<ImportMappingTableProps> = ({
+  nodeRefs,
+  catalog,
+  catalogUnavailable = false,
+  picks,
+  onPick,
+}) => {
+  const displayNames = buildDisplayNames(nodeRefs);
+  const typeById = buildNodeTypeIndex(catalog);
+  const hasUnresolved = nodeRefs.some((nodeRef) => nodeRef.status !== "resolved");
+  // Rows where the user asked to see every node, not just same-type ones.
+  const [showAllFor, setShowAllFor] = useState<Set<string>>(new Set());
+  const allowAll = (key: string) =>
+    setShowAllFor((current) => new Set(current).add(key));
+  return (
+  <div className="space-y-2">
+  {catalogUnavailable && hasUnresolved && (
+    <p className="flex items-start gap-1.5 text-xs text-amber-700 dark:text-amber-400">
+      <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+      Couldn't load this workflow's nodes, so references can't be mapped by hand
+      right now. Retry, or import without the unmatched checks.
+    </p>
+  )}
+  <div className="rounded-lg border overflow-hidden">
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="border-b bg-muted text-left text-xs font-medium text-muted-foreground">
+          <th className="px-4 py-2 font-medium">Reference</th>
+          <th className="px-4 py-2 font-medium">Kind</th>
+          <th className="px-4 py-2 font-medium">Target</th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-border">
+        {nodeRefs.map((nodeRef) => {
+          const isResolved = nodeRef.status === "resolved";
+          // A note means the name matched but something about it needs a human
+          // decision (a differing node type), so offer the whole catalog rather
+          // than only the suspicious candidate.
+          const needsReview = Boolean(nodeRef.note);
+          const isAmbiguous = nodeRef.status === "ambiguous";
+          const rowKey = nodeRefKey(nodeRef);
+          const allOptions =
+            isAmbiguous && !needsReview
+              ? nodeRef.candidates
+              : catalogOptionsForKind(catalog, nodeRef.kind);
+          // Offer only nodes that could play the same role as the original;
+          // picking among every node in the graph is not a decision anyone can
+          // make well. The full list stays one click away.
+          // A "needs review" row asks the user to confirm one specific candidate,
+          // so that candidate must survive narrowing. Only that row: for an
+          // ambiguous row the options ARE the candidates, and keeping them all
+          // would disable narrowing entirely.
+          const sameType = showAllFor.has(rowKey)
+            ? null
+            : narrowToOriginalType(
+                allOptions,
+                nodeRef.original_type,
+                typeById,
+                needsReview ? nodeRef.candidates : [],
+              );
+          const options = sameType ?? allOptions;
+          const hiddenCount = sameType ? allOptions.length - sameType.length : 0;
+          // Nodes of this kind exist, but none of the original's type.
+          const noSuitableType = options.length === 0 && allOptions.length > 0;
+          const optionCounts = countLabels(options.map((o) => o.label));
+          return (
+            <tr key={`${nodeRef.kind}:${nodeRef.ref}`}>
+              <td className="px-4 py-2">
+                <span className="font-medium">{displayNames[rowKey]}</span>
+                {nodeRef.original_type && !isResolved && (
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    was a {nodeRef.original_type}
+                  </p>
+                )}
+                {nodeRef.note && (
+                  <p className="mt-0.5 text-xs text-muted-foreground">{nodeRef.note}</p>
+                )}
+              </td>
+              <td className="px-4 py-2">
+                <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+                  {KIND_LABELS[nodeRef.kind] ?? nodeRef.kind}
+                </Badge>
+              </td>
+              <td className="px-4 py-2">
+                {isResolved ? (
+                  <span className="flex items-center gap-1.5 text-green-700 dark:text-green-400">
+                    <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+                    {nodeRef.resolved_label || nodeRef.resolved_id}
+                  </span>
+                ) : options.length > 0 ? (
+                  <>
+                  <Select
+                    value={picks[rowKey] ?? ""}
+                    onValueChange={(value) => onPick(rowKey, value)}
+                  >
+                    <SelectTrigger className="h-8 w-full max-w-64">
+                      <SelectValue
+                        placeholder={
+                          needsReview
+                            ? "Confirm or pick the right node"
+                            : isAmbiguous
+                              ? "Several matches — choose one"
+                              : "No match — choose manually"
+                        }
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {options.map((option) => (
+                        <SelectItem key={option.id} value={option.id}>
+                          {disambiguate(option.label, option.id, optionCounts)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {hiddenCount > 0 && (
+                    <button
+                      type="button"
+                      onClick={() => allowAll(rowKey)}
+                      className="mt-1 text-xs text-muted-foreground underline hover:text-foreground"
+                    >
+                      Showing same-type nodes only — show all {allOptions.length}
+                    </button>
+                  )}
+                  </>
+                ) : noSuitableType ? (
+                  <div className="space-y-1">
+                    <span className="flex items-center gap-1.5 text-amber-700 dark:text-amber-400">
+                      <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+                      No {nodeRef.original_type} in this workflow
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => allowAll(rowKey)}
+                      className="text-xs text-muted-foreground underline hover:text-foreground"
+                    >
+                      Choose from all {allOptions.length} anyway
+                    </button>
+                  </div>
+                ) : (
+                  <span className="flex items-center gap-1.5 text-amber-700 dark:text-amber-400">
+                    <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+                    This workflow has no {KIND_PLURALS[nodeRef.kind] ?? "matches"} to
+                    map to
+                  </span>
+                )}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  </div>
+  </div>
+  );
+};

--- a/frontend/src/views/TestSuites/components/WorkflowVersionPicker.tsx
+++ b/frontend/src/views/TestSuites/components/WorkflowVersionPicker.tsx
@@ -1,0 +1,127 @@
+import React, { useMemo, useState } from "react";
+import { Check, ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { WorkflowMinimal } from "@/interfaces/workflow.interface";
+import { groupWorkflowVersions } from "../helpers/workflowVersions";
+
+interface WorkflowVersionPickerProps {
+  workflows: WorkflowMinimal[];
+  selectedWorkflowId: string;
+  onSelect: (workflowId: string) => void;
+  /** Rendered above the workflows, e.g. "Use dataset's default workflow". */
+  leadingOption?: React.ReactNode;
+  emptyMessage?: string;
+}
+
+/** Workflows as collapsible groups, each listing its versions with the live one
+ * marked. Shared by the evaluation wizard and the import dialog so both agree
+ * on what "current" means. */
+export const WorkflowVersionPicker: React.FC<WorkflowVersionPickerProps> = ({
+  workflows,
+  selectedWorkflowId,
+  onSelect,
+  leadingOption,
+  emptyMessage = "No workflows available.",
+}) => {
+  const groups = useMemo(() => groupWorkflowVersions(workflows), [workflows]);
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
+
+  return (
+    <div className="rounded-lg border p-2 space-y-0.5">
+      {leadingOption}
+
+      {groups.length === 0 && !leadingOption && (
+        <p className="px-2.5 py-2 text-sm text-muted-foreground">{emptyMessage}</p>
+      )}
+
+      {groups.map((group) => {
+        const isExpanded = expandedKey === group.key;
+        const selectedInGroup = group.versions.find(
+          (workflow) => workflow.id === selectedWorkflowId,
+        );
+        // Opening a group selects what a plain run would execute: the live
+        // version, or the newest when the workflow has no active pointer.
+        const defaultForGroup = group.activeVersionId ?? group.versions[0].id;
+        return (
+          <div key={group.key}>
+            <button
+              type="button"
+              onClick={() => {
+                if (isExpanded) {
+                  setExpandedKey(null);
+                  return;
+                }
+                setExpandedKey(group.key);
+                // Only default the selection when this group has none —
+                // re-opening a group must not discard a chosen version.
+                if (!selectedInGroup) onSelect(defaultForGroup);
+              }}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left transition-colors",
+                selectedInGroup ? "bg-primary/10" : "hover:bg-muted",
+              )}
+            >
+              <ChevronRight
+                className={cn(
+                  "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+                  isExpanded && "rotate-90",
+                )}
+              />
+              <span
+                className={cn(
+                  "truncate text-sm font-semibold",
+                  selectedInGroup ? "text-primary" : "text-foreground",
+                )}
+              >
+                {group.name}
+              </span>
+              {!isExpanded && selectedInGroup && (
+                <span className="ml-auto shrink-0 text-xs font-medium text-primary">
+                  v{selectedInGroup.version}
+                </span>
+              )}
+            </button>
+
+            {isExpanded && (
+              <div className="relative py-0.5 pl-[30px]">
+                <div className="absolute bottom-0 left-[18px] top-0 w-px bg-border" />
+                {group.versions.map((workflow) => {
+                  const selected = selectedWorkflowId === workflow.id;
+                  return (
+                    <button
+                      key={workflow.id}
+                      type="button"
+                      onClick={() => onSelect(workflow.id)}
+                      className={cn(
+                        "flex w-full items-center gap-2 rounded-md px-2.5 py-[6px] text-sm transition-colors",
+                        selected
+                          ? "bg-primary/10 font-semibold text-primary"
+                          : "font-medium text-muted-foreground hover:bg-muted hover:text-foreground",
+                      )}
+                    >
+                      <span className="truncate">v{workflow.version}</span>
+                      {workflow.id === group.activeVersionId && (
+                        <span className="rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold text-primary-foreground">
+                          Current
+                        </span>
+                      )}
+                      {/* A version's own name is what tells two apart once a
+                          workflow has been renamed between saves. */}
+                      {workflow.name !== group.name && (
+                        <span className="truncate text-xs text-muted-foreground">
+                          {workflow.name}
+                        </span>
+                      )}
+                      {selected && <Check className="ml-auto h-4 w-4 shrink-0" />}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/frontend/src/views/TestSuites/helpers/evalBundle.ts
+++ b/frontend/src/views/TestSuites/helpers/evalBundle.ts
@@ -1,0 +1,147 @@
+import {
+  EVALUATION_BUNDLE_KIND,
+  BundleRefCandidate,
+  EvaluationBundle,
+} from "@/interfaces/evalBundle.interface";
+import { EvaluationToolCatalog } from "@/interfaces/testEvaluation.interface";
+
+export const bundleFilename = (evaluationName: string): string => {
+  const slug = evaluationName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `evaluation-${slug || "bundle"}.json`;
+};
+
+export const downloadJsonFile = (filename: string, data: unknown): void => {
+  const blob = new Blob([JSON.stringify(data, null, 2)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+};
+
+const dedupeById = (options: BundleRefCandidate[]): BundleRefCandidate[] => {
+  const seen = new Set<string>();
+  return options.filter((option) => {
+    if (seen.has(option.id)) return false;
+    seen.add(option.id);
+    return true;
+  });
+};
+
+/** Target-workflow options a manual pick can choose from, per reference kind. */
+export const catalogOptionsForKind = (
+  catalog: EvaluationToolCatalog | null,
+  kind: string,
+): BundleRefCandidate[] => {
+  if (!catalog) return [];
+  if (kind === "tool") {
+    return dedupeById(
+      catalog.agents.flatMap((agent) =>
+        agent.tools.map((tool) => ({ id: tool.id, label: tool.label })),
+      ),
+    );
+  }
+  if (kind === "agent") {
+    return catalog.agents.map((agent) => ({ id: agent.id, label: agent.label }));
+  }
+  if (kind === "router") {
+    return catalog.routers.map((router) => ({ id: router.id, label: router.label }));
+  }
+  return catalog.action_nodes.map((node) => ({ id: node.id, label: node.label }));
+};
+
+/** Node type per target-workflow node id. Routers are omitted upstream because
+ * they are all routerNode, so a type comparison there says nothing. */
+export const buildNodeTypeIndex = (
+  catalog: EvaluationToolCatalog | null,
+): Record<string, string> => {
+  const types: Record<string, string> = {};
+  if (!catalog) return types;
+  for (const agent of catalog.agents) {
+    if (agent.type) types[agent.id] = agent.type;
+    for (const tool of agent.tools) {
+      if (tool.type) types[tool.id] = tool.type;
+    }
+  }
+  for (const node of catalog.action_nodes) {
+    if (node.type) types[node.id] = node.type;
+  }
+  return types;
+};
+
+/** Narrow a candidate list to nodes that could play the same role as the
+ * original — the ones sharing its node type.
+ *
+ * Returns null when narrowing says nothing: no recorded type, or every option
+ * already matches. An empty array is meaningful and distinct — the workflow has
+ * nodes of this kind but none of the right type — so the caller can say so
+ * rather than offering an arbitrary pick.
+ */
+export const narrowToOriginalType = (
+  options: BundleRefCandidate[],
+  originalType: string | null | undefined,
+  typeById: Record<string, string>,
+  alwaysKeep: BundleRefCandidate[] = [],
+): BundleRefCandidate[] | null => {
+  // With no types known (e.g. the catalog failed to load) narrowing would hide
+  // every option and claim nothing fits.
+  if (!originalType || Object.keys(typeById).length === 0) return null;
+  const keepIds = new Set(alwaysKeep.map((option) => option.id));
+  const narrowed = options.filter(
+    (option) => typeById[option.id] === originalType || keepIds.has(option.id),
+  );
+  return narrowed.length === options.length ? null : narrowed;
+};
+
+/** Key for manual resolution picks: a ref value can appear under two kinds
+ * (an agent node id is also an action node), so picks are keyed by both. */
+export const nodeRefKey = (nodeRef: { ref: string; kind: string }): string =>
+  `${nodeRef.kind}:${nodeRef.ref}`;
+
+export const parseBundleFile = (fileText: string): EvaluationBundle => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fileText);
+  } catch {
+    throw new Error("The file is not valid JSON.");
+  }
+  const bundle = parsed as EvaluationBundle;
+  const isBundle =
+    bundle &&
+    bundle.kind === EVALUATION_BUNDLE_KIND &&
+    Boolean(bundle.evaluation?.name) &&
+    Boolean(bundle.dataset?.name);
+  if (!isBundle) {
+    throw new Error("The file is not an evaluation bundle export.");
+  }
+  // A hand-edited bundle may omit optional collections; normalize them so the
+  // dialog never renders against undefined.
+  return {
+    ...bundle,
+    notes: Array.isArray(bundle.notes) ? bundle.notes : [],
+    evaluation: {
+      ...bundle.evaluation,
+      techniques: Array.isArray(bundle.evaluation.techniques)
+        ? bundle.evaluation.techniques
+        : [],
+    },
+    dataset: {
+      ...bundle.dataset,
+      cases: Array.isArray(bundle.dataset.cases) ? bundle.dataset.cases : [],
+    },
+    references: {
+      nodes: bundle.references?.nodes ?? {},
+      llm_providers: bundle.references?.llm_providers ?? {},
+      cases: bundle.references?.cases ?? {},
+    },
+  };
+};

--- a/frontend/src/views/TestSuites/helpers/workflowVersions.ts
+++ b/frontend/src/views/TestSuites/helpers/workflowVersions.ts
@@ -1,0 +1,59 @@
+import { WorkflowMinimal } from "@/interfaces/workflow.interface";
+
+/** Compare version strings numerically ("10" > "9", "1.2" > "1.1"), tolerating
+ * decoration like "v1.2". Returns a - b, so a plain ascending sort puts the
+ * highest version last. */
+export const compareVersions = (a: string, b: string): number => {
+  const parse = (value: string) =>
+    value.split(".").map((part) => parseInt(part.replace(/\D/g, ""), 10) || 0);
+  const left = parse(a);
+  const right = parse(b);
+  for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+    const diff = (left[index] ?? 0) - (right[index] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+};
+
+export interface WorkflowGroup {
+  key: string;
+  name: string;
+  /** Newest version first. */
+  versions: WorkflowMinimal[];
+  activeVersionId: string | null;
+}
+
+/** Group versions by the workflow they belong to, newest first.
+ *
+ * Versions of one workflow are separate rows sharing an ``agent_id``, and their
+ * names can differ (a rename between saves), so grouping by name would split
+ * them apart. The group takes its name from the live version, and the active
+ * version is the one its agent points at — the same pointer the builder marks
+ * Active and a plain evaluation run executes.
+ */
+export const groupWorkflowVersions = (
+  workflows: WorkflowMinimal[],
+): WorkflowGroup[] => {
+  const byWorkflow = new Map<string, WorkflowMinimal[]>();
+  for (const workflow of workflows) {
+    if (!workflow.id) continue;
+    // Legacy rows without an agent stand alone; fall back to name so they still group.
+    const key = workflow.agent_id ?? `name:${workflow.name}`;
+    byWorkflow.set(key, [...(byWorkflow.get(key) ?? []), workflow]);
+  }
+
+  return Array.from(byWorkflow.entries())
+    .map(([key, versions]) => {
+      const ordered = [...versions].sort((a, b) =>
+        compareVersions(b.version, a.version),
+      );
+      const active = ordered.find((workflow) => workflow.is_active_version);
+      return {
+        key,
+        name: (active ?? ordered[0]).name,
+        versions: ordered,
+        activeVersionId: active?.id ?? null,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+};

--- a/frontend/src/views/TestSuites/pages/EvaluationsPage.tsx
+++ b/frontend/src/views/TestSuites/pages/EvaluationsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { Activity, ListChecks, Loader2, Plus } from "lucide-react";
+import { Activity, ListChecks, Loader2, Plus, Upload } from "lucide-react";
 
 import { PageLayout } from "@/components/PageLayout";
 import { PageHeader } from "@/components/PageHeader";
@@ -21,6 +21,7 @@ import { WorkflowMinimal } from "@/interfaces/workflow.interface";
 import { TestSuite } from "@/interfaces/testSuite.interface";
 import { LLMProviderMinimal } from "@/interfaces/llmProvider.interface";
 import { EvaluationWizard, EvaluationWizardData } from "../components/EvaluationWizard";
+import { ImportEvaluationDialog } from "../components/ImportEvaluationDialog";
 import { EntityTitle } from "../components/EntityTitle";
 import { buildTechniqueConfigs, wizardMetadata } from "../helpers/evaluationForm";
 import { accuracyColorClass } from "../helpers/evaluationMetrics";
@@ -50,6 +51,7 @@ const EvaluationsPage: React.FC = () => {
   const [reloadKey, setReloadKey] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
 
   // Summaries carry the live health and running state. staleTime 0 makes
   // react-query refetch them when the tab regains focus; the interval only runs
@@ -201,6 +203,13 @@ const EvaluationsPage: React.FC = () => {
         searchPlaceholder="Search workflows..."
         actionButtonText="New Evaluation"
         onActionClick={() => setIsCreateDialogOpen(true)}
+        secondaryActionButtonText={
+          <>
+            <Upload className="w-4 h-4" />
+            Import
+          </>
+        }
+        onSecondaryActionClick={() => setIsImportDialogOpen(true)}
       />
 
       <div className="rounded-lg border bg-card dark:bg-zinc-900 overflow-hidden">
@@ -261,6 +270,16 @@ const EvaluationsPage: React.FC = () => {
         workflows={workflows}
         providers={providers}
         mode="create"
+      />
+
+      <ImportEvaluationDialog
+        isOpen={isImportDialogOpen}
+        onOpenChange={setIsImportDialogOpen}
+        workflows={workflows}
+        onImported={(result) => {
+          void refetchSummaries();
+          navigate(`/tests/evaluations/${result.evaluation_id}`);
+        }}
       />
     </PageLayout>
   );

--- a/frontend/src/views/TestSuites/pages/WorkflowEvaluationsPage.tsx
+++ b/frontend/src/views/TestSuites/pages/WorkflowEvaluationsPage.tsx
@@ -24,6 +24,7 @@ import { getTestRunsBatch, listTestSuites } from "@/services/testSuites";
 import { getLLMProvidersMinimal } from "@/services/llmProviders";
 import {
   deleteTestEvaluation,
+  exportTestEvaluation,
   getWorkflowEvaluationsPage,
   runTestEvaluation,
   runWorkflowEvaluations,
@@ -37,6 +38,7 @@ import { EvaluationWizard, EvaluationWizardData } from "../components/Evaluation
 import { EvaluationListRow } from "../components/EvaluationListRow";
 import { RunAgainstVersionDialog } from "../components/RunAgainstVersionDialog";
 import { buildTechniqueConfigs, getEditInitialData, wizardMetadata } from "../helpers/evaluationForm";
+import { bundleFilename, downloadJsonFile } from "../helpers/evalBundle";
 
 const PAGE_SIZE = 20;
 const UNASSIGNED = "unassigned";
@@ -354,6 +356,21 @@ const WorkflowEvaluationsPage: React.FC = () => {
     }
   };
 
+  const handleExport = async (evaluation: TestEvaluationConfig) => {
+    if (!evaluation.id) return;
+    try {
+      const bundle = await exportTestEvaluation(evaluation.id);
+      if (!bundle) {
+        toast.error("You don't have permission to export evaluations.");
+        return;
+      }
+      downloadJsonFile(bundleFilename(evaluation.name), bundle);
+      toast.success("Evaluation exported");
+    } catch {
+      toast.error("Failed to export evaluation");
+    }
+  };
+
   const handleDelete = async (id: string) => {
     try {
       await deleteTestEvaluation(id);
@@ -494,6 +511,7 @@ const WorkflowEvaluationsPage: React.FC = () => {
                 }
                 onOpen={() => navigate(`/tests/evaluations/${evaluation.id}`)}
                 onEdit={() => setEditingEvaluation(evaluation)}
+                onExport={() => void handleExport(evaluation)}
                 onDelete={() => setDeletingEvaluationId(evaluation.id ?? null)}
                 onRun={(e) => handleQuickRun(evaluation, e)}
               />


### PR DESCRIPTION
## Description

- Export endpoint returns a portable bundle, with secret-looking fields stripped from configs and case inputs
- Import preview resolves references by node ID first then by name, and reports resolved / needs confirmation / missing before anything is written
- Unmatched rules can be dropped, unless that would leave the evaluation with no checks at all
- Datasets already on the target workflow are reused instead of duplicated, and provider references re-link to the target environment's own active provider by model name
- Fixes one workflow showing as several identical rows in the evaluations overview, and version pickers now mark the actually active version as Current

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [x] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
