### PR TITLE
feat: add Zendesk OAuth client-credentials auth

### DIFF
--- a/backend/app/core/config/settings.py
+++ b/backend/app/core/config/settings.py
@@ -211,6 +211,12 @@ class ProjectSettings(BaseSettings):
     ZENDESK_SUBDOMAIN: Optional[str] = "<enter-value-here>"
     ZENDESK_EMAIL: Optional[str] = "<enter-value-here>"
     ZENDESK_API_TOKEN: Optional[str] = "<enter-value-here>"
+    # Zendesk is deprecating API tokens (removed 2027-04-30). OAuth2 client-credentials
+    # is the forward path; "api_token" stays the default for backward compatibility.
+    ZENDESK_AUTH_METHOD: Optional[str] = "api_token"
+    ZENDESK_CLIENT_ID: Optional[str] = None
+    ZENDESK_CLIENT_SECRET: Optional[str] = None
+    ZENDESK_OAUTH_SCOPE: Optional[str] = "read write"
     ZENDESK_CUSTOM_FIELD_CONVERSATION_ID: Optional[int] = 0
 
     SALESFORCE_INSTANCE_URL: Optional[str] = None

--- a/backend/app/modules/integration/zendesk.py
+++ b/backend/app/modules/integration/zendesk.py
@@ -87,7 +87,9 @@ class ZendeskConnector:
         value = re.split(r"[/?#@:]", value, maxsplit=1)[0]
         label = value[: -len(".zendesk.com")] if value.endswith(".zendesk.com") else value
         if not cls._SUBDOMAIN_LABEL_RE.fullmatch(label):
-            logger.warning("Ignoring invalid Zendesk subdomain %r", raw)
+            logger.warning(
+                "Ignoring invalid Zendesk subdomain (must be a single *.zendesk.com label)"
+            )
             return ""
         return f"{label}.zendesk.com"
 

--- a/backend/app/modules/integration/zendesk.py
+++ b/backend/app/modules/integration/zendesk.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import re
 from datetime import timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -28,14 +29,9 @@ class ZendeskConnector:
         client_secret: Optional[str] = None,
         oauth_scope: Optional[str] = None,
     ):
-        raw = (subdomain or settings.ZENDESK_SUBDOMAIN or "").strip()
-        # Normalize subdomain: ensure it has .zendesk.com (matches connection_tester)
-        if not raw:
-            self.subdomain = ""
-        elif raw.endswith(".zendesk.com"):
-            self.subdomain = raw
-        else:
-            self.subdomain = f"{raw}.zendesk.com"
+        # Validate/normalize into a safe ``<label>.zendesk.com`` host. The subdomain is
+        # operator-supplied and flows into the request URL, so this guards against SSRF.
+        self.subdomain = self._normalize_subdomain(subdomain or settings.ZENDESK_SUBDOMAIN)
 
         self.email = email or settings.ZENDESK_EMAIL
         self.api_token = api_token or settings.ZENDESK_API_TOKEN
@@ -69,6 +65,31 @@ class ZendeskConnector:
         self._access_token: Optional[str] = None
         self._token_lock = asyncio.Lock()
         self.page_size = 50
+
+    # A Zendesk subdomain is a single DNS label (letters, digits, internal hyphens).
+    _SUBDOMAIN_LABEL_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")
+
+    @classmethod
+    def _normalize_subdomain(cls, raw: Optional[str]) -> str:
+        """Validate an operator-supplied subdomain into a safe ``<label>.zendesk.com`` host.
+
+        SSRF guard: this value ends up in the request URL, so we strip any
+        scheme/path/query/fragment/port/userinfo and require the remaining host to be a
+        single valid label (optionally already suffixed with ``.zendesk.com``). Anything
+        else returns "" — requests then fail locally instead of reaching an
+        attacker-chosen host (e.g. ``evil.com#`` -> host ``evil.com``).
+        """
+        value = (raw or "").strip().lower()
+        if not value:
+            return ""
+        # Keep only the host portion: drop scheme, then anything from the first / ? # @ :
+        value = re.sub(r"^https?://", "", value)
+        value = re.split(r"[/?#@:]", value, maxsplit=1)[0]
+        label = value[: -len(".zendesk.com")] if value.endswith(".zendesk.com") else value
+        if not cls._SUBDOMAIN_LABEL_RE.fullmatch(label):
+            logger.warning("Ignoring invalid Zendesk subdomain %r", raw)
+            return ""
+        return f"{label}.zendesk.com"
 
     def _resolve_auth_method(
         self, auth_method: Optional[str], has_param_client_creds: bool = False
@@ -433,11 +454,9 @@ class ZendeskConnector:
         Support product is inactive (expired trial), so it reported "connected"
         for accounts where ticket creation 403s.
         """
-        subdomain = cd.get("subdomain", "")
-        if not subdomain.endswith(".zendesk.com"):
-            subdomain = f"{subdomain}.zendesk.com"
+        # The connector validates/normalizes the subdomain (SSRF guard), so pass it raw.
         connector = ZendeskConnector(
-            subdomain=subdomain,
+            subdomain=cd.get("subdomain"),
             email=cd.get("email"),
             api_token=cd.get("api_token"),
             auth_method=cd.get("auth_method"),

--- a/backend/app/modules/integration/zendesk.py
+++ b/backend/app/modules/integration/zendesk.py
@@ -23,6 +23,10 @@ class ZendeskConnector:
         subdomain: Optional[str] = None,
         email: Optional[str] = None,
         api_token: Optional[str] = None,
+        auth_method: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        oauth_scope: Optional[str] = None,
     ):
         raw = (subdomain or settings.ZENDESK_SUBDOMAIN or "").strip()
         # Normalize subdomain: ensure it has .zendesk.com (matches connection_tester)
@@ -35,12 +39,153 @@ class ZendeskConnector:
 
         self.email = email or settings.ZENDESK_EMAIL
         self.api_token = api_token or settings.ZENDESK_API_TOKEN
+
+        # OAuth2 client-credentials fields. Zendesk is deprecating API tokens
+        # (fully removed 2027-04-30), so client credentials are the forward path.
+        self.client_id = client_id or settings.ZENDESK_CLIENT_ID
+        self.client_secret = client_secret or settings.ZENDESK_CLIENT_SECRET
+        self.oauth_scope = (
+            oauth_scope or settings.ZENDESK_OAUTH_SCOPE or "read write"
+        )
+
+        # Resolve the effective auth method. Precedence: an explicit auth_method wins;
+        # then explicit per-call client credentials imply OAuth; then the global
+        # settings default (used by the no-arg env-based callers); finally infer from
+        # whatever credentials ended up configured.
+        self.auth_method = self._resolve_auth_method(
+            auth_method,
+            has_param_client_creds=bool(client_id and client_secret),
+        )
+
         self.base_url = f"https://{self.subdomain}/api/v2"
         self.help_center_url = f"https://{self.subdomain}/api/v2/help_center"
+        self.token_url = f"https://{self.subdomain}/oauth/tokens"
         # Ensure api_token is not None for auth tuple
         token = self.api_token or ""
         self._auth: Tuple[str, str] = (f"{self.email}/token", token)
+        # Populated lazily after a successful client-credentials token exchange.
+        # The lock serializes the token fetch so a concurrent first-request burst
+        # (e.g. the category fan-out in fetch_articles) does one exchange, not N.
+        self._access_token: Optional[str] = None
+        self._token_lock = asyncio.Lock()
         self.page_size = 50
+
+    def _resolve_auth_method(
+        self, auth_method: Optional[str], has_param_client_creds: bool = False
+    ) -> str:
+        """Normalize the auth method to ``api_token`` or ``oauth_client_credentials``."""
+        known = ("api_token", "oauth_client_credentials")
+        # 1. An explicit, recognized method always wins.
+        method = (auth_method or "").strip()
+        if method in known:
+            return method
+        # 2. Explicit per-call client credentials imply OAuth.
+        if has_param_client_creds:
+            return "oauth_client_credentials"
+        # 3. The global settings default (for no-arg env-based callers).
+        settings_method = (getattr(settings, "ZENDESK_AUTH_METHOD", None) or "").strip()
+        if settings_method in known:
+            return settings_method
+        # 4. Last resort: infer from whatever credentials are configured.
+        if self.client_id and self.client_secret:
+            return "oauth_client_credentials"
+        return "api_token"
+
+    def _require_credentials(self) -> None:
+        """Validate that credentials for the active auth method are present."""
+        if self.auth_method == "oauth_client_credentials":
+            if not self.client_id or not self.client_secret:
+                raise ValueError("Zendesk client id and client secret are required")
+        else:
+            if not self.api_token:
+                raise ValueError("Zendesk API token is required")
+            if not self.email:
+                raise ValueError("Zendesk email is required")
+
+    async def _request_json(
+        self,
+        method: str,
+        url: str,
+        json: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        auth: Optional[Tuple[str, str]] = None,
+        timeout: float = 10.0,
+        context: str = "Zendesk API",
+    ) -> Dict[str, Any]:
+        """Perform a single HTTP request and return the parsed JSON.
+
+        Shared transport core for both the API calls and the OAuth token exchange.
+        Uses trust_env=True so HTTP_PROXY/HTTPS_PROXY from env are respected (e.g. in
+        the Celery worker), and wraps httpx errors in ``HTTPException``.
+        """
+        async with httpx.AsyncClient(
+            auth=auth,
+            timeout=timeout,
+            trust_env=True,  # Use HTTP_PROXY/HTTPS_PROXY from environment
+            follow_redirects=True,
+        ) as client:
+            try:
+                response = await client.request(
+                    method, url, json=json, params=params, headers=headers
+                )
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as e:
+                logger.error(
+                    f"{context} error [{e.response.status_code}]: {e.response.text}"
+                )
+                raise HTTPException(
+                    status_code=e.response.status_code,
+                    detail=e.response.text,
+                ) from e
+            except httpx.RequestError as e:
+                logger.error(
+                    "%s network error (check worker outbound access, proxy, DNS): %s",
+                    context,
+                    e,
+                    exc_info=True,
+                )
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"{context} network error: {type(e).__name__}: {e}",
+                ) from e
+
+    async def _get_access_token(self, force_refresh: bool = False) -> str:
+        """Authenticate via the OAuth2 **client-credentials** grant.
+
+        POSTs ``client_id``/``client_secret`` to ``/oauth/tokens`` and caches the
+        returned ``access_token`` on the instance. Unlike other flows this grant
+        returns no refresh token and needs no user authorization, so it is only
+        suitable for server-side/trusted use. Pass ``force_refresh=True`` to discard
+        a cached token (e.g. after a 401). The fetch is serialized under a lock with
+        a double-check so concurrent callers share a single token exchange.
+        """
+        if self._access_token and not force_refresh:
+            return self._access_token
+
+        async with self._token_lock:
+            if self._access_token and not force_refresh:
+                return self._access_token
+            if not self.client_id or not self.client_secret:
+                raise ValueError("Zendesk client id and client secret are required")
+
+            result = await self._request_json(
+                "POST",
+                self.token_url,
+                json={
+                    "grant_type": "client_credentials",
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                    "scope": self.oauth_scope,
+                },
+                context="Zendesk OAuth token",
+            )
+            access_token = result.get("access_token")
+            if not access_token:
+                raise ValueError("Zendesk OAuth2 response did not include an access_token")
+            self._access_token = access_token
+            return access_token
 
     async def _make_request(
         self,
@@ -50,37 +195,33 @@ class ZendeskConnector:
         params: Optional[Dict[str, Any]] = None,
         timeout: float = 10.0,
     ) -> Dict[str, Any]:
-        """Internal method to make HTTP requests to Zendesk API.
-        Uses trust_env=True so HTTP_PROXY/HTTPS_PROXY from env are respected (e.g. in Celery worker).
+        """Make an authenticated HTTP request to the Zendesk API.
+
+        Authentication depends on ``self.auth_method``: ``api_token`` uses HTTP Basic
+        (``email/token``); ``oauth_client_credentials`` sends a Bearer access token,
+        refreshing it once and retrying if the cached token is rejected with a 401.
         """
-        async with httpx.AsyncClient(
-            auth=self._auth,
-            timeout=timeout,
-            trust_env=True,  # Use HTTP_PROXY/HTTPS_PROXY from environment
-            follow_redirects=True,
-        ) as client:
-            try:
-                response = await client.request(method, url, json=json, params=params)
-                response.raise_for_status()
-                return response.json()
-            except httpx.HTTPStatusError as e:
-                logger.error(
-                    f"Zendesk API error [{e.response.status_code}]: {e.response.text}"
-                )
-                raise HTTPException(
-                    status_code=e.response.status_code,
-                    detail=e.response.text,
-                ) from e
-            except httpx.RequestError as e:
-                logger.error(
-                    "Zendesk network error (check worker outbound access, proxy, DNS): %s",
-                    e,
-                    exc_info=True,
-                )
-                raise HTTPException(
-                    status_code=500,
-                    detail=f"Zendesk API network error: {type(e).__name__}: {e}",
-                ) from e
+        if self.auth_method != "oauth_client_credentials":
+            return await self._request_json(
+                method, url, json=json, params=params, auth=self._auth, timeout=timeout
+            )
+
+        token = await self._get_access_token()
+        try:
+            return await self._request_json(
+                method, url, json=json, params=params,
+                headers={"Authorization": f"Bearer {token}"}, timeout=timeout,
+            )
+        except HTTPException as e:
+            if e.status_code != 401:
+                raise
+            # A cached access token was rejected; refresh once and retry.
+            logger.info("Zendesk OAuth token rejected (401); refreshing and retrying")
+            token = await self._get_access_token(force_refresh=True)
+            return await self._request_json(
+                method, url, json=json, params=params,
+                headers={"Authorization": f"Bearer {token}"}, timeout=timeout,
+            )
 
     async def create_ticket(
         self,
@@ -96,10 +237,7 @@ class ZendeskConnector:
         Create a Zendesk ticket via the REST API.
         Returns the ticket ID on success, None on failure.
         """
-        if not self.api_token:
-            raise ValueError("Zendesk API token is required")
-        if not self.email:
-            raise ValueError("Zendesk email is required")
+        self._require_credentials()
 
         url = f"{self.base_url}/tickets.json"
         payload: Dict[str, Any] = {
@@ -302,6 +440,10 @@ class ZendeskConnector:
             subdomain=subdomain,
             email=cd.get("email"),
             api_token=cd.get("api_token"),
+            auth_method=cd.get("auth_method"),
+            client_id=cd.get("client_id"),
+            client_secret=cd.get("client_secret"),
+            oauth_scope=cd.get("oauth_scope"),
         )
         await connector._make_request("GET", f"{connector.base_url}/tickets/count.json")
         return {"success": True, "message": "Successfully connected to Zendesk."}

--- a/backend/app/modules/workflow/engine/nodes/zendesk_tool_node.py
+++ b/backend/app/modules/workflow/engine/nodes/zendesk_tool_node.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from ..base_node import BaseNode
 from ..node_result import node_failure
+from app.core.utils.encryption_utils import decrypt_key
 from app.modules.integration.zendesk import ZendeskConnector
 from app.services.app_settings import AppSettingsService
 from app.dependencies.injector import injector
@@ -50,15 +51,29 @@ class ZendeskToolNode(BaseNode):
             app_settings_service = injector.get(AppSettingsService)
             app_settings = await app_settings_service.get_by_id(UUID(app_settings_id))
 
-            # Extract subdomain, email, and api_token from app settings values
+            # Extract credentials from app settings values. Zendesk supports two auth
+            # methods: legacy API token (email + api_token) and OAuth client
+            # credentials (client_id + client_secret). The client secret is stored
+            # encrypted, so decrypt it before use.
             values = (
                 app_settings.values if isinstance(app_settings.values, dict) else {}
             )
-            subdomain = str(values.get("zendesk_subdomain"))
-            email = str(values.get("zendesk_email"))
-            api_token = str(values.get("zendesk_api_token"))
+            subdomain = values.get("zendesk_subdomain")
+            email = values.get("zendesk_email")
+            api_token = values.get("zendesk_api_token")
+            auth_method = values.get("zendesk_auth_method")
+            client_id = values.get("zendesk_client_id")
+            client_secret = values.get("zendesk_client_secret")
+            if client_secret:
+                client_secret = decrypt_key(client_secret)
             zendesk_connector = ZendeskConnector(
-                subdomain=subdomain, email=email, api_token=api_token)
+                subdomain=subdomain,
+                email=email,
+                api_token=api_token,
+                auth_method=auth_method,
+                client_id=client_id,
+                client_secret=client_secret,
+            )
             # Create the Zendesk ticket
             result = await zendesk_connector.create_ticket(
                 subject=subject,

--- a/backend/app/schemas/dynamic_form_schemas/app_settings_schemas.py
+++ b/backend/app/schemas/dynamic_form_schemas/app_settings_schemas.py
@@ -6,7 +6,12 @@ All schemas use the unified TypeSchema structure from base.py.
 """
 
 from typing import List, Dict, Optional
-from .base import FieldSchema, TypeSchema, convert_typed_schemas_to_dict
+from .base import (
+    ConditionalField,
+    FieldSchema,
+    TypeSchema,
+    convert_typed_schemas_to_dict,
+)
 
 # Define field schemas for each integration type
 APP_SETTINGS_SCHEMAS: Dict[str, TypeSchema] = {
@@ -23,6 +28,25 @@ APP_SETTINGS_SCHEMAS: Dict[str, TypeSchema] = {
                 encrypted=False,
             ),
             FieldSchema(
+                name="zendesk_auth_method",
+                label="Authentication Method",
+                type="select",
+                required=True,
+                default="oauth_client_credentials",
+                options=[
+                    {
+                        "value": "oauth_client_credentials",
+                        "label": "OAuth Client Credentials (Recommended)",
+                    },
+                    {"value": "api_token", "label": "API Token (Legacy)"},
+                ],
+                description=(
+                    "Zendesk is removing API tokens on 2027-04-30. Use OAuth client "
+                    "credentials for new connections."
+                ),
+                encrypted=False,
+            ),
+            FieldSchema(
                 name="zendesk_email",
                 label="Zendesk Email",
                 type="text",
@@ -30,6 +54,9 @@ APP_SETTINGS_SCHEMAS: Dict[str, TypeSchema] = {
                 placeholder="admin@example.com",
                 description="Email address for API authentication",
                 encrypted=False,
+                conditional=ConditionalField(
+                    field="zendesk_auth_method", value="api_token"
+                ),
             ),
             FieldSchema(
                 name="zendesk_api_token",
@@ -39,6 +66,33 @@ APP_SETTINGS_SCHEMAS: Dict[str, TypeSchema] = {
                 placeholder="Enter API token",
                 description="Zendesk API token for authentication",
                 encrypted=False,
+                conditional=ConditionalField(
+                    field="zendesk_auth_method", value="api_token"
+                ),
+            ),
+            FieldSchema(
+                name="zendesk_client_id",
+                label="Zendesk Client ID",
+                type="text",
+                required=True,
+                placeholder="Enter OAuth client ID",
+                description="OAuth client (unique identifier) from Zendesk Admin Center",
+                encrypted=False,
+                conditional=ConditionalField(
+                    field="zendesk_auth_method", value="oauth_client_credentials"
+                ),
+            ),
+            FieldSchema(
+                name="zendesk_client_secret",
+                label="Zendesk Client Secret",
+                type="password",
+                required=True,
+                placeholder="Enter OAuth client secret",
+                description="OAuth client secret (client-credentials flow)",
+                encrypted=True,
+                conditional=ConditionalField(
+                    field="zendesk_auth_method", value="oauth_client_credentials"
+                ),
             ),
         ],
     ),

--- a/backend/app/schemas/dynamic_form_schemas/data_source_schemas.py
+++ b/backend/app/schemas/dynamic_form_schemas/data_source_schemas.py
@@ -261,12 +261,31 @@ DATA_SOURCE_SCHEMAS: Dict[str, TypeSchema] = {
                 placeholder="yourcompany.zendesk.com",
             ),
             FieldSchema(
+                name="auth_method",
+                type="select",
+                label="Authentication Method",
+                required=True,
+                default="oauth_client_credentials",
+                options=[
+                    {
+                        "value": "oauth_client_credentials",
+                        "label": "OAuth Client Credentials (Recommended)",
+                    },
+                    {"value": "api_token", "label": "API Token (Legacy)"},
+                ],
+                description=(
+                    "Zendesk is removing API tokens on 2027-04-30. Use OAuth client "
+                    "credentials for new connections."
+                ),
+            ),
+            FieldSchema(
                 name="email",
                 type="text",
                 label="Email",
                 required=True,
                 description="Zendesk account email address",
                 placeholder="user@example.com",
+                conditional=ConditionalField(field="auth_method", value="api_token"),
             ),
             FieldSchema(
                 name="api_token",
@@ -274,6 +293,27 @@ DATA_SOURCE_SCHEMAS: Dict[str, TypeSchema] = {
                 label="API Token",
                 required=True,
                 description="Zendesk API token for authentication",
+                conditional=ConditionalField(field="auth_method", value="api_token"),
+            ),
+            FieldSchema(
+                name="client_id",
+                type="text",
+                label="Client ID",
+                required=True,
+                description="OAuth client (unique identifier) from Zendesk Admin Center",
+                conditional=ConditionalField(
+                    field="auth_method", value="oauth_client_credentials"
+                ),
+            ),
+            FieldSchema(
+                name="client_secret",
+                type="password",
+                label="Client Secret",
+                required=True,
+                description="OAuth client secret (client-credentials flow)",
+                conditional=ConditionalField(
+                    field="auth_method", value="oauth_client_credentials"
+                ),
             ),
             FieldSchema(
                 name="locale",

--- a/backend/app/services/app_settings.py
+++ b/backend/app/services/app_settings.py
@@ -66,6 +66,9 @@ class AppSettingsService:
                         "subdomain": cd.get("zendesk_subdomain"),
                         "email": cd.get("zendesk_email"),
                         "api_token": cd.get("zendesk_api_token"),
+                        "auth_method": cd.get("zendesk_auth_method"),
+                        "client_id": cd.get("zendesk_client_id"),
+                        "client_secret": cd.get("zendesk_client_secret"),
                     }
                 )
             return {
@@ -151,8 +154,20 @@ class AppSettingsService:
                 error_detail=f"Unknown type: {setting_type}",
             )
 
-        # Validate required fields
-        required_fields = [field.name for field in schema.fields if field.required]
+        # Validate required fields. A field guarded by a ``conditional`` is only
+        # required when its controlling field currently holds the matching value
+        # (e.g. Zendesk's client_secret is required only for the OAuth auth method).
+        def _is_active(field) -> bool:
+            cond = getattr(field, "conditional", None)
+            if not cond:
+                return True
+            return (values or {}).get(cond.field) == cond.value
+
+        required_fields = [
+            field.name
+            for field in schema.fields
+            if field.required and _is_active(field)
+        ]
         missing_fields = [
             field
             for field in required_fields

--- a/backend/app/services/datasources.py
+++ b/backend/app/services/datasources.py
@@ -27,6 +27,7 @@ class DataSourceService:
         "refresh_token",
         "password",
         "api_token",
+        "client_secret",
         "private_key_passphrase",
         "smb_password",
         "connection_string",

--- a/backend/app/tasks/zendesk_article_sync_tasks.py
+++ b/backend/app/tasks/zendesk_article_sync_tasks.py
@@ -284,14 +284,31 @@ async def import_zendesk_articles_to_kb_async(
         conn_data = ds.connection_data
 
         subdomain = conn_data.get("subdomain")
-        email = conn_data.get("email")
-        api_token = conn_data.get("api_token")
+        # OAuth client-credentials fields (Zendesk removes API tokens on 2027-04-30).
+        # conn_data is decrypted (get_by_id(..., True)), so client_secret is plaintext.
         locale = conn_data.get("locale")  # Optional
         category_ids = _parse_zendesk_category_ids(conn_data)
         section_id = conn_data.get("section_id")  # Optional
 
-        if not subdomain or not email or not api_token:
-            err = "Incomplete Zendesk connection (subdomain, email, and api_token required)"
+        # Build the connector up front so it is the single source of truth for the
+        # resolved auth method, then validate the credentials that method needs.
+        zendesk_connector = ZendeskConnector(
+            subdomain=subdomain,
+            email=conn_data.get("email"),
+            api_token=conn_data.get("api_token"),
+            auth_method=conn_data.get("auth_method"),
+            client_id=conn_data.get("client_id"),
+            client_secret=conn_data.get("client_secret"),
+        )
+        try:
+            if not subdomain:
+                raise ValueError("Zendesk subdomain is required")
+            zendesk_connector._require_credentials()
+            creds_ok, err = True, ""
+        except ValueError as e:
+            creds_ok, err = False, f"Incomplete Zendesk connection ({e})"
+
+        if not creds_ok:
             logger.error(f"Knowledge base {kb.id}: {err}")
             ku = _kb_update_dict(kb)
             ku["last_synced"] = datetime.now()
@@ -309,11 +326,6 @@ async def import_zendesk_articles_to_kb_async(
             continue
 
         try:
-            # Fetch articles from Zendesk using ZendeskConnector
-            zendesk_connector = ZendeskConnector(
-                subdomain=subdomain, email=email, api_token=api_token
-            )
-
             fetched_articles = await zendesk_connector.fetch_articles(
                 locale=locale,
                 category_ids=category_ids,

--- a/backend/tests/unit/integration/test_zendesk_connector.py
+++ b/backend/tests/unit/integration/test_zendesk_connector.py
@@ -1,0 +1,218 @@
+"""Unit tests for ZendeskConnector OAuth client-credentials support.
+
+Zendesk is removing API tokens on 2027-04-30, so the connector supports two auth
+methods: the legacy API token (HTTP Basic ``email/token``) and the OAuth2
+client-credentials grant (Bearer access token from ``/oauth/tokens``). These tests
+cover auth-method resolution, credential validation, and that requests send the
+right auth (Basic vs Bearer), refreshing the token once on a 401.
+
+httpx is faked at the module level because ``_get_access_token`` opens its own
+client (unlike ``_make_request``), so patching ``_make_request`` alone would not
+intercept the token exchange.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from app.modules.integration.zendesk import ZendeskConnector
+
+_OAUTH = {
+    "subdomain": "acme",
+    "auth_method": "oauth_client_credentials",
+    "client_id": "client-id",
+    "client_secret": "client-secret",
+}
+
+
+def _resp(status: int, url: str, *, json=None, text=""):
+    """Build a real httpx.Response so raise_for_status()/json() behave normally."""
+    req = httpx.Request("GET", url)
+    if json is not None:
+        return httpx.Response(status, json=json, request=req)
+    return httpx.Response(status, text=text, request=req)
+
+
+def _patch_httpx(responses):
+    """Patch httpx.AsyncClient with a fake that serves ``responses`` in order.
+
+    Returns a ``calls`` list of (method, url, headers) tuples so tests can assert
+    the auth header sent on each request. All requests (API calls and the OAuth
+    token exchange) go through httpx.AsyncClient.request.
+    """
+    calls = []
+    queue = list(responses)
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def request(self, method, url, json=None, params=None, headers=None):
+            calls.append((method, url, headers))
+            return queue.pop(0)
+
+    patcher = patch(
+        "app.modules.integration.zendesk.httpx.AsyncClient", _FakeClient
+    )
+    return patcher, calls
+
+
+# --------------------------------------------------------------------------- #
+# Auth-method resolution (synchronous, no network)
+# --------------------------------------------------------------------------- #
+
+def test_explicit_auth_method_wins():
+    c = ZendeskConnector(subdomain="acme", auth_method="api_token", client_id="x", client_secret="y")
+    assert c.auth_method == "api_token"
+
+
+def test_explicit_client_credentials_imply_oauth():
+    # No auth_method passed, but per-call client credentials are present.
+    c = ZendeskConnector(subdomain="acme", client_id="x", client_secret="y", auth_method=None)
+    assert c.auth_method == "oauth_client_credentials"
+
+
+def test_defaults_to_api_token_without_credentials():
+    c = ZendeskConnector(subdomain="acme", email="a@b.com", api_token="tok", auth_method=None)
+    assert c.auth_method == "api_token"
+
+
+def test_subdomain_and_token_url_normalized():
+    c = ZendeskConnector(**_OAUTH)
+    assert c.subdomain == "acme.zendesk.com"
+    assert c.token_url == "https://acme.zendesk.com/oauth/tokens"
+
+
+# --------------------------------------------------------------------------- #
+# Credential validation
+# --------------------------------------------------------------------------- #
+
+def test_require_credentials_oauth_missing_secret():
+    with patch("app.modules.integration.zendesk.settings.ZENDESK_CLIENT_SECRET", None):
+        c = ZendeskConnector(
+            subdomain="acme", auth_method="oauth_client_credentials", client_id="id"
+        )
+    with pytest.raises(ValueError):
+        c._require_credentials()
+
+
+def test_require_credentials_api_token_missing_token():
+    # The settings fallback for the token is a placeholder string, so neutralize it
+    # to exercise the "no token" branch.
+    with patch("app.modules.integration.zendesk.settings.ZENDESK_API_TOKEN", ""):
+        c = ZendeskConnector(
+            subdomain="acme", auth_method="api_token", email="a@b.com", api_token=None
+        )
+    with pytest.raises(ValueError):
+        c._require_credentials()
+
+
+# --------------------------------------------------------------------------- #
+# Request auth: Bearer (OAuth) vs Basic (API token)
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_oauth_request_sends_bearer_token():
+    c = ZendeskConnector(**_OAUTH)
+    responses = [
+        _resp(200, c.token_url, json={"access_token": "TOKEN1"}),
+        _resp(200, f"{c.base_url}/tickets/count.json", json={"count": {"value": 3}}),
+    ]
+    patcher, calls = _patch_httpx(responses)
+    with patcher:
+        result = await c._make_request("GET", f"{c.base_url}/tickets/count.json")
+
+    assert result == {"count": {"value": 3}}
+    # First call is the token exchange (POST to the token endpoint), then the API
+    # call carrying the Bearer header.
+    assert calls[0][0] == "POST" and calls[0][1] == c.token_url
+    assert calls[1][2]["Authorization"] == "Bearer TOKEN1"
+
+
+@pytest.mark.asyncio
+async def test_oauth_refreshes_token_once_on_401():
+    c = ZendeskConnector(**_OAUTH)
+    url = f"{c.base_url}/tickets/count.json"
+    responses = [
+        _resp(200, c.token_url, json={"access_token": "TOKEN1"}),
+        _resp(401, url, text="unauthorized"),  # stale token → 401
+        _resp(200, c.token_url, json={"access_token": "TOKEN2"}),  # refreshed
+        _resp(200, url, json={"count": {"value": 7}}),
+    ]
+    patcher, calls = _patch_httpx(responses)
+    with patcher:
+        result = await c._make_request("GET", url)
+
+    assert result == {"count": {"value": 7}}
+    # Two token exchanges (initial + forced refresh) and the retry carries the new token.
+    token_exchanges = [x for x in calls if x[1] == c.token_url]
+    assert len(token_exchanges) == 2
+    assert calls[-1][2]["Authorization"] == "Bearer TOKEN2"
+
+
+@pytest.mark.asyncio
+async def test_api_token_mode_uses_basic_auth_no_token_exchange():
+    c = ZendeskConnector(
+        subdomain="acme", email="a@b.com", api_token="tok", auth_method="api_token"
+    )
+    url = f"{c.base_url}/tickets/count.json"
+    patcher, calls = _patch_httpx([_resp(200, url, json={"ok": True})])
+    with patcher:
+        result = await c._make_request("GET", url)
+
+    assert result == {"ok": True}
+    # No token endpoint call in API-token mode, and no Bearer header.
+    assert all(x[1] != c.token_url for x in calls)
+    assert calls[0][2] is None  # headers not set for Basic auth
+
+
+# --------------------------------------------------------------------------- #
+# test_connection wiring
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_test_connection_forwards_oauth_fields():
+    """test_connection passes OAuth fields through and reports success."""
+    with patch.object(
+        ZendeskConnector, "_make_request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = {"count": {"value": 0}}
+        result = await ZendeskConnector.test_connection(
+            {
+                "subdomain": "acme",
+                "auth_method": "oauth_client_credentials",
+                "client_id": "client-id",
+                "client_secret": "client-secret",
+                "oauth_scope": "read write",
+            }
+        )
+
+    assert result == {"success": True, "message": "Successfully connected to Zendesk."}
+    method, url = mock_request.await_args.args[:2]
+    assert method == "GET"
+    assert url.endswith("/tickets/count.json")
+
+
+@pytest.mark.asyncio
+async def test_test_connection_raises_on_auth_failure():
+    with patch.object(
+        ZendeskConnector, "_make_request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.side_effect = HTTPException(status_code=401, detail="invalid")
+        with pytest.raises(HTTPException):
+            await ZendeskConnector.test_connection(
+                {
+                    "subdomain": "acme",
+                    "auth_method": "oauth_client_credentials",
+                    "client_id": "client-id",
+                    "client_secret": "client-secret",
+                }
+            )

--- a/backend/tests/unit/integration/test_zendesk_connector.py
+++ b/backend/tests/unit/integration/test_zendesk_connector.py
@@ -91,6 +91,28 @@ def test_subdomain_and_token_url_normalized():
     assert c.token_url == "https://acme.zendesk.com/oauth/tokens"
 
 
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("acme", "acme.zendesk.com"),
+        ("acme.zendesk.com", "acme.zendesk.com"),
+        ("ACME", "acme.zendesk.com"),                    # lower-cased
+        ("https://acme.zendesk.com/agent", "acme.zendesk.com"),  # scheme + path stripped
+        ("acme:8080", "acme.zendesk.com"),               # port stripped
+        ("acme.zendesk.com@evil.com", "acme.zendesk.com"),  # userinfo trick neutralized
+        ("evil.com#", ""),                               # fragment trick -> host evil.com, rejected
+        ("evil.com", ""),                                # different host rejected
+        ("acme.zendesk.com.evil.com", ""),               # suffix spoof rejected
+        ("<enter-value-here>", ""),                      # unconfigured placeholder rejected
+        ("", ""),
+    ],
+)
+def test_subdomain_normalization_blocks_ssrf(raw, expected):
+    # The subdomain flows into the request URL; only a clean <label>.zendesk.com host
+    # is allowed, so attacker-crafted values cannot redirect requests to another host.
+    assert ZendeskConnector._normalize_subdomain(raw) == expected
+
+
 # --------------------------------------------------------------------------- #
 # Credential validation
 # --------------------------------------------------------------------------- #

--- a/frontend/src/components/SchemaFormRenderer/index.tsx
+++ b/frontend/src/components/SchemaFormRenderer/index.tsx
@@ -1,5 +1,6 @@
 import { FieldSchema, FieldValue } from '@/interfaces/dynamicFormSchemas.interface';
 import { FormFieldRenderer } from '@/components/FormFieldRenderer';
+import { isFieldVisible } from './schemaFormUtils';
 
 interface SchemaFormRendererProps {
   schema: { fields: FieldSchema[] };
@@ -16,13 +17,8 @@ export function SchemaFormRenderer({
   showAdvanced,
   advancedOnly = false,
 }: SchemaFormRendererProps) {
-  const isFieldVisible = (field: FieldSchema): boolean => {
-    if (!field.conditional) return true;
-    return connectionData[field.conditional.field] === field.conditional.value;
-  };
-
-  const regularFields = schema.fields.filter((f) => f.required && isFieldVisible(f));
-  const advancedFields = schema.fields.filter((f) => !f.required && isFieldVisible(f));
+  const regularFields = schema.fields.filter((f) => f.required && isFieldVisible(f, connectionData));
+  const advancedFields = schema.fields.filter((f) => !f.required && isFieldVisible(f, connectionData));
 
   const fieldsToRender = advancedOnly ? advancedFields : [...regularFields, ...(showAdvanced ? advancedFields : [])];
 

--- a/frontend/src/components/SchemaFormRenderer/schemaFormUtils.ts
+++ b/frontend/src/components/SchemaFormRenderer/schemaFormUtils.ts
@@ -1,0 +1,32 @@
+import type { FieldSchema, FieldValue } from '@/interfaces/dynamicFormSchemas.interface';
+
+/**
+ * Shared helpers for schema-driven forms (used by SchemaFormRenderer and the
+ * data-source / app-setting dialogs) so the conditional-visibility and default
+ * rules live in one place.
+ */
+
+/**
+ * A field is visible when it has no `conditional`, or when its controlling
+ * field currently holds the matching value (e.g. an OAuth secret shown only
+ * when the auth method is set to client credentials).
+ */
+export function isFieldVisible(field: Pick<FieldSchema, 'conditional'>, values: Record<string, FieldValue>): boolean {
+  if (!field.conditional) return true;
+  return values[field.conditional.field] === field.conditional.value;
+}
+
+/**
+ * Collect the schema-declared default values for a set of fields, so a form can
+ * seed them into its state (making conditional fields keyed off a defaulted
+ * select visible immediately).
+ */
+export function getSchemaDefaults(fields: FieldSchema[]): Record<string, FieldValue> {
+  const defaults: Record<string, FieldValue> = {};
+  for (const field of fields) {
+    if (field.default !== undefined && field.default !== null) {
+      defaults[field.name] = field.default;
+    }
+  }
+  return defaults;
+}

--- a/frontend/src/views/AppSettings/components/AppSettingDialog.tsx
+++ b/frontend/src/views/AppSettings/components/AppSettingDialog.tsx
@@ -16,12 +16,13 @@ import { Loader2, Plus, X } from 'lucide-react';
 import { AppSetting } from '@/interfaces/app-setting.interface';
 import { useQuery } from '@tanstack/react-query';
 import { SchemaFormRenderer } from '@/components/SchemaFormRenderer';
+import { getSchemaDefaults, isFieldVisible } from '@/components/SchemaFormRenderer/schemaFormUtils';
 import { ConnectionTestPanel } from '@/components/ConnectionTestPanel';
 import { CollapsibleSection } from '@/components/CollapsibleSection';
 import { CredentialSetupGuidePanel } from './CredentialSetupGuidePanel';
 import { CREDENTIAL_SETUP_GUIDES } from './credentialSetupGuides';
 import type { ConnectionStatus } from '@/interfaces/connectionStatus.interface';
-import type { FieldValue } from '@/interfaces/dynamicFormSchemas.interface';
+import type { FieldSchema, FieldValue } from '@/interfaces/dynamicFormSchemas.interface';
 
 interface AppSettingDialogProps {
   isOpen: boolean;
@@ -73,6 +74,22 @@ export function AppSettingDialog({
 
   const appSettingSchemas = data ?? {};
 
+  // Seed a type's schema-declared field defaults (e.g. Zendesk's auth_method) so that
+  // conditional fields keyed off a defaulted select are visible immediately.
+  const schemaDefaultsFor = (settingType: AppSetting['type']): Record<string, FieldValue> =>
+    getSchemaDefaults(appSettingSchemas[settingType]?.fields ?? []);
+
+  // Labels of required, currently-visible fields the user hasn't filled in — shared by
+  // the submit and test-connection validators.
+  const missingRequiredLabels = (schema: { fields?: FieldSchema[] }): string[] =>
+    (schema.fields ?? [])
+      .filter((field) => {
+        if (!field.required || !isFieldVisible(field, values)) return false;
+        const value = values[field.name];
+        return value === undefined || value === '' || (Array.isArray(value) && value.length === 0);
+      })
+      .map((field) => field.label);
+
   useEffect(() => {
     if (isOpen) {
       resetForm();
@@ -80,9 +97,24 @@ export function AppSettingDialog({
         populateFormWithSetting(settingToEdit);
       } else if (mode === 'create' && initialType) {
         setType(initialType);
+        // Seed defaults here (not only in the schema-load effect below) so a preset
+        // type is populated on every open — including reopens where `type` is
+        // unchanged and the type-keyed effect would not re-fire.
+        setValues(schemaDefaultsFor(initialType));
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, settingToEdit, mode]);
+
+  // In create mode, seed the selected type's defaults once its schema is available.
+  // Covers the first open where the type is set before the schema query resolves.
+  // Only seeds when the user hasn't entered values yet.
+  useEffect(() => {
+    if (mode !== 'create' || type === 'Other') return;
+    if (!appSettingSchemas[type]?.fields) return;
+    setValues((prev) => (Object.keys(prev).length === 0 ? schemaDefaultsFor(type) : prev));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [type, data, mode]);
 
   const resetForm = () => {
     setName('');
@@ -157,15 +189,7 @@ export function AppSettingDialog({
 
     // Validate schema-based fields
     if (type !== 'Other' && appSettingSchemas[type]) {
-      const schema = appSettingSchemas[type];
-      const schemaMissing = schema.fields
-        .filter((field) => {
-          if (!field.required) return false;
-          const value = values[field.name];
-          return value === undefined || value === '' || (Array.isArray(value) && value.length === 0);
-        })
-        .map((field) => field.label);
-
+      const schemaMissing = missingRequiredLabels(appSettingSchemas[type]);
       if (schemaMissing.length > 0) {
         if (schemaMissing.length === 1) {
           toast.error(`${schemaMissing[0]} is required.`);
@@ -226,14 +250,7 @@ export function AppSettingDialog({
     // Validate required schema fields before hitting the connector.
     const schema = appSettingSchemas[type];
     if (schema) {
-      const schemaMissing = schema.fields
-        .filter((field) => {
-          if (!field.required) return false;
-          const value = values[field.name];
-          return value === undefined || value === '' || (Array.isArray(value) && value.length === 0);
-        })
-        .map((field) => field.label);
-
+      const schemaMissing = missingRequiredLabels(schema);
       if (schemaMissing.length > 0) {
         toast.error(`Please provide: ${schemaMissing.join(', ')}.`);
         return;
@@ -303,7 +320,9 @@ export function AppSettingDialog({
                       setCustomFields([{ key: '', value: '' }]);
                     } else {
                       if (type === 'Other' || mode === 'create') {
-                        setValues({});
+                        // Seed schema defaults so conditional fields (e.g. Zendesk's
+                        // OAuth credentials under the default auth method) show at once.
+                        setValues(schemaDefaultsFor(newType));
                       }
                       setCustomFields([{ key: '', value: '' }]);
                     }


### PR DESCRIPTION
Add OAuth client-credentials as a selectable auth method alongside the legacy API token (deprecated 2027-04-30) for App Settings and KB data sources.

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
