### PR TITLE
fix: fail-closed tenant context and race-free background-task flag

### DIFF
--- a/backend/app/core/config/settings.py
+++ b/backend/app/core/config/settings.py
@@ -261,8 +261,9 @@ class ProjectSettings(BaseSettings):
     TEST_USERNAME: Optional[str] = "test"
     TEST_PASSWORD: Optional[str] = "test"
 
-    # Check if inside celery container
-    BACKGROUND_TASK: bool = False
+    # NOTE: the former mutable ``BACKGROUND_TASK`` global was removed. Background-task
+    # state is now context-local — see ``app.core.tenant_scope.background_task_context``
+    # / ``is_background_task`` (avoids the cross-task race under concurrency).
     BEDROCK_MAX_RETRY_QUERY_EMBEDDING: int = 3
     BEDROCK_TIMEOUT_QUERY_EMBEDDING_SECONDS: int = 8
 

--- a/backend/app/core/tenant_scope.py
+++ b/backend/app/core/tenant_scope.py
@@ -5,8 +5,9 @@ Custom tenant-aware scope for dependency injection
 from injector import ScopeDecorator
 import logging
 import threading
+from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Any, Dict, Type, TypeVar
+from typing import Any, Dict, Iterator, Type, TypeVar
 
 from injector import Provider, Scope, InstanceProvider
 
@@ -66,13 +67,48 @@ def set_tenant_context(tenant_id: str) -> None:
 
 
 def get_tenant_context() -> str:
-    """Get the current tenant ID from context"""
+    """Get the current tenant ID from context.
+
+    Lenient accessor: falls back to ``"master"`` when no context is set. Use for
+    non-isolation-critical purposes (cache-key prefixes, storage paths, logging).
+    For paths that route a database session, use :func:`require_tenant_context`
+    instead so a missing context fails closed rather than silently hitting master.
+    """
     try:
         tenant_id = _tenant_id_ctx.get()
         # Return None if tenant_id is None (explicitly set)
         return tenant_id if tenant_id is not None else "master"
     except LookupError:
         return "master"
+
+
+class TenantContextError(RuntimeError):
+    """Raised when a tenant-scoped operation runs without an explicit tenant context."""
+
+
+def require_tenant_context() -> str:
+    """Strict, fail-closed accessor for isolation-critical paths (DB routing).
+
+    Unlike :func:`get_tenant_context`, this raises when no tenant context has been
+    explicitly set, instead of silently defaulting to the master database. Callers
+    that genuinely intend the master DB must opt in explicitly via
+    ``set_tenant_context("master")`` or ``clear_tenant_context()`` (both of which
+    set the context to ``"master"``, so they satisfy this check).
+    """
+    try:
+        tenant_id = _tenant_id_ctx.get()
+    except LookupError:
+        raise TenantContextError(
+            "No tenant context set for a tenant-scoped DB operation. Callers that "
+            'intend the master database must set it explicitly (set_tenant_context("master") '
+            "or clear_tenant_context())."
+        )
+    if tenant_id is None:
+        raise TenantContextError(
+            "Tenant context is None for a tenant-scoped DB operation; expected an "
+            'explicit tenant slug or "master".'
+        )
+    return tenant_id
 
 
 def clear_tenant_context() -> None:
@@ -82,4 +118,30 @@ def clear_tenant_context() -> None:
         _tenant_id_ctx.set("master")
     except LookupError:
         pass
+
+
+# ───────────── background-task scope ─────────────
+# Marks the current execution as a background (Celery) task so DB engine
+# selection can use a NullPool engine. Context-local (ContextVar) rather than a
+# mutable global on ``settings`` so concurrent tasks in one worker can't race.
+_background_task_ctx: ContextVar[bool] = ContextVar("background_task", default=False)
+
+
+def is_background_task() -> bool:
+    """Return whether the current context is running inside a background task."""
+    return _background_task_ctx.get()
+
+
+@contextmanager
+def background_task_context() -> Iterator[None]:
+    """Mark the enclosed block as a background task, restoring the prior value on exit.
+
+    Replaces the previous ``settings.BACKGROUND_TASK`` global mutation, which was
+    shared mutable state and raced under concurrency.
+    """
+    token = _background_task_ctx.set(True)
+    try:
+        yield
+    finally:
+        _background_task_ctx.reset(token)
 

--- a/backend/app/db/multi_tenant_session.py
+++ b/backend/app/db/multi_tenant_session.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from app.core.config.settings import settings
+from app.core.tenant_scope import is_background_task
 from app.db import models  # noqa: F401
 from app.db.base import Base
 
@@ -46,7 +47,8 @@ class MultiTenantSessionManager:
         logger.debug(f"get_tenant_engine called with tenant_id: {tenant}")
         if tenant is None:
             tenant = "master"
-        ktenant = tenant if not settings.BACKGROUND_TASK else tenant + "_background"
+        background_task = is_background_task()
+        ktenant = tenant if not background_task else tenant + "_background"
 
         if ktenant not in self._engines:
             tenant_url = settings.get_tenant_database_url(tenant)
@@ -54,7 +56,7 @@ class MultiTenantSessionManager:
                     f"Creating new engine for tenant {tenant} with URL: {tenant_url}"
                     )
 
-            if settings.BACKGROUND_TASK:
+            if background_task:
                 # Use NullPool for Celery - no connection pooling
                 logger.debug(f"🔧 Creating NullPool engine for Celery, tenant: {tenant}")
                 self._engines[ktenant] = create_async_engine(

--- a/backend/app/dependencies/dependency_injection.py
+++ b/backend/app/dependencies/dependency_injection.py
@@ -193,9 +193,12 @@ class Dependencies(Module):
         Returns an AsyncSession instance managed by fastapi-injector's request scope.
         Note: Sessions must be properly closed via middleware or cleanup mechanism.
         """
-        from app.core.tenant_scope import get_tenant_context
+        from app.core.tenant_scope import require_tenant_context
 
-        tenant_id = get_tenant_context()
+        # Fail closed: a missing tenant context must not silently route this
+        # session to the master database. Intentional master access sets the
+        # context explicitly (set_tenant_context("master") / clear_tenant_context()).
+        tenant_id = require_tenant_context()
         logger.debug(f"DI: Tenant context: {tenant_id}")
 
         session_factory = multi_tenant_manager.get_tenant_session_factory(tenant_id)

--- a/backend/app/tasks/base.py
+++ b/backend/app/tasks/base.py
@@ -5,8 +5,11 @@ import logging
 from typing import Callable, List, Any, Awaitable, Coroutine, Optional
 
 from app.services.tenant import TenantService
-from app.core.tenant_scope import set_tenant_context, clear_tenant_context
-from app.core.config.settings import settings
+from app.core.tenant_scope import (
+    set_tenant_context,
+    clear_tenant_context,
+    background_task_context,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -203,30 +206,29 @@ async def run_task_for_tenant(
         tenant_id: Tenant slug to scope execution to (from ``get_tenant_context()``).
         **kwargs: Arguments forwarded to the task function.
     """
-    settings.BACKGROUND_TASK = True
-    try:
-        logger.debug(f"Starting {task_name} task for tenant '{tenant_id}'...")
+    with background_task_context():
+        try:
+            logger.debug(f"Starting {task_name} task for tenant '{tenant_id}'...")
 
-        if tenant_id and tenant_id != "master":
-            set_tenant_context(tenant_id)
-        else:
+            if tenant_id and tenant_id != "master":
+                set_tenant_context(tenant_id)
+            else:
+                clear_tenant_context()
+
+            wrapper = create_task_wrapper(task_func)
+            result = await wrapper(**kwargs)
+
+            logger.info(f"{task_name} completed for tenant '{tenant_id}'")
+            return {"status": "success", "tenant_id": tenant_id, "result": result}
+        except Exception as e:
+            logger.error(
+                f"Error in {task_name} task for tenant '{tenant_id}': {str(e)}",
+                exc_info=True,
+            )
+            return {"status": "failed", "tenant_id": tenant_id, "error": str(e)}
+        finally:
             clear_tenant_context()
-
-        wrapper = create_task_wrapper(task_func)
-        result = await wrapper(**kwargs)
-
-        logger.info(f"{task_name} completed for tenant '{tenant_id}'")
-        return {"status": "success", "tenant_id": tenant_id, "result": result}
-    except Exception as e:
-        logger.error(
-            f"Error in {task_name} task for tenant '{tenant_id}': {str(e)}",
-            exc_info=True,
-        )
-        return {"status": "failed", "tenant_id": tenant_id, "error": str(e)}
-    finally:
-        clear_tenant_context()
-        settings.BACKGROUND_TASK = False
-        logger.debug(f"{task_name} task finished for tenant '{tenant_id}'.")
+            logger.debug(f"{task_name} task finished for tenant '{tenant_id}'.")
 
 
 async def run_task_for_all_tenants(task_func: Callable, **kwargs) -> List[dict]:
@@ -241,100 +243,98 @@ async def run_task_for_all_tenants(task_func: Callable, **kwargs) -> List[dict]:
         List of results for each tenant and master
     """
     results = []
-    settings.BACKGROUND_TASK = True
 
-    try:
-        from app.db.multi_tenant_session import multi_tenant_manager
-        from app.repositories.tenant import TenantRepository
+    with background_task_context():
+        try:
+            from app.db.multi_tenant_session import multi_tenant_manager
+            from app.repositories.tenant import TenantRepository
 
-        session_factory = multi_tenant_manager.get_tenant_session_factory("master")
-        async with session_factory() as session:
-            try:
-                repository = TenantRepository(session)
-                tenant_service = TenantService(repository=repository)
-                tenants = await tenant_service.get_all_tenants()
-
-                # First, run for master database (no tenant context)
+            session_factory = multi_tenant_manager.get_tenant_session_factory("master")
+            async with session_factory() as session:
                 try:
-                    logger.debug("Running task for master database")
-                    clear_tenant_context()  # Ensure no tenant context
+                    repository = TenantRepository(session)
+                    tenant_service = TenantService(repository=repository)
+                    tenants = await tenant_service.get_all_tenants()
 
-                    result = await task_func(**kwargs)
-                    if result:
+                    # First, run for master database (no tenant context)
+                    try:
+                        logger.debug("Running task for master database")
+                        clear_tenant_context()  # Ensure no tenant context
+
+                        result = await task_func(**kwargs)
+                        if result:
+                            results.append(
+                                {
+                                    "tenant_id": "master",
+                                    "tenant_name": "Master Database",
+                                    "tenant_slug": "master",
+                                    "result": result,
+                                }
+                            )
+                    except Exception as e:
+                        logger.error(
+                            f"Error running task for master database: {e}", exc_info=True
+                        )
                         results.append(
                             {
                                 "tenant_id": "master",
                                 "tenant_name": "Master Database",
                                 "tenant_slug": "master",
-                                "result": result,
+                                "error": str(e),
                             }
                         )
-                except Exception as e:
-                    logger.error(
-                        f"Error running task for master database: {e}", exc_info=True
-                    )
-                    results.append(
-                        {
-                            "tenant_id": "master",
-                            "tenant_name": "Master Database",
-                            "tenant_slug": "master",
-                            "error": str(e),
-                        }
-                    )
-                finally:
-                    # Ensure tenant context is cleared after master run
-                    clear_tenant_context()
+                    finally:
+                        # Ensure tenant context is cleared after master run
+                        clear_tenant_context()
 
-                if not tenants:
-                    logger.info("No active tenants found")
-                    return results
+                    if not tenants:
+                        logger.info("No active tenants found")
+                        return results
 
-                logger.info(f"Running task for {len(tenants)} tenant(s)")
+                    logger.info(f"Running task for {len(tenants)} tenant(s)")
 
-                for tenant in tenants:
-                    try:
-                        # Set tenant context for this tenant
-                        set_tenant_context(str(tenant.slug))
-                        logger.debug(
-                            f"Running task for tenant: {tenant.name} ({tenant.slug})"
-                        )
+                    for tenant in tenants:
+                        try:
+                            # Set tenant context for this tenant
+                            set_tenant_context(str(tenant.slug))
+                            logger.debug(
+                                f"Running task for tenant: {tenant.name} ({tenant.slug})"
+                            )
 
-                        # Run the task function with tenant context
-                        result = await task_func(**kwargs)
-                        if result:
+                            # Run the task function with tenant context
+                            result = await task_func(**kwargs)
+                            if result:
+                                results.append(
+                                    {
+                                        "tenant_id": str(tenant.id),
+                                        "tenant_name": tenant.name,
+                                        "tenant_slug": tenant.slug,
+                                        "result": result,
+                                    }
+                                )
+
+                        except Exception as e:
+                            logger.error(
+                                f"Error running task for tenant {tenant.name}: {e}",
+                                exc_info=True,
+                            )
                             results.append(
                                 {
                                     "tenant_id": str(tenant.id),
                                     "tenant_name": tenant.name,
                                     "tenant_slug": tenant.slug,
-                                    "result": result,
+                                    "error": str(e),
                                 }
                             )
+                finally:
+                    # Clear tenant context after each tenant
+                    clear_tenant_context()
+                # Session is automatically closed by the async context manager
 
-                    except Exception as e:
-                        logger.error(
-                            f"Error running task for tenant {tenant.name}: {e}",
-                            exc_info=True,
-                        )
-                        results.append(
-                            {
-                                "tenant_id": str(tenant.id),
-                                "tenant_name": tenant.name,
-                                "tenant_slug": tenant.slug,
-                                "error": str(e),
-                            }
-                        )
-            finally:
-                # Clear tenant context after each tenant
-                clear_tenant_context()
-            # Session is automatically closed by the async context manager
-
-    except Exception as e:
-        logger.error(f"Error in run_task_for_all_tenants: {e}", exc_info=True)
-    finally:
-        # Ensure context is cleared
-        clear_tenant_context()
-        # Reset BACKGROUND_TASK flag
-        settings.BACKGROUND_TASK = False
+        except Exception as e:
+            logger.error(f"Error in run_task_for_all_tenants: {e}", exc_info=True)
+        finally:
+            # Ensure context is cleared
+            clear_tenant_context()
 
     return results

--- a/backend/app/tasks/test_suite_tasks.py
+++ b/backend/app/tasks/test_suite_tasks.py
@@ -10,7 +10,11 @@ from uuid import UUID
 from celery import shared_task
 
 from app.core.config.settings import settings
-from app.core.tenant_scope import set_tenant_context, clear_tenant_context
+from app.core.tenant_scope import (
+    set_tenant_context,
+    clear_tenant_context,
+    background_task_context,
+)
 from app.tasks.base import create_task_wrapper, run_async_in_celery
 from app.core.tenant_scope import get_tenant_context
 from app.db.multi_tenant_session import multi_tenant_manager
@@ -107,34 +111,35 @@ def execute_test_suite_run_task(
     # the pooled one, so this task never reuses a connection whose event loop
     # run_async_in_celery already closed (a stale pooled connection hangs silently
     # rather than erroring — see the ml-worker asyncio-loop crash history).
-    settings.BACKGROUND_TASK = True
-    try:
-        async def _run():
-            async def task(**kwargs):
-                await _execute_test_suite_run_async(
-                    UUID(kwargs["run_id"]),
-                    kwargs.get("input_metadata"),
-                    kwargs.get("technique_configs"),
+    # Context-local (propagates into the run_async_in_celery event loop) so it can't
+    # race with other tasks in the same worker.
+    with background_task_context():
+        try:
+            async def _run():
+                async def task(**kwargs):
+                    await _execute_test_suite_run_async(
+                        UUID(kwargs["run_id"]),
+                        kwargs.get("input_metadata"),
+                        kwargs.get("technique_configs"),
+                    )
+
+                wrapper = create_task_wrapper(task)
+                await wrapper(
+                    run_id=run_id,
+                    input_metadata=input_metadata,
+                    technique_configs=technique_configs,
                 )
 
-            wrapper = create_task_wrapper(task)
-            await wrapper(
-                run_id=run_id,
-                input_metadata=input_metadata,
-                technique_configs=technique_configs,
+            run_async_in_celery(
+                _run(),
+                timeout=2 * 60 * 60,
+                task_name=f"execute_test_suite_run_task[{run_id}]",
             )
-
-        run_async_in_celery(
-            _run(),
-            timeout=2 * 60 * 60,
-            task_name=f"execute_test_suite_run_task[{run_id}]",
-        )
-    except Exception as exc:
-        logger.error("Error in test suite run task %s: %s", run_id, exc, exc_info=True)
-        raise
-    finally:
-        clear_tenant_context()
-        settings.BACKGROUND_TASK = False
+        except Exception as exc:
+            logger.error("Error in test suite run task %s: %s", run_id, exc, exc_info=True)
+            raise
+        finally:
+            clear_tenant_context()
 
 
 async def reconcile_stuck_test_runs_async() -> None:

--- a/backend/tests/unit/test_tenant_scope.py
+++ b/backend/tests/unit/test_tenant_scope.py
@@ -1,0 +1,134 @@
+"""Unit tests for tenant-context and background-task scoping primitives.
+
+Covers the fail-closed accessor (`require_tenant_context`) and the context-local
+background-task marker (`background_task_context` / `is_background_task`) added in
+place of the mutable `settings.BACKGROUND_TASK` global.
+
+Each case runs inside a fresh `contextvars.Context()` so the "never set" path is
+genuine and tests stay order-independent.
+"""
+
+import contextvars
+
+import pytest
+
+from app.core.tenant_scope import (
+    TenantContextError,
+    background_task_context,
+    clear_tenant_context,
+    get_tenant_context,
+    is_background_task,
+    require_tenant_context,
+    set_tenant_context,
+)
+
+
+def _in_fresh_context(fn):
+    """Run `fn` in a pristine context where the tenant ContextVar is unset."""
+    return contextvars.Context().run(fn)
+
+
+# ───────────── require_tenant_context (fail-closed) ─────────────
+
+def test_require_raises_when_context_never_set():
+    def body():
+        with pytest.raises(TenantContextError):
+            require_tenant_context()
+
+    _in_fresh_context(body)
+
+
+def test_require_raises_when_context_is_none():
+    def body():
+        set_tenant_context(None)  # explicit None must still fail closed
+        with pytest.raises(TenantContextError):
+            require_tenant_context()
+
+    _in_fresh_context(body)
+
+
+def test_require_returns_tenant_slug_when_set():
+    def body():
+        set_tenant_context("acme")
+        assert require_tenant_context() == "acme"
+
+    _in_fresh_context(body)
+
+
+def test_require_accepts_explicit_master_via_clear():
+    def body():
+        # clear_tenant_context() sets the value to "master" — an explicit,
+        # intentional master target, so require_tenant_context must NOT raise.
+        clear_tenant_context()
+        assert require_tenant_context() == "master"
+
+    _in_fresh_context(body)
+
+
+def test_require_accepts_explicit_master_via_set():
+    def body():
+        set_tenant_context("master")
+        assert require_tenant_context() == "master"
+
+    _in_fresh_context(body)
+
+
+# ───────────── get_tenant_context (lenient) ─────────────
+
+def test_get_is_lenient_when_unset():
+    def body():
+        assert get_tenant_context() == "master"
+
+    _in_fresh_context(body)
+
+
+def test_get_returns_set_value():
+    def body():
+        set_tenant_context("acme")
+        assert get_tenant_context() == "acme"
+
+    _in_fresh_context(body)
+
+
+# ───────────── background_task_context ─────────────
+
+def test_background_defaults_false():
+    def body():
+        assert is_background_task() is False
+
+    _in_fresh_context(body)
+
+
+def test_background_context_sets_and_restores():
+    def body():
+        assert is_background_task() is False
+        with background_task_context():
+            assert is_background_task() is True
+        assert is_background_task() is False
+
+    _in_fresh_context(body)
+
+
+def test_background_context_nested_restores_to_outer():
+    def body():
+        with background_task_context():
+            assert is_background_task() is True
+            with background_task_context():
+                assert is_background_task() is True
+            # inner exit must not clear the still-active outer scope
+            assert is_background_task() is True
+        assert is_background_task() is False
+
+    _in_fresh_context(body)
+
+
+def test_background_context_restores_on_exception():
+    def body():
+        assert is_background_task() is False
+        with pytest.raises(RuntimeError):
+            with background_task_context():
+                assert is_background_task() is True
+                raise RuntimeError("boom")
+        assert is_background_task() is False
+
+    _in_fresh_context(body)

--- a/backend/tests/unit/test_tenant_scope.py
+++ b/backend/tests/unit/test_tenant_scope.py
@@ -125,10 +125,16 @@ def test_background_context_nested_restores_to_outer():
 def test_background_context_restores_on_exception():
     def body():
         assert is_background_task() is False
-        with pytest.raises(RuntimeError):
+        raised = False
+        try:
             with background_task_context():
                 assert is_background_task() is True
                 raise RuntimeError("boom")
+        except RuntimeError:
+            raised = True
+        # exception must propagate out of the context manager...
+        assert raised is True
+        # ...and the flag must still be restored on the way out
         assert is_background_task() is False
 
     _in_fresh_context(body)


### PR DESCRIPTION
## Description

Close two multi-tenancy correctness gaps in the DB-per-tenant model.
- Add require_tenant_context() (raises TenantContextError when no tenant context is set) and use it in the DI session provider, so a path that forgets to set context fails loudly instead of silently routing to the master database. get_tenant_context() stays lenient for non-isolation uses (cache keys, storage prefixes).
- Replace the mutable settings.BACKGROUND_TASK global with a context-local background_task_context()/is_background_task() (ContextVar), removing a race between concurrent background tasks in one worker. get_tenant_engine now reads the context-local flag; the dead settings field is removed.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
