### PR TITLE
feat: export and import all evaluations of a workflow at once

### DIFF
--- a/backend/app/api/v1/routes/test_evaluations.py
+++ b/backend/app/api/v1/routes/test_evaluations.py
@@ -12,10 +12,15 @@ from app.dependencies.dependency_injection import RedisString
 from app.dependencies.injector import injector
 from app.schemas.eval_bundle import (
     EvaluationBundle,
+    EvaluationBundleSet,
     EvaluationImportPreview,
     EvaluationImportPreviewRequest,
     EvaluationImportRequest,
     EvaluationImportResult,
+    EvaluationSetImportPreview,
+    EvaluationSetImportPreviewRequest,
+    EvaluationSetImportRequest,
+    EvaluationSetImportResult,
 )
 from app.schemas.test_suite import (
     EvaluationRunRequest,
@@ -117,6 +122,33 @@ async def import_evaluation(
     return await service.import_bundle(data)
 
 
+@router.post(
+    "/evaluations/import-set/preview",
+    response_model=EvaluationSetImportPreview,
+    dependencies=[Depends(auth), Depends(permissions(P.Evaluation.READ))],
+)
+async def preview_evaluation_set_import(
+    data: EvaluationSetImportPreviewRequest,
+    service: EvalBundleService = Injected(EvalBundleService),
+):
+    """Resolve a bundle set's references against a target workflow without importing."""
+    return await service.preview_set_import(data)
+
+
+@router.post(
+    "/evaluations/import-set",
+    response_model=EvaluationSetImportResult,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(auth), Depends(permissions(P.Evaluation.UPDATE))],
+)
+async def import_evaluation_set(
+    data: EvaluationSetImportRequest,
+    service: EvalBundleService = Injected(EvalBundleService),
+):
+    """Import the selected evaluations of a bundle set; one result per item."""
+    return await service.import_bundle_set(data)
+
+
 @router.get(
     "/evaluations/{evaluation_id}",
     response_model=TestEvaluation,
@@ -140,6 +172,19 @@ async def export_evaluation(
 ):
     """The evaluation, its dataset and reference labels as a portable bundle."""
     return await service.export_evaluation(evaluation_id)
+
+
+@router.get(
+    "/workflows/{workflow_id}/evaluations/export",
+    response_model=EvaluationBundleSet,
+    dependencies=[Depends(auth), Depends(permissions(P.Evaluation.READ))],
+)
+async def export_workflow_evaluations(
+    workflow_id: UUID,
+    service: EvalBundleService = Injected(EvalBundleService),
+):
+    """Every evaluation of this workflow as one portable bundle set."""
+    return await service.export_workflow_evaluations(workflow_id)
 
 
 @router.patch(

--- a/backend/app/schemas/eval_bundle.py
+++ b/backend/app/schemas/eval_bundle.py
@@ -117,6 +117,47 @@ class EvaluationBundle(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Bundle set: every evaluation of one workflow in a single file
+# ---------------------------------------------------------------------------
+
+EVALUATION_BUNDLE_SET_KIND = "genassist.evaluation-bundle-set"
+EVALUATION_BUNDLE_SET_SCHEMA_VERSION = 1
+
+MAX_SET_EVALUATIONS = 200
+MAX_SET_TOTAL_CASES = 20000
+# Datasets are not bounded by the evaluation count on their own: unreferenced
+# ones are rejected, but the cap keeps a crafted file from driving the
+# per-dataset lookups before that check can run.
+MAX_SET_DATASETS = 200
+
+
+class BundleSetDataset(BundleDataset):
+    """One dataset stored once for the whole set; items point at ``local_id``."""
+
+    local_id: int
+
+
+class BundleSetItem(BaseModel):
+    """One evaluation in a set; its dataset lives in the set's ``datasets``."""
+
+    evaluation: BundleEvaluation
+    dataset_local_id: int
+    references: BundleReferences = Field(default_factory=BundleReferences)
+    notes: List[str] = Field(default_factory=list)
+
+
+class EvaluationBundleSet(BaseModel):
+    # Plain str for the same reason as EvaluationBundle.kind: the runtime check
+    # gives a readable 400 where a Literal would fail with a raw 422.
+    kind: str = EVALUATION_BUNDLE_SET_KIND
+    schema_version: int = EVALUATION_BUNDLE_SET_SCHEMA_VERSION
+    source: BundleSource = Field(default_factory=BundleSource)
+    datasets: List[BundleSetDataset] = Field(default_factory=list)
+    evaluations: List[BundleSetItem] = Field(default_factory=list)
+    notes: List[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
 # Import preview / commit
 # ---------------------------------------------------------------------------
 
@@ -208,3 +249,84 @@ class EvaluationImportResult(BaseModel):
     reused_dataset: bool = False
     dropped_rules: List[str] = Field(default_factory=list)
     warnings: List[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Set import preview / commit
+# ---------------------------------------------------------------------------
+
+SET_ITEM_IMPORTED = "imported"
+SET_ITEM_SKIPPED = "skipped"
+SET_ITEM_FAILED = "failed"
+
+
+class EvaluationSetItemPreview(BaseModel):
+    """How one evaluation of the set would land on the target workflow."""
+
+    name: str
+    dataset_name: str
+    case_count: int
+    # An evaluation with this name already exists on the target workflow, so
+    # the import skips it unless the caller opts out of skipping.
+    already_exists: bool = False
+    dropping_all_would_empty: bool = False
+    # The reference keys THIS evaluation uses, so the UI can judge each row on
+    # its own instead of on the set-wide unmatched count.
+    node_ref_keys: List[str] = Field(default_factory=list)
+
+
+class BundleSetDatasetPreview(BaseModel):
+    local_id: int
+    name: str
+    case_count: int
+    existing_dataset: Optional[BundleExistingDataset] = None
+
+
+class EvaluationSetImportPreviewRequest(BaseModel):
+    bundle_set: EvaluationBundleSet
+    target_workflow_id: UUID
+
+
+class EvaluationSetImportPreview(BaseModel):
+    workflow_name_matches: bool
+    evaluations: List[EvaluationSetItemPreview] = Field(default_factory=list)
+    datasets: List[BundleSetDatasetPreview] = Field(default_factory=list)
+    # The union of every item's references, resolved once — each ref appears a
+    # single time no matter how many evaluations use it.
+    node_refs: List[BundleNodeResolution] = Field(default_factory=list)
+    provider_refs: List[BundleProviderResolution] = Field(default_factory=list)
+    warnings: List[str] = Field(default_factory=list)
+    can_import: bool
+
+
+class EvaluationSetImportRequest(BaseModel):
+    bundle_set: EvaluationBundleSet
+    target_workflow_id: UUID
+    # Positions (0-based) of the evaluations to import; None imports all.
+    include: Optional[List[int]] = Field(default=None, max_length=MAX_SET_EVALUATIONS)
+    # Shared manual picks, applied to every evaluation in the set.
+    resolutions: Dict[str, str] = Field(
+        default_factory=dict, max_length=MAX_BUNDLE_RESOLUTIONS
+    )
+    drop_unresolved_rules: bool = False
+    skip_existing: bool = True
+
+
+class EvaluationSetItemResult(BaseModel):
+    name: str
+    status: str
+    evaluation_id: Optional[UUID] = None
+    suite_id: Optional[UUID] = None
+    case_count: int = 0
+    reused_dataset: bool = False
+    dropped_rules: List[str] = Field(default_factory=list)
+    warnings: List[str] = Field(default_factory=list)
+    # Why the item failed or was skipped, in one client-safe sentence.
+    detail: Optional[str] = None
+
+
+class EvaluationSetImportResult(BaseModel):
+    results: List[EvaluationSetItemResult] = Field(default_factory=list)
+    imported: int = 0
+    skipped: int = 0
+    failed: int = 0

--- a/backend/app/services/eval_bundle.py
+++ b/backend/app/services/eval_bundle.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import copy
 import logging
 import re
+from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple
 from uuid import UUID
 
@@ -23,8 +24,13 @@ from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.schemas.eval_bundle import (
     EVALUATION_BUNDLE_KIND,
-    MAX_BUNDLE_CASES,
     EVALUATION_BUNDLE_SCHEMA_VERSION,
+    EVALUATION_BUNDLE_SET_KIND,
+    EVALUATION_BUNDLE_SET_SCHEMA_VERSION,
+    MAX_BUNDLE_CASES,
+    MAX_SET_DATASETS,
+    MAX_SET_EVALUATIONS,
+    MAX_SET_TOTAL_CASES,
     REF_KIND_ACTION,
     REF_KIND_AGENT,
     REF_KIND_ROUTER,
@@ -32,6 +38,9 @@ from app.schemas.eval_bundle import (
     REF_STATUS_AMBIGUOUS,
     REF_STATUS_MISSING,
     REF_STATUS_RESOLVED,
+    SET_ITEM_FAILED,
+    SET_ITEM_IMPORTED,
+    SET_ITEM_SKIPPED,
     BundleCase,
     BundleDataset,
     BundleEvaluation,
@@ -42,12 +51,22 @@ from app.schemas.eval_bundle import (
     BundleProviderResolution,
     BundleRefCandidate,
     BundleReferences,
+    BundleSetDataset,
+    BundleSetDatasetPreview,
+    BundleSetItem,
     BundleSource,
     EvaluationBundle,
+    EvaluationBundleSet,
     EvaluationImportPreview,
     EvaluationImportPreviewRequest,
     EvaluationImportRequest,
     EvaluationImportResult,
+    EvaluationSetImportPreview,
+    EvaluationSetImportPreviewRequest,
+    EvaluationSetImportRequest,
+    EvaluationSetImportResult,
+    EvaluationSetItemPreview,
+    EvaluationSetItemResult,
 )
 from app.db.models.test_suite import TestCaseModel
 from app.repositories.test_suite import TestCaseRepository
@@ -125,6 +144,40 @@ _MAX_METADATA_WARNINGS = 10
 
 def _normalize_name(value: Any) -> str:
     return str(value).strip().lower()
+
+
+_GENERIC_ITEM_FAILURE = "The evaluation could not be imported."
+_MAX_ITEM_DETAIL_CHARS = 300
+
+
+def _client_safe_item_detail(error: AppException) -> str:
+    """One item's failure reason, safe to return inside a 2xx batch result.
+
+    A batch result never reaches the exception handler, so it never passes that
+    gate on which error keys may expose ``error_detail`` outside dev. Only this
+    feature's own bundle messages are written for users; anything else could
+    carry internal text such as a raw validation error.
+    """
+    detail = (error.error_detail or "").strip()
+    if error.error_key != ErrorKey.EVALUATION_BUNDLE_INVALID or not detail:
+        return _GENERIC_ITEM_FAILURE
+    return detail[:_MAX_ITEM_DETAIL_CHARS]
+
+
+@dataclass
+class _BatchState:
+    """Bookkeeping shared by the items of one batch import."""
+
+    existing_names: set
+    # The caller's manual picks, applied to whichever items use those refs.
+    resolutions: Dict[str, str]
+    # Set-wide node metadata, so every item resolves as the preview did.
+    merged_nodes: Dict[str, BundleNodeRef]
+    suites_by_local: Dict[int, UUID] = field(default_factory=dict)
+    # Normalized dataset name -> the local id that already materialized it. A
+    # second dataset sharing that name is a different dataset and keeps its own
+    # cases, whether the first one was created here or already on the target.
+    dataset_owner_by_name: Dict[str, int] = field(default_factory=dict)
 
 
 class UnresolvedRefError(ValueError):
@@ -848,23 +901,37 @@ class EvalBundleService:
         Scoped to the workflow: two workflows can each own a "Regression set",
         and reusing the other one's would grade the wrong cases.
         """
+        found = await self._existing_datasets_by_name([name], target_workflow_id)
+        return found.get(_normalize_name(name))
+
+    async def _existing_datasets_by_name(
+        self, names: List[str], target_workflow_id: UUID
+    ) -> Dict[str, BundleExistingDataset]:
+        """Look several dataset names up in one pass, keyed by normalized name.
+
+        A set import asks about every dataset in the file, and scanning the
+        target's suites once per name turns a large file into a long run of
+        identical full scans.
+        """
+        wanted = {_normalize_name(name) for name in names}
+        if not wanted:
+            return {}
         version_ids = await self._workflow_version_ids(target_workflow_id)
-        suites = await self.suites.list_suites()
-        match = next(
-            (
-                s
-                for s in suites
-                if _normalize_name(s.name) == _normalize_name(name)
-                and str(s.workflow_id) in version_ids
-            ),
-            None,
-        )
-        if not match:
-            return None
-        cases = await self.suites.list_cases_for_suite(match.id)
-        return BundleExistingDataset(
-            id=match.id, name=match.name, case_count=len(cases)
-        )
+        matches: Dict[str, Any] = {}
+        for suite in await self.suites.list_suites():
+            key = _normalize_name(suite.name)
+            if key not in wanted or key in matches:
+                continue
+            if str(suite.workflow_id) in version_ids:
+                matches[key] = suite
+        return {
+            key: BundleExistingDataset(
+                id=suite.id,
+                name=suite.name,
+                case_count=len(await self.suites.list_cases_for_suite(suite.id)),
+            )
+            for key, suite in matches.items()
+        }
 
     def _dropping_all_would_empty(
         self, bundle: EvaluationBundle, resolution: Dict[str, Any]
@@ -1213,6 +1280,346 @@ class EvalBundleService:
             )
         return warnings
 
+    # ---- Set export / import ------------------------------------------------
+
+    async def export_workflow_evaluations(
+        self, workflow_id: UUID
+    ) -> EvaluationBundleSet:
+        """Every evaluation of the workflow (all versions) in one file, with
+        each shared dataset stored once."""
+        await self.workflows.get_by_id(workflow_id)
+        evaluations = await self._group_evaluations(workflow_id)
+        if not evaluations:
+            raise AppException(
+                status_code=404,
+                error_key=ErrorKey.NOT_FOUND,
+                error_detail="This workflow has no evaluations to export.",
+            )
+        if len(evaluations) > MAX_SET_EVALUATIONS:
+            raise AppException(
+                status_code=400,
+                error_key=ErrorKey.EVALUATION_BUNDLE_INVALID,
+                error_detail=(
+                    f"This workflow has {len(evaluations)} evaluations; the "
+                    f"export limit is {MAX_SET_EVALUATIONS}."
+                ),
+            )
+
+        datasets: Dict[str, BundleSetDataset] = {}
+        items: List[BundleSetItem] = []
+        for evaluation in evaluations:
+            bundle = await self.export_evaluation(evaluation.id)
+            suite_key = str(evaluation.suite_id)
+            if suite_key not in datasets:
+                datasets[suite_key] = BundleSetDataset(
+                    local_id=len(datasets) + 1, **bundle.dataset.model_dump()
+                )
+            items.append(
+                BundleSetItem(
+                    evaluation=bundle.evaluation,
+                    dataset_local_id=datasets[suite_key].local_id,
+                    references=bundle.references,
+                    notes=bundle.notes,
+                )
+            )
+
+        # Both bounds match the import side: a file this export refuses to cap
+        # would be rejected wholesale on the way back in.
+        oversized = next(
+            (d for d in datasets.values() if len(d.cases) > MAX_BUNDLE_CASES),
+            None,
+        )
+        if oversized:
+            raise AppException(
+                status_code=400,
+                error_key=ErrorKey.EVALUATION_BUNDLE_INVALID,
+                error_detail=(
+                    f"Dataset '{oversized.name}' has {len(oversized.cases)} "
+                    f"test cases; the limit is {MAX_BUNDLE_CASES}."
+                ),
+            )
+        total_cases = sum(len(d.cases) for d in datasets.values())
+        if total_cases > MAX_SET_TOTAL_CASES:
+            raise AppException(
+                status_code=400,
+                error_key=ErrorKey.EVALUATION_BUNDLE_INVALID,
+                error_detail=(
+                    f"The datasets hold {total_cases} test cases in total; the "
+                    f"export limit is {MAX_SET_TOTAL_CASES}."
+                ),
+            )
+        return EvaluationBundleSet(
+            source=await self._bundle_source(workflow_id),
+            datasets=list(datasets.values()),
+            evaluations=items,
+        )
+
+    async def _group_evaluations(self, workflow_id: UUID) -> List[Any]:
+        """The workflow group's evaluations, ordered by name for a stable file."""
+        version_ids = await self._workflow_version_ids(workflow_id)
+        evaluations = await self.suites.list_evaluations()
+        matched = [e for e in evaluations if str(e.workflow_id) in version_ids]
+        return sorted(matched, key=lambda e: _normalize_name(e.name))
+
+    async def preview_set_import(
+        self, request: EvaluationSetImportPreviewRequest
+    ) -> EvaluationSetImportPreview:
+        bundle_set = request.bundle_set
+        _validate_set_header(bundle_set)
+        target_workflow = await self.workflows.get_by_id(request.target_workflow_id)
+        resolution = await self._resolve_set_refs(
+            bundle_set, request.target_workflow_id
+        )
+        existing_names = await self._existing_evaluation_names(
+            request.target_workflow_id
+        )
+
+        datasets_by_id = {d.local_id: d for d in bundle_set.datasets}
+        keys_by_item = resolution["keys_by_item"]
+        item_previews: List[EvaluationSetItemPreview] = []
+        warnings: List[str] = []
+        for index, item in enumerate(bundle_set.evaluations):
+            dataset = datasets_by_id[item.dataset_local_id]
+            item_bundle = _item_bundle(
+                bundle_set, item, resolution["merged_nodes"]
+            )
+            item_previews.append(
+                EvaluationSetItemPreview(
+                    name=item.evaluation.name,
+                    dataset_name=dataset.name,
+                    case_count=len(dataset.cases),
+                    already_exists=_normalize_name(item.evaluation.name)
+                    in existing_names,
+                    dropping_all_would_empty=self._dropping_all_would_empty(
+                        item_bundle, resolution
+                    ),
+                    node_ref_keys=keys_by_item[index],
+                )
+            )
+            warnings.extend(self._preview_warnings(item_bundle, resolution))
+
+        existing_by_name = await self._existing_datasets_by_name(
+            [d.name for d in bundle_set.datasets], request.target_workflow_id
+        )
+        # Only the first dataset of a given name can attach to the target's own
+        # copy; the import gives every later namesake its own, so promising
+        # reuse for all of them would contradict what actually happens.
+        claimed_names: set = set()
+        dataset_previews = []
+        for dataset in bundle_set.datasets:
+            name_key = _normalize_name(dataset.name)
+            existing = (
+                None if name_key in claimed_names else existing_by_name.get(name_key)
+            )
+            claimed_names.add(name_key)
+            dataset_previews.append(
+                BundleSetDatasetPreview(
+                    local_id=dataset.local_id,
+                    name=dataset.name,
+                    case_count=len(dataset.cases),
+                    existing_dataset=existing,
+                )
+            )
+        workflow_name_matches = bool(
+            bundle_set.source.workflow_name
+            and _normalize_name(bundle_set.source.workflow_name)
+            == _normalize_name(target_workflow.name)
+        )
+        return EvaluationSetImportPreview(
+            workflow_name_matches=workflow_name_matches,
+            evaluations=item_previews,
+            datasets=dataset_previews,
+            node_refs=resolution["node_refs"],
+            provider_refs=resolution["provider_refs"],
+            warnings=list(dict.fromkeys(warnings)),
+            can_import=all(
+                ref.status == REF_STATUS_RESOLVED
+                for ref in resolution["node_refs"]
+            ),
+        )
+
+    async def _resolve_set_refs(
+        self, bundle_set: EvaluationBundleSet, target_workflow_id: UUID
+    ) -> Dict[str, Any]:
+        """The union of every item's references, each resolved exactly once.
+
+        Items are exported against their own pinned version, so one ref can
+        carry a label in one item and nothing in another. Resolution therefore
+        uses the best metadata ANY item recorded, and ``import_bundle_set``
+        replays the outcome to every item — a per-item re-resolution could
+        otherwise disagree with the preview the user approved.
+        """
+        catalog = await self._workflow_catalog(target_workflow_id)
+        indexes = build_node_indexes(catalog)
+        metadata = _merge_set_node_metadata(bundle_set)
+        merged_nodes = metadata["nodes"]
+        node_refs = [
+            resolve_node_ref(
+                ref,
+                kind,
+                merged_nodes[ref].label,
+                indexes,
+                merged_nodes[ref].node_type,
+            )
+            for ref, kind in metadata["refs_by_key"].values()
+        ]
+
+        provider_refs: List[BundleProviderResolution] = []
+        provider_meta = _merge_set_provider_metadata(bundle_set)
+        if provider_meta:
+            providers = await self.providers.get_all_minimal()
+            provider_refs = [
+                resolve_provider_ref(provider_id, meta, providers)
+                for provider_id, meta in provider_meta.items()
+            ]
+        return {
+            "catalog": catalog,
+            "node_refs": node_refs,
+            "provider_refs": provider_refs,
+            "keys_by_item": metadata["keys_by_item"],
+            "merged_nodes": merged_nodes,
+        }
+
+    async def _existing_evaluation_names(self, target_workflow_id: UUID) -> set:
+        """Names already used by the target workflow group's evaluations."""
+        version_ids = await self._workflow_version_ids(target_workflow_id)
+        evaluations = await self.suites.list_evaluations()
+        return {
+            _normalize_name(e.name)
+            for e in evaluations
+            if str(e.workflow_id) in version_ids
+        }
+
+    async def import_bundle_set(
+        self, request: EvaluationSetImportRequest
+    ) -> EvaluationSetImportResult:
+        """Import the selected evaluations one by one; a failure is recorded on
+        its item and never stops the rest of the batch."""
+        bundle_set = request.bundle_set
+        _validate_set_header(bundle_set)
+        await self.workflows.get_by_id(request.target_workflow_id)
+        selected = _selected_items(bundle_set, request.include)
+        existing_names = (
+            await self._existing_evaluation_names(request.target_workflow_id)
+            if request.skip_existing
+            else set()
+        )
+
+        # Every item resolves from the set-wide merge the preview used, so none
+        # of them can reach a verdict the user was not shown.
+        resolution = await self._resolve_set_refs(
+            bundle_set, request.target_workflow_id
+        )
+        batch = _BatchState(
+            existing_names=existing_names,
+            resolutions=request.resolutions,
+            merged_nodes=resolution["merged_nodes"],
+        )
+        results = [
+            await self._import_set_item(bundle_set, item, request, batch)
+            for item in selected
+        ]
+        return EvaluationSetImportResult(
+            results=results,
+            imported=sum(r.status == SET_ITEM_IMPORTED for r in results),
+            skipped=sum(r.status == SET_ITEM_SKIPPED for r in results),
+            failed=sum(r.status == SET_ITEM_FAILED for r in results),
+        )
+
+    async def _import_set_item(
+        self,
+        bundle_set: EvaluationBundleSet,
+        item: BundleSetItem,
+        request: EvaluationSetImportRequest,
+        batch: "_BatchState",
+    ) -> EvaluationSetItemResult:
+        name = item.evaluation.name
+        if _normalize_name(name) in batch.existing_names:
+            return EvaluationSetItemResult(
+                name=name,
+                status=SET_ITEM_SKIPPED,
+                detail=(
+                    "An evaluation with this name already exists on the "
+                    "target workflow."
+                ),
+            )
+        try:
+            result = await self.import_bundle(
+                EvaluationImportRequest(
+                    bundle=_item_bundle(bundle_set, item, batch.merged_nodes),
+                    target_workflow_id=request.target_workflow_id,
+                    existing_suite_id=await self._suite_to_reuse(
+                        bundle_set, item, request, batch
+                    ),
+                    resolutions=_resolutions_for_item(item, batch.resolutions),
+                    drop_unresolved_rules=request.drop_unresolved_rules,
+                )
+            )
+        except AppException as error:
+            logger.warning(
+                "Importing evaluation '%s' from a bundle set failed: %s (%s)",
+                name,
+                error.error_key,
+                error.error_detail,
+            )
+            return EvaluationSetItemResult(
+                name=name,
+                status=SET_ITEM_FAILED,
+                detail=_client_safe_item_detail(error),
+            )
+        except Exception:  # pylint: disable=broad-except
+            logger.exception(
+                "Importing evaluation '%s' from a bundle set failed", name
+            )
+            return EvaluationSetItemResult(
+                name=name,
+                status=SET_ITEM_FAILED,
+                detail=_GENERIC_ITEM_FAILURE,
+            )
+
+        batch.suites_by_local[item.dataset_local_id] = result.suite_id
+        batch.dataset_owner_by_name.setdefault(
+            _normalize_name(_dataset_of(bundle_set, item).name),
+            item.dataset_local_id,
+        )
+        if request.skip_existing:
+            # A second copy of the same name inside the file must not slip past
+            # the check that only looked at the database.
+            batch.existing_names.add(_normalize_name(name))
+        return EvaluationSetItemResult(
+            name=name,
+            status=SET_ITEM_IMPORTED,
+            evaluation_id=result.evaluation_id,
+            suite_id=result.suite_id,
+            case_count=result.case_count,
+            reused_dataset=result.reused_dataset,
+            dropped_rules=result.dropped_rules,
+            warnings=result.warnings,
+        )
+
+    async def _suite_to_reuse(
+        self,
+        bundle_set: EvaluationBundleSet,
+        item: BundleSetItem,
+        request: EvaluationSetImportRequest,
+        batch: "_BatchState",
+    ) -> Optional[UUID]:
+        """The dataset this item should attach to, if one already exists."""
+        batch_suite_id = batch.suites_by_local.get(item.dataset_local_id)
+        if batch_suite_id:
+            return batch_suite_id
+        dataset = _dataset_of(bundle_set, item)
+        owner = batch.dataset_owner_by_name.get(_normalize_name(dataset.name))
+        if owner is not None and owner != item.dataset_local_id:
+            # Another dataset in this file already took that name. The file
+            # keeps the two apart, so this one gets its own copy rather than
+            # collapsing onto the first and losing its cases.
+            return None
+        found = await self._find_existing_dataset(
+            dataset.name, request.target_workflow_id
+        )
+        return found.id if found else None
+
 
 def _bundle_case(
     case: TestCaseInDB,
@@ -1279,6 +1686,195 @@ def _map_resolver(node_map: Dict[str, str]) -> Resolver:
         return mapped
 
     return resolve
+
+
+def _resolutions_for_item(
+    item: BundleSetItem, resolutions: Dict[str, str]
+) -> Dict[str, str]:
+    """Only the picks this item's own references need.
+
+    An item's request carries its own resolution cap, and the set's union plus
+    the caller's manual picks can together exceed it — sending the whole map
+    would fail every item on a size limit that none of them actually reach.
+    """
+    configs = item.evaluation.technique_configs or {}
+    keys = {ref_key(ref, kind) for ref, kind in collect_node_refs(configs)}
+    return {key: value for key, value in resolutions.items() if key in keys}
+
+
+def _merge_set_node_metadata(bundle_set: EvaluationBundleSet) -> Dict[str, Any]:
+    """Best label and type recorded for each ref across all items, the union of
+    ref keys, and the keys each item uses.
+
+    First non-empty value wins: an item pinned to a version where the node was
+    deleted records nothing, and that absence must not hide the label a sibling
+    item carries.
+    """
+    labels: Dict[str, str] = {}
+    types: Dict[str, str] = {}
+    kinds: Dict[str, str] = {}
+    refs_by_key: Dict[str, Tuple[str, str]] = {}
+    keys_by_item: List[List[str]] = []
+    for item in bundle_set.evaluations:
+        configs = item.evaluation.technique_configs or {}
+        item_keys: List[str] = []
+        for ref, kind in collect_node_refs(configs):
+            key = ref_key(ref, kind)
+            refs_by_key.setdefault(key, (ref, kind))
+            kinds.setdefault(ref, kind)
+            if key not in item_keys:
+                item_keys.append(key)
+            node = item.references.nodes.get(ref)
+            if not node:
+                continue
+            if node.label and ref not in labels:
+                labels[ref] = node.label
+            if node.node_type and ref not in types:
+                types[ref] = node.node_type
+        keys_by_item.append(item_keys)
+    return {
+        "refs_by_key": refs_by_key,
+        "keys_by_item": keys_by_item,
+        # The merged view every item resolves from, so no item can reach a
+        # different verdict than the set-wide one the user was shown.
+        "nodes": {
+            ref: BundleNodeRef(
+                label=labels.get(ref), kind=kind, node_type=types.get(ref)
+            )
+            for ref, kind in kinds.items()
+        },
+    }
+
+
+def _merge_set_provider_metadata(
+    bundle_set: EvaluationBundleSet,
+) -> Dict[str, Optional[BundleProviderRef]]:
+    """Each provider id once, described by the first item that recorded it."""
+    merged: Dict[str, Optional[BundleProviderRef]] = {}
+    for item in bundle_set.evaluations:
+        configs = item.evaluation.technique_configs or {}
+        for provider_id in collect_provider_ids(configs):
+            if merged.get(provider_id) is not None:
+                continue
+            merged[provider_id] = item.references.llm_providers.get(provider_id)
+    return merged
+
+
+def _dataset_of(
+    bundle_set: EvaluationBundleSet, item: BundleSetItem
+) -> BundleSetDataset:
+    return next(
+        d for d in bundle_set.datasets if d.local_id == item.dataset_local_id
+    )
+
+
+def _item_bundle(
+    bundle_set: EvaluationBundleSet,
+    item: BundleSetItem,
+    merged_nodes: Optional[Dict[str, BundleNodeRef]] = None,
+) -> EvaluationBundle:
+    """A self-contained single bundle for one set item, so every single-bundle
+    rule (validation, resolution, dataset reuse) applies unchanged.
+
+    ``merged_nodes`` swaps the item's own node metadata for the set-wide merge.
+    Resolution is deterministic in its inputs, so an item given the merged view
+    reaches exactly the union's verdict: it can neither fail on a ref the
+    preview resolved, nor quietly resolve one the preview refused.
+    """
+    dataset = _dataset_of(bundle_set, item)
+    references = item.references
+    if merged_nodes is not None:
+        references = BundleReferences(
+            nodes=merged_nodes,
+            llm_providers=item.references.llm_providers,
+            # Case ids are this item's own; only node metadata is shared.
+            cases=item.references.cases,
+        )
+    return EvaluationBundle(
+        source=bundle_set.source,
+        evaluation=item.evaluation,
+        dataset=BundleDataset(**dataset.model_dump(exclude={"local_id"})),
+        references=references,
+        notes=item.notes,
+    )
+
+
+def _selected_items(
+    bundle_set: EvaluationBundleSet, include: Optional[List[int]]
+) -> List[BundleSetItem]:
+    """The items the caller picked, in file order; ``None`` selects all."""
+    if include is None:
+        return list(bundle_set.evaluations)
+    items = []
+    for position in dict.fromkeys(include):
+        if position < 0 or position >= len(bundle_set.evaluations):
+            raise AppException(
+                status_code=400,
+                error_key=ErrorKey.EVALUATION_BUNDLE_INVALID,
+                error_detail=f"Selection index {position} is out of range.",
+            )
+        items.append(bundle_set.evaluations[position])
+    return items
+
+
+def _validate_set_header(bundle_set: EvaluationBundleSet) -> None:
+    def invalid(detail: str) -> AppException:
+        return AppException(
+            status_code=400,
+            error_key=ErrorKey.EVALUATION_BUNDLE_INVALID,
+            error_detail=detail,
+        )
+
+    if bundle_set.kind != EVALUATION_BUNDLE_SET_KIND:
+        if bundle_set.kind == EVALUATION_BUNDLE_KIND:
+            raise invalid(
+                "The file is a single-evaluation bundle, not a bundle set."
+            )
+        raise invalid("The file is not an evaluation bundle set.")
+    if bundle_set.schema_version > EVALUATION_BUNDLE_SET_SCHEMA_VERSION:
+        raise invalid(
+            "The bundle set was exported by a newer version of the platform "
+            "and cannot be imported here."
+        )
+    if not bundle_set.evaluations:
+        raise invalid("The bundle set contains no evaluations.")
+    if len(bundle_set.evaluations) > MAX_SET_EVALUATIONS:
+        raise invalid(
+            f"This file has {len(bundle_set.evaluations)} evaluations; the "
+            f"import limit is {MAX_SET_EVALUATIONS}."
+        )
+    if len(bundle_set.datasets) > MAX_SET_DATASETS:
+        raise invalid(
+            f"This file has {len(bundle_set.datasets)} datasets; the import "
+            f"limit is {MAX_SET_DATASETS}."
+        )
+
+    local_ids = [d.local_id for d in bundle_set.datasets]
+    if len(set(local_ids)) != len(local_ids):
+        raise invalid("The file's datasets carry duplicate ids.")
+    known_ids = set(local_ids)
+    used_ids = {item.dataset_local_id for item in bundle_set.evaluations}
+    if used_ids - known_ids:
+        raise invalid(
+            "An evaluation in the file references a dataset that is not "
+            "part of the file."
+        )
+    if known_ids - used_ids:
+        # Unused datasets are pure payload: no evaluation would import them,
+        # but every one still costs a lookup in the preview.
+        raise invalid("The file contains datasets that no evaluation uses.")
+    for dataset in bundle_set.datasets:
+        if len(dataset.cases) > MAX_BUNDLE_CASES:
+            raise invalid(
+                f"Dataset '{dataset.name}' has {len(dataset.cases)} test "
+                f"cases; the import limit is {MAX_BUNDLE_CASES}."
+            )
+    total_cases = sum(len(d.cases) for d in bundle_set.datasets)
+    if total_cases > MAX_SET_TOTAL_CASES:
+        raise invalid(
+            f"The file holds {total_cases} test cases in total; the import "
+            f"limit is {MAX_SET_TOTAL_CASES}."
+        )
 
 
 def _validate_bundle_header(bundle: EvaluationBundle) -> None:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -19366,6 +19366,108 @@
         ]
       }
     },
+    "/api/genagent/eval/evaluations/import-set/preview": {
+      "post": {
+        "tags": [
+          "v1",
+          "Test Evaluations"
+        ],
+        "summary": "Preview Evaluation Set Import",
+        "description": "Resolve a bundle set's references against a target workflow without importing.",
+        "operationId": "preview_evaluation_set_import_api_genagent_eval_evaluations_import_set_preview_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvaluationSetImportPreviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluationSetImportPreview"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/genagent/eval/evaluations/import-set": {
+      "post": {
+        "tags": [
+          "v1",
+          "Test Evaluations"
+        ],
+        "summary": "Import Evaluation Set",
+        "description": "Import the selected evaluations of a bundle set; one result per item.",
+        "operationId": "import_evaluation_set_api_genagent_eval_evaluations_import_set_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvaluationSetImportRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluationSetImportResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
     "/api/genagent/eval/evaluations/{evaluation_id}": {
       "get": {
         "tags": [
@@ -19559,6 +19661,59 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EvaluationBundle-Output"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/genagent/eval/workflows/{workflow_id}/evaluations/export": {
+      "get": {
+        "tags": [
+          "v1",
+          "Test Evaluations"
+        ],
+        "summary": "Export Workflow Evaluations",
+        "description": "Every evaluation of this workflow as one portable bundle set.",
+        "operationId": "export_workflow_evaluations_api_genagent_eval_workflows__workflow_id__evaluations_export_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workflow_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workflow Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluationBundleSet-Output"
                 }
               }
             }
@@ -30230,6 +30385,145 @@
         "title": "BundleReferences",
         "description": "Label maps for every environment-specific id embedded in the configs.\n\n``cases`` maps an exported test case id to its ``local_id`` inside the\nbundle, so turn-targeted rules can be re-pointed at the recreated cases."
       },
+      "BundleSetDataset": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 200,
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "default_input_metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Input Metadata"
+          },
+          "cases": {
+            "items": {
+              "$ref": "#/components/schemas/BundleCase"
+            },
+            "type": "array",
+            "title": "Cases"
+          },
+          "local_id": {
+            "type": "integer",
+            "title": "Local Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "local_id"
+        ],
+        "title": "BundleSetDataset",
+        "description": "One dataset stored once for the whole set; items point at ``local_id``."
+      },
+      "BundleSetDatasetPreview": {
+        "properties": {
+          "local_id": {
+            "type": "integer",
+            "title": "Local Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "case_count": {
+            "type": "integer",
+            "title": "Case Count"
+          },
+          "existing_dataset": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BundleExistingDataset"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "local_id",
+          "name",
+          "case_count"
+        ],
+        "title": "BundleSetDatasetPreview"
+      },
+      "BundleSetItem-Input": {
+        "properties": {
+          "evaluation": {
+            "$ref": "#/components/schemas/BundleEvaluation"
+          },
+          "dataset_local_id": {
+            "type": "integer",
+            "title": "Dataset Local Id"
+          },
+          "references": {
+            "$ref": "#/components/schemas/BundleReferences"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "evaluation",
+          "dataset_local_id"
+        ],
+        "title": "BundleSetItem",
+        "description": "One evaluation in a set; its dataset lives in the set's ``datasets``."
+      },
+      "BundleSetItem-Output": {
+        "properties": {
+          "evaluation": {
+            "$ref": "#/components/schemas/BundleEvaluation"
+          },
+          "dataset_local_id": {
+            "type": "integer",
+            "title": "Dataset Local Id"
+          },
+          "references": {
+            "$ref": "#/components/schemas/BundleReferences"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "evaluation",
+          "dataset_local_id"
+        ],
+        "title": "BundleSetItem",
+        "description": "One evaluation in a set; its dataset lives in the set's ``datasets``."
+      },
       "BundleSource": {
         "properties": {
           "workflow_id": {
@@ -32068,6 +32362,86 @@
         ],
         "title": "EvaluationBundle"
       },
+      "EvaluationBundleSet-Input": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "title": "Kind",
+            "default": "genassist.evaluation-bundle-set"
+          },
+          "schema_version": {
+            "type": "integer",
+            "title": "Schema Version",
+            "default": 1
+          },
+          "source": {
+            "$ref": "#/components/schemas/BundleSource"
+          },
+          "datasets": {
+            "items": {
+              "$ref": "#/components/schemas/BundleSetDataset"
+            },
+            "type": "array",
+            "title": "Datasets"
+          },
+          "evaluations": {
+            "items": {
+              "$ref": "#/components/schemas/BundleSetItem-Input"
+            },
+            "type": "array",
+            "title": "Evaluations"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "title": "EvaluationBundleSet"
+      },
+      "EvaluationBundleSet-Output": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "title": "Kind",
+            "default": "genassist.evaluation-bundle-set"
+          },
+          "schema_version": {
+            "type": "integer",
+            "title": "Schema Version",
+            "default": 1
+          },
+          "source": {
+            "$ref": "#/components/schemas/BundleSource"
+          },
+          "datasets": {
+            "items": {
+              "$ref": "#/components/schemas/BundleSetDataset"
+            },
+            "type": "array",
+            "title": "Datasets"
+          },
+          "evaluations": {
+            "items": {
+              "$ref": "#/components/schemas/BundleSetItem-Output"
+            },
+            "type": "array",
+            "title": "Evaluations"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "title": "EvaluationBundleSet"
+      },
       "EvaluationImportPreview": {
         "properties": {
           "evaluation_name": {
@@ -32318,6 +32692,274 @@
         "type": "object",
         "title": "EvaluationRunRequest",
         "description": "Options for starting a single evaluation run."
+      },
+      "EvaluationSetImportPreview": {
+        "properties": {
+          "workflow_name_matches": {
+            "type": "boolean",
+            "title": "Workflow Name Matches"
+          },
+          "evaluations": {
+            "items": {
+              "$ref": "#/components/schemas/EvaluationSetItemPreview"
+            },
+            "type": "array",
+            "title": "Evaluations"
+          },
+          "datasets": {
+            "items": {
+              "$ref": "#/components/schemas/BundleSetDatasetPreview"
+            },
+            "type": "array",
+            "title": "Datasets"
+          },
+          "node_refs": {
+            "items": {
+              "$ref": "#/components/schemas/BundleNodeResolution"
+            },
+            "type": "array",
+            "title": "Node Refs"
+          },
+          "provider_refs": {
+            "items": {
+              "$ref": "#/components/schemas/BundleProviderResolution"
+            },
+            "type": "array",
+            "title": "Provider Refs"
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Warnings"
+          },
+          "can_import": {
+            "type": "boolean",
+            "title": "Can Import"
+          }
+        },
+        "type": "object",
+        "required": [
+          "workflow_name_matches",
+          "can_import"
+        ],
+        "title": "EvaluationSetImportPreview"
+      },
+      "EvaluationSetImportPreviewRequest": {
+        "properties": {
+          "bundle_set": {
+            "$ref": "#/components/schemas/EvaluationBundleSet-Input"
+          },
+          "target_workflow_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Target Workflow Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "bundle_set",
+          "target_workflow_id"
+        ],
+        "title": "EvaluationSetImportPreviewRequest"
+      },
+      "EvaluationSetImportRequest": {
+        "properties": {
+          "bundle_set": {
+            "$ref": "#/components/schemas/EvaluationBundleSet-Input"
+          },
+          "target_workflow_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Target Workflow Id"
+          },
+          "include": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array",
+                "maxItems": 200
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include"
+          },
+          "resolutions": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "maxProperties": 1000,
+            "title": "Resolutions"
+          },
+          "drop_unresolved_rules": {
+            "type": "boolean",
+            "title": "Drop Unresolved Rules",
+            "default": false
+          },
+          "skip_existing": {
+            "type": "boolean",
+            "title": "Skip Existing",
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "bundle_set",
+          "target_workflow_id"
+        ],
+        "title": "EvaluationSetImportRequest"
+      },
+      "EvaluationSetImportResult": {
+        "properties": {
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/EvaluationSetItemResult"
+            },
+            "type": "array",
+            "title": "Results"
+          },
+          "imported": {
+            "type": "integer",
+            "title": "Imported",
+            "default": 0
+          },
+          "skipped": {
+            "type": "integer",
+            "title": "Skipped",
+            "default": 0
+          },
+          "failed": {
+            "type": "integer",
+            "title": "Failed",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "title": "EvaluationSetImportResult"
+      },
+      "EvaluationSetItemPreview": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "dataset_name": {
+            "type": "string",
+            "title": "Dataset Name"
+          },
+          "case_count": {
+            "type": "integer",
+            "title": "Case Count"
+          },
+          "already_exists": {
+            "type": "boolean",
+            "title": "Already Exists",
+            "default": false
+          },
+          "dropping_all_would_empty": {
+            "type": "boolean",
+            "title": "Dropping All Would Empty",
+            "default": false
+          },
+          "node_ref_keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Node Ref Keys"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "dataset_name",
+          "case_count"
+        ],
+        "title": "EvaluationSetItemPreview",
+        "description": "How one evaluation of the set would land on the target workflow."
+      },
+      "EvaluationSetItemResult": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "evaluation_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluation Id"
+          },
+          "suite_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suite Id"
+          },
+          "case_count": {
+            "type": "integer",
+            "title": "Case Count",
+            "default": 0
+          },
+          "reused_dataset": {
+            "type": "boolean",
+            "title": "Reused Dataset",
+            "default": false
+          },
+          "dropped_rules": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Dropped Rules"
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Warnings"
+          },
+          "detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "status"
+        ],
+        "title": "EvaluationSetItemResult"
       },
       "EvaluationToolCatalog": {
         "properties": {

--- a/backend/tests/unit/test_eval_bundle.py
+++ b/backend/tests/unit/test_eval_bundle.py
@@ -10,7 +10,12 @@ import pytest
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.schemas.eval_bundle import (
+    EVALUATION_BUNDLE_KIND,
     EVALUATION_BUNDLE_SCHEMA_VERSION,
+    EVALUATION_BUNDLE_SET_KIND,
+    EVALUATION_BUNDLE_SET_SCHEMA_VERSION,
+    MAX_SET_DATASETS,
+    MAX_SET_EVALUATIONS,
     REF_KIND_ACTION,
     REF_KIND_AGENT,
     REF_KIND_ROUTER,
@@ -18,16 +23,24 @@ from app.schemas.eval_bundle import (
     REF_STATUS_AMBIGUOUS,
     REF_STATUS_MISSING,
     REF_STATUS_RESOLVED,
+    SET_ITEM_FAILED,
+    SET_ITEM_IMPORTED,
+    SET_ITEM_SKIPPED,
     BundleCase,
     BundleDataset,
     BundleEvaluation,
     BundleNodeRef,
     BundleProviderRef,
     BundleReferences,
+    BundleSetDataset,
+    BundleSetItem,
     BundleSource,
     EvaluationBundle,
+    EvaluationBundleSet,
     EvaluationImportPreviewRequest,
     EvaluationImportRequest,
+    EvaluationSetImportPreviewRequest,
+    EvaluationSetImportRequest,
 )
 from app.schemas.test_suite import (
     EvaluationToolCatalog,
@@ -35,6 +48,7 @@ from app.schemas.test_suite import (
     TestEvaluation,
     TestSuiteInDB,
 )
+from app.services import eval_bundle
 from app.services.eval_bundle import (
     EvalBundleService,
     UnresolvedRefError,
@@ -1277,3 +1291,938 @@ class TestRoundTrip:
         assert rule["tool_ids"] == ["tgt-tool-search"]
         assert created.technique_configs["route_taken"]["rules"][0]["router"] == "tgt-router"
         assert result.case_count == 1
+
+
+def _route_only_evaluation(name: str) -> BundleEvaluation:
+    return BundleEvaluation(
+        name=name,
+        techniques=["route_taken"],
+        technique_configs={
+            "route_taken": {"rules": [{"router": "src-router", "expected": "hr"}]}
+        },
+    )
+
+
+def _bundle_set(case_id: str, provider_id: str) -> EvaluationBundleSet:
+    """Two evaluations sharing one dataset: the full single-bundle evaluation
+    plus a route-only one."""
+    single = _bundle(case_id, provider_id)
+    return EvaluationBundleSet(
+        source=single.source,
+        datasets=[BundleSetDataset(local_id=1, **single.dataset.model_dump())],
+        evaluations=[
+            BundleSetItem(
+                evaluation=single.evaluation,
+                dataset_local_id=1,
+                references=single.references,
+            ),
+            BundleSetItem(
+                evaluation=_route_only_evaluation("Routing only"),
+                dataset_local_id=1,
+                references=single.references,
+            ),
+        ],
+    )
+
+
+def _set_import_service(target_provider_id):
+    service = _import_service(target_provider_id)
+    service.suites.list_evaluations.return_value = []
+    return service
+
+
+def _wire_batch_dataset_reuse(service, target_workflow_id):
+    """Make suites real enough that reusing the WRONG id fails.
+
+    Each create_suite call mints its own id; get_suite only knows ids this batch
+    created, so forwarding an evaluation id (or a stale one) raises instead of
+    quietly resolving to the single canned suite.
+    """
+    created = {}
+
+    async def create_suite(data):
+        suite = SimpleNamespace(
+            id=uuid4(), name=data.name, workflow_id=target_workflow_id
+        )
+        created[str(suite.id)] = suite
+        return suite
+
+    async def get_suite(suite_id):
+        suite = created.get(str(suite_id))
+        if not suite:
+            raise AppException(status_code=404, error_key=ErrorKey.NOT_FOUND)
+        return suite
+
+    async def list_cases_for_suite(suite_id):
+        assert str(suite_id) in created, f"unknown suite {suite_id}"
+        return [
+            TestCaseInDB(
+                id=uuid4(), suite_id=suite_id, input_data={"message": "hi"},
+                created_at=NOW, updated_at=NOW,
+            ),
+            TestCaseInDB(
+                id=uuid4(), suite_id=suite_id, input_data={"message": "bye"},
+                created_at=NOW, updated_at=NOW,
+            ),
+        ]
+
+    async def list_suites():
+        # A suite created earlier in the batch is visible to later lookups, as
+        # it would be in the database — without this, a name-collision test
+        # passes for the wrong reason.
+        return list(created.values())
+
+    service.suites.create_suite.side_effect = create_suite
+    service.suites.get_suite.side_effect = get_suite
+    service.suites.list_cases_for_suite.side_effect = list_cases_for_suite
+    service.suites.list_suites.side_effect = list_suites
+    return created
+
+
+def _stored_evaluation(name: str, suite_id, workflow_id) -> TestEvaluation:
+    return TestEvaluation(
+        id=uuid4(),
+        name=name,
+        description=None,
+        suite_id=suite_id,
+        workflow_id=workflow_id,
+        techniques=["route_taken"],
+        technique_configs={
+            "route_taken": {"rules": [{"router": "src-router", "expected": "hr"}]}
+        },
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+class TestBundleSetExport:
+    @pytest.mark.asyncio
+    async def test_export_set_dedupes_shared_datasets_and_sorts_by_name(self):
+        workflow_id, suite_a, suite_b = uuid4(), uuid4(), uuid4()
+        evaluations = [
+            _stored_evaluation("B checks", suite_a, workflow_id),
+            _stored_evaluation("A checks", suite_a, workflow_id),
+            _stored_evaluation("C checks", suite_b, workflow_id),
+        ]
+        suites = {
+            suite_a: TestSuiteInDB(
+                id=suite_a, name="Shared dataset", workflow_id=workflow_id,
+                created_at=NOW, updated_at=NOW,
+            ),
+            suite_b: TestSuiteInDB(
+                id=suite_b, name="Other dataset", workflow_id=workflow_id,
+                created_at=NOW, updated_at=NOW,
+            ),
+        }
+        service = _service()
+        service.suites.list_evaluations.return_value = evaluations
+        service.suites.get_evaluation.side_effect = lambda eid: next(
+            e for e in evaluations if e.id == eid
+        )
+        service.suites.get_suite.side_effect = lambda sid: suites[sid]
+        service.suites.list_cases_for_suite.return_value = [
+            TestCaseInDB(
+                id=uuid4(), suite_id=suite_a, input_data={"message": "hi"},
+                created_at=NOW, updated_at=NOW,
+            )
+        ]
+        service.suites.get_evaluation_tool_catalog.return_value = (
+            EvaluationToolCatalog(**_catalog("src"))
+        )
+        service.workflows.get_by_id.return_value = SimpleNamespace(
+            id=workflow_id, name="HR Assistant", version="1.0"
+        )
+        service.workflows.get_all_minimal.return_value = []
+        service.providers.get_all_minimal.return_value = []
+
+        bundle_set = await service.export_workflow_evaluations(workflow_id)
+
+        assert bundle_set.kind == EVALUATION_BUNDLE_SET_KIND
+        assert [i.evaluation.name for i in bundle_set.evaluations] == [
+            "A checks", "B checks", "C checks",
+        ]
+        assert len(bundle_set.datasets) == 2
+        shared, other = bundle_set.evaluations[0], bundle_set.evaluations[1]
+        assert shared.dataset_local_id == other.dataset_local_id
+        assert bundle_set.evaluations[2].dataset_local_id != shared.dataset_local_id
+
+    @pytest.mark.asyncio
+    async def test_export_set_with_no_evaluations_404s(self):
+        service = _service()
+        service.suites.list_evaluations.return_value = []
+        service.workflows.get_by_id.return_value = SimpleNamespace(
+            id=uuid4(), name="HR Assistant", version="1.0"
+        )
+        service.workflows.get_all_minimal.return_value = []
+
+        with pytest.raises(AppException) as excinfo:
+            await service.export_workflow_evaluations(uuid4())
+        assert excinfo.value.status_code == 404
+
+
+class TestBundleSetPreview:
+    @pytest.mark.asyncio
+    async def test_preview_unions_refs_and_flags_existing_names(self):
+        target_workflow_id = uuid4()
+        service = _set_import_service(uuid4())
+        service.suites.list_evaluations.return_value = [
+            _stored_evaluation("Routing only", uuid4(), target_workflow_id)
+        ]
+        bundle_set = _bundle_set(str(uuid4()), str(uuid4()))
+
+        preview = await service.preview_set_import(
+            EvaluationSetImportPreviewRequest(
+                bundle_set=bundle_set, target_workflow_id=target_workflow_id
+            )
+        )
+
+        assert preview.can_import is True
+        # Both items reference src-router; the union carries it exactly once.
+        router_rows = [r for r in preview.node_refs if r.ref == "src-router"]
+        assert len(router_rows) == 1
+        assert router_rows[0].resolved_id == "tgt-router"
+        assert [i.already_exists for i in preview.evaluations] == [False, True]
+        assert preview.datasets[0].existing_dataset is None
+
+    @pytest.mark.asyncio
+    async def test_single_bundle_file_is_rejected_with_a_clear_message(self):
+        service = _set_import_service(uuid4())
+        bundle_set = _bundle_set(str(uuid4()), str(uuid4()))
+        bundle_set.kind = EVALUATION_BUNDLE_KIND
+
+        with pytest.raises(AppException) as excinfo:
+            await service.preview_set_import(
+                EvaluationSetImportPreviewRequest(
+                    bundle_set=bundle_set, target_workflow_id=uuid4()
+                )
+            )
+        assert excinfo.value.status_code == 400
+        assert "single-evaluation" in excinfo.value.error_detail
+
+    @pytest.mark.asyncio
+    async def test_dangling_dataset_reference_is_rejected(self):
+        service = _set_import_service(uuid4())
+        bundle_set = _bundle_set(str(uuid4()), str(uuid4()))
+        bundle_set.evaluations[1].dataset_local_id = 99
+
+        with pytest.raises(AppException) as excinfo:
+            await service.preview_set_import(
+                EvaluationSetImportPreviewRequest(
+                    bundle_set=bundle_set, target_workflow_id=uuid4()
+                )
+            )
+        assert excinfo.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_empty_set_is_rejected(self):
+        service = _set_import_service(uuid4())
+        bundle_set = _bundle_set(str(uuid4()), str(uuid4()))
+        bundle_set.evaluations = []
+
+        with pytest.raises(AppException) as excinfo:
+            await service.preview_set_import(
+                EvaluationSetImportPreviewRequest(
+                    bundle_set=bundle_set, target_workflow_id=uuid4()
+                )
+            )
+        assert excinfo.value.status_code == 400
+
+
+class TestBundleSetImport:
+    @pytest.mark.asyncio
+    async def test_batch_shares_created_dataset_and_skips_existing(self):
+        target_workflow_id = uuid4()
+        service = _set_import_service(uuid4())
+        service.suites.list_evaluations.return_value = [
+            _stored_evaluation("Third checks", uuid4(), target_workflow_id)
+        ]
+        _wire_batch_dataset_reuse(service, target_workflow_id)
+        bundle_set = _bundle_set(str(uuid4()), str(uuid4()))
+        bundle_set.evaluations.append(
+            BundleSetItem(
+                evaluation=_route_only_evaluation("Third checks"),
+                dataset_local_id=1,
+                references=bundle_set.evaluations[0].references,
+            )
+        )
+
+        result = await service.import_bundle_set(
+            EvaluationSetImportRequest(
+                bundle_set=bundle_set, target_workflow_id=target_workflow_id
+            )
+        )
+
+        assert [r.status for r in result.results] == [
+            SET_ITEM_IMPORTED, SET_ITEM_IMPORTED, SET_ITEM_SKIPPED,
+        ]
+        assert (result.imported, result.skipped, result.failed) == (2, 1, 0)
+        service.suites.create_suite.assert_awaited_once()
+        assert result.results[1].reused_dataset is True
+        # Not just "a" reuse: the second item must land on the suite the first
+        # one created, which a wrong id in the batch map would not.
+        assert result.results[1].suite_id == result.results[0].suite_id
+
+    @pytest.mark.asyncio
+    async def test_one_failing_item_does_not_stop_the_batch(self):
+        target_workflow_id = uuid4()
+        service = _set_import_service(uuid4())
+        bundle_set = _bundle_set(str(uuid4()), str(uuid4()))
+        broken = bundle_set.evaluations[0]
+        broken.evaluation.technique_configs["route_taken"]["rules"][0][
+            "router"
+        ] = "missing-node"
+        broken.references = BundleReferences()
+
+        result = await service.import_bundle_set(
+            EvaluationSetImportRequest(
+                bundle_set=bundle_set, target_workflow_id=target_workflow_id
+            )
+        )
+
+        assert [r.status for r in result.results] == [
+            SET_ITEM_FAILED, SET_ITEM_IMPORTED,
+        ]
+        assert result.results[0].detail
+        assert (result.imported, result.skipped, result.failed) == (1, 0, 1)
+
+    @pytest.mark.asyncio
+    async def test_include_imports_only_the_selected_items(self):
+        target_workflow_id = uuid4()
+        service = _set_import_service(uuid4())
+        bundle_set = _bundle_set(str(uuid4()), str(uuid4()))
+
+        result = await service.import_bundle_set(
+            EvaluationSetImportRequest(
+                bundle_set=bundle_set,
+                target_workflow_id=target_workflow_id,
+                include=[1],
+            )
+        )
+
+        assert len(result.results) == 1
+        assert result.results[0].name == "Routing only"
+        assert result.results[0].status == SET_ITEM_IMPORTED
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_selection_is_rejected(self):
+        service = _set_import_service(uuid4())
+        bundle_set = _bundle_set(str(uuid4()), str(uuid4()))
+
+        with pytest.raises(AppException) as excinfo:
+            await service.import_bundle_set(
+                EvaluationSetImportRequest(
+                    bundle_set=bundle_set,
+                    target_workflow_id=uuid4(),
+                    include=[5],
+                )
+            )
+        assert excinfo.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_skip_existing_off_imports_duplicates(self):
+        target_workflow_id = uuid4()
+        service = _set_import_service(uuid4())
+        service.suites.list_evaluations.return_value = [
+            _stored_evaluation("Routing only", uuid4(), target_workflow_id)
+        ]
+        _wire_batch_dataset_reuse(service, target_workflow_id)
+
+        result = await service.import_bundle_set(
+            EvaluationSetImportRequest(
+                bundle_set=_bundle_set(str(uuid4()), str(uuid4())),
+                target_workflow_id=target_workflow_id,
+                skip_existing=False,
+            )
+        )
+
+        assert (result.imported, result.skipped, result.failed) == (2, 0, 0)
+
+
+def _dataset(local_id: int, name: str, case_count: int = 1) -> BundleSetDataset:
+    return BundleSetDataset(
+        local_id=local_id,
+        name=name,
+        cases=[
+            BundleCase(local_id=i, input_data={"message": f"m{i}"})
+            for i in range(1, case_count + 1)
+        ],
+    )
+
+
+def _item(name: str, dataset_local_id: int, references=None) -> BundleSetItem:
+    return BundleSetItem(
+        evaluation=_route_only_evaluation(name),
+        dataset_local_id=dataset_local_id,
+        references=references or BundleReferences(),
+    )
+
+
+def _router_references() -> BundleReferences:
+    return BundleReferences(
+        nodes={"src-router": BundleNodeRef(label="Intent Router", kind=REF_KIND_ROUTER)}
+    )
+
+
+class TestBundleSetSameNamedDatasets:
+    """Two source suites can legitimately share a name; the file keeps them
+    apart by local_id and the import must not collapse them."""
+
+    @pytest.mark.asyncio
+    async def test_same_named_datasets_stay_separate(self):
+        target_workflow_id = uuid4()
+        service = _set_import_service(uuid4())
+        created = _wire_batch_dataset_reuse(service, target_workflow_id)
+        bundle_set = EvaluationBundleSet(
+            source=BundleSource(workflow_name="HR Assistant"),
+            datasets=[_dataset(1, "Shared name", 2), _dataset(2, "Shared name", 3)],
+            evaluations=[
+                _item("First", 1, _router_references()),
+                _item("Second", 2, _router_references()),
+            ],
+        )
+
+        result = await service.import_bundle_set(
+            EvaluationSetImportRequest(
+                bundle_set=bundle_set, target_workflow_id=target_workflow_id
+            )
+        )
+
+        assert (result.imported, result.failed) == (2, 0)
+        assert result.results[0].suite_id != result.results[1].suite_id
+        assert [r.reused_dataset for r in result.results] == [False, False]
+        assert len(created) == 2
+        # Both datasets' cases were created, not just the first one's.
+        assert service.case_repo.create_many.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_dataset_already_on_target_is_still_reused(self):
+        """The batch guard must not disable ordinary reuse of a PRE-EXISTING
+        dataset, only of one this same batch created."""
+        target_workflow_id = uuid4()
+        existing_suite_id = uuid4()
+        service = _set_import_service(uuid4())
+        service.suites.list_suites.return_value = [
+            SimpleNamespace(
+                id=existing_suite_id,
+                name="Shared name",
+                workflow_id=target_workflow_id,
+            )
+        ]
+        service.suites.get_suite.return_value = SimpleNamespace(
+            id=existing_suite_id, name="Shared name", workflow_id=target_workflow_id
+        )
+        service.suites.list_cases_for_suite.return_value = [
+            TestCaseInDB(
+                id=uuid4(), suite_id=existing_suite_id, input_data={"message": "hi"},
+                created_at=NOW, updated_at=NOW,
+            )
+        ]
+        bundle_set = EvaluationBundleSet(
+            datasets=[_dataset(1, "Shared name", 1)],
+            evaluations=[_item("First", 1, _router_references())],
+        )
+
+        result = await service.import_bundle_set(
+            EvaluationSetImportRequest(
+                bundle_set=bundle_set, target_workflow_id=target_workflow_id
+            )
+        )
+
+        assert result.results[0].status == SET_ITEM_IMPORTED
+        assert result.results[0].reused_dataset is True
+        assert result.results[0].suite_id == existing_suite_id
+        service.suites.create_suite.assert_not_awaited()
+
+
+class TestBundleSetSharedResolution:
+    @pytest.mark.asyncio
+    async def test_label_from_a_later_item_resolves_the_whole_set(self):
+        """Items are exported against their own version, so only some record a
+        label. Resolution uses the best metadata any item has, and the import
+        replays it so no item disagrees with the preview."""
+        target_workflow_id = uuid4()
+        service = _set_import_service(uuid4())
+        _wire_batch_dataset_reuse(service, target_workflow_id)
+        bundle_set = EvaluationBundleSet(
+            datasets=[_dataset(1, "Shared dataset", 2)],
+            evaluations=[
+                _item("No label recorded", 1, BundleReferences()),
+                _item("Label recorded", 1, _router_references()),
+            ],
+        )
+
+        preview = await service.preview_set_import(
+            EvaluationSetImportPreviewRequest(
+                bundle_set=bundle_set, target_workflow_id=target_workflow_id
+            )
+        )
+        result = await service.import_bundle_set(
+            EvaluationSetImportRequest(
+                bundle_set=bundle_set, target_workflow_id=target_workflow_id
+            )
+        )
+
+        assert preview.can_import is True
+        assert preview.node_refs[0].resolved_id == "tgt-router"
+        # The label-less item must import too, on the preview's decision.
+        assert [r.status for r in result.results] == [
+            SET_ITEM_IMPORTED, SET_ITEM_IMPORTED,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_preview_reports_each_item_s_own_refs(self):
+        service = _set_import_service(uuid4())
+        bundle_set = EvaluationBundleSet(
+            datasets=[_dataset(1, "Shared dataset")],
+            evaluations=[
+                _item("Uses the router", 1, _router_references()),
+                BundleSetItem(
+                    evaluation=BundleEvaluation(
+                        name="Uses nothing",
+                        techniques=["llm_judge"],
+                        technique_configs={"llm_judge": {"rules": []}},
+                    ),
+                    dataset_local_id=1,
+                ),
+            ],
+        )
+
+        preview = await service.preview_set_import(
+            EvaluationSetImportPreviewRequest(
+                bundle_set=bundle_set, target_workflow_id=uuid4()
+            )
+        )
+
+        assert preview.evaluations[0].node_ref_keys == ["router:src-router"]
+        assert preview.evaluations[1].node_ref_keys == []
+
+    @pytest.mark.asyncio
+    async def test_shared_provider_is_resolved_once(self):
+        provider_id = str(uuid4())
+        service = _set_import_service(uuid4())
+        judge = {
+            "llm_judge": {
+                "rules": [{"rubric": "Grade", "min_score": 0.5}],
+                "llm_provider_id": provider_id,
+            }
+        }
+        items = [
+            BundleSetItem(
+                evaluation=BundleEvaluation(
+                    name=name, techniques=["llm_judge"], technique_configs=judge
+                ),
+                dataset_local_id=1,
+                references=BundleReferences(
+                    llm_providers={provider_id: BundleProviderRef(model="gpt-4o")}
+                ),
+            )
+            for name in ("First", "Second")
+        ]
+        bundle_set = EvaluationBundleSet(
+            datasets=[_dataset(1, "Shared dataset")], evaluations=items
+        )
+
+        preview = await service.preview_set_import(
+            EvaluationSetImportPreviewRequest(
+                bundle_set=bundle_set, target_workflow_id=uuid4()
+            )
+        )
+
+        assert len(preview.provider_refs) == 1
+        service.providers.get_all_minimal.assert_awaited_once()
+
+
+class TestBundleSetDuplicateNamesInFile:
+    @pytest.mark.asyncio
+    async def test_second_copy_of_a_name_inside_the_file_is_skipped(self):
+        target_workflow_id = uuid4()
+        service = _set_import_service(uuid4())
+        _wire_batch_dataset_reuse(service, target_workflow_id)
+        bundle_set = EvaluationBundleSet(
+            datasets=[_dataset(1, "Shared dataset", 2)],
+            evaluations=[
+                _item("Same name", 1, _router_references()),
+                _item("Same name", 1, _router_references()),
+            ],
+        )
+
+        result = await service.import_bundle_set(
+            EvaluationSetImportRequest(
+                bundle_set=bundle_set, target_workflow_id=target_workflow_id
+            )
+        )
+
+        assert [r.status for r in result.results] == [
+            SET_ITEM_IMPORTED, SET_ITEM_SKIPPED,
+        ]
+        assert (result.imported, result.skipped) == (1, 1)
+
+
+class TestBundleSetItemFailureDetail:
+    @pytest.mark.asyncio
+    async def test_only_bundle_messages_reach_the_client(self, monkeypatch):
+        """A batch result never passes the exception handler's gate, so an
+        internal detail would be returned verbatim inside a 201."""
+        target_workflow_id = uuid4()
+        service = _set_import_service(uuid4())
+        _wire_batch_dataset_reuse(service, target_workflow_id)
+        leaked = "ValidationError: 3 validation errors for InternalModel"
+
+        async def explode(_request):
+            raise AppException(
+                status_code=400,
+                error_key=ErrorKey.INVALID_REQUEST,
+                error_detail=leaked,
+            )
+
+        monkeypatch.setattr(service, "import_bundle", explode)
+        bundle_set = EvaluationBundleSet(
+            datasets=[_dataset(1, "Shared dataset")],
+            evaluations=[_item("Boom", 1, _router_references())],
+        )
+
+        result = await service.import_bundle_set(
+            EvaluationSetImportRequest(
+                bundle_set=bundle_set, target_workflow_id=target_workflow_id
+            )
+        )
+
+        assert result.results[0].status == SET_ITEM_FAILED
+        assert leaked not in (result.results[0].detail or "")
+        assert result.results[0].detail == "The evaluation could not be imported."
+
+    @pytest.mark.asyncio
+    async def test_bundle_invalid_detail_is_passed_through_and_capped(
+        self, monkeypatch
+    ):
+        target_workflow_id = uuid4()
+        service = _set_import_service(uuid4())
+        _wire_batch_dataset_reuse(service, target_workflow_id)
+
+        async def explode(_request):
+            raise AppException(
+                status_code=400,
+                error_key=ErrorKey.EVALUATION_BUNDLE_INVALID,
+                error_detail="Every check was dropped. " + "x" * 500,
+            )
+
+        monkeypatch.setattr(service, "import_bundle", explode)
+        bundle_set = EvaluationBundleSet(
+            datasets=[_dataset(1, "Shared dataset")],
+            evaluations=[_item("Boom", 1, _router_references())],
+        )
+
+        result = await service.import_bundle_set(
+            EvaluationSetImportRequest(
+                bundle_set=bundle_set, target_workflow_id=target_workflow_id
+            )
+        )
+
+        detail = result.results[0].detail
+        assert detail.startswith("Every check was dropped.")
+        assert len(detail) <= 300
+
+
+class TestBundleSetHeaderLimits:
+    def _valid_set(self):
+        return EvaluationBundleSet(
+            datasets=[_dataset(1, "Shared dataset")],
+            evaluations=[_item("One", 1)],
+        )
+
+    async def _expect_400(self, bundle_set):
+        service = _set_import_service(uuid4())
+        with pytest.raises(AppException) as excinfo:
+            await service.preview_set_import(
+                EvaluationSetImportPreviewRequest(
+                    bundle_set=bundle_set, target_workflow_id=uuid4()
+                )
+            )
+        assert excinfo.value.status_code == 400
+        return excinfo.value
+
+    @pytest.mark.asyncio
+    async def test_newer_schema_version_is_rejected(self):
+        bundle_set = self._valid_set()
+        bundle_set.schema_version = EVALUATION_BUNDLE_SET_SCHEMA_VERSION + 1
+        await self._expect_400(bundle_set)
+
+    @pytest.mark.asyncio
+    async def test_duplicate_dataset_ids_are_rejected(self):
+        bundle_set = self._valid_set()
+        bundle_set.datasets.append(_dataset(1, "Another"))
+        await self._expect_400(bundle_set)
+
+    @pytest.mark.asyncio
+    async def test_datasets_no_evaluation_uses_are_rejected(self):
+        bundle_set = self._valid_set()
+        bundle_set.datasets.append(_dataset(2, "Unreferenced"))
+        error = await self._expect_400(bundle_set)
+        assert "no evaluation uses" in error.error_detail
+
+    @pytest.mark.asyncio
+    async def test_too_many_evaluations_is_rejected(self):
+        bundle_set = self._valid_set()
+        bundle_set.evaluations = [
+            _item(f"Eval {i}", 1) for i in range(MAX_SET_EVALUATIONS + 1)
+        ]
+        await self._expect_400(bundle_set)
+
+    @pytest.mark.asyncio
+    async def test_too_many_datasets_is_rejected(self):
+        bundle_set = self._valid_set()
+        bundle_set.datasets = [
+            _dataset(i, f"Dataset {i}") for i in range(1, MAX_SET_DATASETS + 2)
+        ]
+        await self._expect_400(bundle_set)
+
+    @pytest.mark.asyncio
+    async def test_oversized_dataset_is_rejected(self, monkeypatch):
+        monkeypatch.setattr(eval_bundle, "MAX_BUNDLE_CASES", 1)
+        bundle_set = self._valid_set()
+        bundle_set.datasets = [_dataset(1, "Big", case_count=2)]
+        error = await self._expect_400(bundle_set)
+        assert "test cases" in error.error_detail
+
+    @pytest.mark.asyncio
+    async def test_too_many_cases_in_total_is_rejected(self, monkeypatch):
+        monkeypatch.setattr(eval_bundle, "MAX_SET_TOTAL_CASES", 3)
+        bundle_set = self._valid_set()
+        bundle_set.datasets = [_dataset(1, "A", 2), _dataset(2, "B", 2)]
+        bundle_set.evaluations = [_item("One", 1), _item("Two", 2)]
+        error = await self._expect_400(bundle_set)
+        assert "in total" in error.error_detail
+
+
+class TestBundleSetExportLimits:
+    @pytest.mark.asyncio
+    async def test_export_refuses_a_dataset_the_import_would_reject(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(eval_bundle, "MAX_BUNDLE_CASES", 1)
+        workflow_id, suite_id = uuid4(), uuid4()
+        evaluation = _stored_evaluation("Only one", suite_id, workflow_id)
+        service = _service()
+        service.suites.list_evaluations.return_value = [evaluation]
+        service.suites.get_evaluation.return_value = evaluation
+        service.suites.get_suite.return_value = TestSuiteInDB(
+            id=suite_id, name="Big dataset", workflow_id=workflow_id,
+            created_at=NOW, updated_at=NOW,
+        )
+        service.suites.list_cases_for_suite.return_value = [
+            TestCaseInDB(
+                id=uuid4(), suite_id=suite_id, input_data={"message": "a"},
+                created_at=NOW, updated_at=NOW,
+            ),
+            TestCaseInDB(
+                id=uuid4(), suite_id=suite_id, input_data={"message": "b"},
+                created_at=NOW, updated_at=NOW,
+            ),
+        ]
+        service.suites.get_evaluation_tool_catalog.return_value = (
+            EvaluationToolCatalog(**_catalog("src"))
+        )
+        service.workflows.get_by_id.return_value = SimpleNamespace(
+            id=workflow_id, name="HR Assistant", version="1.0"
+        )
+        service.workflows.get_all_minimal.return_value = []
+        service.providers.get_all_minimal.return_value = []
+
+        with pytest.raises(AppException) as excinfo:
+            await service.export_workflow_evaluations(workflow_id)
+        assert excinfo.value.status_code == 400
+        assert "Big dataset" in excinfo.value.error_detail
+
+
+class TestBundleSetResolutionSize:
+    @pytest.mark.asyncio
+    async def test_large_pick_map_does_not_fail_every_item(self):
+        """The union plus the caller's picks can exceed one item's resolution
+        cap; each item must only be sent the picks its own refs need."""
+        target_workflow_id = uuid4()
+        service = _set_import_service(uuid4())
+        _wire_batch_dataset_reuse(service, target_workflow_id)
+        bundle_set = EvaluationBundleSet(
+            datasets=[_dataset(1, "Shared dataset", 2)],
+            evaluations=[_item("One", 1, _router_references())],
+        )
+        # Filled to the cap with picks for refs this item does not use.
+        filler = {f"action:node-{i}": "tgt-escalation" for i in range(1000)}
+
+        result = await service.import_bundle_set(
+            EvaluationSetImportRequest(
+                bundle_set=bundle_set,
+                target_workflow_id=target_workflow_id,
+                resolutions=filler,
+            )
+        )
+
+        assert result.results[0].status == SET_ITEM_IMPORTED
+
+
+class TestBundleSetVerdictIsShared:
+    """An item must reach the union's verdict, not its own. Replaying only the
+    union's successes let an item quietly resolve what the preview refused."""
+
+    @pytest.mark.asyncio
+    async def test_item_cannot_resolve_a_ref_the_preview_refused(self):
+        target_workflow_id = uuid4()
+        service = _set_import_service(uuid4())
+        _wire_batch_dataset_reuse(service, target_workflow_id)
+        # Item 1 records a type that contradicts the target node, which
+        # downgrades the whole set's ref to "confirm this yourself".
+        typed = BundleReferences(
+            nodes={
+                "src-escalation": BundleNodeRef(
+                    label="Escalation Message", kind=REF_KIND_ACTION,
+                    node_type="httpNode",
+                )
+            }
+        )
+        untyped = BundleReferences(
+            nodes={
+                "src-escalation": BundleNodeRef(
+                    label="Escalation Message", kind=REF_KIND_ACTION
+                )
+            }
+        )
+        # A second check keeps each evaluation importable once the action rule
+        # is dropped, so the test observes the binding rather than the
+        # zero-checks refusal.
+        action_config = {
+            "action_taken": {"rules": [{"node": "src-escalation", "should_fire": True}]},
+            "llm_judge": {"rules": [{"rubric": "Grade", "min_score": 0.5}]},
+        }
+        items = [
+            BundleSetItem(
+                evaluation=BundleEvaluation(
+                    name=name,
+                    techniques=["action_taken", "llm_judge"],
+                    technique_configs=action_config,
+                ),
+                dataset_local_id=1,
+                references=references,
+            )
+            for name, references in (("Typed", typed), ("Untyped", untyped))
+        ]
+        bundle_set = EvaluationBundleSet(
+            datasets=[_dataset(1, "Shared dataset", 2)], evaluations=items
+        )
+
+        preview = await service.preview_set_import(
+            EvaluationSetImportPreviewRequest(
+                bundle_set=bundle_set, target_workflow_id=target_workflow_id
+            )
+        )
+        result = await service.import_bundle_set(
+            EvaluationSetImportRequest(
+                bundle_set=bundle_set,
+                target_workflow_id=target_workflow_id,
+                drop_unresolved_rules=True,
+            )
+        )
+
+        assert preview.can_import is False
+        assert preview.node_refs[0].status == REF_STATUS_AMBIGUOUS
+        # Neither item may bind the reference the user was told to confirm.
+        created = [
+            call.args[0] for call in service.suites.create_evaluation.await_args_list
+        ]
+        for evaluation in created:
+            assert evaluation.technique_configs.get("action_taken") is None
+        assert all(r.dropped_rules for r in result.results)
+
+    @pytest.mark.asyncio
+    async def test_item_is_not_failed_by_a_ref_the_preview_resolved(self):
+        """The other direction: the label-less item must still import."""
+        target_workflow_id = uuid4()
+        service = _set_import_service(uuid4())
+        _wire_batch_dataset_reuse(service, target_workflow_id)
+        bundle_set = EvaluationBundleSet(
+            datasets=[_dataset(1, "Shared dataset", 2)],
+            evaluations=[
+                _item("No metadata", 1, BundleReferences()),
+                _item("Has the label", 1, _router_references()),
+            ],
+        )
+
+        result = await service.import_bundle_set(
+            EvaluationSetImportRequest(
+                bundle_set=bundle_set, target_workflow_id=target_workflow_id
+            )
+        )
+
+        assert [r.status for r in result.results] == [
+            SET_ITEM_IMPORTED, SET_ITEM_IMPORTED,
+        ]
+        assert all(not r.dropped_rules for r in result.results)
+
+
+class TestBundleSetSameNameWithPreexistingTarget:
+    @pytest.mark.asyncio
+    async def test_only_the_first_same_named_dataset_reuses_the_target_one(self):
+        """Two file datasets share a name AND the target already owns it. The
+        first attaches to the existing one; the second keeps its own cases."""
+        target_workflow_id = uuid4()
+        existing_suite_id = uuid4()
+        service = _set_import_service(uuid4())
+        existing = SimpleNamespace(
+            id=existing_suite_id, name="Regression", workflow_id=target_workflow_id
+        )
+        created = _wire_batch_dataset_reuse(service, target_workflow_id)
+        created[str(existing_suite_id)] = existing
+
+        bundle_set = EvaluationBundleSet(
+            datasets=[_dataset(1, "Regression", 1), _dataset(2, "Regression", 5)],
+            evaluations=[
+                _item("First", 1, _router_references()),
+                _item("Second", 2, _router_references()),
+            ],
+        )
+
+        result = await service.import_bundle_set(
+            EvaluationSetImportRequest(
+                bundle_set=bundle_set, target_workflow_id=target_workflow_id
+            )
+        )
+
+        assert (result.imported, result.failed) == (2, 0)
+        assert result.results[0].suite_id == existing_suite_id
+        assert result.results[0].reused_dataset is True
+        # The second dataset is a different dataset; its cases must exist.
+        assert result.results[1].suite_id != existing_suite_id
+        assert result.results[1].reused_dataset is False
+        service.case_repo.create_many.assert_awaited_once()
+
+
+class TestBundleSetPreviewMatchesImport:
+    @pytest.mark.asyncio
+    async def test_only_the_first_namesake_is_previewed_as_reused(self):
+        """Import gives every later namesake its own dataset, so the preview
+        must not promise reuse for all of them."""
+        target_workflow_id = uuid4()
+        existing_suite_id = uuid4()
+        service = _set_import_service(uuid4())
+        service.suites.list_suites.return_value = [
+            SimpleNamespace(
+                id=existing_suite_id, name="Regression",
+                workflow_id=target_workflow_id,
+            )
+        ]
+        service.suites.list_cases_for_suite.return_value = []
+        bundle_set = EvaluationBundleSet(
+            datasets=[_dataset(1, "Regression", 1), _dataset(2, "Regression", 5)],
+            evaluations=[
+                _item("First", 1, _router_references()),
+                _item("Second", 2, _router_references()),
+            ],
+        )
+
+        preview = await service.preview_set_import(
+            EvaluationSetImportPreviewRequest(
+                bundle_set=bundle_set, target_workflow_id=target_workflow_id
+            )
+        )
+
+        assert preview.datasets[0].existing_dataset is not None
+        assert preview.datasets[1].existing_dataset is None

--- a/frontend/src/interfaces/evalBundle.interface.ts
+++ b/frontend/src/interfaces/evalBundle.interface.ts
@@ -104,3 +104,76 @@ export interface EvaluationImportResult {
   dropped_rules: string[];
   warnings: string[];
 }
+
+export const EVALUATION_BUNDLE_SET_KIND = "genassist.evaluation-bundle-set";
+
+export interface BundleSetDataset {
+  local_id: number;
+  name: string;
+  description?: string | null;
+  default_input_metadata?: Record<string, unknown> | null;
+  cases: BundleCase[];
+}
+
+export interface BundleSetItem {
+  evaluation: EvaluationBundle["evaluation"];
+  dataset_local_id: number;
+  references: EvaluationBundle["references"];
+  notes?: string[];
+}
+
+export interface EvaluationBundleSet {
+  kind: string;
+  schema_version: number;
+  source: EvaluationBundle["source"];
+  datasets: BundleSetDataset[];
+  evaluations: BundleSetItem[];
+  notes: string[];
+}
+
+export interface EvaluationSetItemPreview {
+  name: string;
+  dataset_name: string;
+  case_count: number;
+  already_exists: boolean;
+  dropping_all_would_empty: boolean;
+  node_ref_keys?: string[];
+}
+
+export interface BundleSetDatasetPreview {
+  local_id: number;
+  name: string;
+  case_count: number;
+  existing_dataset?: BundleExistingDataset | null;
+}
+
+export interface EvaluationSetImportPreview {
+  workflow_name_matches: boolean;
+  evaluations: EvaluationSetItemPreview[];
+  datasets: BundleSetDatasetPreview[];
+  node_refs: BundleNodeResolution[];
+  provider_refs: BundleProviderResolution[];
+  warnings: string[];
+  can_import: boolean;
+}
+
+export type SetItemStatus = "imported" | "skipped" | "failed";
+
+export interface EvaluationSetItemResult {
+  name: string;
+  status: SetItemStatus | string;
+  evaluation_id?: string | null;
+  suite_id?: string | null;
+  case_count: number;
+  reused_dataset: boolean;
+  dropped_rules: string[];
+  warnings: string[];
+  detail?: string | null;
+}
+
+export interface EvaluationSetImportResult {
+  results: EvaluationSetItemResult[];
+  imported: number;
+  skipped: number;
+  failed: number;
+}

--- a/frontend/src/services/testEvaluations.ts
+++ b/frontend/src/services/testEvaluations.ts
@@ -1,8 +1,11 @@
 import { apiRequest } from "@/config/api";
 import {
   EvaluationBundle,
+  EvaluationBundleSet,
   EvaluationImportPreview,
   EvaluationImportResult,
+  EvaluationSetImportPreview,
+  EvaluationSetImportResult,
 } from "@/interfaces/evalBundle.interface";
 import {
   EvaluationToolCatalog,
@@ -134,5 +137,36 @@ export const importEvaluation = (payload: EvaluationImportPayload) =>
   apiRequest<EvaluationImportResult>(
     "POST",
     `${BASE}/evaluations/import`,
+    payload as unknown as Record<string, unknown>,
+  );
+
+export const exportWorkflowEvaluations = (workflowId: string) =>
+  apiRequest<EvaluationBundleSet>(
+    "GET",
+    `${BASE}/workflows/${workflowId}/evaluations/export`,
+  );
+
+export interface EvaluationSetImportPayload {
+  bundle_set: EvaluationBundleSet;
+  target_workflow_id: string;
+  include?: number[];
+  resolutions?: Record<string, string>;
+  drop_unresolved_rules?: boolean;
+  skip_existing?: boolean;
+}
+
+export const previewEvaluationSetImport = (
+  payload: Pick<EvaluationSetImportPayload, "bundle_set" | "target_workflow_id">,
+) =>
+  apiRequest<EvaluationSetImportPreview>(
+    "POST",
+    `${BASE}/evaluations/import-set/preview`,
+    payload as unknown as Record<string, unknown>,
+  );
+
+export const importEvaluationSet = (payload: EvaluationSetImportPayload) =>
+  apiRequest<EvaluationSetImportResult>(
+    "POST",
+    `${BASE}/evaluations/import-set`,
     payload as unknown as Record<string, unknown>,
   );

--- a/frontend/src/views/TestSuites/components/ImportEvaluationDialog.tsx
+++ b/frontend/src/views/TestSuites/components/ImportEvaluationDialog.tsx
@@ -22,54 +22,60 @@ import {
 } from "@/components/select";
 import {
   EvaluationBundle,
+  EvaluationBundleSet,
   EvaluationImportPreview,
   EvaluationImportResult,
+  EvaluationSetImportPreview,
+  EvaluationSetImportResult,
 } from "@/interfaces/evalBundle.interface";
 import { EvaluationToolCatalog } from "@/interfaces/testEvaluation.interface";
 import { WorkflowMinimal } from "@/interfaces/workflow.interface";
 import {
   getEvaluationToolCatalog,
   importEvaluation,
+  importEvaluationSet,
   previewEvaluationImport,
+  previewEvaluationSetImport,
 } from "@/services/testEvaluations";
-import { nodeRefKey, parseBundleFile } from "../helpers/evalBundle";
+import {
+  apiErrorDetail,
+  bundleSetCaseCount,
+  nodeRefKey,
+  parseBundleFile,
+} from "../helpers/evalBundle";
 import { groupWorkflowVersions } from "../helpers/workflowVersions";
 import { ImportMappingTable } from "./ImportMappingTable";
+import { ImportSetResults } from "./ImportSetResults";
+import { ImportSetReview } from "./ImportSetReview";
 import { WorkflowVersionPicker } from "./WorkflowVersionPicker";
 
-type ImportStep = "file" | "workflow" | "review";
+type ImportStep = "file" | "workflow" | "review" | "results";
 
 interface ImportEvaluationDialogProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   workflows: WorkflowMinimal[];
   onImported: (result: EvaluationImportResult) => void;
+  onSetImported?: (result: EvaluationSetImportResult) => void;
 }
-
-/** Prefer the specific reason over the generic message: import errors name the
- * reference that could not be re-linked, which is what the user must act on. */
-const apiErrorDetail = (error: unknown): string | undefined => {
-  const data = (
-    error as { response?: { data?: { error?: unknown; error_detail?: unknown } } }
-  )?.response?.data;
-  for (const candidate of [data?.error_detail, data?.error]) {
-    if (typeof candidate === "string" && candidate.trim()) return candidate;
-  }
-  return undefined;
-};
 
 export const ImportEvaluationDialog: React.FC<ImportEvaluationDialogProps> = ({
   isOpen,
   onOpenChange,
   workflows,
   onImported,
+  onSetImported,
 }) => {
   const [step, setStep] = useState<ImportStep>("file");
   const [bundle, setBundle] = useState<EvaluationBundle | null>(null);
+  const [bundleSet, setBundleSet] = useState<EvaluationBundleSet | null>(null);
   const [fileName, setFileName] = useState("");
   const [fileError, setFileError] = useState("");
   const [targetWorkflowId, setTargetWorkflowId] = useState("");
   const [preview, setPreview] = useState<EvaluationImportPreview | null>(null);
+  const [batchPreview, setBatchPreview] = useState<EvaluationSetImportPreview | null>(null);
+  const [selectedItems, setSelectedItems] = useState<Set<number>>(new Set());
+  const [batchResult, setBatchResult] = useState<EvaluationSetImportResult | null>(null);
   const [catalog, setCatalog] = useState<EvaluationToolCatalog | null>(null);
   const [catalogFailed, setCatalogFailed] = useState(false);
   const [picks, setPicks] = useState<Record<string, string>>({});
@@ -81,15 +87,21 @@ export const ImportEvaluationDialog: React.FC<ImportEvaluationDialogProps> = ({
   // Bumped per preview request (and on reset) so a slow response for a
   // previously chosen workflow can never overwrite the current one.
   const previewRequestRef = useRef(0);
+  // True only while a batch import is awaiting its response.
+  const batchInFlight = useRef(false);
 
   const reset = () => {
     previewRequestRef.current += 1;
     setStep("file");
     setBundle(null);
+    setBundleSet(null);
     setFileName("");
     setFileError("");
     setTargetWorkflowId("");
     setPreview(null);
+    setBatchPreview(null);
+    setSelectedItems(new Set());
+    setBatchResult(null);
     setCatalog(null);
     setCatalogFailed(false);
     setPicks({});
@@ -101,7 +113,17 @@ export const ImportEvaluationDialog: React.FC<ImportEvaluationDialogProps> = ({
   };
 
   const handleOpenChange = (open: boolean) => {
-    if (!open) reset();
+    // Closing mid-batch would leave it running with nothing to report it: the
+    // evaluations land, but the page never learns to refresh. Guarded by a ref
+    // rather than isImporting, because the single-evaluation path closes the
+    // dialog itself while its own import is still marked in flight.
+    if (!open && batchInFlight.current) return;
+    if (!open) {
+      // Whatever the batch already did stays done, even when the dialog is
+      // dismissed from the results step — the page must reflect it.
+      if (batchResult) onSetImported?.(batchResult);
+      reset();
+    }
     onOpenChange(open);
   };
 
@@ -115,12 +137,16 @@ export const ImportEvaluationDialog: React.FC<ImportEvaluationDialogProps> = ({
     reader.onload = (loadEvent) => {
       try {
         const parsed = parseBundleFile(String(loadEvent.target?.result ?? ""));
-        setBundle(parsed);
+        setBundle(parsed.kind === "single" ? parsed.bundle : null);
+        setBundleSet(parsed.kind === "set" ? parsed.bundleSet : null);
         setFileName(file.name);
         setFileError("");
-        preselectWorkflow(parsed);
+        preselectWorkflow(
+          parsed.kind === "single" ? parsed.bundle.source : parsed.bundleSet.source,
+        );
       } catch (error) {
         setBundle(null);
+        setBundleSet(null);
         setFileName(file.name);
         setFileError(error instanceof Error ? error.message : "Could not read the file.");
       }
@@ -128,8 +154,8 @@ export const ImportEvaluationDialog: React.FC<ImportEvaluationDialogProps> = ({
     reader.readAsText(file);
   };
 
-  const preselectWorkflow = (parsed: EvaluationBundle) => {
-    const sourceName = parsed.source?.workflow_name?.trim().toLowerCase();
+  const preselectWorkflow = (source: EvaluationBundle["source"] | undefined) => {
+    const sourceName = source?.workflow_name?.trim().toLowerCase();
     const group = sourceName
       ? workflowGroups.find((g) => g.name.trim().toLowerCase() === sourceName)
       : undefined;
@@ -138,16 +164,22 @@ export const ImportEvaluationDialog: React.FC<ImportEvaluationDialogProps> = ({
     setTargetWorkflowId(group?.activeVersionId ?? group?.versions[0].id ?? "");
   };
 
-  const loadPreview = async () => {
-    if (!bundle || !targetWorkflowId) return;
+  const startPreviewRequest = () => {
     const requestId = ++previewRequestRef.current;
     setStep("review");
     setIsPreviewLoading(true);
     setPreviewError("");
     setPreview(null);
+    setBatchPreview(null);
     setPicks({});
     setDropUnresolved(false);
     setReuseDataset(true);
+    return requestId;
+  };
+
+  const loadPreview = async () => {
+    if (!bundle || !targetWorkflowId) return;
+    const requestId = startPreviewRequest();
     try {
       const [previewData, catalogData] = await Promise.all([
         previewEvaluationImport({ bundle, target_workflow_id: targetWorkflowId }),
@@ -177,12 +209,56 @@ export const ImportEvaluationDialog: React.FC<ImportEvaluationDialogProps> = ({
     }
   };
 
+  const loadBatchPreview = async () => {
+    if (!bundleSet || !targetWorkflowId) return;
+    const requestId = startPreviewRequest();
+    try {
+      const [previewData, catalogData] = await Promise.all([
+        previewEvaluationSetImport({
+          bundle_set: bundleSet,
+          target_workflow_id: targetWorkflowId,
+        }),
+        getEvaluationToolCatalog(targetWorkflowId).catch(() => null),
+      ]);
+      if (requestId !== previewRequestRef.current) return;
+      setBatchPreview(previewData);
+      setCatalog(catalogData);
+      setCatalogFailed(catalogData === null);
+      // Evaluations already on the target start unchecked, so importing twice
+      // duplicates nothing unless the user opts a row back in.
+      setSelectedItems(
+        new Set(
+          (previewData?.evaluations ?? []).flatMap((item, index) =>
+            item.already_exists ? [] : [index],
+          ),
+        ),
+      );
+      const nothingResolved =
+        (previewData?.node_refs.length ?? 0) > 0 &&
+        previewData!.node_refs.every((nodeRef) => nodeRef.status !== "resolved");
+      // Pre-tick dropping only when at least one evaluation would keep a check.
+      setDropUnresolved(
+        nothingResolved &&
+          (previewData?.evaluations ?? []).some(
+            (item) => !item.dropping_all_would_empty,
+          ),
+      );
+      if (!previewData) setPreviewError("Could not preview the import.");
+    } catch (error) {
+      if (requestId !== previewRequestRef.current) return;
+      setPreviewError(apiErrorDetail(error) ?? "Could not preview the import.");
+    } finally {
+      if (requestId === previewRequestRef.current) setIsPreviewLoading(false);
+    }
+  };
+
+  const activeNodeRefs = bundleSet ? batchPreview?.node_refs : preview?.node_refs;
+
   const unresolvedRefs = useMemo(() => {
-    if (!preview) return [];
-    return preview.node_refs.filter(
+    return (activeNodeRefs ?? []).filter(
       (nodeRef) => nodeRef.status !== "resolved" && !picks[nodeRefKey(nodeRef)],
     );
-  }, [preview, picks]);
+  }, [activeNodeRefs, picks]);
 
   // Nothing at all matching means this is almost certainly the wrong workflow,
   // not a mapping exercise — say so rather than posing a row of unanswerable
@@ -201,6 +277,102 @@ export const ImportEvaluationDialog: React.FC<ImportEvaluationDialogProps> = ({
     Boolean(preview) &&
     !isImporting &&
     (unresolvedRefs.length === 0 || dropUnresolved);
+
+  // Per evaluation, how many of ITS references are still unmatched. The set-wide
+  // count would keep flagging a row whose own references the user already
+  // mapped, just because a different row's are outstanding.
+  const unresolvedCountByItem = useMemo(() => {
+    const unresolvedKeys = new Set(unresolvedRefs.map(nodeRefKey));
+    return (batchPreview?.evaluations ?? []).map(
+      (item) =>
+        (item.node_ref_keys ?? []).filter((key) => unresolvedKeys.has(key)).length,
+    );
+  }, [batchPreview, unresolvedRefs]);
+
+  // Manual picks for each evaluation, so a preview-time verdict can be told
+  // apart from one the user has since acted on.
+  const pickedCountByItem = useMemo(
+    () =>
+      (batchPreview?.evaluations ?? []).map(
+        (item) => (item.node_ref_keys ?? []).filter((key) => picks[key]).length,
+      ),
+    [batchPreview, picks],
+  );
+
+  // An evaluation cannot import if its own references are unmatched and either
+  // dropping is off or dropping would leave it with nothing to grade. That last
+  // flag is computed before any manual picks, so it only stands while the user
+  // has mapped none of this evaluation's references — otherwise mapping one
+  // could never unblock the row.
+  // True when dropping the rest would leave this evaluation nothing to grade.
+  // The badge and the Import button both read this, so they cannot disagree.
+  const hasNoMatchingChecks = (index: number): boolean => {
+    const item = batchPreview?.evaluations[index];
+    if (!item || (unresolvedCountByItem[index] ?? 0) === 0) return false;
+    return item.dropping_all_would_empty && (pickedCountByItem[index] ?? 0) === 0;
+  };
+
+  const isItemBlocked = (index: number): boolean => {
+    if ((unresolvedCountByItem[index] ?? 0) === 0) return false;
+    if (!dropUnresolved) return true;
+    return hasNoMatchingChecks(index);
+  };
+
+  const hasImportableSelection = [...selectedItems].some(
+    (index) => !isItemBlocked(index),
+  );
+
+  const canImportBatch =
+    Boolean(batchPreview) &&
+    selectedItems.size > 0 &&
+    !isImporting &&
+    hasImportableSelection;
+
+  const toggleSelectedItem = (index: number) => {
+    setSelectedItems((current) => {
+      const next = new Set(current);
+      if (next.has(index)) {
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
+      return next;
+    });
+  };
+
+  const handleBatchImport = async () => {
+    if (!bundleSet || !targetWorkflowId || selectedItems.size === 0) return;
+    const requestId = ++previewRequestRef.current;
+    batchInFlight.current = true;
+    setIsImporting(true);
+    try {
+      // The checkboxes are the skip decision: unchecked rows are not sent, and
+      // a checked "already here" row is an explicit request for a copy.
+      const result = await importEvaluationSet({
+        bundle_set: bundleSet,
+        target_workflow_id: targetWorkflowId,
+        include: [...selectedItems].sort((a, b) => a - b),
+        resolutions: picks,
+        drop_unresolved_rules: dropUnresolved,
+        skip_existing: false,
+      });
+      // The dialog cannot be closed mid-import, but a reset would still orphan
+      // this response; never write it into a dialog that moved on.
+      if (requestId !== previewRequestRef.current) return;
+      if (!result) {
+        toast.error("You don't have permission to import evaluations.");
+        return;
+      }
+      setBatchResult(result);
+      setStep("results");
+    } catch (error) {
+      if (requestId !== previewRequestRef.current) return;
+      toast.error(apiErrorDetail(error) ?? "Failed to import evaluations");
+    } finally {
+      batchInFlight.current = false;
+      if (requestId === previewRequestRef.current) setIsImporting(false);
+    }
+  };
 
   const handleImport = async () => {
     if (!bundle || !targetWorkflowId) return;
@@ -285,14 +457,37 @@ export const ImportEvaluationDialog: React.FC<ImportEvaluationDialogProps> = ({
           )}
         </div>
       )}
+      {bundleSet && (
+        <div className="rounded-lg border bg-muted/40 p-4 text-sm space-y-1">
+          <div className="font-medium">
+            {bundleSet.evaluations.length} evaluation
+            {bundleSet.evaluations.length !== 1 ? "s" : ""}
+          </div>
+          <div className="text-muted-foreground">
+            {bundleSet.datasets.length} dataset
+            {bundleSet.datasets.length !== 1 ? "s" : ""} ·{" "}
+            {bundleSetCaseCount(bundleSet)} case
+            {bundleSetCaseCount(bundleSet) !== 1 ? "s" : ""}
+          </div>
+          {bundleSet.source?.workflow_name && (
+            <div className="text-muted-foreground">
+              Exported from workflow "{bundleSet.source.workflow_name}"
+              {bundleSet.source.workflow_version
+                ? ` v${bundleSet.source.workflow_version}`
+                : ""}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 
   const renderWorkflowStep = () => (
     <div className="space-y-4">
       <p className="text-sm text-muted-foreground">
-        Choose the workflow this evaluation should test. References in the
-        bundle's checks are matched against it by name.
+        Choose the workflow {bundleSet ? "these evaluations" : "this evaluation"}{" "}
+        should test. References in the bundle's checks are matched against it by
+        name.
       </p>
       <div className="space-y-1.5">
         <Label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
@@ -303,7 +498,7 @@ export const ImportEvaluationDialog: React.FC<ImportEvaluationDialogProps> = ({
           selectedWorkflowId={targetWorkflowId}
           onSelect={setTargetWorkflowId}
         />
-        {bundle?.source?.workflow_name && targetWorkflowId && (
+        {(bundle ?? bundleSet)?.source?.workflow_name && targetWorkflowId && (
           <p className="text-xs text-muted-foreground">
             Pre-selected by matching the exported workflow's name.
           </p>
@@ -321,13 +516,36 @@ export const ImportEvaluationDialog: React.FC<ImportEvaluationDialogProps> = ({
         </div>
       );
     }
-    if (previewError || !preview) {
+    if (previewError || (!preview && !batchPreview)) {
       return (
         <div className="py-8 text-center text-sm text-destructive">
           {previewError || "Could not preview the import."}
         </div>
       );
     }
+    if (bundleSet && batchPreview) {
+      return (
+        <ImportSetReview
+          preview={batchPreview}
+          sourceWorkflowName={bundleSet.source?.workflow_name}
+          catalog={catalog}
+          catalogUnavailable={catalogFailed}
+          picks={picks}
+          onPick={(pickKey, targetId) =>
+            setPicks((current) => ({ ...current, [pickKey]: targetId }))
+          }
+          selected={selectedItems}
+          onToggleItem={toggleSelectedItem}
+          unresolvedCount={unresolvedRefs.length}
+          noMatchingChecks={(batchPreview?.evaluations ?? []).map((_, index) =>
+            hasNoMatchingChecks(index),
+          )}
+          dropUnresolved={dropUnresolved}
+          onDropUnresolvedChange={setDropUnresolved}
+        />
+      );
+    }
+    if (!preview) return null;
     return (
       <div className="space-y-4">
         <div className="rounded-lg border bg-muted/40 p-4 text-sm space-y-2">
@@ -437,17 +655,22 @@ export const ImportEvaluationDialog: React.FC<ImportEvaluationDialogProps> = ({
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-2xl">
         <DialogHeader>
-          <DialogTitle>Import evaluation</DialogTitle>
+          <DialogTitle>
+            {bundleSet ? "Import evaluations" : "Import evaluation"}
+          </DialogTitle>
         </DialogHeader>
 
         <div className="max-h-[60vh] overflow-y-auto pr-1">
           {step === "file" && renderFileStep()}
           {step === "workflow" && renderWorkflowStep()}
           {step === "review" && renderReviewStep()}
+          {step === "results" && batchResult && (
+            <ImportSetResults result={batchResult} />
+          )}
         </div>
 
         <DialogFooter className="mt-2 gap-2 border-t pt-4">
-          {step !== "file" && (
+          {step !== "file" && step !== "results" && (
             <Button
               variant="ghost"
               className="mr-auto"
@@ -458,24 +681,43 @@ export const ImportEvaluationDialog: React.FC<ImportEvaluationDialogProps> = ({
               Back
             </Button>
           )}
-          <Button variant="outline" onClick={() => handleOpenChange(false)}>
-            Cancel
-          </Button>
+          {step !== "results" && (
+            <Button
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={isImporting}
+            >
+              Cancel
+            </Button>
+          )}
           {step === "file" && (
-            <Button disabled={!bundle} onClick={() => setStep("workflow")}>
+            <Button disabled={!bundle && !bundleSet} onClick={() => setStep("workflow")}>
               Next
             </Button>
           )}
           {step === "workflow" && (
-            <Button disabled={!targetWorkflowId} onClick={() => void loadPreview()}>
+            <Button
+              disabled={!targetWorkflowId}
+              onClick={() => void (bundleSet ? loadBatchPreview() : loadPreview())}
+            >
               Next
             </Button>
           )}
-          {step === "review" && (
+          {step === "review" && !bundleSet && (
             <Button disabled={!canImport} onClick={() => void handleImport()}>
               {isImporting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               Import
             </Button>
+          )}
+          {step === "review" && bundleSet && (
+            <Button disabled={!canImportBatch} onClick={() => void handleBatchImport()}>
+              {isImporting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Import {selectedItems.size > 0 ? selectedItems.size : ""} evaluation
+              {selectedItems.size !== 1 ? "s" : ""}
+            </Button>
+          )}
+          {step === "results" && (
+            <Button onClick={() => handleOpenChange(false)}>Done</Button>
           )}
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/views/TestSuites/components/ImportSetResults.tsx
+++ b/frontend/src/views/TestSuites/components/ImportSetResults.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { AlertTriangle, CheckCircle2, MinusCircle } from "lucide-react";
+
+import {
+  EvaluationSetImportResult,
+  EvaluationSetItemResult,
+} from "@/interfaces/evalBundle.interface";
+
+interface ImportSetResultsProps {
+  result: EvaluationSetImportResult;
+}
+
+const statusIcon = (status: string) => {
+  if (status === "imported") {
+    return <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />;
+  }
+  if (status === "skipped") {
+    return <MinusCircle className="h-4 w-4 shrink-0 text-muted-foreground" />;
+  }
+  return <AlertTriangle className="h-4 w-4 shrink-0 text-destructive" />;
+};
+
+const itemNotes = (item: EvaluationSetItemResult): string[] => {
+  const notes: string[] = [];
+  if (item.detail) notes.push(item.detail);
+  if (item.reused_dataset) notes.push("Reused the existing dataset.");
+  if (item.dropped_rules.length > 0) {
+    notes.push(
+      `${item.dropped_rules.length} rule${
+        item.dropped_rules.length !== 1 ? "s" : ""
+      } dropped.`,
+    );
+  }
+  return [...notes, ...item.warnings];
+};
+
+/** Per-evaluation outcome of a bundle set import. */
+export const ImportSetResults: React.FC<ImportSetResultsProps> = ({ result }) => {
+  const summary = [
+    `${result.imported} imported`,
+    result.skipped > 0 ? `${result.skipped} skipped` : null,
+    result.failed > 0 ? `${result.failed} failed` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm font-medium">{summary}</p>
+      <div className="rounded-lg border">
+        <div className="max-h-72 divide-y divide-border overflow-y-auto">
+          {result.results.map((item, index) => (
+            <div key={`${item.name}-${index}`} className="flex items-start gap-3 px-4 py-2.5">
+              <span className="mt-0.5">{statusIcon(item.status)}</span>
+              <div className="min-w-0 flex-1 text-sm">
+                <div className="truncate font-medium">{item.name}</div>
+                {itemNotes(item).map((note) => (
+                  <div key={note} className="text-xs text-muted-foreground">
+                    {note}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/views/TestSuites/components/ImportSetReview.tsx
+++ b/frontend/src/views/TestSuites/components/ImportSetReview.tsx
@@ -1,0 +1,159 @@
+import React from "react";
+import { AlertTriangle } from "lucide-react";
+
+import { Badge } from "@/components/badge";
+import { Checkbox } from "@/components/checkbox";
+import { EvaluationSetImportPreview } from "@/interfaces/evalBundle.interface";
+import { EvaluationToolCatalog } from "@/interfaces/testEvaluation.interface";
+import { ImportMappingTable } from "./ImportMappingTable";
+
+interface ImportSetReviewProps {
+  preview: EvaluationSetImportPreview;
+  sourceWorkflowName?: string | null;
+  catalog: EvaluationToolCatalog | null;
+  catalogUnavailable: boolean;
+  picks: Record<string, string>;
+  onPick: (pickKey: string, targetId: string) => void;
+  selected: Set<number>;
+  onToggleItem: (index: number) => void;
+  unresolvedCount: number;
+  /** Per evaluation, whether dropping the unmatched references would leave it
+   * nothing to grade. Positionally aligned with `preview.evaluations`. */
+  noMatchingChecks: boolean[];
+  dropUnresolved: boolean;
+  onDropUnresolvedChange: (checked: boolean) => void;
+}
+
+/** Review step for a bundle set: pick which evaluations to import and map the
+ * shared references once for all of them. */
+export const ImportSetReview: React.FC<ImportSetReviewProps> = ({
+  preview,
+  sourceWorkflowName,
+  catalog,
+  catalogUnavailable,
+  picks,
+  onPick,
+  selected,
+  onToggleItem,
+  unresolvedCount,
+  noMatchingChecks,
+  dropUnresolved,
+  onDropUnresolvedChange,
+}) => {
+  const looksLikeWrongWorkflow =
+    preview.node_refs.length > 0 &&
+    preview.node_refs.every((nodeRef) => nodeRef.status !== "resolved");
+  const reusedDatasets = preview.datasets.filter((dataset) =>
+    Boolean(dataset.existing_dataset),
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border">
+        <div className="border-b bg-muted/40 px-4 py-2 text-xs font-medium text-muted-foreground">
+          {selected.size} of {preview.evaluations.length} evaluation
+          {preview.evaluations.length !== 1 ? "s" : ""} selected
+        </div>
+        <div className="max-h-56 divide-y divide-border overflow-y-auto">
+          {preview.evaluations.map((item, index) => (
+            <label
+              key={`${item.name}-${index}`}
+              className="flex cursor-pointer items-start gap-3 px-4 py-2.5 text-sm hover:bg-muted/30"
+            >
+              <Checkbox
+                checked={selected.has(index)}
+                onCheckedChange={() => onToggleItem(index)}
+                className="mt-0.5"
+              />
+              <span className="min-w-0 flex-1">
+                <span className="flex flex-wrap items-center gap-2">
+                  <span className="truncate font-medium">{item.name}</span>
+                  {item.already_exists && (
+                    <Badge variant="secondary" className="shrink-0">
+                      Already here
+                    </Badge>
+                  )}
+                  {noMatchingChecks[index] && (
+                    <Badge
+                      variant="outline"
+                      className="shrink-0 text-amber-700 dark:text-amber-300"
+                    >
+                      No matching checks
+                    </Badge>
+                  )}
+                </span>
+                <span className="block text-xs text-muted-foreground">
+                  Dataset "{item.dataset_name}" · {item.case_count} case
+                  {item.case_count !== 1 ? "s" : ""}
+                </span>
+              </span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {reusedDatasets.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          {reusedDatasets.map((dataset) => dataset.name).join(", ")}{" "}
+          {reusedDatasets.length !== 1 ? "already exist" : "already exists"} here
+          and will be reused instead of duplicated.
+        </p>
+      )}
+
+      {looksLikeWrongWorkflow && (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/40 p-3">
+          <div className="flex items-start gap-2 text-sm text-amber-900 dark:text-amber-200">
+            <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+            <div>
+              <p>No references match this workflow.</p>
+              <p className="mt-0.5 text-xs text-amber-800 dark:text-amber-300">
+                {sourceWorkflowName ? `Exported from "${sourceWorkflowName}". ` : ""}
+                Go back to change the target, or import without the unmatched
+                checks.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {preview.node_refs.length > 0 && (
+        <ImportMappingTable
+          nodeRefs={preview.node_refs}
+          catalog={catalog}
+          catalogUnavailable={catalogUnavailable}
+          picks={picks}
+          onPick={onPick}
+        />
+      )}
+
+      {preview.warnings.length > 0 && (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/40 p-3 space-y-1">
+          {preview.warnings.map((warning) => (
+            <div
+              key={warning}
+              className="flex items-start gap-2 text-xs text-amber-800 dark:text-amber-300"
+            >
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+              {warning}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {unresolvedCount > 0 && (
+        <label className="flex items-start gap-2 text-sm">
+          <Checkbox
+            checked={dropUnresolved}
+            onCheckedChange={(checked) => onDropUnresolvedChange(checked === true)}
+            className="mt-0.5"
+          />
+          <span>
+            Drop the checks that use the {unresolvedCount} reference
+            {unresolvedCount !== 1 ? "s" : ""} I haven't matched. An evaluation
+            left with no checks at all is not imported and is reported instead.
+          </span>
+        </label>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/views/TestSuites/helpers/evalBundle.ts
+++ b/frontend/src/views/TestSuites/helpers/evalBundle.ts
@@ -1,18 +1,24 @@
 import {
   EVALUATION_BUNDLE_KIND,
+  EVALUATION_BUNDLE_SET_KIND,
   BundleRefCandidate,
   EvaluationBundle,
+  EvaluationBundleSet,
 } from "@/interfaces/evalBundle.interface";
 import { EvaluationToolCatalog } from "@/interfaces/testEvaluation.interface";
 
-export const bundleFilename = (evaluationName: string): string => {
-  const slug = evaluationName
+const slugify = (value: string): string =>
+  value
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
-  return `evaluation-${slug || "bundle"}.json`;
-};
+
+export const bundleFilename = (evaluationName: string): string =>
+  `evaluation-${slugify(evaluationName) || "bundle"}.json`;
+
+export const bundleSetFilename = (workflowName: string): string =>
+  `evaluations-${slugify(workflowName) || "workflow"}.json`;
 
 export const downloadJsonFile = (filename: string, data: unknown): void => {
   const blob = new Blob([JSON.stringify(data, null, 2)], {
@@ -26,6 +32,18 @@ export const downloadJsonFile = (filename: string, data: unknown): void => {
   anchor.click();
   document.body.removeChild(anchor);
   URL.revokeObjectURL(url);
+};
+
+/** Prefer the specific reason over the generic message: bundle errors name the
+ * reference or limit that the user must act on. */
+export const apiErrorDetail = (error: unknown): string | undefined => {
+  const data = (
+    error as { response?: { data?: { error?: unknown; error_detail?: unknown } } }
+  )?.response?.data;
+  for (const candidate of [data?.error_detail, data?.error]) {
+    if (typeof candidate === "string" && candidate.trim()) return candidate;
+  }
+  return undefined;
 };
 
 const dedupeById = (options: BundleRefCandidate[]): BundleRefCandidate[] => {
@@ -107,41 +125,87 @@ export const narrowToOriginalType = (
 export const nodeRefKey = (nodeRef: { ref: string; kind: string }): string =>
   `${nodeRef.kind}:${nodeRef.ref}`;
 
-export const parseBundleFile = (fileText: string): EvaluationBundle => {
+const normalizeReferences = (
+  references: EvaluationBundle["references"] | undefined,
+): EvaluationBundle["references"] => ({
+  nodes: references?.nodes ?? {},
+  llm_providers: references?.llm_providers ?? {},
+  cases: references?.cases ?? {},
+});
+
+const normalizeEvaluation = (
+  evaluation: EvaluationBundle["evaluation"],
+): EvaluationBundle["evaluation"] => ({
+  ...evaluation,
+  techniques: Array.isArray(evaluation.techniques) ? evaluation.techniques : [],
+});
+
+/** A hand-edited bundle may omit optional collections; normalize them so the
+ * dialog never renders against undefined. */
+const normalizeBundle = (bundle: EvaluationBundle): EvaluationBundle => {
+  const isBundle = Boolean(bundle?.evaluation?.name) && Boolean(bundle?.dataset?.name);
+  if (!isBundle) {
+    throw new Error("The file is not an evaluation bundle export.");
+  }
+  return {
+    ...bundle,
+    notes: Array.isArray(bundle.notes) ? bundle.notes : [],
+    evaluation: normalizeEvaluation(bundle.evaluation),
+    dataset: {
+      ...bundle.dataset,
+      cases: Array.isArray(bundle.dataset.cases) ? bundle.dataset.cases : [],
+    },
+    references: normalizeReferences(bundle.references),
+  };
+};
+
+const normalizeBundleSet = (bundleSet: EvaluationBundleSet): EvaluationBundleSet => {
+  const datasets = Array.isArray(bundleSet?.datasets) ? bundleSet.datasets : [];
+  const items = Array.isArray(bundleSet?.evaluations) ? bundleSet.evaluations : [];
+  const isValid =
+    items.length > 0 &&
+    items.every((item) => Boolean(item?.evaluation?.name)) &&
+    datasets.every((dataset) => Boolean(dataset?.name));
+  if (!isValid) {
+    throw new Error("The file is not an evaluation bundle export.");
+  }
+  return {
+    ...bundleSet,
+    notes: Array.isArray(bundleSet.notes) ? bundleSet.notes : [],
+    datasets: datasets.map((dataset) => ({
+      ...dataset,
+      cases: Array.isArray(dataset.cases) ? dataset.cases : [],
+    })),
+    evaluations: items.map((item) => ({
+      ...item,
+      notes: Array.isArray(item.notes) ? item.notes : [],
+      evaluation: normalizeEvaluation(item.evaluation),
+      references: normalizeReferences(item.references),
+    })),
+  };
+};
+
+export type ParsedBundleFile =
+  | { kind: "single"; bundle: EvaluationBundle }
+  | { kind: "set"; bundleSet: EvaluationBundleSet };
+
+/** Parse either bundle flavor; the file's ``kind`` field decides which. */
+export const parseBundleFile = (fileText: string): ParsedBundleFile => {
   let parsed: unknown;
   try {
     parsed = JSON.parse(fileText);
   } catch {
     throw new Error("The file is not valid JSON.");
   }
-  const bundle = parsed as EvaluationBundle;
-  const isBundle =
-    bundle &&
-    bundle.kind === EVALUATION_BUNDLE_KIND &&
-    Boolean(bundle.evaluation?.name) &&
-    Boolean(bundle.dataset?.name);
-  if (!isBundle) {
-    throw new Error("The file is not an evaluation bundle export.");
+  const kind = (parsed as { kind?: unknown })?.kind;
+  if (kind === EVALUATION_BUNDLE_SET_KIND) {
+    return { kind: "set", bundleSet: normalizeBundleSet(parsed as EvaluationBundleSet) };
   }
-  // A hand-edited bundle may omit optional collections; normalize them so the
-  // dialog never renders against undefined.
-  return {
-    ...bundle,
-    notes: Array.isArray(bundle.notes) ? bundle.notes : [],
-    evaluation: {
-      ...bundle.evaluation,
-      techniques: Array.isArray(bundle.evaluation.techniques)
-        ? bundle.evaluation.techniques
-        : [],
-    },
-    dataset: {
-      ...bundle.dataset,
-      cases: Array.isArray(bundle.dataset.cases) ? bundle.dataset.cases : [],
-    },
-    references: {
-      nodes: bundle.references?.nodes ?? {},
-      llm_providers: bundle.references?.llm_providers ?? {},
-      cases: bundle.references?.cases ?? {},
-    },
-  };
+  if (kind === EVALUATION_BUNDLE_KIND) {
+    return { kind: "single", bundle: normalizeBundle(parsed as EvaluationBundle) };
+  }
+  throw new Error("The file is not an evaluation bundle export.");
 };
+
+export const bundleSetCaseCount = (bundleSet: EvaluationBundleSet): number =>
+  bundleSet.datasets.reduce((sum, dataset) => sum + dataset.cases.length, 0);

--- a/frontend/src/views/TestSuites/pages/EvaluationsPage.tsx
+++ b/frontend/src/views/TestSuites/pages/EvaluationsPage.tsx
@@ -280,6 +280,7 @@ const EvaluationsPage: React.FC = () => {
           void refetchSummaries();
           navigate(`/tests/evaluations/${result.evaluation_id}`);
         }}
+        onSetImported={() => void refetchSummaries()}
       />
     </PageLayout>
   );

--- a/frontend/src/views/TestSuites/pages/WorkflowEvaluationsPage.tsx
+++ b/frontend/src/views/TestSuites/pages/WorkflowEvaluationsPage.tsx
@@ -1,7 +1,15 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronLeft, GitBranch, ListChecks, Loader2, Play, Search } from "lucide-react";
+import {
+  ChevronLeft,
+  Download,
+  GitBranch,
+  ListChecks,
+  Loader2,
+  Play,
+  Search,
+} from "lucide-react";
 import toast from "react-hot-toast";
 
 import { PageLayout } from "@/components/PageLayout";
@@ -25,6 +33,7 @@ import { getLLMProvidersMinimal } from "@/services/llmProviders";
 import {
   deleteTestEvaluation,
   exportTestEvaluation,
+  exportWorkflowEvaluations,
   getWorkflowEvaluationsPage,
   runTestEvaluation,
   runWorkflowEvaluations,
@@ -38,7 +47,12 @@ import { EvaluationWizard, EvaluationWizardData } from "../components/Evaluation
 import { EvaluationListRow } from "../components/EvaluationListRow";
 import { RunAgainstVersionDialog } from "../components/RunAgainstVersionDialog";
 import { buildTechniqueConfigs, getEditInitialData, wizardMetadata } from "../helpers/evaluationForm";
-import { bundleFilename, downloadJsonFile } from "../helpers/evalBundle";
+import {
+  apiErrorDetail,
+  bundleFilename,
+  bundleSetFilename,
+  downloadJsonFile,
+} from "../helpers/evalBundle";
 
 const PAGE_SIZE = 20;
 const UNASSIGNED = "unassigned";
@@ -371,6 +385,23 @@ const WorkflowEvaluationsPage: React.FC = () => {
     }
   };
 
+  const handleExportAll = async () => {
+    try {
+      const bundleSet = await exportWorkflowEvaluations(workflowId);
+      if (!bundleSet) {
+        toast.error("You don't have permission to export evaluations.");
+        return;
+      }
+      downloadJsonFile(bundleSetFilename(workflowName), bundleSet);
+      const count = bundleSet.evaluations.length;
+      toast.success(`Exported ${count} evaluation${count !== 1 ? "s" : ""}`);
+    } catch (error) {
+      // The backend explains its export limits precisely; a generic message
+      // would hide both the limit and how far over it this workflow is.
+      toast.error(apiErrorDetail(error) ?? "Failed to export evaluations");
+    }
+  };
+
   const handleDelete = async (id: string) => {
     try {
       await deleteTestEvaluation(id);
@@ -427,6 +458,21 @@ const WorkflowEvaluationsPage: React.FC = () => {
           </div>
           {!isUnassigned && (
             <div className="flex items-center gap-2">
+              <TooltipProvider delayDuration={200}>
+                <TooltipButton
+                  button={
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      onClick={() => void handleExportAll()}
+                      aria-label="Export all evaluations"
+                    >
+                      <Download className="h-4 w-4" />
+                    </Button>
+                  }
+                  tooltipContent={{ children: <p>Export all evaluations</p> }}
+                />
+              </TooltipProvider>
               {canRunAgainstVersion && (
                 <TooltipProvider delayDuration={200}>
                   <TooltipButton


### PR DESCRIPTION
## Description

- Export every evaluation of a workflow as a single JSON file, and import them back in one pass
- Each dataset is stored once in the file, so evaluations that share one do not duplicate its test cases
- References are matched against the target workflow once for the whole set, so the same node is mapped a single time instead of once per evaluation

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
