### PR TITLE
feat: refactor node dialog state management with useNodeDialogState hook

### DIFF
--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -34,7 +34,7 @@ const processQueue = (error: unknown, token: string | null = null) => {
 const ensureTrailingSlash = (url: string): string =>
   url.endsWith("/") ? url : `${url}/`;
 
-/** Default HTTP client timeout for JSON/API calls (not used for large file uploads — see uploadConstants). */
+/** Default HTTP client timeout for JSON/API calls (not used for large file uploads — see uploadConstants) */
 export const API_DEFAULT_TIMEOUT_MS = 120000;
 
 const api = axios.create({

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/APIToolDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/APIToolDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { APIToolNodeData } from "../types/nodes";
 import { Button } from "@/components/button";
 import { RichInput } from "@/components/richInput";
@@ -16,6 +16,7 @@ import { BaseNodeDialogProps } from "./base";
 import { DraggableInput } from "../components/custom/DraggableInput";
 import { DraggableTextArea } from "../components/custom/DraggableTextArea";
 import toast from "react-hot-toast";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 // HTTP methods
 const HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"] as const;
@@ -24,43 +25,28 @@ type HttpMethod = (typeof HTTP_METHODS)[number];
 export const APIToolDialog: React.FC<
   BaseNodeDialogProps<APIToolNodeData, APIToolNodeData>
 > = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { onClose, onUpdate, data } = props;
 
-  const [name, setName] = useState(data.name || "");
-  const [endpoint, setEndpoint] = useState(data.endpoint || "");
-  const [method, setMethod] = useState<HttpMethod>(
-    (data.method as HttpMethod) || "GET"
-  );
-  const [headers, setHeaders] = useState<Record<string, string>>(
-    data.headers || {}
-  );
-  const [parameters, setParameters] = useState<Record<string, string>>(
-    data.parameters || {}
-  );
-  const [requestBody, setRequestBody] = useState(
-    typeof data.requestBody === "string"
-      ? data.requestBody
-      : JSON.stringify(data.requestBody) || ""
-  );
-  useEffect(() => {
-    setName(data.name || "");
-    setEndpoint(data.endpoint || "");
-    setMethod((data.method as HttpMethod) || "GET");
-    setHeaders(data.headers || {});
-    setParameters(data.parameters || {});
-    setRequestBody(
+  const { values, setField, merged } = useNodeDialogState(props, () => ({
+    name: data.name || "",
+    endpoint: data.endpoint || "",
+    method: (data.method as HttpMethod) || "GET",
+    headers: (data.headers || {}) as Record<string, string>,
+    parameters: (data.parameters || {}) as Record<string, string>,
+    requestBody:
       typeof data.requestBody === "string"
         ? data.requestBody
-        : JSON.stringify(data.requestBody) || ""
-    );
-  }, [isOpen]);
+        : JSON.stringify(data.requestBody) || "",
+  }));
 
-  // Handle save
+  // Handle save — keeps the request-body JSON validation/abort that the hook's generic
+  // handleSave cannot express. `merged` feeds NodeConfigPanel's data prop with the RAW
+  // body string (dirty-detection unchanged); only the persisted payload is parsed.
   const handleSave = () => {
-    let requestBodyParsed = requestBody;
+    let requestBodyParsed = values.requestBody;
     try {
-      if (requestBody && requestBody.trim() !== "") {
-        requestBodyParsed = JSON.parse(requestBody);
+      if (values.requestBody && values.requestBody.trim() !== "") {
+        requestBodyParsed = JSON.parse(values.requestBody);
       }
     } catch (error) {
       toast.error("Invalid JSON in request body.");
@@ -69,12 +55,7 @@ export const APIToolDialog: React.FC<
     }
 
     onUpdate({
-      ...data,
-      name,
-      endpoint,
-      method,
-      headers,
-      parameters,
+      ...merged,
       requestBody: requestBodyParsed,
     });
     onClose();
@@ -82,7 +63,7 @@ export const APIToolDialog: React.FC<
 
   // Add new header
   const addHeader = () => {
-    setHeaders({ ...headers, "": "" });
+    setField("headers", { ...values.headers, "": "" });
   };
 
   // Update header key/value
@@ -90,7 +71,7 @@ export const APIToolDialog: React.FC<
     const newHeaders: Record<string, string> = {};
 
     // Iterate through existing headers to maintain order
-    for (const [key, val] of Object.entries(headers)) {
+    for (const [key, val] of Object.entries(values.headers)) {
       if (key === oldKey) {
         // Update the header with new key and value
         newHeaders[newKey] = value;
@@ -100,19 +81,19 @@ export const APIToolDialog: React.FC<
       }
     }
 
-    setHeaders(newHeaders);
+    setField("headers", newHeaders);
   };
 
   // Remove header
   const removeHeader = (key: string) => {
-    const newHeaders = { ...headers };
+    const newHeaders = { ...values.headers };
     delete newHeaders[key];
-    setHeaders(newHeaders);
+    setField("headers", newHeaders);
   };
 
   // Add new parameter
   const addParameter = () => {
-    setParameters({ ...parameters, "": "" });
+    setField("parameters", { ...values.parameters, "": "" });
   };
 
   // Update parameter key/value
@@ -120,7 +101,7 @@ export const APIToolDialog: React.FC<
     const newParameters: Record<string, string> = {};
 
     // Iterate through existing parameters to maintain order
-    for (const [key, val] of Object.entries(parameters)) {
+    for (const [key, val] of Object.entries(values.parameters)) {
       if (key === oldKey) {
         // Update the parameter with new key and value
         newParameters[newKey] = value;
@@ -130,14 +111,14 @@ export const APIToolDialog: React.FC<
       }
     }
 
-    setParameters(newParameters);
+    setField("parameters", newParameters);
   };
 
   // Remove parameter
   const removeParameter = (key: string) => {
-    const newParameters = { ...parameters };
+    const newParameters = { ...values.parameters };
     delete newParameters[key];
-    setParameters(newParameters);
+    setField("parameters", newParameters);
   };
 
   return (
@@ -154,22 +135,14 @@ export const APIToolDialog: React.FC<
         </>
       }
       {...props}
-      data={{
-        ...data,
-        name,
-        endpoint,
-        method,
-        headers,
-        parameters,
-        requestBody,
-      }}
+      data={merged}
     >
       <div className="space-y-2">
         <Label htmlFor="name">Name</Label>
         <RichInput
           id="name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={values.name}
+          onChange={(e) => setField("name", e.target.value)}
           placeholder="API Tool"
           className="break-all w-full"
         />
@@ -179,8 +152,8 @@ export const APIToolDialog: React.FC<
         <Label htmlFor="endpoint">Endpoint URL</Label>
         <DraggableInput
           id="endpoint"
-          value={endpoint}
-          onChange={(e) => setEndpoint(e.target.value)}
+          value={values.endpoint}
+          onChange={(e) => setField("endpoint", e.target.value)}
           placeholder="https://api.example.com/data"
           className="break-all w-full"
         />
@@ -192,9 +165,9 @@ export const APIToolDialog: React.FC<
       <div className="space-y-2">
         <Label htmlFor="method">HTTP Method </Label>
         <Select
-          value={method}
+          value={values.method}
           onValueChange={(value) =>
-            setMethod(value as (typeof HTTP_METHODS)[number])
+            setField("method", value as (typeof HTTP_METHODS)[number])
           }
         >
           <SelectTrigger>
@@ -224,7 +197,7 @@ export const APIToolDialog: React.FC<
         </div>
 
         <div className="space-y-2">
-          {Object.entries(headers).map(([key, value], idx) => (
+          {Object.entries(values.headers).map(([key, value], idx) => (
             <div
               key={`header-${idx}`}
               className="flex items-center gap-2 w-full"
@@ -268,7 +241,7 @@ export const APIToolDialog: React.FC<
         </div>
 
         <div className="space-y-2">
-          {Object.entries(parameters).map(([key, value], idx) => (
+          {Object.entries(values.parameters).map(([key, value], idx) => (
             <div
               key={`param-${idx}`}
               className="flex items-center gap-2 w-full"
@@ -298,13 +271,15 @@ export const APIToolDialog: React.FC<
         </div>
       </div>
 
-      {(method === "POST" || method === "PUT" || method === "PATCH") && (
+      {(values.method === "POST" ||
+        values.method === "PUT" ||
+        values.method === "PATCH") && (
         <div className="space-y-2">
           <Label htmlFor="requestBody">Request Body (JSON)</Label>
           <DraggableTextArea
             id="requestBody"
-            value={requestBody}
-            onChange={(e) => setRequestBody(e.target.value)}
+            value={values.requestBody}
+            onChange={(e) => setField("requestBody", e.target.value)}
             placeholder='{"key": "value"}'
             className="font-mono text-xs h-24 resize-none w-full"
           />

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/AgentDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/AgentDialog.tsx
@@ -1,32 +1,20 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { AgentNodeData, BaseLLMNodeData } from "../types/nodes";
 import { Button } from "@/components/button";
 import { ModelConfiguration } from "../components/ModelConfiguration";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type AgentDialogProps = BaseNodeDialogProps<AgentNodeData, BaseLLMNodeData>;
 
 export const AgentDialog: React.FC<AgentDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { onClose, data } = props;
 
-  const [config, setConfig] = useState<BaseLLMNodeData>(data);
-
-  // Reset state when the dialog is opened to reflect the current node data
-  useEffect(() => {
-    if (isOpen) {
-      setConfig(data);
-    }
-  }, [isOpen, data]);
-
-  // Handle saving the changes
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      ...config,
-    });
-    onClose();
-  };
+  const { values, setValues, merged, handleSave } = useNodeDialogState<
+    BaseLLMNodeData,
+    BaseLLMNodeData
+  >(props, () => data);
 
   return (
     <NodeConfigPanel
@@ -41,15 +29,12 @@ export const AgentDialog: React.FC<AgentDialogProps> = (props) => {
         </>
       }
       {...props}
-      data={{
-        ...data,
-        ...config,
-      }}
+      data={merged}
     >
       <ModelConfiguration
         id="agent-config"
-        config={config}
-        onConfigChange={setConfig}
+        config={values}
+        onConfigChange={setValues}
         typeSelect="agent"
       />
     </NodeConfigPanel>

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/AggregatorDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/AggregatorDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { AggregatorNodeData } from "../types/nodes";
 import { Button } from "@/components/button";
 import { RichInput } from "@/components/richInput";
@@ -22,6 +22,7 @@ import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { DraggableInput } from "../components/custom/DraggableInput";
 import { useWorkflowExecution } from "../context/WorkflowExecutionContext";
 import { BaseNodeDialogProps } from "./base";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 const AGGREGATION_STRATEGY_OPTIONS = [
   "list",
@@ -38,25 +39,12 @@ type AggregatorDialogProps = BaseNodeDialogProps<
 >;
 
 export const AggregatorDialog: React.FC<AggregatorDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { onClose, data } = props;
   const { edges } = useWorkflowExecution();
 
-  const [name, setName] = useState(data.name || "");
-  const [aggregationStrategy, setAggregationStrategy] =
-    useState<AggregationStrategyType>("list");
-  const [timeoutSeconds, setTimeoutSeconds] = useState(15);
-  const [forwardTemplate, setForwardTemplate] = useState("");
-  const [requireAllInputs, setRequireAllInputs] = useState(true);
-
-  useEffect(() => {
-    if (isOpen) {
-      setName(data.name || "");
-      setAggregationStrategy(
-        (data.aggregationStrategy as AggregationStrategyType) ?? "list"
-      );
-      setTimeoutSeconds(data.timeoutSeconds ?? 15);
-      setRequireAllInputs(data.requireAllInputs ?? true);
-
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => {
       // Auto-generate default forward template from direct predecessor nodes
       const directSources =
         edges?.filter((e) => e.target === props.nodeId)?.map((e) => e.source) ??
@@ -66,21 +54,16 @@ export const AggregatorDialog: React.FC<AggregatorDialogProps> = (props) => {
         ? directSources.map((id) => `{{node_outputs.${id}}}`).join(", ")
         : "";
 
-      setForwardTemplate(data.forwardTemplate ?? autoTemplate);
+      return {
+        name: data.name || "",
+        aggregationStrategy:
+          (data.aggregationStrategy as AggregationStrategyType) ?? "list",
+        timeoutSeconds: data.timeoutSeconds ?? 15,
+        forwardTemplate: data.forwardTemplate ?? autoTemplate,
+        requireAllInputs: data.requireAllInputs ?? true,
+      };
     }
-  }, [isOpen, data, edges, props.nodeId]);
-
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name,
-      aggregationStrategy,
-      timeoutSeconds,
-      forwardTemplate,
-      requireAllInputs,
-    });
-    onClose();
-  };
+  );
 
   return (
     <NodeConfigPanel
@@ -96,21 +79,14 @@ export const AggregatorDialog: React.FC<AggregatorDialogProps> = (props) => {
         </>
       }
       {...props}
-      data={{
-        ...data,
-        name,
-        aggregationStrategy,
-        timeoutSeconds,
-        forwardTemplate,
-        requireAllInputs,
-      }}
+      data={merged}
     >
       <div className="space-y-2">
         <Label htmlFor="node-name">Node Name</Label>
         <RichInput
           id="node-name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={values.name}
+          onChange={(e) => setField("name", e.target.value)}
           placeholder="Enter the name of this node"
           className="w-full"
         />
@@ -119,9 +95,9 @@ export const AggregatorDialog: React.FC<AggregatorDialogProps> = (props) => {
       <div className="space-y-2">
         <Label htmlFor="aggregation-strategy">Aggregation Strategy</Label>
         <Select
-          value={aggregationStrategy}
+          value={values.aggregationStrategy}
           onValueChange={(value) =>
-            setAggregationStrategy(value as AggregationStrategyType)
+            setField("aggregationStrategy", value as AggregationStrategyType)
           }
         >
           <SelectTrigger id="aggregation-strategy">
@@ -136,11 +112,14 @@ export const AggregatorDialog: React.FC<AggregatorDialogProps> = (props) => {
           </SelectContent>
         </Select>
         <p className="text-sm text-muted-foreground">
-          {aggregationStrategy === "list" && "Combine all results into a list"}
-          {aggregationStrategy === "merge" &&
+          {values.aggregationStrategy === "list" &&
+            "Combine all results into a list"}
+          {values.aggregationStrategy === "merge" &&
             "Merge all results into a single object"}
-          {aggregationStrategy === "first" && "Use the first result received"}
-          {aggregationStrategy === "last" && "Use the last result received"}
+          {values.aggregationStrategy === "first" &&
+            "Use the first result received"}
+          {values.aggregationStrategy === "last" &&
+            "Use the last result received"}
         </p>
       </div>
 
@@ -151,8 +130,8 @@ export const AggregatorDialog: React.FC<AggregatorDialogProps> = (props) => {
           type="number"
           min="1"
           max="300"
-          value={timeoutSeconds}
-          onChange={(e) => setTimeoutSeconds(parseInt(e.target.value))}
+          value={values.timeoutSeconds}
+          onChange={(e) => setField("timeoutSeconds", parseInt(e.target.value))}
           placeholder="15"
           className="w-full"
         />
@@ -165,8 +144,8 @@ export const AggregatorDialog: React.FC<AggregatorDialogProps> = (props) => {
         <Label htmlFor="forward-template">Forward Template</Label>
         <DraggableInput
           id="forward-template"
-          value={forwardTemplate}
-          onChange={(e) => setForwardTemplate(e.target.value)}
+          value={values.forwardTemplate}
+          onChange={(e) => setField("forwardTemplate", e.target.value)}
           placeholder="Enter forward template (optional)"
           className="w-full"
         />
@@ -196,8 +175,10 @@ export const AggregatorDialog: React.FC<AggregatorDialogProps> = (props) => {
           <div className="flex-1" />
           <Switch
             id="require-all-inputs"
-            checked={requireAllInputs}
-            onCheckedChange={setRequireAllInputs}
+            checked={values.requireAllInputs}
+            onCheckedChange={(checked) =>
+              setField("requireAllInputs", checked)
+            }
           />
         </div>
       </TooltipProvider>

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/CalendarEventDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/CalendarEventDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { CalendarEventToolNodeData } from "../types/nodes";
 import { DataSource } from "@/interfaces/dataSource.interface";
 import { Button } from "@/components/button";
@@ -17,6 +17,7 @@ import { DraggableInput } from "../components/custom/DraggableInput";
 import { BaseNodeDialogProps } from "./base";
 import { DataSourceDialog } from "@/views/DataSources/components/DataSourceDialog";
 import { CreateNewSelectItem } from "@/components/CreateNewSelectItem";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 interface CalendarEventDialogProps
   extends BaseNodeDialogProps<
@@ -29,49 +30,23 @@ interface CalendarEventDialogProps
 export const CalendarEventDialog: React.FC<CalendarEventDialogProps> = (
   props
 ) => {
-  const { isOpen, onClose, data, onUpdate, connectors } = props;
+  const { onClose, data, connectors } = props;
 
-  const [name, setName] = useState(data.name || "");
-  const [summary, setSummary] = useState(data.summary || "");
-  const [start, setStart] = useState(data.start || "");
-  const [end, setEnd] = useState(data.end || "");
-  const [operation, setOperation] = useState(data.operation || "");
-  const [dataSourceId, setDataSourceId] = useState(
-    data.dataSourceId?.toString() || ""
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name || "",
+      summary: data.summary || "",
+      start: data.start || "",
+      end: data.end || "",
+      operation: data.operation || "",
+      dataSourceId: data.dataSourceId?.toString() || "",
+      subjectContains: data.subjectContains || "",
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || "",
+    })
   );
-  const [subjectContains, setSubjectContains] = useState(
-    data.subjectContains || ""
-  );
-  const [timezone, setTimezone] = useState("");
+
   const [isCreateDataSourceOpen, setIsCreateDataSourceOpen] = useState(false);
-
-  useEffect(() => {
-    if (isOpen) {
-      setName(data.name || "");
-      setSummary(data.summary || "");
-      setStart(data.start || "");
-      setEnd(data.end || "");
-      setOperation(data.operation || "");
-      setDataSourceId(data.dataSourceId?.toString() || "");
-      setSubjectContains(data.subjectContains || "");
-      setTimezone(Intl.DateTimeFormat().resolvedOptions().timeZone || "");
-    }
-  }, [isOpen, data]);
-
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name,
-      summary,
-      start,
-      end,
-      operation,
-      dataSourceId,
-      subjectContains,
-      timezone,
-    });
-    onClose();
-  };
 
   return (
     <>
@@ -88,23 +63,14 @@ export const CalendarEventDialog: React.FC<CalendarEventDialogProps> = (
           </>
         }
         {...props}
-        data={{
-          ...data,
-          name,
-          summary,
-          start,
-          end,
-          operation,
-          dataSourceId,
-          subjectContains,
-        }}
+        data={merged}
       >
         <div className="space-y-2">
           <Label htmlFor="node-name">Node Name</Label>
           <RichInput
             id="node-name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="Enter the name of this node"
             className="w-full"
           />
@@ -113,13 +79,13 @@ export const CalendarEventDialog: React.FC<CalendarEventDialogProps> = (
         <div className="space-y-2">
           <Label htmlFor="connector-select">Select Connector</Label>
           <Select
-            value={dataSourceId}
+            value={values.dataSourceId}
             onValueChange={(val) => {
               if (val === "__create__") {
                 setIsCreateDataSourceOpen(true);
                 return;
               }
-              setDataSourceId(val);
+              setField("dataSourceId", val);
             }}
           >
             <SelectTrigger id="connector-select">
@@ -143,8 +109,8 @@ export const CalendarEventDialog: React.FC<CalendarEventDialogProps> = (
                 <DraggableInput
                   id="summary"
                   type="text"
-                  value={summary}
-                  onChange={(e) => setSummary(e.target.value)}
+                  value={values.summary}
+                  onChange={(e) => setField("summary", e.target.value)}
                   placeholder="e.g., General assembly meeting"
                   className="w-full"
                 />
@@ -152,8 +118,8 @@ export const CalendarEventDialog: React.FC<CalendarEventDialogProps> = (
               <div className="space-y-2">
                 <Label htmlFor="operation-select">Operation</Label>
                 <Select
-                  value={operation}
-                  onValueChange={(val) => setOperation(val)}
+                  value={values.operation}
+                  onValueChange={(val) => setField("operation", val)}
                 >
                   <SelectTrigger id="operation-select">
                     <SelectValue placeholder="Select operation" />
@@ -174,8 +140,8 @@ export const CalendarEventDialog: React.FC<CalendarEventDialogProps> = (
                   <DraggableInput
                     id="start"
                     type="datetime"
-                    value={start}
-                    onChange={(e) => setStart(e.target.value)}
+                    value={values.start}
+                    onChange={(e) => setField("start", e.target.value)}
                     placeholder="e.g., 2025-07-22T19:41:00"
                     className="w-full"
                   />
@@ -185,8 +151,8 @@ export const CalendarEventDialog: React.FC<CalendarEventDialogProps> = (
                   <DraggableInput
                     id="end"
                     type="datetime"
-                    value={end}
-                    onChange={(e) => setEnd(e.target.value)}
+                    value={values.end}
+                    onChange={(e) => setField("end", e.target.value)}
                     placeholder="e.g., 2025-07-22T19:51:00"
                     className="w-full"
                   />
@@ -197,8 +163,8 @@ export const CalendarEventDialog: React.FC<CalendarEventDialogProps> = (
                 <DraggableInput
                   id="subjectContains"
                   type="text"
-                  value={subjectContains}
-                  onChange={(e) => setSubjectContains(e.target.value)}
+                  value={values.subjectContains}
+                  onChange={(e) => setField("subjectContains", e.target.value)}
                   placeholder="e.g., Fundraiser"
                   className="w-full"
                 />
@@ -211,7 +177,7 @@ export const CalendarEventDialog: React.FC<CalendarEventDialogProps> = (
         isOpen={isCreateDataSourceOpen}
         onOpenChange={setIsCreateDataSourceOpen}
         onDataSourceSaved={(created) => {
-          if (created?.id) setDataSourceId(created.id);
+          if (created?.id) setField("dataSourceId", created.id);
         }}
         mode="create"
       />

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/CreateWorkflowScheduleDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/CreateWorkflowScheduleDialog.tsx
@@ -19,6 +19,7 @@ import { DraggableTextArea } from "../components/custom/DraggableTextArea";
 import { DraggableInput } from "../components/custom/DraggableInput";
 import { getAgentConfigsList } from "@/services/api";
 import { AgentListItem } from "@/interfaces/ai-agent.interface";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type CreateWorkflowScheduleDialogProps = BaseNodeDialogProps<
   CreateWorkflowScheduleNodeData,
@@ -28,36 +29,32 @@ type CreateWorkflowScheduleDialogProps = BaseNodeDialogProps<
 export const CreateWorkflowScheduleDialog: React.FC<
   CreateWorkflowScheduleDialogProps
 > = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
-  const [name, setName] = useState(data.name || "");
-  const [scheduleName, setScheduleName] = useState(data.scheduleName || "");
-  const [agentId, setAgentId] = useState(data.agentId || "");
-  const [cronSchedule, setCronSchedule] = useState(
-    data.cronSchedule || "0 0 * * *"
+  // Note: we intentionally do NOT hard-validate the additional-input JSON on
+  // save. The field supports dropped source variables (e.g. {{source.id}}),
+  // which aren't valid JSON at design time; the backend resolves templates
+  // first and then parses leniently, ignoring anything it can't read.
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name || "",
+      scheduleName: data.scheduleName || "",
+      agentId: data.agentId || "",
+      cronSchedule: data.cronSchedule || "0 0 * * *",
+      isActive: data.isActive ?? true,
+      threadIdMode: (data.threadIdMode || "per_run") as "per_run" | "fixed",
+      fixedThreadId: data.fixedThreadId || "",
+      message: data.message || "",
+      inputData: data.inputData || "",
+    })
   );
-  const [isActive, setIsActive] = useState(data.isActive ?? true);
-  const [threadIdMode, setThreadIdMode] = useState<"per_run" | "fixed">(
-    data.threadIdMode || "per_run"
-  );
-  const [fixedThreadId, setFixedThreadId] = useState(data.fixedThreadId || "");
-  const [message, setMessage] = useState(data.message || "");
-  const [inputData, setInputData] = useState(data.inputData || "");
+
   const [agents, setAgents] = useState<AgentListItem[]>([]);
   const { toast } = useToast();
 
   useEffect(() => {
     if (isOpen) {
-      setName(data.name || "");
-      setScheduleName(data.scheduleName || "");
-      setAgentId(data.agentId || "");
-      setCronSchedule(data.cronSchedule || "0 0 * * *");
-      setIsActive(data.isActive ?? true);
-      setThreadIdMode(data.threadIdMode || "per_run");
-      setFixedThreadId(data.fixedThreadId || "");
-      setMessage(data.message || "");
-      setInputData(data.inputData || "");
-
       const loadAgents = async () => {
         try {
           const res = await getAgentConfigsList(1, 100);
@@ -73,39 +70,6 @@ export const CreateWorkflowScheduleDialog: React.FC<
       loadAgents();
     }
   }, [isOpen, data, toast]);
-
-  const handleSave = () => {
-    // Note: we intentionally do NOT hard-validate the additional-input JSON
-    // here. The field supports dropped source variables (e.g. {{source.id}}),
-    // which aren't valid JSON at design time; the backend resolves templates
-    // first and then parses leniently, ignoring anything it can't read.
-    onUpdate({
-      ...data,
-      name,
-      scheduleName,
-      agentId,
-      cronSchedule,
-      isActive,
-      threadIdMode,
-      fixedThreadId,
-      message,
-      inputData,
-    });
-    onClose();
-  };
-
-  const currentData = {
-    ...data,
-    name,
-    scheduleName,
-    agentId,
-    cronSchedule,
-    isActive,
-    threadIdMode,
-    fixedThreadId,
-    message,
-    inputData,
-  };
 
   return (
     <NodeConfigPanel
@@ -123,14 +87,14 @@ export const CreateWorkflowScheduleDialog: React.FC<
         </>
       }
       {...props}
-      data={currentData}
+      data={merged}
     >
       <div className="space-y-2">
         <Label htmlFor="name">Node Name</Label>
         <RichInput
           id="name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={values.name}
+          onChange={(e) => setField("name", e.target.value)}
           placeholder="Enter the name of this node"
           className="w-full"
         />
@@ -138,7 +102,10 @@ export const CreateWorkflowScheduleDialog: React.FC<
 
       <div className="space-y-2">
         <Label htmlFor="workflow">Workflow</Label>
-        <Select value={agentId} onValueChange={setAgentId}>
+        <Select
+          value={values.agentId}
+          onValueChange={(value) => setField("agentId", value)}
+        >
           <SelectTrigger id="workflow">
             <SelectValue placeholder="Select a workflow" />
           </SelectTrigger>
@@ -160,8 +127,8 @@ export const CreateWorkflowScheduleDialog: React.FC<
         <Label htmlFor="scheduleName">Schedule Name</Label>
         <DraggableInput
           id="scheduleName"
-          value={scheduleName}
-          onChange={(e) => setScheduleName(e.target.value)}
+          value={values.scheduleName}
+          onChange={(e) => setField("scheduleName", e.target.value)}
           placeholder="Name shown for the created schedule"
           className="w-full"
         />
@@ -171,8 +138,8 @@ export const CreateWorkflowScheduleDialog: React.FC<
         <Label htmlFor="cron">Cron Schedule</Label>
         <DraggableInput
           id="cron"
-          value={cronSchedule}
-          onChange={(e) => setCronSchedule(e.target.value)}
+          value={values.cronSchedule}
+          onChange={(e) => setField("cronSchedule", e.target.value)}
           placeholder="0 0 * * *"
           className="w-full"
         />
@@ -185,8 +152,8 @@ export const CreateWorkflowScheduleDialog: React.FC<
         <Label htmlFor="message">Message</Label>
         <DraggableTextArea
           id="message"
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
+          value={values.message}
+          onChange={(e) => setField("message", e.target.value)}
           placeholder="Message passed to the workflow's input node on each run"
           className="w-full"
         />
@@ -196,8 +163,8 @@ export const CreateWorkflowScheduleDialog: React.FC<
         <Label htmlFor="inputData">Additional input fields (JSON)</Label>
         <DraggableTextArea
           id="inputData"
-          value={inputData}
-          onChange={(e) => setInputData(e.target.value)}
+          value={values.inputData}
+          onChange={(e) => setField("inputData", e.target.value)}
           placeholder='{ "customer_id": "123" }'
           className="w-full font-mono text-xs"
         />
@@ -209,8 +176,10 @@ export const CreateWorkflowScheduleDialog: React.FC<
       <div className="space-y-2">
         <Label htmlFor="threadIdMode">Conversation Thread</Label>
         <Select
-          value={threadIdMode}
-          onValueChange={(v) => setThreadIdMode(v as "per_run" | "fixed")}
+          value={values.threadIdMode}
+          onValueChange={(v) =>
+            setField("threadIdMode", v as "per_run" | "fixed")
+          }
         >
           <SelectTrigger id="threadIdMode">
             <SelectValue />
@@ -224,13 +193,13 @@ export const CreateWorkflowScheduleDialog: React.FC<
         </Select>
       </div>
 
-      {threadIdMode === "fixed" && (
+      {values.threadIdMode === "fixed" && (
         <div className="space-y-2">
           <Label htmlFor="fixedThreadId">Fixed Thread ID</Label>
           <DraggableInput
             id="fixedThreadId"
-            value={fixedThreadId}
-            onChange={(e) => setFixedThreadId(e.target.value)}
+            value={values.fixedThreadId}
+            onChange={(e) => setField("fixedThreadId", e.target.value)}
             placeholder="Leave blank to auto-generate on first run"
             className="w-full"
           />
@@ -242,8 +211,10 @@ export const CreateWorkflowScheduleDialog: React.FC<
         <div className="flex items-center space-x-2 h-10">
           <Checkbox
             id="isActive"
-            checked={isActive}
-            onCheckedChange={(checked) => setIsActive(checked as boolean)}
+            checked={values.isActive}
+            onCheckedChange={(checked) =>
+              setField("isActive", checked as boolean)
+            }
           />
           <Label
             htmlFor="isActive"

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/DataMapperDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/DataMapperDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { Button } from "@/components/button";
 import { Label } from "@/components/label";
 import { Save, HelpCircle } from "lucide-react";
@@ -15,6 +15,7 @@ import "ace-builds/src-noconflict/theme-twilight";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
 import { DraggableAceEditor } from "../components/custom/DraggableAceEditor";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type DataMapperDialogProps = BaseNodeDialogProps<
   DataMapperNodeData,
@@ -22,27 +23,15 @@ type DataMapperDialogProps = BaseNodeDialogProps<
 >;
 
 export const DataMapperDialog: React.FC<DataMapperDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { onClose, data } = props;
 
-  const [name, setName] = useState(data.name);
-  const [pythonScript, setPythonScript] = useState(data.pythonScript);
-
-  useEffect(() => {
-    if (isOpen) {
-      setName(data.name);
-      setPythonScript(data.pythonScript);
-    }
-  }, [isOpen, data]);
-
-  const handleSave = () => {
-    const updatedData = {
-      ...data,
-      name,
-      pythonScript,
-    };
-    onUpdate(updatedData);
-    onClose();
-  };
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name,
+      pythonScript: data.pythonScript,
+    })
+  );
 
   return (
     <NodeConfigPanel
@@ -58,18 +47,14 @@ export const DataMapperDialog: React.FC<DataMapperDialogProps> = (props) => {
         </>
       }
       {...props}
-      data={{
-        ...data,
-        name,
-        pythonScript,
-      }}
+      data={merged}
     >
       <div className="space-y-4">
         <div>
           <Label>Node Name</Label>
           <RichInput
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="Enter the name of this node"
             className="w-full"
           />
@@ -112,8 +97,8 @@ export const DataMapperDialog: React.FC<DataMapperDialogProps> = (props) => {
             name="python-editor"
             mode="python"
             theme="twilight"
-            value={pythonScript}
-            onChange={setPythonScript}
+            value={values.pythonScript}
+            onChange={(value) => setField("pythonScript", value)}
             width="100%"
             height="100%"
             placeholder="Enter your Python transformation script here..."

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/ExternalAgentDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/ExternalAgentDialog.tsx
@@ -18,6 +18,7 @@ import { DraggableAceEditor } from "../components/custom/DraggableAceEditor";
 import { RichInput } from "@/components/richInput";
 import "ace-builds/src-noconflict/mode-python";
 import "ace-builds/src-noconflict/theme-twilight";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH"] as const;
 const AUTH_TYPES = ["none", "bearer", "api_key", "basic"] as const;
@@ -26,94 +27,48 @@ type AuthType = (typeof AUTH_TYPES)[number];
 export const ExternalAgentDialog: React.FC<
   BaseNodeDialogProps<ExternalAgentNodeData, ExternalAgentNodeData>
 > = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
-  const [name, setName] = useState(data.name || "");
-  const [endpoint, setEndpoint] = useState(data.endpoint || "");
-  const [method, setMethod] = useState(data.method || "POST");
-  const [headers, setHeaders] = useState<Record<string, string>>(data.headers || {});
-  const [requestBody, setRequestBody] = useState(data.requestBody || "");
-  const [authType, setAuthType] = useState<AuthType>((data.authType as AuthType) || "none");
-  const [authToken, setAuthToken] = useState(data.authToken || "");
-  const [authHeader, setAuthHeader] = useState(data.authHeader || "Authorization");
-  const [authUsername, setAuthUsername] = useState(data.authUsername || "");
-  const [authPassword, setAuthPassword] = useState(data.authPassword || "");
-  const [messageField, setMessageField] = useState(data.messageField || "message");
-  const [stepsField, setStepsField] = useState(data.stepsField || "steps");
-  const [timeout, setTimeout] = useState<number>(data.timeout ?? 30);
-  const [mappingScript, setMappingScript] = useState(data.mappingScript || "");
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name || "",
+      endpoint: data.endpoint || "",
+      method: data.method || "POST",
+      headers: data.headers || {},
+      requestBody: data.requestBody || "",
+      authType: (data.authType as AuthType) || "none",
+      authToken: data.authToken || "",
+      authHeader: data.authHeader || "Authorization",
+      authUsername: data.authUsername || "",
+      authPassword: data.authPassword || "",
+      messageField: data.messageField || "message",
+      stepsField: data.stepsField || "steps",
+      timeout: data.timeout ?? 30,
+      mappingScript: data.mappingScript || "",
+    })
+  );
+
   const [showAdvanced, setShowAdvanced] = useState(!!data.mappingScript);
 
   useEffect(() => {
-    setName(data.name || "");
-    setEndpoint(data.endpoint || "");
-    setMethod(data.method || "POST");
-    setHeaders(data.headers || {});
-    setRequestBody(data.requestBody || "");
-    setAuthType((data.authType as AuthType) || "none");
-    setAuthToken(data.authToken || "");
-    setAuthHeader(data.authHeader || "Authorization");
-    setAuthUsername(data.authUsername || "");
-    setAuthPassword(data.authPassword || "");
-    setMessageField(data.messageField || "message");
-    setStepsField(data.stepsField || "steps");
-    setTimeout(data.timeout ?? 30);
-    setMappingScript(data.mappingScript || "");
     setShowAdvanced(!!data.mappingScript);
-  }, [isOpen]);
+  }, [isOpen, data]);
 
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name,
-      endpoint,
-      method,
-      headers,
-      requestBody,
-      authType,
-      authToken,
-      authHeader,
-      authUsername,
-      authPassword,
-      timeout,
-      messageField,
-      stepsField,
-      mappingScript,
-    });
-    onClose();
-  };
-
-  const addHeader = () => setHeaders({ ...headers, "": "" });
+  const addHeader = () => setField("headers", { ...values.headers, "": "" });
 
   const updateHeader = (oldKey: string, newKey: string, value: string) => {
     const updated: Record<string, string> = {};
-    for (const [k, v] of Object.entries(headers)) {
+    for (const [k, v] of Object.entries(values.headers)) {
       updated[k === oldKey ? newKey : k] = k === oldKey ? value : v;
     }
-    setHeaders(updated);
+    setField("headers", updated);
   };
 
   const removeHeader = (key: string) => {
-    const updated = { ...headers };
+    const updated = { ...values.headers };
     delete updated[key];
-    setHeaders(updated);
-  };
-
-  const previewData = {
-    ...data,
-    name,
-    endpoint,
-    method,
-    headers,
-    requestBody,
-    authType,
-    authToken,
-    authHeader,
-    authUsername,
-    authPassword,
-    messageField,
-    stepsField,
-    mappingScript,
+    setField("headers", updated);
   };
 
   return (
@@ -130,15 +85,15 @@ export const ExternalAgentDialog: React.FC<
         </>
       }
       {...props}
-      data={previewData}
+      data={merged}
     >
       {/* Name */}
       <div className="space-y-2">
         <Label htmlFor="name">Name</Label>
         <RichInput
           id="name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={values.name}
+          onChange={(e) => setField("name", e.target.value)}
           placeholder="External Agent"
           className="w-full"
         />
@@ -149,8 +104,8 @@ export const ExternalAgentDialog: React.FC<
         <Label htmlFor="endpoint">Endpoint URL</Label>
         <DraggableInput
           id="endpoint"
-          value={endpoint}
-          onChange={(e) => setEndpoint(e.target.value)}
+          value={values.endpoint}
+          onChange={(e) => setField("endpoint", e.target.value)}
           placeholder="https://api.example.com/agent"
           className="w-full"
         />
@@ -159,7 +114,7 @@ export const ExternalAgentDialog: React.FC<
 
       <div className="space-y-2">
         <Label htmlFor="method">HTTP Method</Label>
-        <Select value={method} onValueChange={setMethod}>
+        <Select value={values.method} onValueChange={(v) => setField("method", v)}>
           <SelectTrigger>
             <SelectValue placeholder="Select method" />
           </SelectTrigger>
@@ -178,8 +133,8 @@ export const ExternalAgentDialog: React.FC<
         <RichInput
           id="timeout"
           type="number"
-          value={String(timeout)}
-          onChange={(e) => setTimeout(Math.max(1, parseInt(e.target.value) || 30))}
+          value={String(values.timeout)}
+          onChange={(e) => setField("timeout", Math.max(1, parseInt(e.target.value) || 30))}
           placeholder="30"
           className="w-full"
         />
@@ -188,7 +143,7 @@ export const ExternalAgentDialog: React.FC<
       {/* Authentication */}
       <div className="space-y-2">
         <Label>Authentication</Label>
-        <Select value={authType} onValueChange={(v) => setAuthType(v as AuthType)}>
+        <Select value={values.authType} onValueChange={(v) => setField("authType", v as AuthType)}>
           <SelectTrigger>
             <SelectValue placeholder="Auth type" />
           </SelectTrigger>
@@ -200,38 +155,38 @@ export const ExternalAgentDialog: React.FC<
           </SelectContent>
         </Select>
 
-        {(authType === "bearer" || authType === "api_key") && (
+        {(values.authType === "bearer" || values.authType === "api_key") && (
           <div className="space-y-2 pl-2 border-l-2 border-border">
-            {authType === "api_key" && (
+            {values.authType === "api_key" && (
               <div className="space-y-1">
                 <Label className="text-xs">Header Name</Label>
                 <DraggableInput
-                  value={authHeader}
-                  onChange={(e) => setAuthHeader(e.target.value)}
+                  value={values.authHeader}
+                  onChange={(e) => setField("authHeader", e.target.value)}
                   placeholder="Authorization"
                   className="text-xs w-full"
                 />
               </div>
             )}
             <div className="space-y-1">
-              <Label className="text-xs">{authType === "bearer" ? "Token" : "API Key Value"}</Label>
+              <Label className="text-xs">{values.authType === "bearer" ? "Token" : "API Key Value"}</Label>
               <DraggableInput
-                value={authToken}
-                onChange={(e) => setAuthToken(e.target.value)}
-                placeholder={authType === "bearer" ? "{{session.token}}" : "{{session.apiKey}}"}
+                value={values.authToken}
+                onChange={(e) => setField("authToken", e.target.value)}
+                placeholder={values.authType === "bearer" ? "{{session.token}}" : "{{session.apiKey}}"}
                 className="text-xs w-full"
               />
             </div>
           </div>
         )}
 
-        {authType === "basic" && (
+        {values.authType === "basic" && (
           <div className="space-y-2 pl-2 border-l-2 border-border">
             <div className="space-y-1">
               <Label className="text-xs">Username</Label>
               <DraggableInput
-                value={authUsername}
-                onChange={(e) => setAuthUsername(e.target.value)}
+                value={values.authUsername}
+                onChange={(e) => setField("authUsername", e.target.value)}
                 placeholder="{{session.username}}"
                 className="text-xs w-full"
               />
@@ -239,8 +194,8 @@ export const ExternalAgentDialog: React.FC<
             <div className="space-y-1">
               <Label className="text-xs">Password</Label>
               <DraggableInput
-                value={authPassword}
-                onChange={(e) => setAuthPassword(e.target.value)}
+                value={values.authPassword}
+                onChange={(e) => setField("authPassword", e.target.value)}
                 placeholder="{{session.password}}"
                 className="text-xs w-full"
               />
@@ -258,7 +213,7 @@ export const ExternalAgentDialog: React.FC<
           </Button>
         </div>
         <div className="space-y-2">
-          {Object.entries(headers).map(([key, value], idx) => (
+          {Object.entries(values.headers).map(([key, value], idx) => (
             <div key={`header-${idx}`} className="flex items-center gap-2 w-full">
               <DraggableInput
                 placeholder="Header name"
@@ -286,13 +241,13 @@ export const ExternalAgentDialog: React.FC<
       </div>
 
       {/* Request body */}
-      {(method === "POST" || method === "PUT" || method === "PATCH") && (
+      {(values.method === "POST" || values.method === "PUT" || values.method === "PATCH") && (
         <div className="space-y-2">
           <Label htmlFor="requestBody">Request Body (JSON)</Label>
           <DraggableTextArea
             id="requestBody"
-            value={requestBody}
-            onChange={(e) => setRequestBody(e.target.value)}
+            value={values.requestBody}
+            onChange={(e) => setField("requestBody", e.target.value)}
             placeholder='{"message": "{{source.message}}"}'
             className="font-mono text-xs h-24 resize-none w-full"
           />
@@ -306,12 +261,12 @@ export const ExternalAgentDialog: React.FC<
         <div className="text-xs text-muted-foreground mb-1">
           Point to where the message lives in the JSON response using dot-notation (e.g. <code>output.text</code>). Use the Python script below if you need to combine fields, add fallback logic, or transform the data.
         </div>
-        <div className={`space-y-2 ${mappingScript ? "opacity-40 pointer-events-none" : ""}`}>
+        <div className={`space-y-2 ${values.mappingScript ? "opacity-40 pointer-events-none" : ""}`}>
           <div className="space-y-1">
             <Label className="text-xs">Message field path</Label>
             <DraggableInput
-              value={messageField}
-              onChange={(e) => setMessageField(e.target.value)}
+              value={values.messageField}
+              onChange={(e) => setField("messageField", e.target.value)}
               placeholder="message"
               className="text-xs w-full"
             />
@@ -319,14 +274,14 @@ export const ExternalAgentDialog: React.FC<
           <div className="space-y-1">
             <Label className="text-xs">Steps field path (optional)</Label>
             <DraggableInput
-              value={stepsField}
-              onChange={(e) => setStepsField(e.target.value)}
+              value={values.stepsField}
+              onChange={(e) => setField("stepsField", e.target.value)}
               placeholder="steps"
               className="text-xs w-full"
             />
           </div>
         </div>
-        {mappingScript && (
+        {values.mappingScript && (
           <p className="text-xs text-amber-600 dark:text-amber-400">Field paths are ignored — Python script is active.</p>
         )}
       </div>
@@ -370,8 +325,8 @@ result = {
               name="mapping-script-editor"
               mode="python"
               theme="twilight"
-              value={mappingScript}
-              onChange={setMappingScript}
+              value={values.mappingScript}
+              onChange={(value) => setField("mappingScript", value)}
               width="100%"
               height="100%"
             />

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/FileReaderDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/FileReaderDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { FileReaderNodeData } from "../types/nodes";
 import { Button } from "@/components/button";
 import { RichInput } from "@/components/richInput";
@@ -14,6 +14,7 @@ import { Save } from "lucide-react";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
 import { FileUploader } from "@/components/FileUploader";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type FileReaderDialogProps = BaseNodeDialogProps<
   FileReaderNodeData,
@@ -23,42 +24,19 @@ type FileReaderDialogProps = BaseNodeDialogProps<
 type FileSource = "chatAttachment" | "upload";
 
 export const FileReaderDialog: React.FC<FileReaderDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { onClose, data } = props;
 
-  const [name, setName] = useState(data.name || "File Reader");
-  const [fileSource, setFileSource] = useState<FileSource>(
-    data.fileSource ?? "upload"
-  );
-  const [fileName, setFileName] = useState(data.fileName ?? "");
-  const [filePath, setFilePath] = useState(data.filePath ?? "");
-  const [fileUrl, setFileUrl] = useState(data.fileUrl ?? "");
-  const [fileId, setFileId] = useState(data.fileId ?? "");
+  const { values, setField, setValues, merged, handleSave } =
+    useNodeDialogState(props, () => ({
+      name: data.name || "File Reader",
+      fileSource: data.fileSource ?? "upload",
+      fileName: data.fileName ?? "",
+      filePath: data.filePath ?? "",
+      fileUrl: data.fileUrl ?? "",
+      fileId: data.fileId ?? "",
+    }));
 
-  useEffect(() => {
-    if (isOpen) {
-      setName(data.name || "File Reader");
-      setFileSource(data.fileSource ?? "upload");
-      setFileName(data.fileName ?? "");
-      setFilePath(data.filePath ?? "");
-      setFileUrl(data.fileUrl ?? "");
-      setFileId(data.fileId ?? "");
-    }
-  }, [isOpen, data]);
-
-  const isChatAttachment = fileSource === "chatAttachment";
-
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name,
-      fileSource,
-      fileName,
-      filePath,
-      fileUrl,
-      fileId,
-    });
-    onClose();
-  };
+  const isChatAttachment = values.fileSource === "chatAttachment";
 
   return (
     <NodeConfigPanel
@@ -74,15 +52,15 @@ export const FileReaderDialog: React.FC<FileReaderDialogProps> = (props) => {
         </>
       }
       {...props}
-      data={{ ...data, name, fileSource, fileName, filePath, fileUrl, fileId }}
+      data={merged}
     >
       <div className="space-y-4">
         <div>
           <Label htmlFor="name">Node Name</Label>
           <RichInput
             id="name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="e.g., File Reader"
             className="w-full"
           />
@@ -91,8 +69,8 @@ export const FileReaderDialog: React.FC<FileReaderDialogProps> = (props) => {
         <div className="space-y-2">
           <Label htmlFor="file-source">File Source</Label>
           <Select
-            value={fileSource}
-            onValueChange={(value) => setFileSource(value as FileSource)}
+            value={values.fileSource}
+            onValueChange={(value) => setField("fileSource", value as FileSource)}
           >
             <SelectTrigger id="file-source">
               <SelectValue placeholder="Select file source" />
@@ -114,20 +92,26 @@ export const FileReaderDialog: React.FC<FileReaderDialogProps> = (props) => {
         {!isChatAttachment && (
           <FileUploader
             label="File"
-            initialOriginalFileName={fileName}
-            initialServerFilePath={filePath}
-            initialServerFileUrl={fileUrl}
+            initialOriginalFileName={values.fileName}
+            initialServerFilePath={values.filePath}
+            initialServerFileUrl={values.fileUrl}
             onUploadComplete={(result) => {
-              setFileName(result.original_filename);
-              setFilePath(result.file_path ?? "");
-              setFileUrl(result.file_url ?? "");
-              setFileId(result.file_id ?? "");
+              setValues((v) => ({
+                ...v,
+                fileName: result.original_filename,
+                filePath: result.file_path ?? "",
+                fileUrl: result.file_url ?? "",
+                fileId: result.file_id ?? "",
+              }));
             }}
             onRemove={() => {
-              setFileName("");
-              setFilePath("");
-              setFileUrl("");
-              setFileId("");
+              setValues((v) => ({
+                ...v,
+                fileName: "",
+                filePath: "",
+                fileUrl: "",
+                fileId: "",
+              }));
             }}
           />
         )}

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/GmailDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/GmailDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useRef } from "react";
 import { GmailNodeData, GmailOperation } from "../types/nodes";
 import { DataSource } from "@/interfaces/dataSource.interface";
 import { Button } from "@/components/button";
@@ -18,6 +18,7 @@ import { BaseNodeDialogProps } from "./base";
 import { DraggableTextArea } from "../components/custom/DraggableTextArea";
 import { DataSourceDialog } from "@/views/DataSources/components/DataSourceDialog";
 import { CreateNewSelectItem } from "@/components/CreateNewSelectItem";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 interface GmailDialogProps
   extends BaseNodeDialogProps<GmailNodeData, GmailNodeData> {
@@ -25,52 +26,23 @@ interface GmailDialogProps
 }
 
 export const GmailDialog: React.FC<GmailDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate, connectors } = props;
-  const [name, setName] = useState(data.name || "");
-  const [subject, setSubject] = useState(data.subject || "");
-  const [body, setBody] = useState(data.body || "");
-  const [to, setTo] = useState(data.to || "");
-  const [cc, setCc] = useState(data.cc || "");
-  const [bcc, setBcc] = useState(data.bcc || "");
-  const [dataSourceId, setDataSourceId] = useState(
-    data.dataSourceId?.toString() || ""
-  );
-  const [attachments, setAttachments] = useState<string[]>([]);
-  const [operation, setOperation] = useState<GmailOperation>(
-    (data.operation as GmailOperation) || "send_email"
-  );
+  const { onClose, data, connectors } = props;
+
+  const { values, setField, setValues, merged, handleSave } =
+    useNodeDialogState(props, () => ({
+      name: data.name || "",
+      subject: data.subject || "",
+      body: data.body || "",
+      to: data.to || "",
+      cc: data.cc || "",
+      bcc: data.bcc || "",
+      dataSourceId: data.dataSourceId?.toString() || "",
+      operation: (data.operation as GmailOperation) || "send_email",
+      attachments: data.attachments || [],
+    }));
+
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isCreateDataSourceOpen, setIsCreateDataSourceOpen] = useState(false);
-
-  useEffect(() => {
-    if (isOpen) {
-      setName(data.name || "");
-      setSubject(data.subject || "");
-      setBody(data.body || "");
-      setTo(data.to || "");
-      setCc(data.cc || "");
-      setBcc(data.bcc || "");
-      setDataSourceId(data.dataSourceId?.toString() || "");
-      setAttachments(data.attachments || []);
-      setOperation((data.operation as GmailOperation) || "send_email");
-    }
-  }, [isOpen, data]);
-
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name,
-      subject,
-      body,
-      to,
-      cc,
-      bcc,
-      dataSourceId,
-      operation,
-      attachments,
-    });
-    onClose();
-  };
 
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
@@ -79,7 +51,10 @@ export const GmailDialog: React.FC<GmailDialogProps> = (props) => {
         const reader = new FileReader();
         reader.onload = (e) => {
           const base64Content = e.target?.result as string;
-          setAttachments((prev) => [...prev, base64Content]);
+          setValues((v) => ({
+            ...v,
+            attachments: [...v.attachments, base64Content],
+          }));
         };
         reader.readAsDataURL(file);
       });
@@ -87,7 +62,10 @@ export const GmailDialog: React.FC<GmailDialogProps> = (props) => {
   };
 
   const removeAttachment = (index: number) => {
-    setAttachments((prev) => prev.filter((_, i) => i !== index));
+    setValues((v) => ({
+      ...v,
+      attachments: v.attachments.filter((_, i) => i !== index),
+    }));
   };
 
   const triggerFileSelect = () => {
@@ -109,27 +87,14 @@ export const GmailDialog: React.FC<GmailDialogProps> = (props) => {
           </>
         }
         {...props}
-        data={
-          {
-            ...data,
-            name,
-            subject,
-            body,
-            to,
-            cc,
-            bcc,
-            dataSourceId,
-            operation,
-            attachments,
-          } as GmailNodeData
-        }
+        data={merged}
       >
         <div className="space-y-2">
           <Label htmlFor="node-name">Node Name</Label>
           <RichInput
             id="node-name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="Enter the name of this node"
             className="w-full"
           />
@@ -138,13 +103,13 @@ export const GmailDialog: React.FC<GmailDialogProps> = (props) => {
         <div className="space-y-2">
           <Label htmlFor="connector-select">Select Connector</Label>
           <Select
-            value={dataSourceId}
+            value={values.dataSourceId}
             onValueChange={(val) => {
               if (val === "__create__") {
                 setIsCreateDataSourceOpen(true);
                 return;
               }
-              setDataSourceId(val);
+              setField("dataSourceId", val);
             }}
           >
             <SelectTrigger id="connector-select">
@@ -164,8 +129,10 @@ export const GmailDialog: React.FC<GmailDialogProps> = (props) => {
         <div className="space-y-2">
           <Label htmlFor="operation-select">Operation</Label>
           <Select
-            value={operation}
-            onValueChange={(value) => setOperation(value as GmailOperation)}
+            value={values.operation}
+            onValueChange={(value) =>
+              setField("operation", value as GmailOperation)
+            }
           >
             <SelectTrigger id="operation-select">
               <SelectValue placeholder="Select operation" />
@@ -189,8 +156,8 @@ export const GmailDialog: React.FC<GmailDialogProps> = (props) => {
               <DraggableInput
                 id="to"
                 type="email"
-                value={to}
-                onChange={(e) => setTo(e.target.value)}
+                value={values.to}
+                onChange={(e) => setField("to", e.target.value)}
                 placeholder="e.g., recipient@example.com"
                 className="w-full break-all"
               />
@@ -201,8 +168,8 @@ export const GmailDialog: React.FC<GmailDialogProps> = (props) => {
                 <DraggableInput
                   id="cc"
                   type="email"
-                  value={cc}
-                  onChange={(e) => setCc(e.target.value)}
+                  value={values.cc}
+                  onChange={(e) => setField("cc", e.target.value)}
                   placeholder="e.g., cc@example.com"
                   className="w-full break-all"
                 />
@@ -212,8 +179,8 @@ export const GmailDialog: React.FC<GmailDialogProps> = (props) => {
                 <DraggableInput
                   id="bcc"
                   type="email"
-                  value={bcc}
-                  onChange={(e) => setBcc(e.target.value)}
+                  value={values.bcc}
+                  onChange={(e) => setField("bcc", e.target.value)}
                   placeholder="e.g., bcc@example.com"
                   className="w-full break-all"
                 />
@@ -229,8 +196,8 @@ export const GmailDialog: React.FC<GmailDialogProps> = (props) => {
               <Label htmlFor="subject">Subject</Label>
               <DraggableInput
                 id="subject"
-                value={subject}
-                onChange={(e) => setSubject(e.target.value)}
+                value={values.subject}
+                onChange={(e) => setField("subject", e.target.value)}
                 placeholder="Enter email subject"
                 className="w-full"
               />
@@ -240,8 +207,8 @@ export const GmailDialog: React.FC<GmailDialogProps> = (props) => {
               <DraggableTextArea
                 id="body"
                 rows={6}
-                value={body}
-                onChange={(e) => setBody(e.target.value)}
+                value={values.body}
+                onChange={(e) => setField("body", e.target.value)}
                 placeholder="Enter message content"
                 className="w-full resize-none"
               />
@@ -270,8 +237,8 @@ export const GmailDialog: React.FC<GmailDialogProps> = (props) => {
             accept="*/*"
           />
           <div className="space-y-2">
-            {attachments.length > 0 ? (
-              attachments.map((attachment, index) => (
+            {values.attachments.length > 0 ? (
+              values.attachments.map((attachment, index) => (
                 <div
                   key={index}
                   className="flex items-center justify-between p-2 bg-muted rounded-md w-full"
@@ -310,7 +277,7 @@ export const GmailDialog: React.FC<GmailDialogProps> = (props) => {
         isOpen={isCreateDataSourceOpen}
         onOpenChange={setIsCreateDataSourceOpen}
         onDataSourceSaved={(created) => {
-          if (created?.id) setDataSourceId(created.id);
+          if (created?.id) setField("dataSourceId", created.id);
         }}
         mode="create"
         defaultSourceType="gmail"

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/GuardrailNliDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/GuardrailNliDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { RichInput } from "@/components/richInput";
 import { Label } from "@/components/label";
 import { Switch } from "@/components/switch";
@@ -10,12 +10,10 @@ import {
   SelectValue,
 } from "@/components/select";
 import { BaseNodeDialogProps } from "./base";
-import {
-  GuardrailNliNodeData,
-  NodeData,
-} from "../types/nodes";
+import { GuardrailNliNodeData } from "../types/nodes";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { DraggableTextArea } from "../components/custom/DraggableTextArea";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type Props = BaseNodeDialogProps<
   GuardrailNliNodeData,
@@ -34,27 +32,17 @@ const NLI_MODEL_OPTIONS = [
 ];
 
 export const GuardrailNliDialog: React.FC<Props> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
-  const [localData, setLocalData] = useState<GuardrailNliNodeData>(data);
+  const { onClose, data } = props;
 
-  useEffect(() => {
-    if (isOpen) {
-      setLocalData(data);
-    }
-  }, [isOpen, data]);
-
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      ...localData,
-    } as GuardrailNliNodeData & NodeData);
-    onClose();
-  };
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => data
+  );
 
   return (
     <NodeConfigPanel
       {...props}
-      data={localData as unknown as NodeData}
+      data={merged}
       footer={
         <div className="flex justify-end gap-2">
           <button
@@ -78,13 +66,8 @@ export const GuardrailNliDialog: React.FC<Props> = (props) => {
         <div className="space-y-2">
           <Label>Answer</Label>
           <DraggableTextArea
-            value={localData.answer_field || ""}
-            onChange={(e) =>
-              setLocalData((prev) => ({
-                ...prev,
-                answer_field: e.target.value,
-              }))
-            }
+            value={values.answer_field || ""}
+            onChange={(e) => setField("answer_field", e.target.value)}
             placeholder="answer"
             rows={2}
           />
@@ -92,13 +75,8 @@ export const GuardrailNliDialog: React.FC<Props> = (props) => {
         <div className="space-y-2">
           <Label>Evidence</Label>
           <DraggableTextArea
-            value={localData.evidence_field || ""}
-            onChange={(e) =>
-              setLocalData((prev) => ({
-                ...prev,
-                evidence_field: e.target.value,
-              }))
-            }
+            value={values.evidence_field || ""}
+            onChange={(e) => setField("evidence_field", e.target.value)}
             placeholder="context"
             rows={2}
           />
@@ -107,15 +85,10 @@ export const GuardrailNliDialog: React.FC<Props> = (props) => {
           <Label>NLI model</Label>
           <Select
             value={
-              localData.nli_model_name ||
+              values.nli_model_name ||
               "cross-encoder/nli-deberta-v3-base"
             }
-            onValueChange={(value) =>
-              setLocalData((prev) => ({
-                ...prev,
-                nli_model_name: value,
-              }))
-            }
+            onValueChange={(value) => setField("nli_model_name", value)}
           >
             <SelectTrigger className="w-full">
               <SelectValue placeholder="Select NLI model" />
@@ -136,12 +109,9 @@ export const GuardrailNliDialog: React.FC<Props> = (props) => {
             step="0.01"
             min={0}
             max={1}
-            value={localData.min_entail_score ?? 0.5}
+            value={values.min_entail_score ?? 0.5}
             onChange={(e) =>
-              setLocalData((prev) => ({
-                ...prev,
-                min_entail_score: Number(e.target.value),
-              }))
+              setField("min_entail_score", Number(e.target.value))
             }
           />
         </div>
@@ -154,12 +124,9 @@ export const GuardrailNliDialog: React.FC<Props> = (props) => {
               </p>
             </div>
             <Switch
-              checked={localData.fail_on_contradiction ?? false}
+              checked={values.fail_on_contradiction ?? false}
               onCheckedChange={(checked) =>
-                setLocalData((prev) => ({
-                  ...prev,
-                  fail_on_contradiction: checked,
-                }))
+                setField("fail_on_contradiction", checked)
               }
             />
           </div>
@@ -172,26 +139,18 @@ export const GuardrailNliDialog: React.FC<Props> = (props) => {
             </p>
           </div>
           <Switch
-            checked={localData.fallback_answer_enabled ?? false}
+            checked={values.fallback_answer_enabled ?? false}
             onCheckedChange={(checked) =>
-              setLocalData((prev) => ({
-                ...prev,
-                fallback_answer_enabled: checked,
-              }))
+              setField("fallback_answer_enabled", checked)
             }
           />
         </div>
-        {localData.fallback_answer_enabled && (
+        {values.fallback_answer_enabled && (
           <div className="space-y-2">
             <Label>Fallback answer text</Label>
             <DraggableTextArea
-              value={localData.fallback_answer ?? ""}
-              onChange={(e) =>
-                setLocalData((prev) => ({
-                  ...prev,
-                  fallback_answer: e.target.value,
-                }))
-              }
+              value={values.fallback_answer ?? ""}
+              onChange={(e) => setField("fallback_answer", e.target.value)}
               placeholder="e.g. I'm sorry, I cannot provide an answer based on the available information."
               rows={3}
             />

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/GuardrailProvenanceDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/GuardrailProvenanceDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { RichInput } from "@/components/richInput";
 import { Label } from "@/components/label";
 import { Switch } from "@/components/switch";
@@ -13,14 +13,12 @@ import { useQuery } from "@tanstack/react-query";
 import { getAllLLMProviders } from "@/services/llmProviders";
 import { LLMProvider } from "@/interfaces/llmProvider.interface";
 import { BaseNodeDialogProps } from "./base";
-import {
-  GuardrailProvenanceNodeData,
-  NodeData,
-} from "../types/nodes";
+import { GuardrailProvenanceNodeData } from "../types/nodes";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { DraggableTextArea } from "../components/custom/DraggableTextArea";
 import { useWorkflow } from "../context/WorkflowContext";
 import { PromptEditorButton } from "../components/PromptEditor/PromptEditorButton";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type Props = BaseNodeDialogProps<
   GuardrailProvenanceNodeData,
@@ -28,9 +26,11 @@ type Props = BaseNodeDialogProps<
 >;
 
 export const GuardrailProvenanceDialog: React.FC<Props> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
-  const [localData, setLocalData] = useState<GuardrailProvenanceNodeData>(data);
+  const { isOpen, onClose, data } = props;
   const { workflow } = useWorkflow();
+
+  const { values, setValues, setField, merged, handleSave } =
+    useNodeDialogState(props, () => data);
 
   const { data: providers = [] } = useQuery({
     queryKey: ["llmProviders"],
@@ -38,39 +38,25 @@ export const GuardrailProvenanceDialog: React.FC<Props> = (props) => {
     select: (rows: LLMProvider[]) => rows.filter((p) => p.is_active === 1),
   });
 
-  useEffect(() => {
-    if (isOpen) {
-      setLocalData(data);
-    }
-  }, [isOpen, data]);
-
   // When switching to LLM mode and no provider is set, default to first active provider
   useEffect(() => {
     if (
       isOpen &&
-      (localData.provenance_mode === "llm" || localData.use_llm_judge) &&
-      !localData.llm_provider_id &&
+      (values.provenance_mode === "llm" || values.use_llm_judge) &&
+      !values.llm_provider_id &&
       providers.length > 0
     ) {
-      setLocalData((prev) => ({
+      setValues((prev) => ({
         ...prev,
         llm_provider_id: providers[0].id,
       }));
     }
-  }, [isOpen, localData.provenance_mode, localData.use_llm_judge, localData.llm_provider_id, providers]);
-
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      ...localData,
-    } as GuardrailProvenanceNodeData & NodeData);
-    onClose();
-  };
+  }, [isOpen, values.provenance_mode, values.use_llm_judge, values.llm_provider_id, providers, setValues]);
 
   return (
     <NodeConfigPanel
       {...props}
-      data={localData as unknown as NodeData}
+      data={merged}
       footer={
         <div className="flex justify-end gap-2">
           <button
@@ -94,13 +80,8 @@ export const GuardrailProvenanceDialog: React.FC<Props> = (props) => {
         <div className="space-y-2">
           <Label>Answer field key</Label>
           <DraggableTextArea
-            value={localData.answer_field ?? "answer"}
-            onChange={(e) =>
-              setLocalData((prev) => ({
-                ...prev,
-                answer_field: e.target.value,
-              }))
-            }
+            value={values.answer_field ?? "answer"}
+            onChange={(e) => setField("answer_field", e.target.value)}
             placeholder="answer"
             rows={2}
           />
@@ -108,13 +89,8 @@ export const GuardrailProvenanceDialog: React.FC<Props> = (props) => {
         <div className="space-y-2">
           <Label>Context field key</Label>
           <DraggableTextArea
-            value={localData.context_field ?? "context"}
-            onChange={(e) =>
-              setLocalData((prev) => ({
-                ...prev,
-                context_field: e.target.value,
-              }))
-            }
+            value={values.context_field ?? "context"}
+            onChange={(e) => setField("context_field", e.target.value)}
             placeholder="context"
             rows={2}
           />
@@ -126,13 +102,8 @@ export const GuardrailProvenanceDialog: React.FC<Props> = (props) => {
             step="0.01"
             min={0}
             max={1}
-            value={localData.min_score ?? 0.5}
-            onChange={(e) =>
-              setLocalData((prev) => ({
-                ...prev,
-                min_score: Number(e.target.value),
-              }))
-            }
+            value={values.min_score ?? 0.5}
+            onChange={(e) => setField("min_score", Number(e.target.value))}
           />
         </div>
         {false && (
@@ -144,12 +115,9 @@ export const GuardrailProvenanceDialog: React.FC<Props> = (props) => {
               </p>
             </div>
             <Switch
-              checked={localData.fail_on_violation ?? false}
+              checked={values.fail_on_violation ?? false}
               onCheckedChange={(checked) =>
-                setLocalData((prev) => ({
-                  ...prev,
-                  fail_on_violation: checked,
-                }))
+                setField("fail_on_violation", checked)
               }
             />
           </div>
@@ -162,26 +130,18 @@ export const GuardrailProvenanceDialog: React.FC<Props> = (props) => {
             </p>
           </div>
           <Switch
-            checked={localData.fallback_answer_enabled ?? false}
+            checked={values.fallback_answer_enabled ?? false}
             onCheckedChange={(checked) =>
-              setLocalData((prev) => ({
-                ...prev,
-                fallback_answer_enabled: checked,
-              }))
+              setField("fallback_answer_enabled", checked)
             }
           />
         </div>
-        {localData.fallback_answer_enabled && (
+        {values.fallback_answer_enabled && (
           <div className="space-y-2">
             <Label>Fallback answer text</Label>
             <DraggableTextArea
-              value={localData.fallback_answer ?? ""}
-              onChange={(e) =>
-                setLocalData((prev) => ({
-                  ...prev,
-                  fallback_answer: e.target.value,
-                }))
-              }
+              value={values.fallback_answer ?? ""}
+              onChange={(e) => setField("fallback_answer", e.target.value)}
               placeholder="e.g. I'm sorry, I cannot provide an answer based on the available information."
               rows={3}
             />
@@ -191,9 +151,9 @@ export const GuardrailProvenanceDialog: React.FC<Props> = (props) => {
         <div className="space-y-2 pt-2 border-t border-border">
           <Label>Provenance mode</Label>
           <Select
-            value={localData.provenance_mode || "embeddings"}
+            value={values.provenance_mode || "embeddings"}
             onValueChange={(value: "embeddings" | "llm") =>
-              setLocalData((prev) => ({
+              setValues((prev) => ({
                 ...prev,
                 provenance_mode: value,
                 use_llm_judge: value === "llm",
@@ -212,20 +172,15 @@ export const GuardrailProvenanceDialog: React.FC<Props> = (props) => {
           </Select>
         </div>
 
-        {localData.provenance_mode === "embeddings" && (
+        {values.provenance_mode === "embeddings" && (
           <div className="space-y-4">
             <div className="space-y-2">
               <Label>Embedding provider</Label>
               <Select
-                value={localData.embedding_type || "huggingface"}
+                value={values.embedding_type || "huggingface"}
                 onValueChange={(
                   value: "openai" | "huggingface" | "bedrock",
-                ) =>
-                  setLocalData((prev) => ({
-                    ...prev,
-                    embedding_type: value,
-                  }))
-                }
+                ) => setField("embedding_type", value)}
               >
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="Select provider" />
@@ -240,12 +195,9 @@ export const GuardrailProvenanceDialog: React.FC<Props> = (props) => {
             <div className="space-y-2">
               <Label>Embedding model name</Label>
               <RichInput
-                value={localData.embedding_model_name ?? ""}
+                value={values.embedding_model_name ?? ""}
                 onChange={(e) =>
-                  setLocalData((prev) => ({
-                    ...prev,
-                    embedding_model_name: e.target.value,
-                  }))
+                  setField("embedding_model_name", e.target.value)
                 }
                 placeholder="e.g. all-MiniLM-L6-v2"
               />
@@ -253,7 +205,7 @@ export const GuardrailProvenanceDialog: React.FC<Props> = (props) => {
           </div>
         )}
 
-        {localData.provenance_mode === "llm" && (
+        {values.provenance_mode === "llm" && (
           <div className="space-y-4">
             <div className="space-y-1">
               <Label>LLM as judge</Label>
@@ -265,13 +217,8 @@ export const GuardrailProvenanceDialog: React.FC<Props> = (props) => {
             <div className="space-y-2">
               <Label>LLM Provider</Label>
               <Select
-                value={localData.llm_provider_id || ""}
-                onValueChange={(val) =>
-                  setLocalData((prev) => ({
-                    ...prev,
-                    llm_provider_id: val,
-                  }))
-                }
+                value={values.llm_provider_id || ""}
+                onValueChange={(val) => setField("llm_provider_id", val)}
               >
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="Select provider" />
@@ -294,14 +241,11 @@ export const GuardrailProvenanceDialog: React.FC<Props> = (props) => {
                     workflowId={workflow.id}
                     nodeId={props.nodeId}
                     promptField="llm_judge_system_prompt_suffix"
-                    currentValue={localData.llm_judge_system_prompt_suffix ?? ""}
+                    currentValue={values.llm_judge_system_prompt_suffix ?? ""}
                     onPromptChange={(val) =>
-                      setLocalData((prev) => ({
-                        ...prev,
-                        llm_judge_system_prompt_suffix: val,
-                      }))
+                      setField("llm_judge_system_prompt_suffix", val)
                     }
-                    defaultProviderId={localData.llm_provider_id}
+                    defaultProviderId={values.llm_provider_id}
                   />
                 )}
               </div>
@@ -310,12 +254,9 @@ export const GuardrailProvenanceDialog: React.FC<Props> = (props) => {
                 E.g. <em>"When no Context is available, treat the answer as supported."</em>
               </p>
               <DraggableTextArea
-                value={localData.llm_judge_system_prompt_suffix ?? ""}
+                value={values.llm_judge_system_prompt_suffix ?? ""}
                 onChange={(e) =>
-                  setLocalData((prev) => ({
-                    ...prev,
-                    llm_judge_system_prompt_suffix: e.target.value,
-                  }))
+                  setField("llm_judge_system_prompt_suffix", e.target.value)
                 }
                 placeholder="Optional extra instructions for the judge..."
                 rows={4}

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/HtmlToImageDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/HtmlToImageDialog.tsx
@@ -17,6 +17,7 @@ import {
 import { Save, ChevronDown, ChevronUp } from "lucide-react";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 // open the advanced section when any advanced option is set away from its default
 const hasAdvancedOptions = (data: HtmlToImageNodeData): boolean =>
@@ -25,44 +26,26 @@ const hasAdvancedOptions = (data: HtmlToImageNodeData): boolean =>
 export const HtmlToImageDialog: React.FC<
   BaseNodeDialogProps<HtmlToImageNodeData, HtmlToImageNodeData>
 > = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
-  const [name, setName] = useState(data.name || "");
-  const [html, setHtml] = useState(data.html || "");
-  const [captureMode, setCaptureMode] = useState<HtmlToImageCaptureMode>(
-    data.captureMode || "fullPage"
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name || "",
+      html: data.html || "",
+      captureMode: data.captureMode || "fullPage",
+      viewportWidth: data.viewportWidth ?? 1280,
+      viewportHeight: data.viewportHeight ?? 720,
+      waitFor: data.waitFor ?? 0,
+    })
   );
-  const [viewportWidth, setViewportWidth] = useState<number>(
-    data.viewportWidth ?? 1280
-  );
-  const [viewportHeight, setViewportHeight] = useState<number>(
-    data.viewportHeight ?? 720
-  );
-  const [waitFor, setWaitFor] = useState<number>(data.waitFor ?? 0);
+
   const [showAdvanced, setShowAdvanced] = useState(hasAdvancedOptions(data));
-
   useEffect(() => {
-    setName(data.name || "");
-    setHtml(data.html || "");
-    setCaptureMode(data.captureMode || "fullPage");
-    setViewportWidth(data.viewportWidth ?? 1280);
-    setViewportHeight(data.viewportHeight ?? 720);
-    setWaitFor(data.waitFor ?? 0);
-    setShowAdvanced(hasAdvancedOptions(data));
-  }, [isOpen]);
-
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name,
-      html,
-      captureMode,
-      viewportWidth,
-      viewportHeight,
-      waitFor,
-    });
-    onClose();
-  };
+    if (isOpen) {
+      setShowAdvanced(hasAdvancedOptions(data));
+    }
+  }, [isOpen, data]);
 
   return (
     <NodeConfigPanel
@@ -78,22 +61,14 @@ export const HtmlToImageDialog: React.FC<
         </>
       }
       {...props}
-      data={{
-        ...data,
-        name,
-        html,
-        captureMode,
-        viewportWidth,
-        viewportHeight,
-        waitFor,
-      }}
+      data={merged}
     >
       <div className="space-y-2">
         <Label htmlFor="name">Name</Label>
         <RichInput
           id="name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={values.name}
+          onChange={(e) => setField("name", e.target.value)}
           placeholder="HTML to Image"
           className="break-all w-full"
         />
@@ -103,8 +78,8 @@ export const HtmlToImageDialog: React.FC<
         <Label htmlFor="html">HTML</Label>
         <RichTextarea
           id="html"
-          value={html}
-          onChange={(e) => setHtml(e.target.value)}
+          value={values.html}
+          onChange={(e) => setField("html", e.target.value)}
           placeholder="<html>...</html>"
           className="w-full min-h-[160px] font-mono"
         />
@@ -117,9 +92,9 @@ export const HtmlToImageDialog: React.FC<
       <div className="space-y-2">
         <Label htmlFor="captureMode">Capture Mode</Label>
         <Select
-          value={captureMode}
+          value={values.captureMode}
           onValueChange={(value) =>
-            setCaptureMode(value as HtmlToImageCaptureMode)
+            setField("captureMode", value as HtmlToImageCaptureMode)
           }
         >
           <SelectTrigger>
@@ -141,24 +116,27 @@ export const HtmlToImageDialog: React.FC<
         <RichInput
           id="viewportWidth"
           type="number"
-          value={String(viewportWidth)}
+          value={String(values.viewportWidth)}
           onChange={(e) =>
-            setViewportWidth(Math.max(1, parseInt(e.target.value) || 0))
+            setField("viewportWidth", Math.max(1, parseInt(e.target.value) || 0))
           }
           placeholder="1280"
           className="w-full"
         />
       </div>
 
-      {captureMode === "viewport" && (
+      {values.captureMode === "viewport" && (
         <div className="space-y-2">
           <Label htmlFor="viewportHeight">Viewport Height (px)</Label>
           <RichInput
             id="viewportHeight"
             type="number"
-            value={String(viewportHeight)}
+            value={String(values.viewportHeight)}
             onChange={(e) =>
-              setViewportHeight(Math.max(1, parseInt(e.target.value) || 0))
+              setField(
+                "viewportHeight",
+                Math.max(1, parseInt(e.target.value) || 0)
+              )
             }
             placeholder="720"
             className="w-full"
@@ -187,9 +165,9 @@ export const HtmlToImageDialog: React.FC<
               <RichInput
                 id="waitFor"
                 type="number"
-                value={String(waitFor)}
+                value={String(values.waitFor)}
                 onChange={(e) =>
-                  setWaitFor(Math.max(0, parseInt(e.target.value) || 0))
+                  setField("waitFor", Math.max(0, parseInt(e.target.value) || 0))
                 }
                 placeholder="0"
                 className="w-full"

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/HumanInTheLoopDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/HumanInTheLoopDialog.tsx
@@ -26,6 +26,7 @@ import { DraggableTextArea } from "../components/custom/DraggableTextArea";
 import { TranslationTrigger } from "../../components/TranslationTrigger";
 import { getLanguages } from "@/services/translations";
 import { Language } from "@/interfaces/translation.interface";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 const FIELD_TYPES = [
   { value: "text", label: "Text" },
@@ -55,7 +56,7 @@ interface FieldDialogState {
 export const HumanInTheLoopDialog: React.FC<
   BaseNodeDialogProps<HumanInTheLoopNodeData, HumanInTheLoopNodeData>
 > = (props) => {
-  const { isOpen, onClose, data, onUpdate, nodeId } = props;
+  const { isOpen, onClose, data, nodeId } = props;
   const { agentId } = useParams<{ agentId: string }>();
 
   // Active languages, loaded once per open so each per-field trigger reuses the same list.
@@ -69,29 +70,29 @@ export const HumanInTheLoopDialog: React.FC<
   const fieldKey = (fieldName: string, attr: string) =>
     `${nodePrefix}.fields.${fieldName}.${attr}`;
 
-  const [name, setName] = useState(data.name || "");
-  const [message, setMessage] = useState(
-    data.message || "Please provide the following information:"
-  );
-  const [askOnce, setAskOnce] = useState(data.ask_once !== false);
-  const [formFields, setFormFields] = useState<HumanInTheLoopFormField[]>(
-    data.form_fields || []
-  );
+  const { values, setField, setValues, merged, handleSave } =
+    useNodeDialogState(
+      props,
+      () => ({
+        name: data.name || "",
+        message: data.message || "Please provide the following information:",
+        askOnce: data.ask_once !== false,
+        formFields: data.form_fields || [],
+      }),
+      (v) => ({
+        name: v.name,
+        message: v.message,
+        ask_once: v.askOnce,
+        form_fields: v.formFields,
+      })
+    );
+
   const [fieldDialog, setFieldDialog] = useState<FieldDialogState>({
     isOpen: false,
     mode: "add",
     editIndex: null,
     field: { ...emptyField },
   });
-
-  useEffect(() => {
-    if (isOpen) {
-      setName(data.name || "");
-      setMessage(data.message || "Please provide the following information:");
-      setAskOnce(data.ask_once !== false);
-      setFormFields(data.form_fields || []);
-    }
-  }, [isOpen, data]);
 
   // Load the active language list once when the panel opens (only when translations are
   // actually usable, i.e. the agent/node context is known), shared by every trigger.
@@ -104,17 +105,6 @@ export const HumanInTheLoopDialog: React.FC<
         });
     }
   }, [isOpen, nodePrefix, languages.length]);
-
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name,
-      message,
-      ask_once: askOnce,
-      form_fields: formFields,
-    });
-    onClose();
-  };
 
   // Field CRUD
   const openAddFieldDialog = () => {
@@ -131,7 +121,7 @@ export const HumanInTheLoopDialog: React.FC<
       isOpen: true,
       mode: "edit",
       editIndex: index,
-      field: { ...formFields[index] },
+      field: { ...values.formFields[index] },
     });
   };
 
@@ -140,17 +130,23 @@ export const HumanInTheLoopDialog: React.FC<
     if (!field.name || !field.label) return;
 
     if (fieldDialog.mode === "add") {
-      setFormFields((prev) => [...prev, field]);
+      setValues((prev) => ({ ...prev, formFields: [...prev.formFields, field] }));
     } else if (fieldDialog.editIndex !== null) {
-      setFormFields((prev) =>
-        prev.map((f, i) => (i === fieldDialog.editIndex ? field : f))
-      );
+      setValues((prev) => ({
+        ...prev,
+        formFields: prev.formFields.map((f, i) =>
+          i === fieldDialog.editIndex ? field : f
+        ),
+      }));
     }
     setFieldDialog((prev) => ({ ...prev, isOpen: false }));
   };
 
   const handleDeleteField = (index: number) => {
-    setFormFields((prev) => prev.filter((_, i) => i !== index));
+    setValues((prev) => ({
+      ...prev,
+      formFields: prev.formFields.filter((_, i) => i !== index),
+    }));
   };
 
   const updateDialogField = (
@@ -202,20 +198,14 @@ export const HumanInTheLoopDialog: React.FC<
         </>
       }
       {...props}
-      data={{
-        ...data,
-        name,
-        message,
-        ask_once: askOnce,
-        form_fields: formFields,
-      }}
+      data={merged}
     >
       <div className="space-y-2">
         <Label htmlFor="name">Name</Label>
         <RichInput
           id="name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={values.name}
+          onChange={(e) => setField("name", e.target.value)}
           placeholder="Human In The Loop"
           className="break-all w-full"
         />
@@ -224,18 +214,18 @@ export const HumanInTheLoopDialog: React.FC<
       <div className="space-y-2">
         <div className="flex items-center justify-between gap-2">
           <Label htmlFor="message">Message</Label>
-          {nodePrefix && message.trim() && (
+          {nodePrefix && values.message.trim() && (
             <TranslationTrigger
               translationKey={`${nodePrefix}.message`}
-              currentValue={message}
+              currentValue={values.message}
               languages={languages}
             />
           )}
         </div>
         <DraggableTextArea
           id="message"
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
+          value={values.message}
+          onChange={(e) => setField("message", e.target.value)}
           placeholder="Message shown above the form..."
           className="text-sm h-20 resize-none w-full"
         />
@@ -248,14 +238,14 @@ export const HumanInTheLoopDialog: React.FC<
         </div>
         <Switch
           id="ask_once"
-          checked={askOnce}
-          onCheckedChange={(val) => setAskOnce(val)}
+          checked={values.askOnce}
+          onCheckedChange={(val) => setField("askOnce", val)}
         />
       </div>
 
       <div className="space-y-2">
         <div className="flex justify-between items-center">
-          <Label>Form Fields ({formFields.length})</Label>
+          <Label>Form Fields ({values.formFields.length})</Label>
           <Button
             size="sm"
             variant="outline"
@@ -267,7 +257,7 @@ export const HumanInTheLoopDialog: React.FC<
         </div>
 
         <div className="space-y-2">
-          {formFields.map((field, index) => (
+          {values.formFields.map((field, index) => (
             <div
               key={index}
               className="p-2.5 bg-muted rounded-lg border space-y-2"
@@ -351,7 +341,7 @@ export const HumanInTheLoopDialog: React.FC<
             </div>
           ))}
 
-          {formFields.length === 0 && (
+          {values.formFields.length === 0 && (
             <div className="text-sm text-muted-foreground italic text-center py-4 border border-dashed rounded-lg">
               No fields configured. Click &quot;Add Field&quot; to get started.
             </div>

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/JiraDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/JiraDialog.tsx
@@ -19,33 +19,37 @@ import { getAllAppSettings } from "@/services/appSettings";
 import { AppSetting } from "@/interfaces/app-setting.interface";
 import { AppSettingDialog } from "@/views/AppSettings/components/AppSettingDialog";
 import { CreateNewSelectItem } from "@/components/CreateNewSelectItem";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type JiraDialogProps = BaseNodeDialogProps<JiraNodeData, JiraNodeData>;
 
 export const JiraDialog: React.FC<JiraDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
-  const [name, setName] = useState(data.name);
-  const [spaceKey, setSpaceKey] = useState(data.spaceKey || "");
-  const [taskName, setTaskName] = useState(data.taskName || "");
-  const [taskDescription, setTaskDescription] = useState(
-    data.taskDescription || ""
+  const { isOpen, onClose, data } = props;
+
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name,
+      spaceKey: data.spaceKey || "",
+      taskName: data.taskName || "",
+      taskDescription: data.taskDescription || "",
+      app_settings_id: data.app_settings_id || "",
+    }),
+    (v) => ({
+      name: v.name,
+      spaceKey: v.spaceKey,
+      taskName: v.taskName,
+      taskDescription: v.taskDescription,
+      app_settings_id: v.app_settings_id || undefined,
+    })
   );
-  const [appSettingsId, setAppSettingsId] = useState(
-    data.app_settings_id || ""
-  );
+
   const [appSettings, setAppSettings] = useState<AppSetting[]>([]);
   const [isLoadingAppSettings, setIsLoadingAppSettings] = useState(false);
   const [isCreateSettingOpen, setIsCreateSettingOpen] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
-      setName(data.name);
-      setSpaceKey(data.spaceKey || "");
-      setTaskName(data.taskName || "");
-      setTaskDescription(data.taskDescription || "");
-
-      setAppSettingsId(data.app_settings_id || "");
-
       const fetchAppSettings = async () => {
         setIsLoadingAppSettings(true);
         try {
@@ -62,18 +66,6 @@ export const JiraDialog: React.FC<JiraDialogProps> = (props) => {
     }
   }, [isOpen, data]);
 
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name,
-      spaceKey,
-      taskName,
-      taskDescription,
-      app_settings_id: appSettingsId || undefined,
-    });
-    onClose();
-  };
-
   return (
     <>
       <NodeConfigPanel
@@ -89,21 +81,14 @@ export const JiraDialog: React.FC<JiraDialogProps> = (props) => {
           </>
         }
         {...props}
-        data={{
-          ...data,
-          name,
-          spaceKey,
-          taskName,
-          taskDescription,
-          app_settings_id: appSettingsId || undefined,
-        }}
+        data={merged}
       >
         <div className="space-y-2">
           <Label htmlFor="name">Tool Name</Label>
           <RichInput
             id="name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="Enter tool name"
             className="w-full"
           />
@@ -111,13 +96,13 @@ export const JiraDialog: React.FC<JiraDialogProps> = (props) => {
         <div className="space-y-2">
           <Label htmlFor="app-settings-id">Configuration Vars (Optional)</Label>
           <Select
-            value={appSettingsId || ""}
+            value={values.app_settings_id || ""}
             onValueChange={(value) => {
               if (value === "__create__") {
                 setIsCreateSettingOpen(true);
                 return;
               }
-              setAppSettingsId(value || "");
+              setField("app_settings_id", value || "");
             }}
             disabled={isLoadingAppSettings}
           >
@@ -143,8 +128,8 @@ export const JiraDialog: React.FC<JiraDialogProps> = (props) => {
           <Label htmlFor="name">Space Key</Label>
           <DraggableInput
             id="space_key"
-            value={spaceKey}
-            onChange={(e) => setSpaceKey(e.target.value)}
+            value={values.spaceKey}
+            onChange={(e) => setField("spaceKey", e.target.value)}
             placeholder="Enter project name"
             className="w-full"
           />
@@ -153,8 +138,8 @@ export const JiraDialog: React.FC<JiraDialogProps> = (props) => {
           <Label htmlFor="name">Task Name</Label>
           <DraggableInput
             id="task_name"
-            value={taskName}
-            onChange={(e) => setTaskName(e.target.value)}
+            value={values.taskName}
+            onChange={(e) => setField("taskName", e.target.value)}
             placeholder="Enter task name"
             className="w-full"
           />
@@ -164,8 +149,8 @@ export const JiraDialog: React.FC<JiraDialogProps> = (props) => {
           <DraggableTextArea
             id="task_description"
             rows={6}
-            value={taskDescription}
-            onChange={(e) => setTaskDescription(e.target.value)}
+            value={values.taskDescription}
+            onChange={(e) => setField("taskDescription", e.target.value)}
             placeholder="Enter task description"
             className="w-full resize-none"
           />
@@ -184,7 +169,7 @@ export const JiraDialog: React.FC<JiraDialogProps> = (props) => {
           } catch (e) {
             // ignore
           }
-          if (created?.id) setAppSettingsId(created.id);
+          if (created?.id) setField("app_settings_id", created.id);
         }}
       />
     </>

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/KnowledgeBaseDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/KnowledgeBaseDialog.tsx
@@ -12,6 +12,7 @@ import { Save, Plus, ExternalLink } from "lucide-react";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
 import { DraggableTextArea } from "../components/custom/DraggableTextArea";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type KnowledgeBaseDialogProps = BaseNodeDialogProps<
   KnowledgeBaseNodeData,
@@ -21,26 +22,22 @@ type KnowledgeBaseDialogProps = BaseNodeDialogProps<
 export const KnowledgeBaseDialog: React.FC<KnowledgeBaseDialogProps> = (
   props
 ) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
-  const [name, setName] = useState(data.name || "");
-  const [query, setQuery] = useState(data.query || "");
-  const [limit, setLimit] = useState(data.limit || 5);
-  const [force, setForce] = useState(data.force || false);
-  const [selectedBases, setSelectedBases] = useState<string[]>(
-    data.selectedBases || []
-  );
+  const { values, setField, setValues, merged, handleSave } =
+    useNodeDialogState(props, () => ({
+      name: data.name || "",
+      query: data.query || "",
+      limit: data.limit || 5,
+      force: data.force || false,
+      selectedBases: data.selectedBases || [],
+    }));
+
   const [availableBases, setAvailableBases] = useState<KnowledgeItem[]>([]);
   const { toast } = useToast();
 
   useEffect(() => {
     if (isOpen) {
-      setName(data.name || "");
-      setQuery(data.query || "");
-      setLimit(data.limit || 5);
-      setForce(data.force || false);
-      setSelectedBases(data.selectedBases || []);
-
       const loadKnowledgeBases = async () => {
         try {
           const bases = await getAllKnowledgeItems();
@@ -57,24 +54,13 @@ export const KnowledgeBaseDialog: React.FC<KnowledgeBaseDialogProps> = (
     }
   }, [isOpen, data, toast]);
 
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name,
-      query,
-      limit,
-      force,
-      selectedBases,
-    });
-    onClose();
-  };
-
   const toggleBase = (baseId: string) => {
-    setSelectedBases((prev) =>
-      prev.includes(baseId)
-        ? prev.filter((id) => id !== baseId)
-        : [...prev, baseId]
-    );
+    setValues((v) => ({
+      ...v,
+      selectedBases: v.selectedBases.includes(baseId)
+        ? v.selectedBases.filter((id) => id !== baseId)
+        : [...v.selectedBases, baseId],
+    }));
   };
 
   return (
@@ -93,21 +79,14 @@ export const KnowledgeBaseDialog: React.FC<KnowledgeBaseDialogProps> = (
         </>
       }
       {...props}
-      data={{
-        ...data,
-        name,
-        query,
-        limit,
-        force,
-        selectedBases,
-      }}
+      data={merged}
     >
       <div className="space-y-2">
         <Label htmlFor="name">Node Name</Label>
         <RichInput
           id="name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={values.name}
+          onChange={(e) => setField("name", e.target.value)}
           placeholder="Enter the name of this node"
           className="w-full"
         />
@@ -117,8 +96,8 @@ export const KnowledgeBaseDialog: React.FC<KnowledgeBaseDialogProps> = (
         <Label htmlFor="query">Query</Label>
         <DraggableTextArea
           id="query"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          value={values.query}
+          onChange={(e) => setField("query", e.target.value)}
           placeholder="Enter a query for this node"
           className="w-full"
         />
@@ -130,8 +109,8 @@ export const KnowledgeBaseDialog: React.FC<KnowledgeBaseDialogProps> = (
           <RichInput
             id="limit"
             type="number"
-            value={limit}
-            onChange={(e) => setLimit(parseInt(e.target.value))}
+            value={values.limit}
+            onChange={(e) => setField("limit", parseInt(e.target.value))}
             placeholder="5"
             min="1"
             className="w-full"
@@ -142,8 +121,10 @@ export const KnowledgeBaseDialog: React.FC<KnowledgeBaseDialogProps> = (
           <div className="flex items-center space-x-2 h-10">
             <Checkbox
               id="force"
-              checked={force}
-              onCheckedChange={(checked) => setForce(checked as boolean)}
+              checked={values.force}
+              onCheckedChange={(checked) =>
+                setField("force", checked as boolean)
+              }
             />
             <Label
               htmlFor="force"
@@ -174,7 +155,7 @@ export const KnowledgeBaseDialog: React.FC<KnowledgeBaseDialogProps> = (
               <div key={base.id} className="flex items-center space-x-2 w-full">
                 <Checkbox
                   id={`kb-${base.id}`}
-                  checked={selectedBases.includes(base.id)}
+                  checked={values.selectedBases.includes(base.id)}
                   onCheckedChange={() => toggleBase(base.id)}
                 />
                 <Label

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/LLModelDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/LLModelDialog.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { BaseLLMNodeData, LLMModelNodeData } from "../types/nodes";
 import { Button } from "@/components/button";
 import { ModelConfiguration } from "../components/ModelConfiguration";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type LLModelDialogProps = BaseNodeDialogProps<
   LLMModelNodeData,
@@ -11,25 +12,12 @@ type LLModelDialogProps = BaseNodeDialogProps<
 >;
 
 export const LLModelDialog: React.FC<LLModelDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { onClose, data } = props;
 
-  const [config, setConfig] = useState<BaseLLMNodeData>(data);
-
-  // Reset state when the dialog is opened to reflect the current node data
-  useEffect(() => {
-    if (isOpen) {
-      setConfig(data);
-    }
-  }, [isOpen, data]);
-
-  // Handle saving the changes
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      ...config,
-    });
-    onClose();
-  };
+  const { values, setValues, merged, handleSave } = useNodeDialogState<
+    BaseLLMNodeData,
+    BaseLLMNodeData
+  >(props, () => data);
 
   return (
     <NodeConfigPanel
@@ -44,15 +32,12 @@ export const LLModelDialog: React.FC<LLModelDialogProps> = (props) => {
         </>
       }
       {...props}
-      data={{
-        ...data,
-        ...config,
-      }}
+      data={merged}
     >
       <ModelConfiguration
         id="agent-config"
-        config={config}
-        onConfigChange={setConfig}
+        config={values}
+        onConfigChange={setValues}
         typeSelect="model"
       />
     </NodeConfigPanel>

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/MCPDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/MCPDialog.tsx
@@ -9,6 +9,7 @@ import { RichTextarea } from "@/components/richTextarea";
 import { Save, RefreshCw } from "lucide-react";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
+import { useNodeDialogState } from "./useNodeDialogState";
 import { DraggableInput } from "../components/custom/DraggableInput";
 import {
   Select,
@@ -43,8 +44,6 @@ export const MCPDialog: React.FC<MCPDialogProps> = (props) => {
     }
   };
 
-  const [name, setName] = useState(data.name || "");
-  const [description, setDescription] = useState(data.description || "");
   const [connectionType, setConnectionType] = useState<MCPConnectionType>(
     getInitialConnectionType()
   );
@@ -60,6 +59,26 @@ export const MCPDialog: React.FC<MCPDialogProps> = (props) => {
     data.whitelistedTools || []
   );
   const [isLoadingTools, setIsLoadingTools] = useState(false);
+
+  // `name`/`description` are the only saved fields not driven by the async
+  // tool-discovery handlers or the connection-config builder effect below, so the
+  // hook owns their seed/re-seed. The remaining saved fields stay as their own
+  // state (mutated by those effects) and are folded into `merged` via toPayload.
+  const { values, setField, merged } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name || "",
+      description: data.description || "",
+    }),
+    (v) => ({
+      name: v.name,
+      description: v.description,
+      connectionType,
+      connectionConfig,
+      availableTools,
+      whitelistedTools,
+    })
+  );
 
   // STDIO-specific state
   const [stdioCommand, setStdioCommand] = useState(
@@ -136,8 +155,6 @@ export const MCPDialog: React.FC<MCPDialogProps> = (props) => {
 
   useEffect(() => {
     if (isOpen) {
-      setName(data.name || "");
-      setDescription(data.description || "");
       setConnectionType(data.connectionType || "http");
 
       if (data.connectionConfig) {
@@ -282,15 +299,7 @@ export const MCPDialog: React.FC<MCPDialogProps> = (props) => {
       }
     }
 
-    onUpdate({
-      ...data,
-      name,
-      description,
-      connectionType,
-      connectionConfig,
-      availableTools,
-      whitelistedTools,
-    });
+    onUpdate(merged);
     onClose();
   };
 
@@ -366,22 +375,14 @@ export const MCPDialog: React.FC<MCPDialogProps> = (props) => {
         </>
       }
       {...props}
-      data={{
-        ...data,
-        name,
-        description,
-        connectionType,
-        connectionConfig,
-        availableTools,
-        whitelistedTools,
-      }}
+      data={merged}
     >
       <div className="space-y-2">
         <Label htmlFor="name">Node Name</Label>
         <RichInput
           id="name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={values.name}
+          onChange={(e) => setField("name", e.target.value)}
           placeholder="MCP Server"
           className="w-full"
         />
@@ -391,8 +392,8 @@ export const MCPDialog: React.FC<MCPDialogProps> = (props) => {
         <Label htmlFor="description">Description</Label>
         <RichInput
           id="description"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
+          value={values.description}
+          onChange={(e) => setField("description", e.target.value)}
           placeholder="MCP server tool connector"
           className="w-full"
         />

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/MLModelInferenceDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/MLModelInferenceDialog.tsx
@@ -16,19 +16,30 @@ import { DraggableInput } from "../components/custom/DraggableInput";
 import toast from "react-hot-toast";
 import { getAllMLModels } from "@/services/mlModels";
 import { MLModel } from "@/interfaces/ml-model.interface";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 export const MLModelInferenceDialog: React.FC<
   BaseNodeDialogProps<MLModelInferenceNodeData, MLModelInferenceNodeData>
 > = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
   const [mlModels, setMlModels] = useState<MLModel[]>([]);
   const [selectedModel, setSelectedModel] = useState<MLModel | null>(null);
-  const [modelId, setModelId] = useState(data.modelId || "");
-  const [inferenceInputs, setInferenceInputs] = useState<
-    Record<string, string>
-  >(data.inferenceInputs || {});
   const [loading, setLoading] = useState(false);
+
+  const { values, setField, setValues, merged, handleSave: saveNode } =
+    useNodeDialogState(
+      props,
+      () => ({
+        modelId: data.modelId || "",
+        inferenceInputs: data.inferenceInputs || {},
+      }),
+      (v) => ({
+        modelId: v.modelId,
+        modelName: selectedModel?.name,
+        inferenceInputs: v.inferenceInputs,
+      }),
+    );
 
   // Fetch ML models on mount
   useEffect(() => {
@@ -57,15 +68,9 @@ export const MLModelInferenceDialog: React.FC<
     }
   }, [isOpen, data.modelId]);
 
-  // Update state when data changes
-  useEffect(() => {
-    setModelId(data.modelId || "");
-    setInferenceInputs(data.inferenceInputs || {});
-  }, [data, isOpen]);
-
   // Handle model selection change
   const handleModelChange = (value: string) => {
-    setModelId(value);
+    setField("modelId", value);
     const model = mlModels.find((m) => m.id === value);
     setSelectedModel(model || null);
 
@@ -74,35 +79,32 @@ export const MLModelInferenceDialog: React.FC<
       const newInferenceInputs: Record<string, string> = {};
       if (model.features) {
         model.features.forEach((key) => {
-          newInferenceInputs[key] = inferenceInputs[key] || "";
+          newInferenceInputs[key] = values.inferenceInputs[key] || "";
         });
       }
-      setInferenceInputs(newInferenceInputs);
+      setField("inferenceInputs", newInferenceInputs);
     }
   };
 
   // Update inference input value
   const updateInferenceInput = (key: string, value: string) => {
-    setInferenceInputs((prev) => ({
+    setValues((prev) => ({
       ...prev,
-      [key]: value,
+      inferenceInputs: {
+        ...prev.inferenceInputs,
+        [key]: value,
+      },
     }));
   };
 
   // Handle save
   const handleSave = () => {
-    if (!modelId) {
+    if (!values.modelId) {
       toast.error("Please select an ML model");
       return;
     }
 
-    onUpdate({
-      ...data,
-      modelId,
-      modelName: selectedModel?.name,
-      inferenceInputs,
-    });
-    onClose();
+    saveNode();
   };
 
   return (
@@ -119,18 +121,14 @@ export const MLModelInferenceDialog: React.FC<
         </>
       }
       {...props}
-      data={{
-        ...data,
-        modelId,
-        inferenceInputs,
-      }}
+      data={merged}
     >
       <div className="space-y-4">
         {/* Model Selection */}
         <div className="space-y-2">
           <Label htmlFor="model">ML Model</Label>
           <Select
-            value={modelId}
+            value={values.modelId}
             onValueChange={handleModelChange}
             disabled={loading}
           >
@@ -178,7 +176,7 @@ export const MLModelInferenceDialog: React.FC<
                     </Label>
                     <DraggableInput
                       id={`param-${key}`}
-                      value={inferenceInputs[key] || ""}
+                      value={values.inferenceInputs[key] || ""}
                       onChange={(e) =>
                         updateInferenceInput(key, e.target.value)
                       }

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/NlpDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/NlpDialog.tsx
@@ -20,6 +20,7 @@ import { getAllLLMProviders } from "@/services/llmProviders";
 import { useToast } from "@/components/use-toast";
 import { LLMProviderDialog } from "@/views/LlmProviders/components/LLMProviderDialog";
 import { CreateNewSelectItem } from "@/components/CreateNewSelectItem";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 const TASK_OPTIONS = [
   { value: "classify", label: "Classify" },
@@ -38,33 +39,56 @@ type StyleType = (typeof STYLE_OPTIONS)[number];
 type NlpDialogProps = BaseNodeDialogProps<NlpNodeData, NlpNodeData>;
 
 export const NlpDialog: React.FC<NlpDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
-  const [name, setName] = useState(data.name || "");
-  const [providerId, setProviderId] = useState(data.providerId || "");
-  const [inputField, setInputField] = useState(
-    data.inputField ?? "{{source.message}}",
-  );
-  const [task, setTask] = useState<TaskType>(
-    (data.task as TaskType) ?? "classify",
-  );
-
-  // classify
-  const [categories, setCategories] = useState(
-    (data.categories ?? []).join(", "),
-  );
-  const [multiLabel, setMultiLabel] = useState(data.multiLabel ?? false);
-  // sentiment
-  const [scale, setScale] = useState<ScaleType>(
-    (data.scale as ScaleType) ?? "1-5",
-  );
-  // extract
-  const [schema, setSchema] = useState(data.schema ?? "");
-  // summarize
-  const [maxLength, setMaxLength] = useState<number>(data.maxLength ?? 200);
-  const [style, setStyle] = useState<StyleType>(
-    (data.style as StyleType) ?? "concise",
-  );
+  const { values, setField, merged, handleSave } =
+    useNodeDialogState(
+      props,
+      () => ({
+        name: data.name || "",
+        providerId: data.providerId || "",
+        inputField: data.inputField ?? "{{source.message}}",
+        task: (data.task as TaskType) ?? "classify",
+        // classify
+        categories: (data.categories ?? []).join(", "),
+        multiLabel: data.multiLabel ?? false,
+        // sentiment
+        scale: (data.scale as ScaleType) ?? "1-5",
+        // extract
+        schema: data.schema ?? "",
+        // summarize
+        maxLength: data.maxLength ?? 200,
+        style: (data.style as StyleType) ?? "concise",
+      }),
+      (v) => {
+        const parsedCategories = v.categories
+          .split(",")
+          .map((c) => c.trim())
+          .filter((c) => c.length > 0);
+        const base = {
+          name: v.name,
+          providerId: v.providerId,
+          inputField: v.inputField,
+          task: v.task,
+        };
+        switch (v.task) {
+          case "classify":
+            return {
+              ...base,
+              categories: parsedCategories,
+              multiLabel: v.multiLabel,
+            };
+          case "sentiment":
+            return { ...base, scale: v.scale };
+          case "extract":
+            return { ...base, schema: v.schema };
+          case "summarize":
+            return { ...base, maxLength: v.maxLength, style: v.style };
+          default:
+            return base;
+        }
+      },
+    );
 
   const [availableProviders, setAvailableProviders] = useState<LLMProvider[]>(
     [],
@@ -87,51 +111,9 @@ export const NlpDialog: React.FC<NlpDialogProps> = (props) => {
 
   useEffect(() => {
     if (isOpen) {
-      setName(data.name || "");
-      setProviderId(data.providerId || "");
-      setInputField(data.inputField ?? "{{source.message}}");
-      setTask((data.task as TaskType) ?? "classify");
-      setCategories((data.categories ?? []).join(", "));
-      setMultiLabel(data.multiLabel ?? false);
-      setScale((data.scale as ScaleType) ?? "1-5");
-      setSchema(data.schema ?? "");
-      setMaxLength(data.maxLength ?? 200);
-      setStyle((data.style as StyleType) ?? "concise");
       void loadProviders();
     }
-  }, [isOpen, data]);
-
-  const parsedCategories = categories
-    .split(",")
-    .map((c) => c.trim())
-    .filter((c) => c.length > 0);
-
-  const buildData = (): NlpNodeData => {
-    const base: NlpNodeData = {
-      ...data,
-      name,
-      providerId,
-      inputField,
-      task,
-    };
-    switch (task) {
-      case "classify":
-        return { ...base, categories: parsedCategories, multiLabel };
-      case "sentiment":
-        return { ...base, scale };
-      case "extract":
-        return { ...base, schema };
-      case "summarize":
-        return { ...base, maxLength, style };
-      default:
-        return base;
-    }
-  };
-
-  const handleSave = () => {
-    onUpdate(buildData());
-    onClose();
-  };
+  }, [isOpen]);
 
   return (
     <>
@@ -148,14 +130,14 @@ export const NlpDialog: React.FC<NlpDialogProps> = (props) => {
           </>
         }
         {...props}
-        data={buildData()}
+        data={merged}
       >
         <div className="space-y-2">
           <Label htmlFor="node-name">Node Name</Label>
           <RichInput
             id="node-name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="Enter the name of this node"
             className="w-full"
           />
@@ -164,13 +146,13 @@ export const NlpDialog: React.FC<NlpDialogProps> = (props) => {
         <div className="space-y-2">
           <Label htmlFor="nlp-provider">LLM Provider</Label>
           <Select
-            value={providerId || ""}
+            value={values.providerId || ""}
             onValueChange={(value) => {
               if (value === "__create__") {
                 setIsCreateProviderOpen(true);
                 return;
               }
-              setProviderId(value);
+              setField("providerId", value);
             }}
           >
             <SelectTrigger id="nlp-provider" className="w-full">
@@ -189,7 +171,10 @@ export const NlpDialog: React.FC<NlpDialogProps> = (props) => {
 
         <div className="space-y-2">
           <Label htmlFor="nlp-task">Task</Label>
-          <Select value={task} onValueChange={(v) => setTask(v as TaskType)}>
+          <Select
+            value={values.task}
+            onValueChange={(v) => setField("task", v as TaskType)}
+          >
             <SelectTrigger id="nlp-task" className="w-full">
               <SelectValue placeholder="Select a task" />
             </SelectTrigger>
@@ -210,8 +195,8 @@ export const NlpDialog: React.FC<NlpDialogProps> = (props) => {
           <Label htmlFor="nlp-input-field">Input Field</Label>
           <DraggableInput
             id="nlp-input-field"
-            value={inputField}
-            onChange={(e) => setInputField(e.target.value)}
+            value={values.inputField}
+            onChange={(e) => setField("inputField", e.target.value)}
             placeholder="{{source.message}}"
             className="w-full"
           />
@@ -220,14 +205,14 @@ export const NlpDialog: React.FC<NlpDialogProps> = (props) => {
           </p>
         </div>
 
-        {task === "classify" && (
+        {values.task === "classify" && (
           <>
             <div className="space-y-2">
               <Label htmlFor="nlp-categories">Categories</Label>
               <DraggableInput
                 id="nlp-categories"
-                value={categories}
-                onChange={(e) => setCategories(e.target.value)}
+                value={values.categories}
+                onChange={(e) => setField("categories", e.target.value)}
                 placeholder="billing, technical, general"
                 className="w-full"
               />
@@ -245,17 +230,22 @@ export const NlpDialog: React.FC<NlpDialogProps> = (props) => {
               </div>
               <Switch
                 id="nlp-multi-label"
-                checked={multiLabel}
-                onCheckedChange={(checked) => setMultiLabel(Boolean(checked))}
+                checked={values.multiLabel}
+                onCheckedChange={(checked) =>
+                  setField("multiLabel", Boolean(checked))
+                }
               />
             </div>
           </>
         )}
 
-        {task === "sentiment" && (
+        {values.task === "sentiment" && (
           <div className="space-y-2">
             <Label htmlFor="nlp-scale">Scale</Label>
-            <Select value={scale} onValueChange={(v) => setScale(v as ScaleType)}>
+            <Select
+              value={values.scale}
+              onValueChange={(v) => setField("scale", v as ScaleType)}
+            >
               <SelectTrigger id="nlp-scale" className="w-full">
                 <SelectValue placeholder="Select scale" />
               </SelectTrigger>
@@ -273,13 +263,13 @@ export const NlpDialog: React.FC<NlpDialogProps> = (props) => {
           </div>
         )}
 
-        {task === "extract" && (
+        {values.task === "extract" && (
           <div className="space-y-2">
             <Label htmlFor="nlp-schema">Schema</Label>
             <DraggableInput
               id="nlp-schema"
-              value={schema}
-              onChange={(e) => setSchema(e.target.value)}
+              value={values.schema}
+              onChange={(e) => setField("schema", e.target.value)}
               placeholder="order_number, email, plan"
               className="w-full"
             />
@@ -289,7 +279,7 @@ export const NlpDialog: React.FC<NlpDialogProps> = (props) => {
           </div>
         )}
 
-        {task === "summarize" && (
+        {values.task === "summarize" && (
           <>
             <div className="space-y-2">
               <Label htmlFor="nlp-max-length">Max Length</Label>
@@ -297,10 +287,10 @@ export const NlpDialog: React.FC<NlpDialogProps> = (props) => {
                 id="nlp-max-length"
                 type="number"
                 min="1"
-                value={maxLength}
+                value={values.maxLength}
                 onChange={(e) => {
                   const parsed = parseInt(e.target.value, 10);
-                  setMaxLength(Number.isNaN(parsed) ? 200 : parsed);
+                  setField("maxLength", Number.isNaN(parsed) ? 200 : parsed);
                 }}
                 placeholder="200"
                 className="w-full"
@@ -313,8 +303,8 @@ export const NlpDialog: React.FC<NlpDialogProps> = (props) => {
             <div className="space-y-2">
               <Label htmlFor="nlp-style">Style</Label>
               <Select
-                value={style}
-                onValueChange={(v) => setStyle(v as StyleType)}
+                value={values.style}
+                onValueChange={(v) => setField("style", v as StyleType)}
               >
                 <SelectTrigger id="nlp-style" className="w-full">
                   <SelectValue placeholder="Select style" />
@@ -337,7 +327,7 @@ export const NlpDialog: React.FC<NlpDialogProps> = (props) => {
         onProviderSaved={async (provider) => {
           await loadProviders();
           if (provider?.id) {
-            setProviderId(provider.id);
+            setField("providerId", provider.id);
           }
         }}
         mode="create"

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/OpenApiDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/OpenApiDialog.tsx
@@ -20,24 +20,23 @@ import { CreateNewSelectItem } from "@/components/CreateNewSelectItem";
 import { LLMProviderDialog } from "@/views/LlmProviders/components/LLMProviderDialog";
 import { DraggableTextArea } from "../components/custom/DraggableTextArea";
 import { FileUploader } from "@/components/FileUploader";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type OpenApiDialogProps = BaseNodeDialogProps<OpenApiNodeData, OpenApiNodeData>;
 
 export const OpenApiDialog: React.FC<OpenApiDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
-  const [name, setName] = useState(data.name || "");
-  const [providerId, setProviderId] = useState(data.providerId || "");
-  const [query, setQuery] = useState(data.query || "");
-  const [originalFileName, setOriginalFileName] = useState(
-    data.originalFileName || "",
-  );
-  const [serverFilePath, setServerFilePath] = useState<string | undefined>(
-    data.serverFilePath,
-  );
-  const [serverFileUrl, setServerFileUrl] = useState<string | undefined>(
-    data.serverFileUrl,
-  );
+  const { values, setField, setValues, merged, handleSave } =
+    useNodeDialogState(props, () => ({
+      name: data.name || "",
+      providerId: data.providerId || "",
+      query: data.query || "",
+      originalFileName: data.originalFileName || "",
+      serverFilePath: (data.serverFilePath || "") as string | undefined,
+      serverFileUrl: (data.serverFileUrl || "") as string | undefined,
+    }));
+
   const [availableProviders, setAvailableProviders] = useState<LLMProvider[]>(
     [],
   );
@@ -46,13 +45,6 @@ export const OpenApiDialog: React.FC<OpenApiDialogProps> = (props) => {
 
   useEffect(() => {
     if (isOpen) {
-      setName(data.name || "");
-      setProviderId(data.providerId || "");
-      setQuery(data.query || "");
-      setOriginalFileName(data.originalFileName || "");
-      setServerFilePath(data.serverFilePath || "");
-      setServerFileUrl(data.serverFileUrl || "");
-
       loadProviders();
     }
   }, [isOpen, data, toast]);
@@ -68,19 +60,6 @@ export const OpenApiDialog: React.FC<OpenApiDialogProps> = (props) => {
         variant: "destructive",
       });
     }
-  };
-
-  const handleSave = async () => {
-    onUpdate({
-      ...data,
-      name,
-      providerId,
-      query,
-      originalFileName,
-      serverFilePath,
-      serverFileUrl,
-    });
-    onClose();
   };
 
   return (
@@ -100,7 +79,7 @@ export const OpenApiDialog: React.FC<OpenApiDialogProps> = (props) => {
           </>
         }
         {...props}
-        data={{ ...data }}
+        data={merged}
       >
         <div className="space-y-4">
           {/* Node Name */}
@@ -108,8 +87,8 @@ export const OpenApiDialog: React.FC<OpenApiDialogProps> = (props) => {
             <Label htmlFor="name">Node Name</Label>
             <RichInput
               id="name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
+              value={values.name}
+              onChange={(e) => setField("name", e.target.value)}
               placeholder="Enter the name of this node"
               className="w-full"
             />
@@ -119,13 +98,13 @@ export const OpenApiDialog: React.FC<OpenApiDialogProps> = (props) => {
           <div className="space-y-2">
             <Label htmlFor="provider">LLM Provider</Label>
             <Select
-              value={providerId || ""}
+              value={values.providerId || ""}
               onValueChange={(value) => {
                 if (value === "__create__") {
                   setIsCreateProviderOpen(true);
                   return;
                 }
-                setProviderId(value);
+                setField("providerId", value);
               }}
             >
               <SelectTrigger className="w-full">
@@ -146,18 +125,24 @@ export const OpenApiDialog: React.FC<OpenApiDialogProps> = (props) => {
           <FileUploader
             label="Specification File"
             acceptedFileTypes={[".json", ".yaml", ".yml"]}
-            initialServerFilePath={serverFilePath}
-            initialServerFileUrl={serverFileUrl}
-            initialOriginalFileName={originalFileName}
+            initialServerFilePath={values.serverFilePath}
+            initialServerFileUrl={values.serverFileUrl}
+            initialOriginalFileName={values.originalFileName}
             onUploadComplete={(result) => {
-              setOriginalFileName(result.original_filename);
-              setServerFilePath(result.file_path);
-              setServerFileUrl(result.file_url);
+              setValues((v) => ({
+                ...v,
+                originalFileName: result.original_filename,
+                serverFilePath: result.file_path,
+                serverFileUrl: result.file_url,
+              }));
             }}
             onRemove={() => {
-              setOriginalFileName("");
-              setServerFilePath(undefined);
-              setServerFileUrl(undefined);
+              setValues((v) => ({
+                ...v,
+                originalFileName: "",
+                serverFilePath: undefined,
+                serverFileUrl: undefined,
+              }));
             }}
             placeholder="Select a JSON or YAML file to upload"
           />
@@ -167,8 +152,8 @@ export const OpenApiDialog: React.FC<OpenApiDialogProps> = (props) => {
             <Label htmlFor="query">Query</Label>
             <DraggableTextArea
               id="query"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
+              value={values.query}
+              onChange={(e) => setField("query", e.target.value)}
               placeholder="Ask a question about the specification file..."
               className="w-full h-24 text-sm resize-none"
             />
@@ -182,7 +167,7 @@ export const OpenApiDialog: React.FC<OpenApiDialogProps> = (props) => {
         onProviderSaved={async (provider) => {
           await loadProviders();
           if (provider?.id) {
-            setProviderId(provider.id);
+            setField("providerId", provider.id);
           }
         }}
         mode="create"

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/PythonCodeDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/PythonCodeDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { PythonCodeNodeData } from "../types/nodes";
 import { Button } from "@/components/button";
 import { Label } from "@/components/label";
@@ -19,6 +19,7 @@ import {
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
 import { RichInput } from "@/components/richInput";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type PythonCodeDialogProps = BaseNodeDialogProps<
   PythonCodeNodeData,
@@ -26,40 +27,27 @@ type PythonCodeDialogProps = BaseNodeDialogProps<
 >;
 
 export const PythonCodeDialog: React.FC<PythonCodeDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
-  const [code, setCode] = useState(data.code || "");
-  const [loading, setLoading] = useState(false);
+  const { onClose, data } = props;
 
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name || "",
+      code: data.code || "",
+      unwrap: data.unwrap || false,
+    })
+  );
+
+  const [loading, setLoading] = useState(false);
   const [isPromptDialogOpen, setIsPromptDialogOpen] = useState(false);
   const [templatePrompt, setTemplatePrompt] = useState("");
-  const [name, setName] = useState(data.name || "");
-  const [unwrap, setUnwrap] = useState(data.unwrap || false);
-
-  useEffect(() => {
-    if (isOpen) {
-      setName(data.name || "");
-      setCode(data.code || "");
-      setUnwrap(data.unwrap || false);
-    }
-  }, [isOpen, data]);
-
-  // Handle save
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      code,
-      name,
-      unwrap,
-    });
-    onClose();
-  };
 
   const handleGenerateTemplate = async (prompt?: string) => {
     try {
       setLoading(true);
       const result = await generatePythonTemplate({}, prompt);
       if (result && typeof result === "object" && "template" in result) {
-        setCode(result.template as string);
+        setField("code", result.template as string);
         toast.success("Template generated successfully.");
       }
     } catch (err) {
@@ -84,20 +72,16 @@ export const PythonCodeDialog: React.FC<PythonCodeDialogProps> = (props) => {
           </>
         }
         {...props}
-        data={{
-          ...data,
-          code,
-          unwrap,
-        }}
+        data={merged}
         showUnwrap={true}
-        onUnwrapChange={setUnwrap}
+        onUnwrapChange={(val) => setField("unwrap", val)}
       >
         <div className="space-y-2">
           <Label htmlFor="name">Name</Label>
           <RichInput
             id="name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="API Tool"
             className="break-all w-full"
           />
@@ -123,8 +107,8 @@ export const PythonCodeDialog: React.FC<PythonCodeDialogProps> = (props) => {
             name="python-editor"
             mode="python"
             theme="twilight"
-            value={code}
-            onChange={(value: string) => setCode(value)}
+            value={values.code}
+            onChange={(value: string) => setField("code", value)}
             width="100%"
             height="100%"
             setOptions={{

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/RouterDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/RouterDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { RouterNodeData } from "../types/nodes";
+import { useNodeDialogState } from "./useNodeDialogState";
 import { Button } from "@/components/button";
 import { RichInput } from "@/components/richInput";
 import { Label } from "@/components/label";
@@ -55,23 +56,39 @@ function isSmartModeEnabledValue(
 type RouterDialogProps = BaseNodeDialogProps<RouterNodeData, RouterNodeData>;
 
 export const RouterDialog: React.FC<RouterDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
-  const [name, setName] = useState(data.name || "");
-  const [smartModeEnabled, setSmartModeEnabled] = useState(
-    data.smartModeEnabled ?? false,
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name || "",
+      smartModeEnabled: isSmartModeEnabledValue(data.smartModeEnabled),
+      providerId: data.providerId || "",
+      smartPrompt: data.smartPrompt || "",
+      systemPrompt: data.systemPrompt || "",
+      fallbackRoute: data.fallbackRoute === "true" ? "true" : "false",
+      firstValue: data.first_value ?? "",
+      compareCondition: (data.compare_condition as ConditionType) ?? "contains",
+      secondValue: data.second_value ?? "",
+    }),
+    (v) => {
+      const normalizedFallback =
+        v.fallbackRoute === "true" || v.fallbackRoute === "false"
+          ? v.fallbackRoute
+          : "false";
+      return {
+        name: v.name,
+        smartModeEnabled: v.smartModeEnabled,
+        providerId: v.providerId,
+        smartPrompt: v.smartPrompt,
+        systemPrompt: v.systemPrompt,
+        fallbackRoute: normalizedFallback,
+        first_value: v.firstValue,
+        compare_condition: v.compareCondition,
+        second_value: v.secondValue,
+      };
+    },
   );
-  const [providerId, setProviderId] = useState(data.providerId || "");
-  const [smartPrompt, setSmartPrompt] = useState(data.smartPrompt || "");
-  const [systemPrompt, setSystemPrompt] = useState(data.systemPrompt || "");
-  const [fallbackRoute, setFallbackRoute] = useState(
-    data.fallbackRoute === "true" ? "true" : "false",
-  );
-  const [compareCondition, setCompareCondition] =
-    useState<ConditionType>("contains");
-  const [firstValue, setFirstValue] = useState("");
-
-  const [secondValue, setSecondValue] = useState("");
 
   const [availableProviders, setAvailableProviders] = useState<LLMProvider[]>(
     [],
@@ -95,40 +112,9 @@ export const RouterDialog: React.FC<RouterDialogProps> = (props) => {
 
   useEffect(() => {
     if (isOpen) {
-      setName(data.name || "");
-      setSmartModeEnabled(isSmartModeEnabledValue(data.smartModeEnabled));
-      setProviderId(data.providerId || "");
-      setSmartPrompt(data.smartPrompt || "");
-      setSystemPrompt(data.systemPrompt || "");
-      setFallbackRoute(data.fallbackRoute === "true" ? "true" : "false");
-      setFirstValue(data.first_value ?? "");
-      setCompareCondition(
-        (data.compare_condition as ConditionType) ?? "contains",
-      );
-      setSecondValue(data.second_value ?? "");
       void loadProviders();
     }
   }, [isOpen, data]);
-
-  const handleSave = () => {
-    const normalizedFallback =
-      fallbackRoute === "true" || fallbackRoute === "false"
-        ? fallbackRoute
-        : "false";
-    onUpdate({
-      ...data,
-      name: name,
-      smartModeEnabled,
-      providerId,
-      smartPrompt,
-      systemPrompt,
-      fallbackRoute: normalizedFallback,
-      first_value: firstValue,
-      compare_condition: compareCondition,
-      second_value: secondValue,
-    });
-    onClose();
-  };
 
   return (
     <>
@@ -145,28 +131,14 @@ export const RouterDialog: React.FC<RouterDialogProps> = (props) => {
           </>
         }
         {...props}
-        data={{
-          ...data,
-          name,
-          smartModeEnabled,
-          providerId,
-          smartPrompt,
-          systemPrompt,
-          fallbackRoute:
-            fallbackRoute === "true" || fallbackRoute === "false"
-              ? fallbackRoute
-              : "false",
-          first_value: firstValue,
-          compare_condition: compareCondition,
-          second_value: secondValue,
-        }}
+        data={merged}
       >
         <div className="space-y-2">
           <Label htmlFor="node-name">Node Name</Label>
           <RichInput
             id="node-name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="Enter the name of this node"
             className="w-full"
           />
@@ -182,19 +154,21 @@ export const RouterDialog: React.FC<RouterDialogProps> = (props) => {
           </div>
           <Switch
             id="smart-mode"
-            checked={smartModeEnabled}
-            onCheckedChange={(checked) => setSmartModeEnabled(Boolean(checked))}
+            checked={values.smartModeEnabled}
+            onCheckedChange={(checked) =>
+              setField("smartModeEnabled", Boolean(checked))
+            }
           />
         </div>
 
-        {!smartModeEnabled && (
+        {!values.smartModeEnabled && (
           <>
             <div className="space-y-2">
               <Label htmlFor="path_name">First Value</Label>
               <DraggableInput
                 id="path_name"
-                value={firstValue}
-                onChange={(e) => setFirstValue(e.target.value)}
+                value={values.firstValue}
+                onChange={(e) => setField("firstValue", e.target.value)}
                 placeholder="first value to compare"
                 className="w-full"
               />
@@ -203,9 +177,9 @@ export const RouterDialog: React.FC<RouterDialogProps> = (props) => {
             <div className="space-y-2">
               <Label htmlFor="compare_condition">Compare Condition</Label>
               <Select
-                value={compareCondition}
+                value={values.compareCondition}
                 onValueChange={(value) =>
-                  setCompareCondition(value as ConditionType)
+                  setField("compareCondition", value as ConditionType)
                 }
               >
                 <SelectTrigger id="compare_condition">
@@ -225,8 +199,8 @@ export const RouterDialog: React.FC<RouterDialogProps> = (props) => {
               <Label htmlFor="value_condition">Second Value</Label>
               <DraggableInput
                 id="value_condition"
-                value={secondValue}
-                onChange={(e) => setSecondValue(e.target.value)}
+                value={values.secondValue}
+                onChange={(e) => setField("secondValue", e.target.value)}
                 placeholder="second value to compare"
                 className="w-full"
               />
@@ -234,18 +208,18 @@ export const RouterDialog: React.FC<RouterDialogProps> = (props) => {
           </>
         )}
 
-        {smartModeEnabled && (
+        {values.smartModeEnabled && (
           <>
             <div className="space-y-2">
               <Label htmlFor="router-provider">LLM Provider</Label>
               <Select
-                value={providerId || ""}
+                value={values.providerId || ""}
                 onValueChange={(value) => {
                   if (value === "__create__") {
                     setIsCreateProviderOpen(true);
                     return;
                   }
-                  setProviderId(value);
+                  setField("providerId", value);
                 }}
               >
                 <SelectTrigger id="router-provider" className="w-full">
@@ -273,16 +247,16 @@ export const RouterDialog: React.FC<RouterDialogProps> = (props) => {
                     workflowId={workflow.id}
                     nodeId={props.nodeId}
                     promptField="systemPrompt"
-                    currentValue={systemPrompt}
-                    onPromptChange={(val) => setSystemPrompt(val)}
-                    defaultProviderId={providerId}
+                    currentValue={values.systemPrompt}
+                    onPromptChange={(val) => setField("systemPrompt", val)}
+                    defaultProviderId={values.providerId}
                   />
                 )}
               </div>
               <DraggableTextArea
                 id="router-system-prompt"
-                value={systemPrompt}
-                onChange={(e) => setSystemPrompt(e.target.value)}
+                value={values.systemPrompt}
+                onChange={(e) => setField("systemPrompt", e.target.value)}
                 placeholder="Optional. Leave empty to use the built-in routing instructions."
                 className="w-full min-h-[100px] text-sm"
               />
@@ -296,16 +270,16 @@ export const RouterDialog: React.FC<RouterDialogProps> = (props) => {
                     workflowId={workflow.id}
                     nodeId={props.nodeId}
                     promptField="smartPrompt"
-                    currentValue={smartPrompt}
-                    onPromptChange={(val) => setSmartPrompt(val)}
-                    defaultProviderId={providerId}
+                    currentValue={values.smartPrompt}
+                    onPromptChange={(val) => setField("smartPrompt", val)}
+                    defaultProviderId={values.providerId}
                   />
                 )}
               </div>
               <DraggableTextArea
                 id="router-smart-prompt"
-                value={smartPrompt}
-                onChange={(e) => setSmartPrompt(e.target.value)}
+                value={values.smartPrompt}
+                onChange={(e) => setField("smartPrompt", e.target.value)}
                 placeholder="Describe when the workflow should take the true branch. The model must answer only true or false."
                 className="w-full min-h-[120px] text-sm"
               />
@@ -314,9 +288,9 @@ export const RouterDialog: React.FC<RouterDialogProps> = (props) => {
             <div className="space-y-2">
               <Label htmlFor="router-fallback">Fallback route</Label>
               <Select
-                value={fallbackRoute}
+                value={values.fallbackRoute}
                 onValueChange={(v) =>
-                  setFallbackRoute(v === "true" ? "true" : "false")
+                  setField("fallbackRoute", v === "true" ? "true" : "false")
                 }
               >
                 <SelectTrigger id="router-fallback" className="w-full">
@@ -344,7 +318,7 @@ export const RouterDialog: React.FC<RouterDialogProps> = (props) => {
         onProviderSaved={async (provider) => {
           await loadProviders();
           if (provider?.id) {
-            setProviderId(provider.id);
+            setField("providerId", provider.id);
           }
         }}
         mode="create"

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/SQLDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/SQLDialog.tsx
@@ -25,22 +25,27 @@ import { DataSourceDialog } from "@/views/DataSources/components/DataSourceDialo
 import { CreateNewSelectItem } from "@/components/CreateNewSelectItem";
 import { useWorkflow } from "../context/WorkflowContext";
 import { PromptEditorButton } from "../components/PromptEditor/PromptEditorButton";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type SQLDialogProps = BaseNodeDialogProps<SQLNodeData, SQLNodeData>;
 
 export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
-  const [name, setName] = useState(data.name || "");
-  const [dataSourceId, setDatasourceId] = useState(data.dataSourceId || "");
-  const [mode, setMode] = useState<SQLMode | undefined>(undefined);
-  const [sqlQuery, setSqlQuery] = useState("");
-  const [providerId, setProviderId] = useState(data.providerId || "");
-  const [systemPrompt, setSystemPrompt] = useState(data.systemPrompt || "");
-  const [humanQuery, setHumanQuery] = useState("");
-  const [parameters, setParameters] = useState<Record<string, string>>(
-    data.parameters || {},
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name || "",
+      dataSourceId: data.dataSourceId || "",
+      mode: data.mode || undefined,
+      sqlQuery: data.sqlQuery || "",
+      providerId: data.providerId || "",
+      systemPrompt: data.systemPrompt || "",
+      humanQuery: data.humanQuery || "",
+      parameters: data.parameters || {},
+    }),
   );
+
   const [availableProviders, setAvailableProviders] = useState<LLMProvider[]>(
     [],
   );
@@ -54,15 +59,6 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
 
   useEffect(() => {
     if (isOpen) {
-      setName(data.name || "");
-      setDatasourceId(data.dataSourceId || "");
-      setMode(data.mode || undefined);
-      setSqlQuery(data.sqlQuery || "");
-      setProviderId(data.providerId || "");
-      setSystemPrompt(data.systemPrompt || "");
-      setHumanQuery(data.humanQuery || "");
-      setParameters(data.parameters || {});
-
       loadProviders();
       loadDataSources();
     }
@@ -104,21 +100,6 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
     }
   };
 
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name,
-      dataSourceId,
-      mode,
-      sqlQuery,
-      providerId,
-      systemPrompt,
-      humanQuery,
-      parameters,
-    });
-    onClose();
-  };
-
   return (
     <>
       <NodeConfigPanel
@@ -136,25 +117,15 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
           </>
         }
         {...props}
-        data={{
-          ...data,
-          name,
-          dataSourceId,
-          mode,
-          sqlQuery,
-          providerId,
-          systemPrompt,
-          humanQuery,
-          parameters,
-        }}
+        data={merged}
       >
         <div className="space-y-4">
           <div className="space-y-2">
             <Label htmlFor="name">Node Name</Label>
             <RichInput
               id="name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
+              value={values.name}
+              onChange={(e) => setField("name", e.target.value)}
               placeholder="Enter the name of this node"
               className="w-full"
             />
@@ -163,13 +134,13 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
           <div className="space-y-2">
             <Label htmlFor="datasource">Data Source</Label>
             <Select
-              value={dataSourceId || ""}
+              value={values.dataSourceId || ""}
               onValueChange={(value) => {
                 if (value === "__create__") {
                   setIsCreateDataSourceOpen(true);
                   return;
                 }
-                setDatasourceId(value);
+                setField("dataSourceId", value);
               }}
             >
               <SelectTrigger className="w-full">
@@ -192,8 +163,8 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
           <div className="space-y-2">
             <Label htmlFor="mode">Mode</Label>
             <Select
-              value={mode || ""}
-              onValueChange={(value) => setMode(value as SQLMode)}
+              value={values.mode || ""}
+              onValueChange={(value) => setField("mode", value as SQLMode)}
             >
               <SelectTrigger className="w-full">
                 <SelectValue placeholder="Select mode" />
@@ -210,13 +181,13 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
             </p>
           </div>
 
-          {mode === "sqlQuery" && (
+          {values.mode === "sqlQuery" && (
             <div className="space-y-2">
               <Label htmlFor="sqlQuery">SQL Query</Label>
               <DraggableTextArea
                 id="sqlQuery"
-                value={sqlQuery}
-                onChange={(e) => setSqlQuery(e.target.value)}
+                value={values.sqlQuery}
+                onChange={(e) => setField("sqlQuery", e.target.value)}
                 placeholder="Enter or drag and drop your SQL query here"
                 className="w-full min-h-[150px] font-mono text-sm"
               />
@@ -227,18 +198,18 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
             </div>
           )}
 
-          {mode === "humanQuery" && (
+          {values.mode === "humanQuery" && (
             <>
               <div className="space-y-2">
                 <Label htmlFor="provider">LLM Provider</Label>
                 <Select
-                  value={providerId || ""}
+                  value={values.providerId || ""}
                   onValueChange={(value) => {
                     if (value === "__create__") {
                       setIsCreateProviderOpen(true);
                       return;
                     }
-                    setProviderId(value);
+                    setField("providerId", value);
                   }}
                 >
                   <SelectTrigger className="w-full">
@@ -266,16 +237,16 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
                       workflowId={workflow.id}
                       nodeId={props.nodeId}
                       promptField="systemPrompt"
-                      currentValue={systemPrompt}
-                      onPromptChange={(val) => setSystemPrompt(val)}
-                      defaultProviderId={providerId}
+                      currentValue={values.systemPrompt}
+                      onPromptChange={(val) => setField("systemPrompt", val)}
+                      defaultProviderId={values.providerId}
                     />
                   )}
                 </div>
                 <DraggableTextArea
                   id="systemPrompt"
-                  value={systemPrompt}
-                  onChange={(e) => setSystemPrompt(e.target.value)}
+                  value={values.systemPrompt}
+                  onChange={(e) => setField("systemPrompt", e.target.value)}
                   placeholder="Enter system prompt for the SQL generator"
                   className="w-full min-h-[100px] text-sm"
                 />
@@ -288,8 +259,8 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
                 <Label htmlFor="humanQuery">Query in Plain English</Label>
                 <DraggableTextArea
                   id="humanQuery"
-                  value={humanQuery}
-                  onChange={(e) => setHumanQuery(e.target.value)}
+                  value={values.humanQuery}
+                  onChange={(e) => setField("humanQuery", e.target.value)}
                   placeholder="e.g., Show me all customers who made purchases last month"
                   className="w-full min-h-[100px] text-sm"
                 />
@@ -301,20 +272,20 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
             </>
           )}
 
-          {mode && (
+          {values.mode && (
             <div className="space-y-2">
               <Label htmlFor="parameters">Parameters</Label>
               <div className="space-y-2">
-                {Object.entries(parameters).map(([key, value], index) => (
+                {Object.entries(values.parameters).map(([key, value], index) => (
                   <div key={index} className="flex gap-2">
                     <DraggableInput
                       placeholder="Parameter name"
                       value={key}
                       onChange={(e) => {
-                        const newParameters = { ...parameters };
+                        const newParameters = { ...values.parameters };
                         delete newParameters[key];
                         newParameters[e.target.value] = value;
-                        setParameters(newParameters);
+                        setField("parameters", newParameters);
                       }}
                       className="flex-1"
                     />
@@ -322,8 +293,8 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
                       placeholder="Parameter value"
                       value={value}
                       onChange={(e) => {
-                        setParameters({
-                          ...parameters,
+                        setField("parameters", {
+                          ...values.parameters,
                           [key]: e.target.value,
                         });
                       }}
@@ -333,9 +304,9 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
                       variant="outline"
                       size="sm"
                       onClick={() => {
-                        const newParameters = { ...parameters };
+                        const newParameters = { ...values.parameters };
                         delete newParameters[key];
-                        setParameters(newParameters);
+                        setField("parameters", newParameters);
                       }}
                     >
                       Remove
@@ -346,8 +317,8 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
                   variant="outline"
                   size="sm"
                   onClick={() => {
-                    setParameters({
-                      ...parameters,
+                    setField("parameters", {
+                      ...values.parameters,
                       "": "",
                     });
                   }}
@@ -369,7 +340,7 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
         onProviderSaved={async (provider) => {
           await loadProviders();
           if (provider?.id) {
-            setProviderId(provider.id);
+            setField("providerId", provider.id);
           }
         }}
         mode="create"
@@ -380,7 +351,7 @@ export const SQLDialog: React.FC<SQLDialogProps> = (props) => {
         onDataSourceSaved={async (created) => {
           await loadDataSources();
           if (created?.id) {
-            setDatasourceId(created.id);
+            setField("dataSourceId", created.id);
           }
         }}
         mode="create"

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/STTDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/STTDialog.tsx
@@ -15,19 +15,21 @@ import { Save } from "lucide-react";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
 import { useAudioProviderConfig } from "../hooks/useAudioProviderConfig";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type STTDialogProps = BaseNodeDialogProps<STTNodeData, STTNodeData>;
 
 export const STTDialog: React.FC<STTDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
-  const [name, setName] = useState(data.name || "Speech to Text");
-  const [audioSource, setAudioSource] = useState(data.audio_source || "");
-  const [audioProviderId, setAudioProviderId] = useState(data.audioProviderId || "");
-  const [model, setModel] = useState(data.model || "whisper-1");
-  const [language, setLanguage] = useState(data.language ?? "");
-  const [responseFormat, setResponseFormat] = useState(data.response_format || "text");
-  const [temperature, setTemperature] = useState(data.temperature ?? 0.0);
+  // `audioProviderId` drives `useAudioProviderConfig` (below), so it must be resolved
+  // before that hook runs. `useNodeDialogState` computes its `merged`/`toPayload` eagerly
+  // and `toPayload` reads `providerType` from the audio-config hook, so the config hook
+  // must run first — which means this field stays as local state (re-seeded by its own
+  // effect) rather than living inside the dialog-state hook.
+  const [audioProviderId, setAudioProviderId] = useState(
+    data.audioProviderId || "",
+  );
 
   const {
     providers: audioProviders,
@@ -38,15 +40,34 @@ export const STTDialog: React.FC<STTDialogProps> = (props) => {
     getDefaultsForProvider,
   } = useAudioProviderConfig({ capability: "stt", audioProviderId, enabled: isOpen });
 
+  const { values, setField, setValues, merged, handleSave } =
+    useNodeDialogState(
+      props,
+      () => ({
+        name: data.name || "Speech to Text",
+        audio_source: data.audio_source || "",
+        model: data.model || "whisper-1",
+        language: data.language ?? "",
+        response_format: data.response_format || "text",
+        temperature: data.temperature ?? 0.0,
+      }),
+      (v) => ({
+        name: v.name,
+        audio_source: v.audio_source,
+        provider: providerType || "openai",
+        audioProviderId: audioProviderId || undefined,
+        model: v.model,
+        language: v.language || undefined,
+        response_format: v.response_format,
+        temperature: v.temperature,
+      }),
+    );
+
+  // Re-seed the externally-held `audioProviderId` when the panel (re)opens or the node
+  // data changes — mirrors the hook's re-seed for the remaining fields.
   useEffect(() => {
     if (isOpen) {
-      setName(data.name || "Speech to Text");
-      setAudioSource(data.audio_source || "");
       setAudioProviderId(data.audioProviderId || "");
-      setModel(data.model || "whisper-1");
-      setLanguage(data.language ?? "");
-      setResponseFormat(data.response_format || "text");
-      setTemperature(data.temperature ?? 0.0);
     }
   }, [isOpen, data]);
 
@@ -54,26 +75,12 @@ export const STTDialog: React.FC<STTDialogProps> = (props) => {
     setAudioProviderId(id);
     const defaults = getDefaultsForProvider(id);
     if (defaults) {
-      setModel(defaults.model);
-      setResponseFormat(defaults.responseFormat);
+      setValues((v) => ({
+        ...v,
+        model: defaults.model,
+        response_format: defaults.responseFormat,
+      }));
     }
-  };
-
-  const buildNodeData = (): STTNodeData => ({
-    ...data,
-    name,
-    audio_source: audioSource,
-    provider: providerType || "openai",
-    audioProviderId: audioProviderId || undefined,
-    model,
-    language: language || undefined,
-    response_format: responseFormat,
-    temperature,
-  });
-
-  const handleSave = () => {
-    onUpdate(buildNodeData());
-    onClose();
   };
 
   return (
@@ -90,15 +97,15 @@ export const STTDialog: React.FC<STTDialogProps> = (props) => {
         </>
       }
       {...props}
-      data={buildNodeData()}
+      data={merged}
     >
       <div className="space-y-4">
         <div>
           <Label htmlFor="name">Node Name</Label>
           <RichInput
             id="name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="e.g., Speech to Text"
             className="w-full"
           />
@@ -108,8 +115,8 @@ export const STTDialog: React.FC<STTDialogProps> = (props) => {
           <Label htmlFor="audio_source">Audio Source</Label>
           <DraggableTextArea
             id="audio_source"
-            value={audioSource}
-            onChange={(e) => setAudioSource(e.target.value)}
+            value={values.audio_source}
+            onChange={(e) => setField("audio_source", e.target.value)}
             placeholder="Drag the audio output variable from a connected TTS node, e.g. {{source.output}}"
             className="h-20 font-mono text-sm"
             rows={3}
@@ -134,7 +141,10 @@ export const STTDialog: React.FC<STTDialogProps> = (props) => {
 
         <div className="space-y-2">
           <Label htmlFor="model">Model</Label>
-          <Select value={model} onValueChange={setModel}>
+          <Select
+            value={values.model}
+            onValueChange={(value) => setField("model", value)}
+          >
             <SelectTrigger className="w-full">
               <SelectValue placeholder="Select model" />
             </SelectTrigger>
@@ -155,8 +165,8 @@ export const STTDialog: React.FC<STTDialogProps> = (props) => {
           </p>
           <RichInput
             id="language"
-            value={language}
-            onChange={(e) => setLanguage(e.target.value)}
+            value={values.language}
+            onChange={(e) => setField("language", e.target.value)}
             placeholder="e.g., en, es, fr"
             className="w-full"
           />
@@ -164,7 +174,10 @@ export const STTDialog: React.FC<STTDialogProps> = (props) => {
 
         <div className="space-y-2">
           <Label htmlFor="response_format">Response Format</Label>
-          <Select value={responseFormat} onValueChange={setResponseFormat}>
+          <Select
+            value={values.response_format}
+            onValueChange={(value) => setField("response_format", value)}
+          >
             <SelectTrigger className="w-full">
               <SelectValue placeholder="Select format" />
             </SelectTrigger>
@@ -180,18 +193,18 @@ export const STTDialog: React.FC<STTDialogProps> = (props) => {
 
         {supportsTemperature && (
           <div>
-            <Label htmlFor="temperature">Temperature ({temperature})</Label>
+            <Label htmlFor="temperature">Temperature ({values.temperature})</Label>
             <p className="text-xs text-muted-foreground mb-1">
               Sampling temperature (0.0 for deterministic)
             </p>
             <RichInput
               id="temperature"
               type="number"
-              value={String(temperature)}
+              value={String(values.temperature)}
               onChange={(e) => {
                 const val = parseFloat(e.target.value);
                 if (!isNaN(val) && val >= 0.0 && val <= 1.0) {
-                  setTemperature(val);
+                  setField("temperature", val);
                 }
               }}
               min={0.0}

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/SalesforceCaseDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/SalesforceCaseDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect } from "react";
 import { toast } from "react-hot-toast";
 import { SalesforceCaseNodeData } from "../types/nodes";
 import { Button } from "@/components/button";
@@ -20,6 +20,7 @@ import { AppSettingDialog } from "@/views/AppSettings/components/AppSettingDialo
 import { CreateNewSelectItem } from "@/components/CreateNewSelectItem";
 import { DraggableInput } from "../components/custom/DraggableInput";
 import { DraggableTextArea } from "../components/custom/DraggableTextArea";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type SalesforceCaseDialogProps = BaseNodeDialogProps<
   SalesforceCaseNodeData,
@@ -29,22 +30,43 @@ type SalesforceCaseDialogProps = BaseNodeDialogProps<
 export const SalesforceCaseDialog: React.FC<SalesforceCaseDialogProps> = (
   props
 ) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
-  const [name, setName] = useState(data.name || "");
-  const [subject, setSubject] = useState(data.subject || "");
-  const [description, setDescription] = useState(data.description || "");
-  const [labelsCsv, setLabelsCsv] = useState((data.labels || []).join(", "));
-  const [appSettingsId, setAppSettingsId] = useState(
-    data.app_settings_id || ""
-  );
+  const { values, setField, setValues, merged, handleSave } =
+    useNodeDialogState(
+      props,
+      () => ({
+        name: data.name || "",
+        subject: data.subject || "",
+        description: data.description || "",
+        labelsCsv: (data.labels || []).join(", "),
+        custom_fields: (data.custom_fields || []) as Array<{
+          key: string;
+          value: string;
+        }>,
+        app_settings_id: data.app_settings_id || "",
+      }),
+      (v) => {
+        const labelsArr = v.labelsCsv
+          .split(",")
+          .map((t) => t.trim())
+          .filter(Boolean);
+        return {
+          name: v.name,
+          subject: v.subject,
+          description: v.description,
+          labels: labelsArr.length > 0 ? labelsArr : undefined,
+          custom_fields:
+            v.custom_fields.length > 0 ? v.custom_fields : undefined,
+          app_settings_id: v.app_settings_id || undefined,
+        };
+      }
+    );
+
   const [appSettings, setAppSettings] = useState<AppSetting[]>([]);
   const [isLoadingAppSettings, setIsLoadingAppSettings] = useState(false);
   const [appSettingsError, setAppSettingsError] = useState(false);
   const [isCreateSettingOpen, setIsCreateSettingOpen] = useState(false);
-  const [customFields, setCustomFields] = useState<
-    Array<{ key: string; value: string }>
-  >(data.custom_fields || []);
 
   const fetchAppSettings = async () => {
     setIsLoadingAppSettings(true);
@@ -61,14 +83,6 @@ export const SalesforceCaseDialog: React.FC<SalesforceCaseDialogProps> = (
 
   useEffect(() => {
     if (isOpen) {
-      setName(data.name || "");
-      setSubject(data.subject || "");
-      setDescription(data.description || "");
-      setLabelsCsv((data.labels || []).join(", "));
-      setCustomFields(data.custom_fields || []);
-
-      setAppSettingsId(data.app_settings_id || "");
-
       fetchAppSettings();
     }
   }, [isOpen, data]);
@@ -78,45 +92,33 @@ export const SalesforceCaseDialog: React.FC<SalesforceCaseDialogProps> = (
     return settingTypeLower === "salesforce" && setting.is_active === 1;
   });
 
-  const labelsArr = useMemo(
-    () =>
-      labelsCsv
-        .split(",")
-        .map((t) => t.trim())
-        .filter(Boolean),
-    [labelsCsv]
-  );
-
-  const handleSave = () => {
+  const handleSaveClick = () => {
     // The backend node schema marks these required — block save with a clear
     // message instead of persisting a node that only fails at run time.
     const missing: string[] = [];
-    if (!appSettingsId) missing.push("Configuration Vars");
-    if (!subject.trim()) missing.push("Subject");
-    if (!description.trim()) missing.push("Description");
+    if (!values.app_settings_id) missing.push("Configuration Vars");
+    if (!values.subject.trim()) missing.push("Subject");
+    if (!values.description.trim()) missing.push("Description");
     if (missing.length > 0) {
       toast.error(`Please provide: ${missing.join(", ")}.`);
       return;
     }
 
-    onUpdate({
-      ...data,
-      name,
-      subject,
-      description,
-      labels: labelsArr.length > 0 ? labelsArr : undefined,
-      custom_fields: customFields.length > 0 ? customFields : undefined,
-      app_settings_id: appSettingsId || undefined,
-    });
-    onClose();
+    handleSave();
   };
 
   const addCustomField = () => {
-    setCustomFields((prev) => [...prev, { key: "", value: "" }]);
+    setValues((v) => ({
+      ...v,
+      custom_fields: [...v.custom_fields, { key: "", value: "" }],
+    }));
   };
 
   const removeCustomField = (index: number) => {
-    setCustomFields((prev) => prev.filter((_, i) => i !== index));
+    setValues((v) => ({
+      ...v,
+      custom_fields: v.custom_fields.filter((_, i) => i !== index),
+    }));
   };
 
   const updateCustomField = (
@@ -124,10 +126,10 @@ export const SalesforceCaseDialog: React.FC<SalesforceCaseDialogProps> = (
     field: "key" | "value",
     value: string
   ) => {
-    setCustomFields((prev) => {
-      const updated = [...prev];
+    setValues((v) => {
+      const updated = [...v.custom_fields];
       updated[index] = { ...updated[index], [field]: value };
-      return updated;
+      return { ...v, custom_fields: updated };
     });
   };
 
@@ -139,31 +141,21 @@ export const SalesforceCaseDialog: React.FC<SalesforceCaseDialogProps> = (
             <Button variant="outline" onClick={onClose}>
               Cancel
             </Button>
-            <Button onClick={handleSave}>
+            <Button onClick={handleSaveClick}>
               <Save className="h-4 w-4 mr-2" />
               Save Changes
             </Button>
           </>
         }
         {...props}
-        data={
-          {
-            ...data,
-            name,
-            subject,
-            description,
-            labels: labelsArr.length > 0 ? labelsArr : undefined,
-            custom_fields: customFields.length > 0 ? customFields : undefined,
-            app_settings_id: appSettingsId || undefined,
-          } as SalesforceCaseNodeData
-        }
+        data={merged}
       >
         <div className="space-y-2">
           <Label htmlFor="node-name">Node Name</Label>
           <RichInput
             id="node-name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="Enter the name of this node"
             className="w-full"
           />
@@ -187,13 +179,13 @@ export const SalesforceCaseDialog: React.FC<SalesforceCaseDialogProps> = (
             </div>
           ) : (
             <Select
-              value={appSettingsId || ""}
+              value={values.app_settings_id || ""}
               onValueChange={(value) => {
                 if (value === "__create__") {
                   setIsCreateSettingOpen(true);
                   return;
                 }
-                setAppSettingsId(value || "");
+                setField("app_settings_id", value || "");
               }}
               disabled={isLoadingAppSettings}
             >
@@ -231,8 +223,8 @@ export const SalesforceCaseDialog: React.FC<SalesforceCaseDialogProps> = (
               <Label htmlFor="subject">Subject</Label>
               <DraggableInput
                 id="subject"
-                value={subject}
-                onChange={(e) => setSubject(e.target.value)}
+                value={values.subject}
+                onChange={(e) => setField("subject", e.target.value)}
                 placeholder="Enter case subject"
                 className="w-full"
               />
@@ -242,8 +234,8 @@ export const SalesforceCaseDialog: React.FC<SalesforceCaseDialogProps> = (
               <DraggableTextArea
                 id="description"
                 rows={4}
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
+                value={values.description}
+                onChange={(e) => setField("description", e.target.value)}
                 placeholder="Enter the issue or request description"
                 className="w-full resize-none"
               />
@@ -257,8 +249,8 @@ export const SalesforceCaseDialog: React.FC<SalesforceCaseDialogProps> = (
           </Label>
           <DraggableInput
             id="labels"
-            value={labelsCsv}
-            onChange={(e) => setLabelsCsv(e.target.value)}
+            value={values.labelsCsv}
+            onChange={(e) => setField("labelsCsv", e.target.value)}
             placeholder="e.g., billing, urgent, follow-up"
             className="w-full"
           />
@@ -282,7 +274,7 @@ export const SalesforceCaseDialog: React.FC<SalesforceCaseDialogProps> = (
             </Button>
           </div>
           <div className="space-y-2">
-            {customFields.map((field, index) => (
+            {values.custom_fields.map((field, index) => (
               <div key={index} className="flex gap-2 items-end">
                 <div className="flex-1 space-y-2">
                   <Label htmlFor={`custom-field-key-${index}`}>
@@ -321,7 +313,7 @@ export const SalesforceCaseDialog: React.FC<SalesforceCaseDialogProps> = (
                 </Button>
               </div>
             ))}
-            {customFields.length === 0 && (
+            {values.custom_fields.length === 0 && (
               <p className="text-sm text-muted-foreground">
                 No custom fields added. Click "Add Field" to add one.
               </p>
@@ -343,7 +335,7 @@ export const SalesforceCaseDialog: React.FC<SalesforceCaseDialogProps> = (
           } catch (e) {
             // ignore
           }
-          if (created?.id) setAppSettingsId(created.id);
+          if (created?.id) setField("app_settings_id", created.id);
         }}
       />
     </>

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/SetStateDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/SetStateDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useMemo } from "react";
 import { Button } from "@/components/button";
 import { Label } from "@/components/label";
 import { Save, HelpCircle, Plus, Trash2 } from "lucide-react";
@@ -21,28 +21,49 @@ import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
 import { DraggableInput } from "../components/custom/DraggableInput";
 import { useNodes } from "reactflow";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type SetStateDialogProps = BaseNodeDialogProps<
   SetStateNodeData,
   SetStateNodeData
 >;
 
-interface StateEntry {
-  key: string;
-  value: string;
-}
-
 export const SetStateDialog: React.FC<SetStateDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { onClose, data } = props;
   const nodes = useNodes();
 
-  const [name, setName] = useState(data.name);
-  const [states, setStates] = useState<StateEntry[]>([]);
+  const { values, setValues, setField, merged, handleSave } =
+    useNodeDialogState(
+      props,
+      () => ({
+        name: data.name,
+        // Migrate legacy single state to array format, or use existing states
+        states:
+          data.states && data.states.length > 0
+            ? [...data.states]
+            : data.stateKey && data.stateValue
+              ? // Migrate legacy format
+                [{ key: data.stateKey, value: data.stateValue }]
+              : [{ key: "", value: "" }],
+      }),
+      (v) => {
+        // Filter out empty entries
+        const validStates = v.states.filter((s) => s.key.trim() !== "");
+        const updatedData = {
+          name: v.name,
+          states: validStates,
+          // Clear legacy fields
+          stateKey: undefined,
+          stateValue: undefined,
+        };
+        return updatedData;
+      },
+    );
 
   // Get all stateful parameters from chat input nodes
   const statefulParams = useMemo(() => {
     const params: string[] = [];
-    
+
     nodes.forEach((node) => {
       if (node.type === "chatInputNode") {
         const nodeData = node.data as ChatInputNodeData;
@@ -56,52 +77,30 @@ export const SetStateDialog: React.FC<SetStateDialogProps> = (props) => {
         }
       }
     });
-    
+
     return params;
   }, [nodes]); // Re-run when nodes change
 
-  useEffect(() => {
-    if (isOpen) {
-      setName(data.name);
-      // Migrate legacy single state to array format, or use existing states
-      if (data.states && data.states.length > 0) {
-        setStates([...data.states]);
-      } else if (data.stateKey && data.stateValue) {
-        // Migrate legacy format
-        setStates([{ key: data.stateKey, value: data.stateValue }]);
-      } else {
-        setStates([{ key: "", value: "" }]);
-      }
-    }
-  }, [isOpen, data]);
-
   const addStateEntry = () => {
-    setStates([...states, { key: "", value: "" }]);
+    setValues((prev) => ({
+      ...prev,
+      states: [...prev.states, { key: "", value: "" }],
+    }));
   };
 
   const removeStateEntry = (index: number) => {
-    setStates(states.filter((_, i) => i !== index));
+    setValues((prev) => ({
+      ...prev,
+      states: prev.states.filter((_, i) => i !== index),
+    }));
   };
 
   const updateStateEntry = (index: number, field: "key" | "value", value: string) => {
-    const updated = [...states];
-    updated[index] = { ...updated[index], [field]: value };
-    setStates(updated);
-  };
-
-  const handleSave = () => {
-    // Filter out empty entries
-    const validStates = states.filter((s) => s.key.trim() !== "");
-    const updatedData = {
-      ...data,
-      name,
-      states: validStates,
-      // Clear legacy fields
-      stateKey: undefined,
-      stateValue: undefined,
-    };
-    onUpdate(updatedData);
-    onClose();
+    setValues((prev) => {
+      const updated = [...prev.states];
+      updated[index] = { ...updated[index], [field]: value };
+      return { ...prev, states: updated };
+    });
   };
 
   return (
@@ -113,7 +112,10 @@ export const SetStateDialog: React.FC<SetStateDialogProps> = (props) => {
           </Button>
           <Button
             onClick={handleSave}
-            disabled={states.length === 0 || states.every((s) => !s.key.trim())}
+            disabled={
+              values.states.length === 0 ||
+              values.states.every((s) => !s.key.trim())
+            }
           >
             <Save className="h-4 w-4 mr-2" />
             Save Changes
@@ -121,18 +123,14 @@ export const SetStateDialog: React.FC<SetStateDialogProps> = (props) => {
         </>
       }
       {...props}
-      data={{
-        ...data,
-        name,
-        states,
-      }}
+      data={merged}
     >
       <div className="space-y-4">
         <div>
           <Label>Node Name</Label>
           <RichInput
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="Enter the name of this node"
             className="w-full"
           />
@@ -182,14 +180,14 @@ export const SetStateDialog: React.FC<SetStateDialogProps> = (props) => {
           </Button>
         </div>
 
-        {states.length === 0 && (
+        {values.states.length === 0 && (
           <div className="text-sm text-muted-foreground text-center py-4 border border-dashed rounded-md">
             No state entries. Click "Add State" to add one.
           </div>
         )}
 
         <div className="space-y-4">
-          {states.map((state, index) => (
+          {values.states.map((state, index) => (
             <div
               key={index}
               className="p-4 border border-border rounded-md space-y-3 bg-muted"
@@ -198,7 +196,7 @@ export const SetStateDialog: React.FC<SetStateDialogProps> = (props) => {
                 <Label className="text-sm font-medium">
                   State Entry {index + 1}
                 </Label>
-                {states.length > 1 && (
+                {values.states.length > 1 && (
                   <Button
                     type="button"
                     variant="ghost"

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/SlackOutputDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/SlackOutputDialog.tsx
@@ -18,6 +18,7 @@ import { getAllAppSettings } from "@/services/appSettings";
 import { AppSetting } from "@/interfaces/app-setting.interface";
 import { AppSettingDialog } from "@/views/AppSettings/components/AppSettingDialog";
 import { CreateNewSelectItem } from "@/components/CreateNewSelectItem";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type SlackOutputDialogProps = BaseNodeDialogProps<
   SlackOutputNodeData,
@@ -25,24 +26,30 @@ type SlackOutputDialogProps = BaseNodeDialogProps<
 >;
 
 export const SlackOutputDialog: React.FC<SlackOutputDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
-  const [name, setName] = useState(data.name);
-  const [channel, setChannel] = useState(data.channel || "");
-  const [message, setMessage] = useState(data.message || "");
-  const [appSettingsId, setAppSettingsId] = useState(
-    data.app_settings_id || ""
+  const { isOpen, onClose, data } = props;
+
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name,
+      channel: data.channel || "",
+      message: data.message || "",
+      app_settings_id: data.app_settings_id || "",
+    }),
+    (v) => ({
+      name: v.name,
+      channel: v.channel,
+      message: v.message,
+      app_settings_id: v.app_settings_id || undefined,
+    })
   );
+
   const [appSettings, setAppSettings] = useState<AppSetting[]>([]);
   const [isLoadingAppSettings, setIsLoadingAppSettings] = useState(false);
   const [isCreateSettingOpen, setIsCreateSettingOpen] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
-      setName(data.name);
-      setChannel(data.channel || "");
-      setMessage(data.message || "");
-      setAppSettingsId(data.app_settings_id || "");
-
       // Fetch app settings
       const fetchAppSettings = async () => {
         setIsLoadingAppSettings(true);
@@ -60,17 +67,6 @@ export const SlackOutputDialog: React.FC<SlackOutputDialogProps> = (props) => {
     }
   }, [isOpen, data]);
 
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name,
-      channel,
-      message,
-      app_settings_id: appSettingsId || undefined,
-    });
-    onClose();
-  };
-
   return (
     <>
       <NodeConfigPanel
@@ -86,20 +82,14 @@ export const SlackOutputDialog: React.FC<SlackOutputDialogProps> = (props) => {
           </>
         }
         {...props}
-        data={{
-          ...data,
-          name,
-          channel,
-          message,
-          app_settings_id: appSettingsId || undefined,
-        }}
+        data={merged}
       >
         <div className="space-y-2">
           <Label htmlFor="name">Name</Label>
           <RichInput
             id="name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="e.g., Slack Message"
             className="w-full"
           />
@@ -107,13 +97,13 @@ export const SlackOutputDialog: React.FC<SlackOutputDialogProps> = (props) => {
         <div className="space-y-2">
           <Label htmlFor="app-settings-id">Configuration Vars (Optional)</Label>
           <Select
-            value={appSettingsId || ""}
+            value={values.app_settings_id || ""}
             onValueChange={(value) => {
               if (value === "__create__") {
                 setIsCreateSettingOpen(true);
                 return;
               }
-              setAppSettingsId(value || "");
+              setField("app_settings_id", value || "");
             }}
             disabled={isLoadingAppSettings}
           >
@@ -141,8 +131,8 @@ export const SlackOutputDialog: React.FC<SlackOutputDialogProps> = (props) => {
           <Label htmlFor="channel">Channel ID</Label>
           <DraggableInput
             id="channel"
-            value={channel}
-            onChange={(e) => setChannel(e.target.value)}
+            value={values.channel}
+            onChange={(e) => setField("channel", e.target.value)}
             placeholder="e.g., C12345678 or user@example.com"
             className="w-full break-all"
           />
@@ -151,8 +141,8 @@ export const SlackOutputDialog: React.FC<SlackOutputDialogProps> = (props) => {
           <Label htmlFor="message">Message</Label>
           <DraggableInput
             id="message"
-            value={message}
-            onChange={(e) => setMessage(e.target.value)}
+            value={values.message}
+            onChange={(e) => setField("message", e.target.value)}
             placeholder="e.g., Hello, how are you?"
             className="w-full"
           />
@@ -171,7 +161,7 @@ export const SlackOutputDialog: React.FC<SlackOutputDialogProps> = (props) => {
           } catch (e) {
             // ignore
           }
-          if (created?.id) setAppSettingsId(created.id);
+          if (created?.id) setField("app_settings_id", created.id);
         }}
       />
     </>

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/SubAgentDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/SubAgentDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import toast from "react-hot-toast";
 import { BaseLLMNodeData, SubAgentMode, SubAgentNodeData } from "../types/nodes";
 import { Button } from "@/components/button";
@@ -15,6 +15,7 @@ import {
 import { ModelConfiguration } from "../components/ModelConfiguration";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
+import { useNodeDialogState } from "./useNodeDialogState";
 import { clampToolName } from "../utils/subAgentGraph";
 
 type SubAgentDialogProps = BaseNodeDialogProps<SubAgentNodeData, SubAgentNodeData>;
@@ -26,24 +27,28 @@ const MODE_HELP: Record<SubAgentMode, string> = {
 };
 
 export const SubAgentDialog: React.FC<SubAgentDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { onClose, data } = props;
 
-  const [config, setConfig] = useState<SubAgentNodeData>(data);
-
-  useEffect(() => {
-    if (isOpen) {
-      setConfig(data);
-    }
-  }, [isOpen, data]);
+  const { values, setValues, setField, merged, handleSave } =
+    useNodeDialogState(
+      props,
+      () => data,
+      (v) => {
+        const name = (v.name || "").trim();
+        const description = (v.description || "").trim();
+        const timeout = Number(v.timeoutSeconds ?? 120);
+        return { ...v, name, description, timeoutSeconds: timeout };
+      }
+    );
 
   // ModelConfiguration edits the shared LLM fields
   const handleModelConfigChange = (updated: BaseLLMNodeData) => {
-    setConfig((prev) => ({ ...prev, ...updated }) as SubAgentNodeData);
+    setValues((prev) => ({ ...prev, ...updated }) as SubAgentNodeData);
   };
 
-  const handleSave = () => {
-    const name = (config.name || "").trim();
-    const description = (config.description || "").trim();
+  const handleSaveClick = () => {
+    const name = (values.name || "").trim();
+    const description = (values.description || "").trim();
     if (!name) {
       toast.error("Give the sub-agent a name.");
       return;
@@ -52,7 +57,7 @@ export const SubAgentDialog: React.FC<SubAgentDialogProps> = (props) => {
       toast.error("Sub-agent name must contain at least one letter or number.");
       return;
     }
-    if (!config.providerId) {
+    if (!values.providerId) {
       toast.error("Select an LLM provider for the sub-agent.");
       return;
     }
@@ -60,20 +65,13 @@ export const SubAgentDialog: React.FC<SubAgentDialogProps> = (props) => {
       toast.error("Add a description so the parent agent knows when to delegate.");
       return;
     }
-    const timeout = Number(config.timeoutSeconds ?? 120);
+    const timeout = Number(values.timeoutSeconds ?? 120);
     if (!Number.isFinite(timeout) || timeout < 5 || timeout > 300) {
       toast.error("Timeout must be between 5 and 300 seconds.");
       return;
     }
 
-    onUpdate({
-      ...data,
-      ...config,
-      name,
-      description,
-      timeoutSeconds: timeout,
-    });
-    onClose();
+    handleSave();
   };
 
   return (
@@ -83,18 +81,15 @@ export const SubAgentDialog: React.FC<SubAgentDialogProps> = (props) => {
           <Button variant="outline" onClick={onClose}>
             Cancel
           </Button>
-          <Button onClick={handleSave}>Save Changes</Button>
+          <Button onClick={handleSaveClick}>Save Changes</Button>
         </>
       }
       {...props}
-      data={{
-        ...data,
-        ...config,
-      }}
+      data={merged}
     >
       <ModelConfiguration
         id="sub-agent-config"
-        config={config}
+        config={values}
         onConfigChange={handleModelConfigChange}
         typeSelect="agent"
         allowedAgentTypes={["ToolSelector", "ReActAgent", "ReActAgentLC"]}
@@ -103,13 +98,8 @@ export const SubAgentDialog: React.FC<SubAgentDialogProps> = (props) => {
             <div className="space-y-2">
               <Label htmlFor="sub-agent-mode">Collaboration Mode</Label>
               <Select
-                value={config.mode}
-                onValueChange={(mode) =>
-                  setConfig((prev) => ({
-                    ...prev,
-                    mode: mode as SubAgentMode,
-                  }))
-                }
+                value={values.mode}
+                onValueChange={(mode) => setField("mode", mode as SubAgentMode)}
               >
                 <SelectTrigger id="sub-agent-mode" className="w-full">
                   <SelectValue placeholder="Select a mode" />
@@ -121,7 +111,7 @@ export const SubAgentDialog: React.FC<SubAgentDialogProps> = (props) => {
                 </SelectContent>
               </Select>
               <p className="text-xs text-muted-foreground">
-                {MODE_HELP[config.mode]}
+                {MODE_HELP[values.mode]}
               </p>
             </div>
 
@@ -131,13 +121,8 @@ export const SubAgentDialog: React.FC<SubAgentDialogProps> = (props) => {
               </Label>
               <Textarea
                 id="sub-agent-description"
-                value={config.description || ""}
-                onChange={(e) =>
-                  setConfig((prev) => ({
-                    ...prev,
-                    description: e.target.value,
-                  }))
-                }
+                value={values.description || ""}
+                onChange={(e) => setField("description", e.target.value)}
                 placeholder="What this sub agent handles, e.g. searches flights and checks fares"
               />
             </div>
@@ -150,12 +135,9 @@ export const SubAgentDialog: React.FC<SubAgentDialogProps> = (props) => {
                 min={5}
                 max={300}
                 step={5}
-                value={config.timeoutSeconds ?? 120}
+                value={values.timeoutSeconds ?? 120}
                 onChange={(e) =>
-                  setConfig((prev) => ({
-                    ...prev,
-                    timeoutSeconds: parseInt(e.target.value) || 120,
-                  }))
+                  setField("timeoutSeconds", parseInt(e.target.value) || 120)
                 }
                 placeholder="120"
               />

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/TTSDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/TTSDialog.tsx
@@ -15,19 +15,21 @@ import { Save } from "lucide-react";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
 import { useAudioProviderConfig } from "../hooks/useAudioProviderConfig";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type TTSDialogProps = BaseNodeDialogProps<TTSNodeData, TTSNodeData>;
 
 export const TTSDialog: React.FC<TTSDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
-  const [name, setName] = useState(data.name || "Text to Speech");
-  const [text, setText] = useState(data.text || "");
-  const [audioProviderId, setAudioProviderId] = useState(data.audioProviderId || "");
-  const [voice, setVoice] = useState(data.voice || "nova");
-  const [model, setModel] = useState(data.model || "tts-1");
-  const [outputFormat, setOutputFormat] = useState(data.output_format || "mp3");
-  const [speed, setSpeed] = useState(data.speed ?? 1.0);
+  // `audioProviderId` drives `useAudioProviderConfig` (below), so it must be resolved
+  // before that hook runs. `useNodeDialogState` computes its `merged`/`toPayload` eagerly
+  // and `toPayload` reads `providerType` from the audio-config hook, so the config hook
+  // must run first — which means this field stays as local state (re-seeded by its own
+  // effect) rather than living inside the dialog-state hook.
+  const [audioProviderId, setAudioProviderId] = useState(
+    data.audioProviderId || "",
+  );
 
   const {
     providers: audioProviders,
@@ -39,15 +41,34 @@ export const TTSDialog: React.FC<TTSDialogProps> = (props) => {
     getDefaultsForProvider,
   } = useAudioProviderConfig({ capability: "tts", audioProviderId, enabled: isOpen });
 
+  const { values, setField, setValues, merged, handleSave } =
+    useNodeDialogState(
+      props,
+      () => ({
+        name: data.name || "Text to Speech",
+        text: data.text || "",
+        voice: data.voice || "nova",
+        model: data.model || "tts-1",
+        output_format: data.output_format || "mp3",
+        speed: data.speed ?? 1.0,
+      }),
+      (v) => ({
+        name: v.name,
+        text: v.text,
+        provider: providerType || "openai",
+        audioProviderId: audioProviderId || undefined,
+        voice: v.voice,
+        model: v.model,
+        output_format: v.output_format,
+        speed: v.speed,
+      }),
+    );
+
+  // Re-seed the externally-held `audioProviderId` when the panel (re)opens or the node
+  // data changes — mirrors the hook's re-seed for the remaining fields.
   useEffect(() => {
     if (isOpen) {
-      setName(data.name || "Text to Speech");
-      setText(data.text || "");
       setAudioProviderId(data.audioProviderId || "");
-      setVoice(data.voice || "nova");
-      setModel(data.model || "tts-1");
-      setOutputFormat(data.output_format || "mp3");
-      setSpeed(data.speed ?? 1.0);
     }
   }, [isOpen, data]);
 
@@ -55,27 +76,13 @@ export const TTSDialog: React.FC<TTSDialogProps> = (props) => {
     setAudioProviderId(id);
     const defaults = getDefaultsForProvider(id);
     if (defaults) {
-      setVoice(defaults.voice);
-      setModel(defaults.model);
-      setOutputFormat(defaults.outputFormat);
+      setValues((v) => ({
+        ...v,
+        voice: defaults.voice,
+        model: defaults.model,
+        output_format: defaults.outputFormat,
+      }));
     }
-  };
-
-  const buildNodeData = (): TTSNodeData => ({
-    ...data,
-    name,
-    text,
-    provider: providerType || "openai",
-    audioProviderId: audioProviderId || undefined,
-    voice,
-    model,
-    output_format: outputFormat,
-    speed,
-  });
-
-  const handleSave = () => {
-    onUpdate(buildNodeData());
-    onClose();
   };
 
   return (
@@ -92,15 +99,15 @@ export const TTSDialog: React.FC<TTSDialogProps> = (props) => {
         </>
       }
       {...props}
-      data={buildNodeData()}
+      data={merged}
     >
       <div className="space-y-4">
         <div>
           <Label htmlFor="name">Node Name</Label>
           <RichInput
             id="name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="e.g., Text to Speech"
             className="w-full"
           />
@@ -110,8 +117,8 @@ export const TTSDialog: React.FC<TTSDialogProps> = (props) => {
           <Label htmlFor="text">Text Input</Label>
           <DraggableTextArea
             id="text"
-            value={text}
-            onChange={(e) => setText(e.target.value)}
+            value={values.text}
+            onChange={(e) => setField("text", e.target.value)}
             placeholder="Enter text or drag variables from the left panel, e.g. {{source.message}}"
             className="h-32 font-mono text-sm"
             rows={5}
@@ -136,7 +143,10 @@ export const TTSDialog: React.FC<TTSDialogProps> = (props) => {
 
         <div className="space-y-2">
           <Label htmlFor="voice">Voice</Label>
-          <Select value={voice} onValueChange={setVoice}>
+          <Select
+            value={values.voice}
+            onValueChange={(value) => setField("voice", value)}
+          >
             <SelectTrigger className="w-full">
               <SelectValue placeholder="Select voice" />
             </SelectTrigger>
@@ -152,7 +162,10 @@ export const TTSDialog: React.FC<TTSDialogProps> = (props) => {
 
         <div className="space-y-2">
           <Label htmlFor="model">Model</Label>
-          <Select value={model} onValueChange={setModel}>
+          <Select
+            value={values.model}
+            onValueChange={(value) => setField("model", value)}
+          >
             <SelectTrigger className="w-full">
               <SelectValue placeholder="Select model" />
             </SelectTrigger>
@@ -168,7 +181,10 @@ export const TTSDialog: React.FC<TTSDialogProps> = (props) => {
 
         <div className="space-y-2">
           <Label htmlFor="output_format">Output Format</Label>
-          <Select value={outputFormat} onValueChange={setOutputFormat}>
+          <Select
+            value={values.output_format}
+            onValueChange={(value) => setField("output_format", value)}
+          >
             <SelectTrigger className="w-full">
               <SelectValue placeholder="Select format" />
             </SelectTrigger>
@@ -184,18 +200,18 @@ export const TTSDialog: React.FC<TTSDialogProps> = (props) => {
 
         {supportsSpeed && (
           <div>
-            <Label htmlFor="speed">Speed ({speed}x)</Label>
+            <Label htmlFor="speed">Speed ({values.speed}x)</Label>
             <p className="text-xs text-muted-foreground mb-1">
               Speech speed (0.25 to 4.0)
             </p>
             <RichInput
               id="speed"
               type="number"
-              value={String(speed)}
+              value={String(values.speed)}
               onChange={(e) => {
                 const val = parseFloat(e.target.value);
                 if (!isNaN(val) && val >= 0.25 && val <= 4.0) {
-                  setSpeed(val);
+                  setField("speed", val);
                 }
               }}
               min={0.25}

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/TemplateNodeDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/TemplateNodeDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { TemplateNodeData } from "../types/nodes";
 import { Button } from "@/components/button";
 import { RichInput } from "@/components/richInput";
@@ -7,6 +7,7 @@ import { DraggableTextArea } from "../components/custom/DraggableTextArea";
 import { Save } from "lucide-react";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type TemplateNodeDialogProps = BaseNodeDialogProps<
   TemplateNodeData,
@@ -16,33 +17,15 @@ type TemplateNodeDialogProps = BaseNodeDialogProps<
 export const TemplateNodeDialog: React.FC<TemplateNodeDialogProps> = (
   props
 ) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { onClose, data } = props;
 
-  const [templateData, setTemplateData] = useState<{
-    name: string;
-    template: string;
-  }>({
-    name: data.name || "",
-    template: data.template || "",
-  });
-
-  useEffect(() => {
-    if (isOpen) {
-      setTemplateData({
-        name: data.name || "",
-        template: data.template || "",
-      });
-    }
-  }, [isOpen, data]);
-
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name: templateData.name,
-      template: templateData.template,
-    });
-    onClose();
-  };
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name || "",
+      template: data.template || "",
+    })
+  );
 
   return (
     <NodeConfigPanel
@@ -58,21 +41,15 @@ export const TemplateNodeDialog: React.FC<TemplateNodeDialogProps> = (
         </>
       }
       {...props}
-      data={{
-        ...data,
-        name: templateData.name,
-        template: templateData.template,
-      }}
+      data={merged}
     >
       <div className="space-y-4">
         <div>
           <Label htmlFor="name">Node Name</Label>
           <RichInput
             id="name"
-            value={templateData.name}
-            onChange={(e) =>
-              setTemplateData({ ...templateData, name: e.target.value })
-            }
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="e.g., Template"
             className="w-full"
           />
@@ -81,10 +58,8 @@ export const TemplateNodeDialog: React.FC<TemplateNodeDialogProps> = (
           <Label htmlFor="template">Template</Label>
           <DraggableTextArea
             id="template"
-            value={templateData.template}
-            onChange={(e) =>
-              setTemplateData({ ...templateData, template: e.target.value })
-            }
+            value={values.template}
+            onChange={(e) => setField("template", e.target.value)}
             placeholder="Enter your template here... Use {{session.message}} or drag variables from the left panel"
             className="h-32 font-mono text-sm"
             rows={8}

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/ThreadRAGDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/ThreadRAGDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { ThreadRAGNodeData } from "../types/nodes";
 import { Button } from "@/components/button";
 import { RichInput } from "@/components/richInput";
@@ -15,6 +15,7 @@ import {
   SelectValue,
 } from "@/components/select";
 import RagVectorConfigSection from "@/views/KnowledgeBase/components/RagVectorConfigSection";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type ThreadRAGDialogProps = BaseNodeDialogProps<
   ThreadRAGNodeData,
@@ -22,56 +23,43 @@ type ThreadRAGDialogProps = BaseNodeDialogProps<
 >;
 
 export const ThreadRAGDialog: React.FC<ThreadRAGDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
-  const [name, setName] = useState(data.name || "");
-  const [action, setAction] = useState<"retrieve" | "add">(
-    data.action || "retrieve"
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name || "",
+      action: (data.action || "retrieve") as "retrieve" | "add",
+      // Retrieve action fields
+      query: data.query || "",
+      top_k: data.top_k || 5,
+      // Add action fields
+      message: data.message || "",
+      // Vector store config
+      ragVectorConfig: (data.ragVectorConfig ?? {}) as Record<string, unknown>,
+    }),
+    (v) => {
+      const updatedData: Partial<ThreadRAGNodeData> = {
+        name: v.name,
+        action: v.action,
+        ragVectorConfig: v.ragVectorConfig,
+      };
+
+      if (v.action === "retrieve") {
+        updatedData.query = v.query;
+        updatedData.top_k = v.top_k;
+        // Clear add action fields
+        updatedData.message = undefined;
+      } else {
+        updatedData.message = v.message;
+        // Clear retrieve action fields
+        updatedData.query = undefined;
+        updatedData.top_k = undefined;
+      }
+
+      return updatedData;
+    },
   );
-  // Retrieve action fields
-  const [query, setQuery] = useState(data.query || "");
-  const [topK, setTopK] = useState(data.top_k || 5);
-  // Add action fields
-  const [message, setMessage] = useState(data.message || "");
-  // Vector store config
-  const [ragVectorConfig, setRagVectorConfig] = useState<Record<string, unknown>>(
-    data.ragVectorConfig ?? {}
-  );
-
-  useEffect(() => {
-    if (isOpen) {
-      setName(data.name || "");
-      setAction(data.action || "retrieve");
-      setQuery(data.query || "");
-      setTopK(data.top_k || 5);
-      setMessage(data.message || "");
-      setRagVectorConfig(data.ragVectorConfig ?? {});
-    }
-  }, [isOpen, data]);
-
-  const handleSave = () => {
-    const updatedData: ThreadRAGNodeData = {
-      ...data,
-      name,
-      action,
-      ragVectorConfig,
-    };
-
-    if (action === "retrieve") {
-      updatedData.query = query;
-      updatedData.top_k = topK;
-      // Clear add action fields
-      updatedData.message = undefined;
-    } else {
-      updatedData.message = message;
-      // Clear retrieve action fields
-      updatedData.query = undefined;
-      updatedData.top_k = undefined;
-    }
-
-    onUpdate(updatedData);
-    onClose();
-  };
 
   return (
     <NodeConfigPanel
@@ -89,21 +77,14 @@ export const ThreadRAGDialog: React.FC<ThreadRAGDialogProps> = (props) => {
         </>
       }
       {...props}
-      data={{
-        ...data,
-        name,
-        action,
-        query,
-        top_k: topK,
-        message,
-      }}
+      data={merged}
     >
       <div className="space-y-2">
         <Label htmlFor="name">Node Name</Label>
         <RichInput
           id="name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={values.name}
+          onChange={(e) => setField("name", e.target.value)}
           placeholder="Enter the name of this node"
           className="w-full"
         />
@@ -112,8 +93,10 @@ export const ThreadRAGDialog: React.FC<ThreadRAGDialogProps> = (props) => {
       <div className="space-y-2">
         <Label htmlFor="action">Action</Label>
         <Select
-          value={action}
-          onValueChange={(value: "retrieve" | "add") => setAction(value)}
+          value={values.action}
+          onValueChange={(value: "retrieve" | "add") =>
+            setField("action", value)
+          }
         >
           <SelectTrigger className="w-full">
             <SelectValue placeholder="Select action" />
@@ -125,14 +108,14 @@ export const ThreadRAGDialog: React.FC<ThreadRAGDialogProps> = (props) => {
         </Select>
       </div>
 
-      {action === "retrieve" ? (
+      {values.action === "retrieve" ? (
         <>
           <div className="space-y-2">
             <Label htmlFor="query">Query</Label>
             <DraggableTextArea
               id="query"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
+              value={values.query}
+              onChange={(e) => setField("query", e.target.value)}
               placeholder="e.g., {{query}}"
               className="w-full"
               rows={3}
@@ -144,8 +127,8 @@ export const ThreadRAGDialog: React.FC<ThreadRAGDialogProps> = (props) => {
             <RichInput
               id="top_k"
               type="number"
-              value={topK}
-              onChange={(e) => setTopK(parseInt(e.target.value))}
+              value={values.top_k}
+              onChange={(e) => setField("top_k", parseInt(e.target.value))}
               placeholder="5"
               min="1"
               className="w-full"
@@ -161,8 +144,8 @@ export const ThreadRAGDialog: React.FC<ThreadRAGDialogProps> = (props) => {
             <Label htmlFor="message">Message</Label>
             <DraggableTextArea
               id="message"
-              value={message}
-              onChange={(e) => setMessage(e.target.value)}
+              value={values.message}
+              onChange={(e) => setField("message", e.target.value)}
               placeholder="e.g., {{message}}"
               className="w-full"
               rows={4}
@@ -178,8 +161,8 @@ export const ThreadRAGDialog: React.FC<ThreadRAGDialogProps> = (props) => {
           are applied on the first operation for this chat thread.
         </p>
         <RagVectorConfigSection
-          config={ragVectorConfig}
-          onChange={setRagVectorConfig}
+          config={values.ragVectorConfig}
+          onChange={(config) => setField("ragVectorConfig", config)}
         />
       </div>
     </NodeConfigPanel>

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/ToolBuilderDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/ToolBuilderDialog.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { ToolBuilderNodeData } from "../types/nodes";
 import { Button } from "@/components/button";
 import { Save } from "lucide-react";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
 import { ToolDefinitionSection } from "../components/ToolDefinitionSection";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type ToolBuilderDialogProps = BaseNodeDialogProps<
   ToolBuilderNodeData,
@@ -12,29 +13,12 @@ type ToolBuilderDialogProps = BaseNodeDialogProps<
 >;
 
 export const ToolBuilderDialog: React.FC<ToolBuilderDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { onClose, data } = props;
 
-  const [toolDefinition, setToolDefinition] = useState<ToolBuilderNodeData>({
-    name: data.name || "Tool Builder",
-    description: data.description || "Custom tool for parameter forwarding",
-    inputSchema: data.inputSchema || {},
-    returnDirect: data.returnDirect || false,
-  });
-
-  useEffect(() => {
-    setToolDefinition({
-      ...data,
-    });
-  }, [isOpen, data]);
-
-  // Handle save
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      ...toolDefinition,
-    });
-    onClose();
-  };
+  const { values, setValues, merged, handleSave } = useNodeDialogState(
+    props,
+    () => ({ ...data })
+  );
 
   return (
     <NodeConfigPanel
@@ -50,16 +34,13 @@ export const ToolBuilderDialog: React.FC<ToolBuilderDialogProps> = (props) => {
         </>
       }
       {...props}
-      data={{
-        ...data,
-        ...toolDefinition,
-      }}
+      data={merged}
       showJsonState={false}
       className="max-w-4xl"
     >
       <ToolDefinitionSection
-        toolDefinition={toolDefinition}
-        onToolDefinitionChange={setToolDefinition}
+        toolDefinition={values}
+        onToolDefinitionChange={setValues}
       />
     </NodeConfigPanel>
   );

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/VoiceAgentDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/VoiceAgentDialog.tsx
@@ -16,6 +16,7 @@ import {
 import { DraggableTextArea } from "../components/custom/DraggableTextArea";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
+import { useNodeDialogState } from "./useNodeDialogState";
 import { getAllAudioProviders } from "@/services/audioProviders";
 
 type VoiceAgentDialogProps = BaseNodeDialogProps<
@@ -56,9 +57,12 @@ const LIVE_VOICES = [
 ];
 
 export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
-  const [config, setConfig] = useState<VoiceAgentNodeData>(data);
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => data
+  );
 
   const hasAdvanced = (d: VoiceAgentNodeData) =>
     d.temperature != null ||
@@ -70,10 +74,10 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
     !!d.contextCompression;
   const [showAdvanced, setShowAdvanced] = useState(() => hasAdvanced(data));
 
-  // Reset state when the dialog is opened to reflect the current node data
+  // Reset advanced-panel visibility when the dialog is opened to reflect the
+  // current node data (config re-seeding is handled by useNodeDialogState).
   useEffect(() => {
     if (isOpen) {
-      setConfig(data);
       setShowAdvanced(hasAdvanced(data));
     }
   }, [isOpen, data]);
@@ -90,18 +94,10 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
   // Flag a configured-but-keyless provider so the operator fixes it before it
   // silently fails at runtime (the widget only ever shows a neutral "unavailable").
   const selectedProvider = geminiProviders?.find(
-    (p) => p.id === config.voiceProviderId
+    (p) => p.id === values.voiceProviderId
   );
   const selectedProviderMissingKey =
     !!selectedProvider && !selectedProvider.connection_data?.api_key;
-
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      ...config,
-    });
-    onClose();
-  };
 
   return (
     <NodeConfigPanel
@@ -114,20 +110,15 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
         </>
       }
       {...props}
-      data={{
-        ...data,
-        ...config,
-      }}
+      data={merged}
     >
       <div className="space-y-4">
         <div>
           <Label htmlFor="name">Node Name</Label>
           <RichInput
             id="name"
-            value={config.name || "Voice Agent"}
-            onChange={(e) =>
-              setConfig((prev) => ({ ...prev, name: e.target.value }))
-            }
+            value={values.name || "Voice Agent"}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="e.g., Voice Agent"
             className="w-full"
           />
@@ -140,10 +131,8 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
             Gemini audio provider under Settings → Audio Providers.
           </p>
           <Select
-            value={config.voiceProviderId || ""}
-            onValueChange={(value) =>
-              setConfig((prev) => ({ ...prev, voiceProviderId: value }))
-            }
+            value={values.voiceProviderId || ""}
+            onValueChange={(value) => setField("voiceProviderId", value)}
           >
             <SelectTrigger className="w-full">
               <SelectValue placeholder="Select a Gemini audio provider" />
@@ -172,10 +161,8 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
         <div className="space-y-2">
           <Label htmlFor="model">Live Model</Label>
           <Select
-            value={config.model || LIVE_MODELS[0].value}
-            onValueChange={(value) =>
-              setConfig((prev) => ({ ...prev, model: value }))
-            }
+            value={values.model || LIVE_MODELS[0].value}
+            onValueChange={(value) => setField("model", value)}
           >
             <SelectTrigger className="w-full">
               <SelectValue placeholder="Select model" />
@@ -193,10 +180,8 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
         <div className="space-y-2">
           <Label htmlFor="voice">Voice</Label>
           <Select
-            value={config.voice || "Kore"}
-            onValueChange={(value) =>
-              setConfig((prev) => ({ ...prev, voice: value }))
-            }
+            value={values.voice || "Kore"}
+            onValueChange={(value) => setField("voice", value)}
           >
             <SelectTrigger className="w-full">
               <SelectValue placeholder="Select voice" />
@@ -218,10 +203,8 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
           </p>
           <RichInput
             id="language"
-            value={config.language || ""}
-            onChange={(e) =>
-              setConfig((prev) => ({ ...prev, language: e.target.value }))
-            }
+            value={values.language || ""}
+            onChange={(e) => setField("language", e.target.value)}
             placeholder="e.g., en-US"
             className="w-full"
           />
@@ -231,10 +214,8 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
           <Label htmlFor="systemPrompt">System Prompt</Label>
           <DraggableTextArea
             id="systemPrompt"
-            value={config.systemPrompt || ""}
-            onChange={(e) =>
-              setConfig((prev) => ({ ...prev, systemPrompt: e.target.value }))
-            }
+            value={values.systemPrompt || ""}
+            onChange={(e) => setField("systemPrompt", e.target.value)}
             placeholder="Instructions for how the voice agent should behave"
             className="h-24 text-sm"
             rows={4}
@@ -248,10 +229,8 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
           </p>
           <DraggableTextArea
             id="userPrompt"
-            value={config.userPrompt || ""}
-            onChange={(e) =>
-              setConfig((prev) => ({ ...prev, userPrompt: e.target.value }))
-            }
+            value={values.userPrompt || ""}
+            onChange={(e) => setField("userPrompt", e.target.value)}
             placeholder="{{session.message}}"
             className="h-16 font-mono text-sm"
             rows={2}
@@ -266,11 +245,11 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
           <RichInput
             id="maxToolCalls"
             type="number"
-            value={String(config.maxToolCalls ?? 10)}
+            value={String(values.maxToolCalls ?? 10)}
             onChange={(e) => {
               const val = parseInt(e.target.value, 10);
               if (!isNaN(val) && val >= 1) {
-                setConfig((prev) => ({ ...prev, maxToolCalls: val }));
+                setField("maxToolCalls", val);
               }
             }}
             min={1}
@@ -283,26 +262,22 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
           <Label htmlFor="voice-agent-memory">Enable Memory</Label>
           <Switch
             id="voice-agent-memory"
-            checked={config.memory}
-            onCheckedChange={(checked) =>
-              setConfig((prev) => ({ ...prev, memory: checked }))
-            }
+            checked={values.memory}
+            onCheckedChange={(checked) => setField("memory", checked)}
           />
         </div>
 
-        {config.memory && (
+        {values.memory && (
           <>
             <div className="space-y-2">
               <Label htmlFor="memoryTrimmingMode">Memory Trimming Mode</Label>
               <Select
-                value={config.memoryTrimmingMode || "message_count"}
+                value={values.memoryTrimmingMode || "message_count"}
                 onValueChange={(value) =>
-                  setConfig((prev) => ({
-                    ...prev,
-                    memoryTrimmingMode: value as
-                      | "message_count"
-                      | "rag_retrieval",
-                  }))
+                  setField(
+                    "memoryTrimmingMode",
+                    value as "message_count" | "rag_retrieval"
+                  )
                 }
               >
                 <SelectTrigger id="memoryTrimmingMode" className="w-full">
@@ -315,18 +290,18 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
               </Select>
             </div>
 
-            {(config.memoryTrimmingMode === "message_count" ||
-              !config.memoryTrimmingMode) && (
+            {(values.memoryTrimmingMode === "message_count" ||
+              !values.memoryTrimmingMode) && (
               <div>
                 <Label htmlFor="maxMessages">Max Messages</Label>
                 <RichInput
                   id="maxMessages"
                   type="number"
-                  value={String(config.maxMessages ?? 10)}
+                  value={String(values.maxMessages ?? 10)}
                   onChange={(e) => {
                     const val = parseInt(e.target.value, 10);
                     if (!isNaN(val) && val >= 1) {
-                      setConfig((prev) => ({ ...prev, maxMessages: val }));
+                      setField("maxMessages", val);
                     }
                   }}
                   min={1}
@@ -348,10 +323,8 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
           </div>
           <Switch
             id="voice-agent-pii"
-            checked={config.piiMasking || false}
-            onCheckedChange={(checked) =>
-              setConfig((prev) => ({ ...prev, piiMasking: checked }))
-            }
+            checked={values.piiMasking || false}
+            onCheckedChange={(checked) => setField("piiMasking", checked)}
           />
         </div>
 
@@ -378,13 +351,10 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
                   <RichInput
                     id="temperature"
                     type="number"
-                    value={config.temperature != null ? String(config.temperature) : ""}
+                    value={values.temperature != null ? String(values.temperature) : ""}
                     onChange={(e) => {
                       const v = e.target.value;
-                      setConfig((prev) => ({
-                        ...prev,
-                        temperature: toNumberOrUndef(v, parseFloat),
-                      }));
+                      setField("temperature", toNumberOrUndef(v, parseFloat));
                     }}
                     min={0}
                     max={2}
@@ -398,13 +368,13 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
                   <RichInput
                     id="maxOutputTokens"
                     type="number"
-                    value={config.maxOutputTokens != null ? String(config.maxOutputTokens) : ""}
+                    value={values.maxOutputTokens != null ? String(values.maxOutputTokens) : ""}
                     onChange={(e) => {
                       const v = e.target.value;
-                      setConfig((prev) => ({
-                        ...prev,
-                        maxOutputTokens: toNumberOrUndef(v, (s) => parseInt(s, 10)),
-                      }));
+                      setField(
+                        "maxOutputTokens",
+                        toNumberOrUndef(v, (s) => parseInt(s, 10))
+                      );
                     }}
                     min={1}
                     step={1}
@@ -422,13 +392,13 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
                 <RichInput
                   id="vadSilenceMs"
                   type="number"
-                  value={config.vadSilenceMs != null ? String(config.vadSilenceMs) : ""}
+                  value={values.vadSilenceMs != null ? String(values.vadSilenceMs) : ""}
                   onChange={(e) => {
                     const v = e.target.value;
-                    setConfig((prev) => ({
-                      ...prev,
-                      vadSilenceMs: toNumberOrUndef(v, (s) => parseInt(s, 10)),
-                    }));
+                    setField(
+                      "vadSilenceMs",
+                      toNumberOrUndef(v, (s) => parseInt(s, 10))
+                    );
                   }}
                   min={0}
                   step={50}
@@ -441,15 +411,14 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
                 <div className="space-y-1">
                   <Label>Start Sensitivity</Label>
                   <Select
-                    value={config.vadStartSensitivity || "default"}
+                    value={values.vadStartSensitivity || "default"}
                     onValueChange={(value) =>
-                      setConfig((prev) => ({
-                        ...prev,
-                        vadStartSensitivity:
-                          value === "default"
-                            ? undefined
-                            : (value as VoiceAgentNodeData["vadStartSensitivity"]),
-                      }))
+                      setField(
+                        "vadStartSensitivity",
+                        value === "default"
+                          ? undefined
+                          : (value as VoiceAgentNodeData["vadStartSensitivity"])
+                      )
                     }
                   >
                     <SelectTrigger className="w-full">
@@ -465,15 +434,14 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
                 <div className="space-y-1">
                   <Label>End Sensitivity</Label>
                   <Select
-                    value={config.vadEndSensitivity || "default"}
+                    value={values.vadEndSensitivity || "default"}
                     onValueChange={(value) =>
-                      setConfig((prev) => ({
-                        ...prev,
-                        vadEndSensitivity:
-                          value === "default"
-                            ? undefined
-                            : (value as VoiceAgentNodeData["vadEndSensitivity"]),
-                      }))
+                      setField(
+                        "vadEndSensitivity",
+                        value === "default"
+                          ? undefined
+                          : (value as VoiceAgentNodeData["vadEndSensitivity"])
+                      )
                     }
                   >
                     <SelectTrigger className="w-full">
@@ -492,9 +460,9 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
                 <Label htmlFor="voice-agent-proactive">Proactive Audio</Label>
                 <Switch
                   id="voice-agent-proactive"
-                  checked={config.proactiveAudio || false}
+                  checked={values.proactiveAudio || false}
                   onCheckedChange={(checked) =>
-                    setConfig((prev) => ({ ...prev, proactiveAudio: checked }))
+                    setField("proactiveAudio", checked)
                   }
                 />
               </div>
@@ -508,9 +476,9 @@ export const VoiceAgentDialog: React.FC<VoiceAgentDialogProps> = (props) => {
                 </div>
                 <Switch
                   id="voice-agent-compression"
-                  checked={config.contextCompression || false}
+                  checked={values.contextCompression || false}
                   onCheckedChange={(checked) =>
-                    setConfig((prev) => ({ ...prev, contextCompression: checked }))
+                    setField("contextCompression", checked)
                   }
                 />
               </div>

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/WebScraperDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/WebScraperDialog.tsx
@@ -19,6 +19,7 @@ import { Plus, X, Save, ChevronDown, ChevronUp } from "lucide-react";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
 import { DraggableInput } from "../components/custom/DraggableInput";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 // open the advanced section when any advanced option is set away from its default
 const hasAdvancedOptions = (data: WebScraperNodeData): boolean =>
@@ -27,77 +28,50 @@ const hasAdvancedOptions = (data: WebScraperNodeData): boolean =>
 export const WebScraperDialog: React.FC<
   BaseNodeDialogProps<WebScraperNodeData, WebScraperNodeData>
 > = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
-  const [name, setName] = useState(data.name || "");
-  const [url, setUrl] = useState(data.url || "");
-  const [format, setFormat] = useState<WebScraperFormat>(
-    data.format || "markdown"
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name || "",
+      url: data.url || "",
+      format: data.format || "markdown",
+      onlyMainContent: data.onlyMainContent ?? true,
+      screenshot: data.screenshot || "off",
+      headers: data.headers || {},
+      waitFor: data.waitFor ?? 0,
+      scrollToBottom: data.scrollToBottom ?? false,
+      maxAge: data.maxAge ?? 0,
+    })
   );
-  const [onlyMainContent, setOnlyMainContent] = useState<boolean>(
-    data.onlyMainContent ?? true
-  );
-  const [screenshot, setScreenshot] = useState<WebScraperScreenshot>(
-    data.screenshot || "off"
-  );
-  const [headers, setHeaders] = useState<Record<string, string>>(
-    data.headers || {}
-  );
-  const [waitFor, setWaitFor] = useState<number>(data.waitFor ?? 0);
-  const [scrollToBottom, setScrollToBottom] = useState<boolean>(
-    data.scrollToBottom ?? false
-  );
-  const [maxAge, setMaxAge] = useState<number>(data.maxAge ?? 0);
+
   const [showAdvanced, setShowAdvanced] = useState(hasAdvancedOptions(data));
   useEffect(() => {
-    setName(data.name || "");
-    setUrl(data.url || "");
-    setFormat(data.format || "markdown");
-    setOnlyMainContent(data.onlyMainContent ?? true);
-    setScreenshot(data.screenshot || "off");
-    setHeaders(data.headers || {});
-    setWaitFor(data.waitFor ?? 0);
-    setScrollToBottom(data.scrollToBottom ?? false);
-    setMaxAge(data.maxAge ?? 0);
-    setShowAdvanced(hasAdvancedOptions(data));
-  }, [isOpen]);
-
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name,
-      url,
-      format,
-      onlyMainContent,
-      screenshot,
-      headers,
-      waitFor,
-      scrollToBottom,
-      maxAge,
-    });
-    onClose();
-  };
+    if (isOpen) {
+      setShowAdvanced(hasAdvancedOptions(data));
+    }
+  }, [isOpen, data]);
 
   const addHeader = () => {
-    setHeaders({ ...headers, "": "" });
+    setField("headers", { ...values.headers, "": "" });
   };
 
   const updateHeader = (oldKey: string, newKey: string, value: string) => {
     const newHeaders: Record<string, string> = {};
-    for (const [key, val] of Object.entries(headers)) {
+    for (const [key, val] of Object.entries(values.headers)) {
       if (key === oldKey) {
         newHeaders[newKey] = value;
       } else {
         newHeaders[key] = val;
       }
     }
-    setHeaders(newHeaders);
+    setField("headers", newHeaders);
   };
 
   const removeHeader = (key: string) => {
-    const newHeaders = { ...headers };
+    const newHeaders = { ...values.headers };
     delete newHeaders[key];
-    setHeaders(newHeaders);
+    setField("headers", newHeaders);
   };
 
   return (
@@ -114,25 +88,14 @@ export const WebScraperDialog: React.FC<
         </>
       }
       {...props}
-      data={{
-        ...data,
-        name,
-        url,
-        format,
-        onlyMainContent,
-        screenshot,
-        headers,
-        waitFor,
-        scrollToBottom,
-        maxAge,
-      }}
+      data={merged}
     >
       <div className="space-y-2">
         <Label htmlFor="name">Name</Label>
         <RichInput
           id="name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={values.name}
+          onChange={(e) => setField("name", e.target.value)}
           placeholder="Web Scraper"
           className="break-all w-full"
         />
@@ -142,8 +105,8 @@ export const WebScraperDialog: React.FC<
         <Label htmlFor="url">URL</Label>
         <DraggableInput
           id="url"
-          value={url}
-          onChange={(e) => setUrl(e.target.value)}
+          value={values.url}
+          onChange={(e) => setField("url", e.target.value)}
           placeholder="https://example.com"
           className="break-all w-full"
         />
@@ -155,8 +118,10 @@ export const WebScraperDialog: React.FC<
       <div className="space-y-2">
         <Label htmlFor="format">Output Format</Label>
         <Select
-          value={format}
-          onValueChange={(value) => setFormat(value as WebScraperFormat)}
+          value={values.format}
+          onValueChange={(value) =>
+            setField("format", value as WebScraperFormat)
+          }
         >
           <SelectTrigger>
             <SelectValue placeholder="Select output format" />
@@ -172,8 +137,10 @@ export const WebScraperDialog: React.FC<
       <div className="space-y-2">
         <Label htmlFor="screenshot">Screenshot</Label>
         <Select
-          value={screenshot}
-          onValueChange={(value) => setScreenshot(value as WebScraperScreenshot)}
+          value={values.screenshot}
+          onValueChange={(value) =>
+            setField("screenshot", value as WebScraperScreenshot)
+          }
         >
           <SelectTrigger>
             <SelectValue placeholder="Select screenshot mode" />
@@ -198,8 +165,8 @@ export const WebScraperDialog: React.FC<
           </p>
         </div>
         <Switch
-          checked={onlyMainContent}
-          onCheckedChange={setOnlyMainContent}
+          checked={values.onlyMainContent}
+          onCheckedChange={(checked) => setField("onlyMainContent", checked)}
         />
       </div>
 
@@ -217,7 +184,7 @@ export const WebScraperDialog: React.FC<
         </div>
 
         <div className="space-y-2">
-          {Object.entries(headers).map(([key, value], idx) => (
+          {Object.entries(values.headers).map(([key, value], idx) => (
             <div
               key={`header-${idx}`}
               className="flex items-center gap-2 w-full"
@@ -268,9 +235,9 @@ export const WebScraperDialog: React.FC<
               <RichInput
                 id="waitFor"
                 type="number"
-                value={String(waitFor)}
+                value={String(values.waitFor)}
                 onChange={(e) =>
-                  setWaitFor(Math.max(0, parseInt(e.target.value) || 0))
+                  setField("waitFor", Math.max(0, parseInt(e.target.value) || 0))
                 }
                 placeholder="0"
                 className="w-full"
@@ -290,8 +257,10 @@ export const WebScraperDialog: React.FC<
                 </p>
               </div>
               <Switch
-                checked={scrollToBottom}
-                onCheckedChange={setScrollToBottom}
+                checked={values.scrollToBottom}
+                onCheckedChange={(checked) =>
+                  setField("scrollToBottom", checked)
+                }
               />
             </div>
 
@@ -300,9 +269,9 @@ export const WebScraperDialog: React.FC<
               <RichInput
                 id="maxAge"
                 type="number"
-                value={String(maxAge)}
+                value={String(values.maxAge)}
                 onChange={(e) =>
-                  setMaxAge(Math.max(0, parseInt(e.target.value) || 0))
+                  setField("maxAge", Math.max(0, parseInt(e.target.value) || 0))
                 }
                 placeholder="0"
                 className="w-full"

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/WebSearchDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/WebSearchDialog.tsx
@@ -14,6 +14,7 @@ import { Save, ChevronDown, ChevronUp } from "lucide-react";
 import { NodeConfigPanel } from "../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "./base";
 import { DraggableInput } from "../components/custom/DraggableInput";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 // open the advanced section when any advanced option differs from its default
 const hasAdvancedOptions = (data: WebSearchNodeData): boolean =>
@@ -26,56 +27,29 @@ const hasAdvancedOptions = (data: WebSearchNodeData): boolean =>
 export const WebSearchDialog: React.FC<
   BaseNodeDialogProps<WebSearchNodeData, WebSearchNodeData>
 > = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
-  const [name, setName] = useState(data.name || "");
-  const [query, setQuery] = useState(data.query || "");
-  const [maxResults, setMaxResults] = useState<number>(data.maxResults ?? 5);
-  const [searchDepth, setSearchDepth] = useState<WebSearchDepth>(
-    data.searchDepth || "basic"
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name || "",
+      query: data.query || "",
+      maxResults: data.maxResults ?? 5,
+      searchDepth: data.searchDepth || "basic",
+      includeDomains: data.includeDomains || "",
+      excludeDomains: data.excludeDomains || "",
+      maxContentChars: data.maxContentChars ?? 2000,
+      maxTotalContentChars: data.maxTotalContentChars ?? 8000,
+      maxAge: data.maxAge ?? 600,
+    })
   );
-  const [includeDomains, setIncludeDomains] = useState(
-    data.includeDomains || ""
-  );
-  const [excludeDomains, setExcludeDomains] = useState(
-    data.excludeDomains || ""
-  );
-  const [maxContentChars, setMaxContentChars] = useState<number>(
-    data.maxContentChars ?? 2000
-  );
-  const [maxTotalContentChars, setMaxTotalContentChars] = useState<number>(
-    data.maxTotalContentChars ?? 8000
-  );
-  const [maxAge, setMaxAge] = useState<number>(data.maxAge ?? 600);
+
   const [showAdvanced, setShowAdvanced] = useState(hasAdvancedOptions(data));
   useEffect(() => {
-    setName(data.name || "");
-    setQuery(data.query || "");
-    setMaxResults(data.maxResults ?? 5);
-    setSearchDepth(data.searchDepth || "basic");
-    setIncludeDomains(data.includeDomains || "");
-    setExcludeDomains(data.excludeDomains || "");
-    setMaxContentChars(data.maxContentChars ?? 2000);
-    setMaxTotalContentChars(data.maxTotalContentChars ?? 8000);
-    setMaxAge(data.maxAge ?? 600);
-    setShowAdvanced(hasAdvancedOptions(data));
-  }, [isOpen]);
-
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name,
-      query,
-      maxResults,
-      searchDepth,
-      includeDomains,
-      excludeDomains,
-      maxContentChars,
-      maxTotalContentChars,
-      maxAge,
-    });
-    onClose();
-  };
+    if (isOpen) {
+      setShowAdvanced(hasAdvancedOptions(data));
+    }
+  }, [isOpen, data]);
 
   return (
     <NodeConfigPanel
@@ -91,25 +65,14 @@ export const WebSearchDialog: React.FC<
         </>
       }
       {...props}
-      data={{
-        ...data,
-        name,
-        query,
-        maxResults,
-        searchDepth,
-        includeDomains,
-        excludeDomains,
-        maxContentChars,
-        maxTotalContentChars,
-        maxAge,
-      }}
+      data={merged}
     >
       <div className="space-y-2">
         <Label htmlFor="name">Name</Label>
         <RichInput
           id="name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={values.name}
+          onChange={(e) => setField("name", e.target.value)}
           placeholder="Web Search"
           className="break-all w-full"
         />
@@ -119,8 +82,8 @@ export const WebSearchDialog: React.FC<
         <Label htmlFor="query">Query</Label>
         <DraggableInput
           id="query"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          value={values.query}
+          onChange={(e) => setField("query", e.target.value)}
           placeholder="Search the web for..."
           className="break-all w-full"
         />
@@ -134,9 +97,9 @@ export const WebSearchDialog: React.FC<
         <RichInput
           id="maxResults"
           type="number"
-          value={String(maxResults)}
+          value={String(values.maxResults)}
           onChange={(e) =>
-            setMaxResults(Math.max(1, parseInt(e.target.value) || 1))
+            setField("maxResults", Math.max(1, parseInt(e.target.value) || 1))
           }
           placeholder="5"
           className="w-full"
@@ -149,8 +112,10 @@ export const WebSearchDialog: React.FC<
       <div className="space-y-2">
         <Label htmlFor="searchDepth">Search Depth</Label>
         <Select
-          value={searchDepth}
-          onValueChange={(value) => setSearchDepth(value as WebSearchDepth)}
+          value={values.searchDepth}
+          onValueChange={(value) =>
+            setField("searchDepth", value as WebSearchDepth)
+          }
         >
           <SelectTrigger>
             <SelectValue placeholder="Select search depth" />
@@ -186,8 +151,8 @@ export const WebSearchDialog: React.FC<
               <Label htmlFor="includeDomains">Include Domain</Label>
               <DraggableInput
                 id="includeDomains"
-                value={includeDomains}
-                onChange={(e) => setIncludeDomains(e.target.value)}
+                value={values.includeDomains}
+                onChange={(e) => setField("includeDomains", e.target.value)}
                 placeholder="example.com"
                 className="break-all w-full"
               />
@@ -200,8 +165,8 @@ export const WebSearchDialog: React.FC<
               <Label htmlFor="excludeDomains">Exclude Domains</Label>
               <DraggableInput
                 id="excludeDomains"
-                value={excludeDomains}
-                onChange={(e) => setExcludeDomains(e.target.value)}
+                value={values.excludeDomains}
+                onChange={(e) => setField("excludeDomains", e.target.value)}
                 placeholder="reddit.com, pinterest.com"
                 className="break-all w-full"
               />
@@ -217,9 +182,12 @@ export const WebSearchDialog: React.FC<
               <RichInput
                 id="maxContentChars"
                 type="number"
-                value={String(maxContentChars)}
+                value={String(values.maxContentChars)}
                 onChange={(e) =>
-                  setMaxContentChars(Math.max(0, parseInt(e.target.value) || 0))
+                  setField(
+                    "maxContentChars",
+                    Math.max(0, parseInt(e.target.value) || 0)
+                  )
                 }
                 placeholder="2000"
                 className="w-full"
@@ -236,9 +204,10 @@ export const WebSearchDialog: React.FC<
               <RichInput
                 id="maxTotalContentChars"
                 type="number"
-                value={String(maxTotalContentChars)}
+                value={String(values.maxTotalContentChars)}
                 onChange={(e) =>
-                  setMaxTotalContentChars(
+                  setField(
+                    "maxTotalContentChars",
                     Math.max(0, parseInt(e.target.value) || 0)
                   )
                 }
@@ -255,9 +224,9 @@ export const WebSearchDialog: React.FC<
               <RichInput
                 id="maxAge"
                 type="number"
-                value={String(maxAge)}
+                value={String(values.maxAge)}
                 onChange={(e) =>
-                  setMaxAge(Math.max(0, parseInt(e.target.value) || 0))
+                  setField("maxAge", Math.max(0, parseInt(e.target.value) || 0))
                 }
                 placeholder="600"
                 className="w-full"

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/WhatsAppDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/WhatsAppDialog.tsx
@@ -18,6 +18,7 @@ import { AppSetting } from "@/interfaces/app-setting.interface";
 import { AppSettingDialog } from "@/views/AppSettings/components/AppSettingDialog";
 import { CreateNewSelectItem } from "@/components/CreateNewSelectItem";
 import { DraggableInput } from "../components/custom/DraggableInput";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type WhatsAppDialogProps = BaseNodeDialogProps<
   WhatsappNodeData,
@@ -25,24 +26,30 @@ type WhatsAppDialogProps = BaseNodeDialogProps<
 >;
 
 export const WhatsAppDialog: React.FC<WhatsAppDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
-  const [name, setName] = useState(data.name);
-  const [textMsg, setMessage] = useState(data.message || "");
-  const [toNumber, setToNumber] = useState(data.recipient_number || "");
-  const [appSettingsId, setAppSettingsId] = useState(
-    data.app_settings_id || ""
+  const { isOpen, onClose, data } = props;
+
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name,
+      message: data.message || "",
+      recipient_number: data.recipient_number || "",
+      app_settings_id: data.app_settings_id || "",
+    }),
+    (v) => ({
+      name: v.name,
+      message: v.message,
+      recipient_number: v.recipient_number,
+      app_settings_id: v.app_settings_id || undefined,
+    })
   );
+
   const [appSettings, setAppSettings] = useState<AppSetting[]>([]);
   const [isLoadingAppSettings, setIsLoadingAppSettings] = useState(false);
   const [isCreateSettingOpen, setIsCreateSettingOpen] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
-      setName(data.name);
-      setMessage(data.message || "");
-      setToNumber(data.recipient_number || "");
-      setAppSettingsId(data.app_settings_id || "");
-
       // Fetch app settings
       const fetchAppSettings = async () => {
         setIsLoadingAppSettings(true);
@@ -60,17 +67,6 @@ export const WhatsAppDialog: React.FC<WhatsAppDialogProps> = (props) => {
     }
   }, [isOpen, data]);
 
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name,
-      message: textMsg,
-      recipient_number: toNumber,
-      app_settings_id: appSettingsId || undefined,
-    });
-    onClose();
-  };
-
   return (
     <>
       <NodeConfigPanel
@@ -86,19 +82,14 @@ export const WhatsAppDialog: React.FC<WhatsAppDialogProps> = (props) => {
           </>
         }
         {...props}
-        data={{
-          ...data,
-          name,
-          message: textMsg,
-          recipient_number: toNumber,
-        }}
+        data={merged}
       >
         <div className="space-y-2">
           <Label htmlFor="name">Tool Name</Label>
           <RichInput
             id="name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="e.g., WhatsApp Message"
             className="w-full"
           />
@@ -106,13 +97,13 @@ export const WhatsAppDialog: React.FC<WhatsAppDialogProps> = (props) => {
         <div className="space-y-2">
           <Label htmlFor="app-settings-id">Configuration Vars (Optional)</Label>
           <Select
-            value={appSettingsId || ""}
+            value={values.app_settings_id || ""}
             onValueChange={(value) => {
               if (value === "__create__") {
                 setIsCreateSettingOpen(true);
                 return;
               }
-              setAppSettingsId(value || "");
+              setField("app_settings_id", value || "");
             }}
             disabled={isLoadingAppSettings}
           >
@@ -140,8 +131,8 @@ export const WhatsAppDialog: React.FC<WhatsAppDialogProps> = (props) => {
           <Label htmlFor="toNumber">Recipient Number</Label>
           <DraggableInput
             id="toNumber"
-            value={toNumber}
-            onChange={(e) => setToNumber(e.target.value)}
+            value={values.recipient_number}
+            onChange={(e) => setField("recipient_number", e.target.value)}
             placeholder="e.g., 15551234567"
             className="w-full"
           />
@@ -155,8 +146,8 @@ export const WhatsAppDialog: React.FC<WhatsAppDialogProps> = (props) => {
           <Label htmlFor="textMsg">Message</Label>
           <DraggableInput
             id="textMsg"
-            value={textMsg}
-            onChange={(e) => setMessage(e.target.value)}
+            value={values.message}
+            onChange={(e) => setField("message", e.target.value)}
             placeholder="e.g., Please call me!"
             className="w-full"
           />
@@ -175,7 +166,7 @@ export const WhatsAppDialog: React.FC<WhatsAppDialogProps> = (props) => {
           } catch (e) {
             // ignore
           }
-          if (created?.id) setAppSettingsId(created.id);
+          if (created?.id) setField("app_settings_id", created.id);
         }}
       />
     </>

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/WorkflowExecutorDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/WorkflowExecutorDialog.tsx
@@ -17,18 +17,23 @@ import { getAllWorkflows } from "@/services/workflows";
 import { Workflow } from "@/interfaces/workflow.interface";
 import { NodeSchema, SchemaField } from "../types/schemas";
 import { RichInput } from "@/components/richInput";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 export const WorkflowExecutorDialog: React.FC<
   BaseNodeDialogProps<WorkflowExecutorNodeData, WorkflowExecutorNodeData>
 > = (props) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
-  const [name, setName] = useState(data.name || "");
-  const [workflowId, setWorkflowId] = useState(data.workflowId || "");
-  const [workflowName, setWorkflowName] = useState(data.workflowName || "");
-  const [inputParameters, setInputParameters] = useState<Record<string, string>>(
-    data.inputParameters || {}
+  const { values, setField, merged, handleSave } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name || "",
+      workflowId: data.workflowId || "",
+      workflowName: data.workflowName || "",
+      inputParameters: data.inputParameters || {},
+    })
   );
+
   const [workflows, setWorkflows] = useState<Workflow[]>([]);
   const [loading, setLoading] = useState(false);
   const [selectedWorkflowInputSchema, setSelectedWorkflowInputSchema] = useState<NodeSchema | null>(null);
@@ -40,26 +45,20 @@ export const WorkflowExecutorDialog: React.FC<
     }
   }, [isOpen]);
 
-  // Update local state when data changes
-  useEffect(() => {
-    setName(data.name || "");
-    setWorkflowId(data.workflowId || "");
-    setWorkflowName(data.workflowName || "");
-    setInputParameters(data.inputParameters || {});
-  }, [isOpen, data]);
-
   // Update input schema when workflow is selected
   useEffect(() => {
-    if (workflowId && workflows.length > 0) {
-      const selectedWorkflow = workflows.find((w) => w.id === workflowId);
+    if (values.workflowId && workflows.length > 0) {
+      const selectedWorkflow = workflows.find(
+        (w) => w.id === values.workflowId
+      );
       if (selectedWorkflow) {
-        setWorkflowName(selectedWorkflow.name);
+        setField("workflowName", selectedWorkflow.name);
         extractInputSchema(selectedWorkflow);
       }
     } else {
       setSelectedWorkflowInputSchema(null);
     }
-  }, [workflowId, workflows]);
+  }, [values.workflowId, workflows, setField]);
 
   const fetchWorkflows = async () => {
     setLoading(true);
@@ -91,43 +90,32 @@ export const WorkflowExecutorDialog: React.FC<
       // Initialize input parameters with empty values for all schema fields
       const newInputParameters: Record<string, string> = {};
       Object.keys(schema).forEach((key) => {
-        if (!(key in inputParameters)) {
+        if (!(key in values.inputParameters)) {
           newInputParameters[key] = "";
         } else {
-          newInputParameters[key] = inputParameters[key];
+          newInputParameters[key] = values.inputParameters[key];
         }
       });
-      setInputParameters(newInputParameters);
+      setField("inputParameters", newInputParameters);
     } else {
       setSelectedWorkflowInputSchema(null);
     }
   };
 
   const handleWorkflowChange = (newWorkflowId: string) => {
-    setWorkflowId(newWorkflowId);
+    setField("workflowId", newWorkflowId);
     const selectedWorkflow = workflows.find((w) => w.id === newWorkflowId);
     if (selectedWorkflow) {
-      setWorkflowName(selectedWorkflow.name);
+      setField("workflowName", selectedWorkflow.name);
       extractInputSchema(selectedWorkflow);
     }
   };
 
   const handleParameterChange = (key: string, value: string) => {
-    setInputParameters({
-      ...inputParameters,
+    setField("inputParameters", {
+      ...values.inputParameters,
       [key]: value,
     });
-  };
-
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name,
-      workflowId,
-      workflowName,
-      inputParameters,
-    });
-    onClose();
   };
 
   return (
@@ -144,20 +132,14 @@ export const WorkflowExecutorDialog: React.FC<
         </>
       }
       {...props}
-      data={{
-        ...data,
-        name,
-        workflowId,
-        workflowName,
-        inputParameters,
-      }}
+      data={merged}
     >
       <div className="space-y-2">
         <Label htmlFor="name">Name</Label>
         <RichInput
           id="name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={values.name}
+          onChange={(e) => setField("name", e.target.value)}
           placeholder="Workflow Executor"
           className="break-all w-full"
         />
@@ -166,7 +148,7 @@ export const WorkflowExecutorDialog: React.FC<
       <div className="space-y-2">
         <Label htmlFor="workflow">Select Workflow</Label>
         <Select
-          value={workflowId}
+          value={values.workflowId}
           onValueChange={handleWorkflowChange}
           disabled={loading}
         >
@@ -181,9 +163,9 @@ export const WorkflowExecutorDialog: React.FC<
             ))}
           </SelectContent>
         </Select>
-        {workflowName && (
+        {values.workflowName && (
           <p className="text-xs text-muted-foreground">
-            Selected: {workflowName}
+            Selected: {values.workflowName}
           </p>
         )}
       </div>
@@ -206,7 +188,7 @@ export const WorkflowExecutorDialog: React.FC<
                 </Label>
                 <DraggableInput
                   id={`param-${key}`}
-                  value={inputParameters[key] || ""}
+                  value={values.inputParameters[key] || ""}
                   onChange={(e) => handleParameterChange(key, e.target.value)}
                   placeholder={`Enter ${key}${field.required ? " (required)" : ""}`}
                   className="text-sm"
@@ -220,13 +202,13 @@ export const WorkflowExecutorDialog: React.FC<
         </div>
       )}
 
-      {workflowId && selectedWorkflowInputSchema && Object.keys(selectedWorkflowInputSchema).length === 0 && (
+      {values.workflowId && selectedWorkflowInputSchema && Object.keys(selectedWorkflowInputSchema).length === 0 && (
         <div className="text-sm text-muted-foreground text-center py-4">
           This workflow has no input parameters defined.
         </div>
       )}
 
-      {!workflowId && (
+      {!values.workflowId && (
         <div className="text-sm text-muted-foreground text-center py-4">
           Select a workflow to configure input parameters.
         </div>

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/ZendeskTicketDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/ZendeskTicketDialog.tsx
@@ -19,6 +19,7 @@ import { AppSettingDialog } from "@/views/AppSettings/components/AppSettingDialo
 import { CreateNewSelectItem } from "@/components/CreateNewSelectItem";
 import { DraggableInput } from "../components/custom/DraggableInput";
 import { DraggableTextArea } from "../components/custom/DraggableTextArea";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 type ZendeskTicketDialogProps = BaseNodeDialogProps<
   ZendeskTicketNodeData,
@@ -28,45 +29,49 @@ type ZendeskTicketDialogProps = BaseNodeDialogProps<
 export const ZendeskTicketDialog: React.FC<ZendeskTicketDialogProps> = (
   props
 ) => {
-  const { isOpen, onClose, data, onUpdate } = props;
+  const { isOpen, onClose, data } = props;
 
-  const [name, setName] = useState(data.name || "");
-  const [subject, setSubject] = useState(data.subject || "");
-  const [description, setDescription] = useState(data.description || "");
-  const [requesterName, setRequesterName] = useState(data.requester_name || "");
-  const [requesterEmail, setRequesterEmail] = useState(
-    data.requester_email || ""
-  );
-  const [tagsCsv, setTagsCsv] = useState((data.tags || []).join(", "));
-  const [appSettingsId, setAppSettingsId] = useState(
-    data.app_settings_id || ""
-  );
+  const { values, setField, setValues, merged, handleSave } =
+    useNodeDialogState(
+      props,
+      () => ({
+        name: data.name || "",
+        subject: data.subject || "",
+        description: data.description || "",
+        requester_name: data.requester_name || "",
+        requester_email: data.requester_email || "",
+        tagsCsv: (data.tags || []).join(", "),
+        custom_fields: (data.custom_fields || []) as Array<{
+          id: string;
+          value: string | number;
+        }>,
+        app_settings_id: data.app_settings_id || "",
+      }),
+      (v) => {
+        const tagsArr = v.tagsCsv
+          .split(",")
+          .map((t) => t.trim())
+          .filter(Boolean);
+        return {
+          name: v.name,
+          subject: v.subject,
+          description: v.description,
+          requester_name: v.requester_name,
+          requester_email: v.requester_email,
+          tags: tagsArr,
+          custom_fields:
+            v.custom_fields.length > 0 ? v.custom_fields : undefined,
+          app_settings_id: v.app_settings_id || undefined,
+        };
+      }
+    );
+
   const [appSettings, setAppSettings] = useState<AppSetting[]>([]);
   const [isLoadingAppSettings, setIsLoadingAppSettings] = useState(false);
   const [isCreateSettingOpen, setIsCreateSettingOpen] = useState(false);
-  const [customFields, setCustomFields] = useState<
-    Array<{ id: string; value: string | number }>
-  >(data.custom_fields || []);
-
-  const getTagsArr = () => {
-    return tagsCsv
-      .split(",")
-      .map((t) => t.trim())
-      .filter(Boolean);
-  };
 
   useEffect(() => {
     if (isOpen) {
-      setName(data.name || "");
-      setSubject(data.subject || "");
-      setDescription(data.description || "");
-      setRequesterName(data.requester_name || "");
-      setRequesterEmail(data.requester_email || "");
-      setTagsCsv((data.tags || []).join(", "));
-      setCustomFields(data.custom_fields || []);
-
-      setAppSettingsId(data.app_settings_id || "");
-
       const fetchAppSettings = async () => {
         setIsLoadingAppSettings(true);
         try {
@@ -83,27 +88,18 @@ export const ZendeskTicketDialog: React.FC<ZendeskTicketDialogProps> = (
     }
   }, [isOpen, data]);
 
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name,
-      subject,
-      description,
-      requester_name: requesterName,
-      requester_email: requesterEmail,
-      tags: getTagsArr(),
-      custom_fields: customFields.length > 0 ? customFields : undefined,
-      app_settings_id: appSettingsId || undefined,
-    });
-    onClose();
-  };
-
   const addCustomField = () => {
-    setCustomFields((prev) => [...prev, { id: "", value: "" }]);
+    setValues((v) => ({
+      ...v,
+      custom_fields: [...v.custom_fields, { id: "", value: "" }],
+    }));
   };
 
   const removeCustomField = (index: number) => {
-    setCustomFields((prev) => prev.filter((_, i) => i !== index));
+    setValues((v) => ({
+      ...v,
+      custom_fields: v.custom_fields.filter((_, i) => i !== index),
+    }));
   };
 
   const updateCustomField = (
@@ -111,14 +107,14 @@ export const ZendeskTicketDialog: React.FC<ZendeskTicketDialogProps> = (
     field: "id" | "value",
     value: string | number
   ) => {
-    setCustomFields((prev) => {
-      const updated = [...prev];
+    setValues((v) => {
+      const updated = [...v.custom_fields];
       if (field === "id") {
         updated[index] = { ...updated[index], id: String(value) };
       } else {
         updated[index] = { ...updated[index], value };
       }
-      return updated;
+      return { ...v, custom_fields: updated };
     });
   };
 
@@ -137,26 +133,14 @@ export const ZendeskTicketDialog: React.FC<ZendeskTicketDialogProps> = (
           </>
         }
         {...props}
-        data={
-          {
-            ...data,
-            name,
-            subject,
-            description,
-            requester_name: requesterName,
-            requester_email: requesterEmail,
-            tags: getTagsArr(),
-            custom_fields: customFields.length > 0 ? customFields : undefined,
-            app_settings_id: appSettingsId || undefined,
-          } as ZendeskTicketNodeData
-        }
+        data={merged}
       >
         <div className="space-y-2">
           <Label htmlFor="node-name">Node Name</Label>
           <RichInput
             id="node-name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="Enter the name of this node"
             className="w-full"
           />
@@ -165,13 +149,13 @@ export const ZendeskTicketDialog: React.FC<ZendeskTicketDialogProps> = (
         <div className="space-y-2">
           <Label htmlFor="app-settings-id">Configuration Vars (Optional)</Label>
           <Select
-            value={appSettingsId || ""}
+            value={values.app_settings_id || ""}
             onValueChange={(value) => {
               if (value === "__create__") {
                 setIsCreateSettingOpen(true);
                 return;
               }
-              setAppSettingsId(value || "");
+              setField("app_settings_id", value || "");
             }}
             disabled={isLoadingAppSettings}
           >
@@ -203,8 +187,8 @@ export const ZendeskTicketDialog: React.FC<ZendeskTicketDialogProps> = (
               <Label htmlFor="subject">Subject</Label>
               <DraggableInput
                 id="subject"
-                value={subject}
-                onChange={(e) => setSubject(e.target.value)}
+                value={values.subject}
+                onChange={(e) => setField("subject", e.target.value)}
                 placeholder="Enter ticket subject"
                 className="w-full"
               />
@@ -214,8 +198,8 @@ export const ZendeskTicketDialog: React.FC<ZendeskTicketDialogProps> = (
               <DraggableTextArea
                 id="description"
                 rows={4}
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
+                value={values.description}
+                onChange={(e) => setField("description", e.target.value)}
                 placeholder="Enter the issue or request description"
                 className="w-full resize-none"
               />
@@ -230,8 +214,8 @@ export const ZendeskTicketDialog: React.FC<ZendeskTicketDialogProps> = (
               <Label htmlFor="requester_name">Requester Name</Label>
               <DraggableInput
                 id="requester_name"
-                value={requesterName}
-                onChange={(e) => setRequesterName(e.target.value)}
+                value={values.requester_name}
+                onChange={(e) => setField("requester_name", e.target.value)}
                 placeholder="e.g., Alice Smith"
                 className="w-full"
               />
@@ -241,8 +225,8 @@ export const ZendeskTicketDialog: React.FC<ZendeskTicketDialogProps> = (
               <DraggableInput
                 id="requester_email"
                 type="email"
-                value={requesterEmail}
-                onChange={(e) => setRequesterEmail(e.target.value)}
+                value={values.requester_email}
+                onChange={(e) => setField("requester_email", e.target.value)}
                 placeholder="e.g., alice@example.com"
                 className="w-full break-all"
               />
@@ -257,8 +241,8 @@ export const ZendeskTicketDialog: React.FC<ZendeskTicketDialogProps> = (
               <Label htmlFor="tags">Tags</Label>
               <DraggableInput
                 id="tags"
-                value={tagsCsv}
-                onChange={(e) => setTagsCsv(e.target.value)}
+                value={values.tagsCsv}
+                onChange={(e) => setField("tagsCsv", e.target.value)}
                 placeholder="e.g., support, urgent, follow-up"
                 className="w-full"
               />
@@ -280,7 +264,7 @@ export const ZendeskTicketDialog: React.FC<ZendeskTicketDialogProps> = (
             </Button>
           </div>
           <div className="space-y-2">
-            {customFields.map((field, index) => (
+            {values.custom_fields.map((field, index) => (
               <div key={index} className="flex gap-2 items-end">
                 <div className="flex-1 space-y-2">
                   <Label htmlFor={`custom-field-id-${index}`}>Field ID</Label>
@@ -317,7 +301,7 @@ export const ZendeskTicketDialog: React.FC<ZendeskTicketDialogProps> = (
                 </Button>
               </div>
             ))}
-            {customFields.length === 0 && (
+            {values.custom_fields.length === 0 && (
               <p className="text-sm text-muted-foreground">
                 No custom fields added. Click "Add Field" to add one.
               </p>
@@ -339,7 +323,7 @@ export const ZendeskTicketDialog: React.FC<ZendeskTicketDialogProps> = (
           } catch (e) {
             // ignore
           }
-          if (created?.id) setAppSettingsId(created.id);
+          if (created?.id) setField("app_settings_id", created.id);
         }}
       />
     </>

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/readMailsDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/readMailsDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { ReadMailsNodeData, SearchCriteria } from "../types/nodes";
 import { DataSource } from "@/interfaces/dataSource.interface";
 import { Button } from "@/components/button";
@@ -19,6 +19,7 @@ import { DraggableTextArea } from "../components/custom/DraggableTextArea";
 import { BaseNodeDialogProps } from "./base";
 import { DataSourceDialog } from "@/views/DataSources/components/DataSourceDialog";
 import { CreateNewSelectItem } from "@/components/CreateNewSelectItem";
+import { useNodeDialogState } from "./useNodeDialogState";
 
 interface ReadMailsDialogProps
   extends BaseNodeDialogProps<ReadMailsNodeData, ReadMailsNodeData> {
@@ -67,40 +68,25 @@ const emptySearchCriteria: SearchCriteria = {
 };
 
 export const ReadMailsDialog: React.FC<ReadMailsDialogProps> = (props) => {
-  const { isOpen, onClose, data, onUpdate, connectors } = props;
+  const { onClose, data, connectors } = props;
 
-  const [name, setName] = useState(data.name || "");
-  const [dataSourceId, setDataSourceId] = useState(
-    data.dataSourceId?.toString() || ""
-  );
-  const [searchCriteria, setSearchCriteria] = useState<SearchCriteria>(
-    data.searchCriteria || emptySearchCriteria
-  );
+  const { values, setField, setValues, merged, handleSave } =
+    useNodeDialogState(props, () => ({
+      name: data.name || "",
+      dataSourceId: data.dataSourceId?.toString() || "",
+      searchCriteria: data.searchCriteria || emptySearchCriteria,
+    }));
+
   const [isCreateDataSourceOpen, setIsCreateDataSourceOpen] = useState(false);
-
-  useEffect(() => {
-    if (isOpen) {
-      setName(data.name || "");
-      setDataSourceId(data.dataSourceId?.toString() || "");
-      setSearchCriteria(data.searchCriteria || emptySearchCriteria);
-    }
-  }, [isOpen, data]);
-
-  const handleSave = () => {
-    onUpdate({
-      ...data,
-      name,
-      dataSourceId,
-      searchCriteria,
-    });
-    onClose();
-  };
 
   const updateSearchCriteriaField = (
     key: keyof SearchCriteria,
     value: string | boolean | number
   ) => {
-    setSearchCriteria((prev) => ({ ...prev, [key]: value }));
+    setValues((v) => ({
+      ...v,
+      searchCriteria: { ...v.searchCriteria, [key]: value },
+    }));
   };
 
   return (
@@ -117,21 +103,14 @@ export const ReadMailsDialog: React.FC<ReadMailsDialogProps> = (props) => {
           </>
         }
         {...props}
-        data={
-          {
-            ...data,
-            name,
-            dataSourceId,
-            searchCriteria,
-          } as ReadMailsNodeData
-        }
+        data={merged}
       >
         <div className="space-y-2">
           <Label htmlFor="node-name">Node Name</Label>
           <RichInput
             id="node-name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="Enter the name of this node"
             className="w-full"
           />
@@ -140,13 +119,13 @@ export const ReadMailsDialog: React.FC<ReadMailsDialogProps> = (props) => {
         <div className="space-y-2">
           <Label>Gmail Data Source</Label>
           <Select
-            value={dataSourceId?.toString() || "none"}
+            value={values.dataSourceId?.toString() || "none"}
             onValueChange={(v) => {
               if (v === "__create__") {
                 setIsCreateDataSourceOpen(true);
                 return;
               }
-              setDataSourceId(v === "none" ? "" : v);
+              setField("dataSourceId", v === "none" ? "" : v);
             }}
           >
             <SelectTrigger>
@@ -174,7 +153,7 @@ export const ReadMailsDialog: React.FC<ReadMailsDialogProps> = (props) => {
             <Label htmlFor="from">From Email</Label>
             <DraggableInput
               id="from"
-              value={searchCriteria.from}
+              value={values.searchCriteria.from}
               onChange={(e) =>
                 updateSearchCriteriaField("from", e.target.value)
               }
@@ -187,7 +166,7 @@ export const ReadMailsDialog: React.FC<ReadMailsDialogProps> = (props) => {
             <Label htmlFor="to">To Email</Label>
             <DraggableInput
               id="to"
-              value={searchCriteria.to}
+              value={values.searchCriteria.to}
               onChange={(e) => updateSearchCriteriaField("to", e.target.value)}
               placeholder="recipient@example.com"
               className="w-full break-all"
@@ -199,7 +178,7 @@ export const ReadMailsDialog: React.FC<ReadMailsDialogProps> = (props) => {
           <Label htmlFor="subject">Subject Contains</Label>
           <DraggableInput
             id="subject"
-            value={searchCriteria.subject}
+            value={values.searchCriteria.subject}
             onChange={(e) =>
               updateSearchCriteriaField("subject", e.target.value)
             }
@@ -211,7 +190,7 @@ export const ReadMailsDialog: React.FC<ReadMailsDialogProps> = (props) => {
         <div className="space-y-2">
           <Label>Gmail Label</Label>
           <Select
-            value={searchCriteria.label || "none"}
+            value={values.searchCriteria.label || "none"}
             onValueChange={(v) =>
               updateSearchCriteriaField("label", v === "none" ? "" : v)
             }
@@ -234,7 +213,7 @@ export const ReadMailsDialog: React.FC<ReadMailsDialogProps> = (props) => {
           <div className="space-y-2">
             <Label>Newer Than</Label>
             <Select
-              value={searchCriteria.newer_than || "none"}
+              value={values.searchCriteria.newer_than || "none"}
               onValueChange={(v) =>
                 updateSearchCriteriaField("newer_than", v === "none" ? "" : v)
               }
@@ -255,7 +234,7 @@ export const ReadMailsDialog: React.FC<ReadMailsDialogProps> = (props) => {
           <div className="space-y-2">
             <Label>Older Than</Label>
             <Select
-              value={searchCriteria.older_than || "none"}
+              value={values.searchCriteria.older_than || "none"}
               onValueChange={(v) =>
                 updateSearchCriteriaField("older_than", v === "none" ? "" : v)
               }
@@ -279,7 +258,7 @@ export const ReadMailsDialog: React.FC<ReadMailsDialogProps> = (props) => {
           <RichInput
             id="max_results"
             type="number"
-            value={searchCriteria.max_results}
+            value={values.searchCriteria.max_results}
             onChange={(e) =>
               updateSearchCriteriaField("max_results", parseInt(e.target.value))
             }
@@ -294,7 +273,7 @@ export const ReadMailsDialog: React.FC<ReadMailsDialogProps> = (props) => {
           <div className="flex items-center space-x-2">
             <Checkbox
               id="has_attachment"
-              checked={searchCriteria.has_attachment}
+              checked={values.searchCriteria.has_attachment}
               onCheckedChange={(c) =>
                 updateSearchCriteriaField("has_attachment", c)
               }
@@ -307,7 +286,7 @@ export const ReadMailsDialog: React.FC<ReadMailsDialogProps> = (props) => {
           <div className="flex items-center space-x-2">
             <Checkbox
               id="is_unread"
-              checked={searchCriteria.is_unread}
+              checked={values.searchCriteria.is_unread}
               onCheckedChange={(c) => updateSearchCriteriaField("is_unread", c)}
             />
             <Label htmlFor="is_unread" className="cursor-pointer">
@@ -320,7 +299,7 @@ export const ReadMailsDialog: React.FC<ReadMailsDialogProps> = (props) => {
           <Label htmlFor="custom_query">Custom Gmail Query</Label>
           <DraggableTextArea
             id="custom_query"
-            value={searchCriteria.custom_query}
+            value={values.searchCriteria.custom_query}
             onChange={(e) =>
               updateSearchCriteriaField("custom_query", e.target.value)
             }
@@ -336,7 +315,7 @@ export const ReadMailsDialog: React.FC<ReadMailsDialogProps> = (props) => {
         isOpen={isCreateDataSourceOpen}
         onOpenChange={setIsCreateDataSourceOpen}
         onDataSourceSaved={(created) => {
-          if (created?.id) setDataSourceId(created.id);
+          if (created?.id) setField("dataSourceId", created.id);
         }}
         mode="create"
         defaultSourceType="gmail"

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/training/TrainDataSourceDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/training/TrainDataSourceDialog.tsx
@@ -18,6 +18,7 @@ import { NodeConfigPanel } from "../../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "../base";
 import { DraggableTextArea } from "../../components/custom/DraggableTextArea";
 import { FileUploader } from "@/components/FileUploader";
+import { useNodeDialogState } from "../useNodeDialogState";
 
 type TrainDataSourceDialogProps = BaseNodeDialogProps<
   TrainDataSourceNodeData,
@@ -29,15 +30,33 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
 ) => {
   const { isOpen, onClose, data, onUpdate } = props;
 
-  const [name, setName] = useState(data.name || "Train Data Source");
-  // sourceType is the single source of truth for which mode we're in
-  const [sourceType, setSourceType] = useState<"datasource" | "csv">(() => {
-    // Determine initial sourceType from existing data
-    if (data.sourceType === "datasource" && data.dataSourceId) {
-      return "datasource";
-    }
-    return "csv";
-  });
+  const { values, setField, setValues, merged } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name || "Train Data Source",
+      // Determine initial sourceType from existing data
+      sourceType: (data.sourceType === "datasource" && data.dataSourceId
+        ? "datasource"
+        : "csv") as "datasource" | "csv",
+      dataSourceId: data.dataSourceId ?? null,
+      query: data.query ?? null,
+      csvFileName: data.csvFileName ?? null,
+      csvFilePath: data.csvFilePath ?? null,
+      csvFileId: data.csvFileId ?? null,
+      csvFileUrl: data.csvFileUrl ?? null,
+    }),
+    (v) => ({
+      name: v.name,
+      sourceType: v.sourceType,
+      dataSourceId: v.dataSourceId ?? undefined,
+      query: v.query ?? undefined,
+      csvFileName: v.csvFileName ?? undefined,
+      csvFilePath: v.csvFilePath ?? undefined,
+      csvFileId: v.csvFileId ?? undefined,
+      csvFileUrl: v.csvFileUrl ?? undefined,
+    })
+  );
+
   // selectedSource tracks what's selected in the dropdown (datasource ID or "csv")
   const [selectedSource, setSelectedSource] = useState<string>(() => {
     if (data.sourceType === "datasource" && data.dataSourceId) {
@@ -45,12 +64,6 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
     }
     return "csv";
   });
-  const [dataSourceId, setDataSourceId] = useState(data.dataSourceId ?? null);
-  const [query, setQuery] = useState(data.query ?? null);
-  const [csvFileName, setCsvFileName] = useState(data.csvFileName ?? null);
-  const [csvFilePath, setCsvFilePath] = useState(data.csvFilePath ?? null);
-  const [csvFileId, setCsvFileId] = useState(data.csvFileId ?? null);
-  const [csvFileUrl, setCsvFileUrl] = useState(data.csvFileUrl ?? null);
   const [isCsvUploading, setIsCsvUploading] = useState(false);
   const [availableDataSources, setAvailableDataSources] = useState<
     DataSource[]
@@ -59,15 +72,11 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
 
   useEffect(() => {
     if (isOpen) {
-      setName(data.name || "Train Data Source");
-
       // Determine sourceType from data
       const currentSourceType: "datasource" | "csv" =
         data.sourceType === "datasource" && data.dataSourceId
           ? "datasource"
           : "csv";
-
-      setSourceType(currentSourceType);
 
       // Set selectedSource based on sourceType
       const initialSelectedSource =
@@ -76,12 +85,6 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
           : "csv";
 
       setSelectedSource(initialSelectedSource);
-      setDataSourceId(data.dataSourceId ?? null);
-      setQuery(data.query ?? null);
-      setCsvFileName(data.csvFileName ?? null);
-      setCsvFilePath(data.csvFilePath ?? null);
-      setCsvFileId(data.csvFileId ?? null);
-      setCsvFileUrl(data.csvFileUrl ?? null);
 
       const loadDataSources = async () => {
         try {
@@ -110,27 +113,30 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
 
     // If value is "csv", switch to CSV mode
     if (value === "csv") {
-      setSourceType("csv");
-      setDataSourceId(null);
-      // Clear query when switching to CSV mode
-      setQuery(null);
+      setValues((v) => ({
+        ...v,
+        sourceType: "csv",
+        dataSourceId: null,
+        // Clear query when switching to CSV mode
+        query: null,
+      }));
     } else {
       // Otherwise, it's a datasource ID - switch to datasource mode
-      setSourceType("datasource");
-      setDataSourceId(value);
-      // Preserve existing query if we're switching between datasources
-      // Only clear if we were previously in CSV mode
-      if (sourceType === "csv") {
-        setQuery(null);
-      }
-      // If query is already set and we're switching datasources, keep it
+      setValues((v) => ({
+        ...v,
+        sourceType: "datasource",
+        dataSourceId: value,
+        // Preserve existing query if we're switching between datasources
+        // Only clear if we were previously in CSV mode
+        query: v.sourceType === "csv" ? null : v.query,
+      }));
     }
   };
 
   const handleSave = async () => {
     // Validate based on source type
-    if (sourceType === "datasource") {
-      if (!dataSourceId || !query || !query.trim()) {
+    if (values.sourceType === "datasource") {
+      if (!values.dataSourceId || !values.query || !values.query.trim()) {
         toast({
           title: "Validation Error",
           description: "Please select a data source and provide a query",
@@ -138,8 +144,13 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
         });
         return;
       }
-    } else if (sourceType === "csv") {
-      if (!csvFileName && !csvFilePath && !csvFileId && !csvFileUrl) {
+    } else if (values.sourceType === "csv") {
+      if (
+        !values.csvFileName &&
+        !values.csvFilePath &&
+        !values.csvFileId &&
+        !values.csvFileUrl
+      ) {
         toast({
           title: "Validation Error",
           description: "Please upload a CSV file",
@@ -149,17 +160,7 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
       }
     }
 
-    onUpdate({
-      ...data,
-      name,
-      sourceType,
-      dataSourceId: dataSourceId ?? undefined,
-      query: query ?? undefined,
-      csvFileName: csvFileName ?? undefined,
-      csvFilePath: csvFilePath ?? undefined,
-      csvFileId: csvFileId ?? undefined,
-      csvFileUrl: csvFileUrl ?? undefined,
-    });
+    onUpdate(merged);
     onClose();
   };
 
@@ -182,14 +183,7 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
         </>
       }
       {...props}
-      data={{
-        ...data,
-        name,
-        sourceType,
-        dataSourceId,
-        query,
-        csvFileName,
-      }}
+      data={merged}
     >
       <div className="space-y-4">
         {/* Node Name */}
@@ -197,8 +191,8 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
           <Label htmlFor="name">Node Name</Label>
           <RichInput
             id="name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={values.name}
+            onChange={(e) => setField("name", e.target.value)}
             placeholder="Enter the name of this node"
             className="w-full"
           />
@@ -227,13 +221,13 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
         </div>
 
         {/* Data Source Configuration */}
-        {sourceType === "datasource" && (
+        {values.sourceType === "datasource" && (
           <div className="space-y-2">
             <Label htmlFor="query">Query *</Label>
             <DraggableTextArea
               id="query"
-              value={query ?? ""}
-              onChange={(e) => setQuery(e.target.value || null)}
+              value={values.query ?? ""}
+              onChange={(e) => setField("query", e.target.value || null)}
               placeholder="SELECT * FROM training_data WHERE ..."
               className="w-full min-h-[120px] font-mono text-sm"
             />
@@ -245,25 +239,31 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
         )}
 
         {/* CSV Upload Configuration */}
-        {sourceType === "csv" && (
+        {values.sourceType === "csv" && (
           <FileUploader
             label="Training File"
             acceptedFileTypes={[".csv"]}
-            initialServerFilePath={csvFilePath ?? ""}
-            initialServerFileUrl={csvFileUrl ?? ""}
-            initialOriginalFileName={csvFileName ?? ""}
+            initialServerFilePath={values.csvFilePath ?? ""}
+            initialServerFileUrl={values.csvFileUrl ?? ""}
+            initialOriginalFileName={values.csvFileName ?? ""}
             onUploadingChange={setIsCsvUploading}
             onUploadComplete={(result) => {
-              setCsvFileName(result.original_filename);
-              setCsvFilePath(result.file_path);
-              setCsvFileId(result.file_id);
-              setCsvFileUrl(result.file_url);
+              setValues((v) => ({
+                ...v,
+                csvFileName: result.original_filename,
+                csvFilePath: result.file_path,
+                csvFileId: result.file_id,
+                csvFileUrl: result.file_url,
+              }));
             }}
             onRemove={() => {
-              setCsvFileName(null);
-              setCsvFilePath(null);
-              setCsvFileId(null);
-              setCsvFileUrl(null);
+              setValues((v) => ({
+                ...v,
+                csvFileName: null,
+                csvFilePath: null,
+                csvFileId: null,
+                csvFileUrl: null,
+              }));
             }}
             placeholder="Select a CSV file to upload"
           />

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/training/TrainModelDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/training/TrainModelDialog.tsx
@@ -21,6 +21,7 @@ import { analyzeCSV, CSVAnalysisResult } from "@/services/mlModels";
 import { CSVAnalysisDisplay } from "./components/CSVAnalysisDisplay";
 import { useWorkflowExecution } from "../../context/WorkflowExecutionContext";
 import { extractDynamicVariables, getValueFromPath } from "../../utils/helpers";
+import { useNodeDialogState } from "../useNodeDialogState";
 
 type TrainModelDialogProps = BaseNodeDialogProps<
   TrainModelNodeData,
@@ -31,59 +32,55 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
   const { isOpen, onClose, data, onUpdate, nodeId } = props;
   const { getAvailableDataForNode } = useWorkflowExecution();
 
-  const [name, setName] = useState(data.name || "Train Model");
-  const [fileUrl, setFileUrl] = useState(data.fileUrl || "");
-  const [modelType, setModelType] = useState(data.modelType || "xgboost");
-  const [targetColumn, setTargetColumn] = useState(data.targetColumn || "");
-  const [featureColumns, setFeatureColumns] = useState<string[]>(
-    data.featureColumns || []
+  const { values, setField, setValues, merged } = useNodeDialogState(
+    props,
+    () => ({
+      name: data.name || "Train Model",
+      fileUrl: data.fileUrl || "",
+      modelType: data.modelType || "xgboost",
+      targetColumn: data.targetColumn || "",
+      featureColumns: data.featureColumns || [],
+      modelParameters: data.modelParameters || {},
+      validationSplit: data.validationSplit || 0.2,
+      analysisResult: data.analysisResult || null,
+    }),
+    (v) => ({
+      name: v.name,
+      fileUrl: v.fileUrl,
+      analysisResult: v.analysisResult || undefined,
+      modelType: v.modelType,
+      targetColumn: v.targetColumn,
+      featureColumns: v.featureColumns,
+      modelParameters: v.modelParameters,
+      validationSplit: v.validationSplit,
+    })
   );
-  const [modelParameters, setModelParameters] = useState<Record<string, unknown>>(
-    data.modelParameters || {}
-  );
-  const [validationSplit, setValidationSplit] = useState(
-    data.validationSplit || 0.2
-  );
-  const [isAnalyzing, setIsAnalyzing] = useState(false);
-  const [analysisResult, setAnalysisResult] = useState<CSVAnalysisResult | null>(null);
-  const { toast } = useToast();
 
-  useEffect(() => {
-    if (isOpen) {
-      setName(data.name || "Train Model");
-      setFileUrl(data.fileUrl || "");
-      setModelType(data.modelType || "xgboost");
-      setTargetColumn(data.targetColumn || "");
-      setFeatureColumns(data.featureColumns || []);
-      setModelParameters(data.modelParameters || {});
-      setValidationSplit(data.validationSplit || 0.2);
-      setAnalysisResult(data.analysisResult || null);
-    }
-  }, [isOpen, data]);
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const { toast } = useToast();
 
   // Clean up featureColumns: remove targetColumn and invalid columns
   useEffect(() => {
-    setFeatureColumns((prev) => {
-      let cleaned = [...prev];
-      
+    setValues((v) => {
+      let cleaned = [...v.featureColumns];
+
       // Remove targetColumn if it's in featureColumns
-      if (targetColumn) {
-        cleaned = cleaned.filter((col) => col !== targetColumn);
+      if (v.targetColumn) {
+        cleaned = cleaned.filter((col) => col !== v.targetColumn);
       }
-      
+
       // If we have analysisResult, only keep columns that exist in the analysis
-      if (analysisResult) {
-        cleaned = cleaned.filter((col) =>
-          analysisResult.column_names.includes(col)
-        );
+      if (v.analysisResult) {
+        const analysis = v.analysisResult;
+        cleaned = cleaned.filter((col) => analysis.column_names.includes(col));
       }
-      
-      return cleaned;
+
+      return { ...v, featureColumns: cleaned };
     });
-  }, [targetColumn, analysisResult]);
+  }, [values.targetColumn, values.analysisResult, setValues]);
 
   const handleSave = () => {
-    if (!targetColumn.trim()) {
+    if (!values.targetColumn.trim()) {
       toast({
         title: "Validation Error",
         description: "Please specify the target column",
@@ -92,7 +89,7 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
       return;
     }
 
-    if (featureColumns.length === 0) {
+    if (values.featureColumns.length === 0) {
       toast({
         title: "Validation Error",
         description: "Please select at least one feature column",
@@ -101,22 +98,12 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
       return;
     }
 
-    onUpdate({
-      ...data,
-      name,
-      fileUrl,
-      analysisResult: analysisResult || undefined,
-      modelType,
-      targetColumn,
-      featureColumns,
-      modelParameters,
-      validationSplit,
-    });
+    onUpdate(merged);
     onClose();
   };
 
   const handleAnalyzeCSV = async () => {
-    if (!fileUrl.trim()) {
+    if (!values.fileUrl.trim()) {
       toast({
         title: "Validation Error",
         description: "Please provide a file URL to analyze",
@@ -127,23 +114,23 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
 
     try {
       setIsAnalyzing(true);
-      
-      let resolvedFileUrl = fileUrl;
-      const variables = extractDynamicVariables(fileUrl);
-      
+
+      let resolvedFileUrl = values.fileUrl;
+      const variables = extractDynamicVariables(values.fileUrl);
+
       if (variables.size > 0 && nodeId) {
         const availableData = getAvailableDataForNode(nodeId);
-        
+
         if (availableData) {
           variables.forEach((variable) => {
             const value = getValueFromPath(availableData, variable);
             if (value !== undefined) {
-              const stringValue = typeof value === "string" 
-                ? value 
-                : typeof value === "object" 
+              const stringValue = typeof value === "string"
+                ? value
+                : typeof value === "object"
                   ? JSON.stringify(value)
                   : String(value);
-              
+
               resolvedFileUrl = resolvedFileUrl.replace(
                 new RegExp(`{{${variable}}}`, "g"),
                 stringValue
@@ -152,10 +139,10 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
           });
         }
       }
-      
+
       const result = await analyzeCSV(resolvedFileUrl);
-      setAnalysisResult(result);
-      
+      setField("analysisResult", result);
+
       toast({
         title: "Analysis Complete",
         description: `Found ${result.column_count} columns and ${result.row_count} rows`,
@@ -173,29 +160,35 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
 
 
   const addFeatureColumn = () => {
-    setFeatureColumns([...featureColumns, ""]);
+    setField("featureColumns", [...values.featureColumns, ""]);
   };
 
   const updateFeatureColumn = (index: number, value: string) => {
-    const newColumns = [...featureColumns];
+    const newColumns = [...values.featureColumns];
     newColumns[index] = value;
-    setFeatureColumns(newColumns);
+    setField("featureColumns", newColumns);
   };
 
   const removeFeatureColumn = (index: number) => {
-    setFeatureColumns(featureColumns.filter((_, i) => i !== index));
+    setField(
+      "featureColumns",
+      values.featureColumns.filter((_, i) => i !== index)
+    );
   };
 
   const handleFeatureColumnToggle = (columnName: string) => {
     // Prevent adding targetColumn as a feature
-    if (columnName === targetColumn) {
+    if (columnName === values.targetColumn) {
       return;
     }
-    const isSelected = featureColumns.includes(columnName);
+    const isSelected = values.featureColumns.includes(columnName);
     if (isSelected) {
-      setFeatureColumns(featureColumns.filter((col) => col !== columnName));
+      setField(
+        "featureColumns",
+        values.featureColumns.filter((col) => col !== columnName)
+      );
     } else {
-      setFeatureColumns([...featureColumns, columnName]);
+      setField("featureColumns", [...values.featureColumns, columnName]);
     }
   };
 
@@ -205,11 +198,11 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
       .split(",")
       .map((col) => col.trim())
       .filter((col) => col.length > 0);
-    setFeatureColumns(parsedColumns);
+    setField("featureColumns", parsedColumns);
   };
 
   const handleModelTypeChange = (value: string) => {
-    setModelType(value as TrainModelNodeData["modelType"]);
+    setField("modelType", value as TrainModelNodeData["modelType"]);
   };
 
   return (
@@ -229,17 +222,7 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
           </>
         }
         {...props}
-        data={{
-          ...data,
-          name,
-          fileUrl,
-          analysisResult: analysisResult || undefined,
-          modelType,
-          targetColumn,
-          featureColumns,
-          modelParameters,
-          validationSplit,
-        }}
+        data={merged}
       >
         <div className="space-y-4">
           {/* Node Name */}
@@ -247,8 +230,8 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
             <Label htmlFor="name">Node Name</Label>
             <RichInput
               id="name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
+              value={values.name}
+              onChange={(e) => setField("name", e.target.value)}
               placeholder="Enter the name of this node"
               className="w-full"
             />
@@ -261,8 +244,8 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
                 <DraggableInput
                   id="fileUrl"
                   label="File URL"
-                  value={fileUrl}
-                  onChange={(e) => setFileUrl(e.target.value)}
+                  value={values.fileUrl}
+                  onChange={(e) => setField("fileUrl", e.target.value)}
                   placeholder="Enter file URL or drag variable"
                   className="w-full"
                 />
@@ -271,22 +254,22 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
                 type="button"
                 variant="outline"
                 onClick={handleAnalyzeCSV}
-                disabled={isAnalyzing || !fileUrl.trim()}
+                disabled={isAnalyzing || !values.fileUrl.trim()}
                 className="mb-0"
               >
                 <Search className="h-4 w-4 mr-2" />
                 {isAnalyzing ? "Analyzing..." : "Analyze"}
               </Button>
             </div>
-            {analysisResult && (
-              <CSVAnalysisDisplay analysisResult={analysisResult} />
+            {values.analysisResult && (
+              <CSVAnalysisDisplay analysisResult={values.analysisResult} />
             )}
           </div>
 
           {/* Model Type */}
           <div className="space-y-2">
             <Label htmlFor="modelType">Model Type *</Label>
-            <Select value={modelType} onValueChange={handleModelTypeChange}>
+            <Select value={values.modelType} onValueChange={handleModelTypeChange}>
               <SelectTrigger className="w-full">
                 <SelectValue placeholder="Select model type" />
               </SelectTrigger>
@@ -313,13 +296,16 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
           {/* Target Column */}
           <div className="space-y-2">
             <Label htmlFor="targetColumn">Target Column *</Label>
-            {analysisResult ? (
-              <Select value={targetColumn} onValueChange={setTargetColumn}>
+            {values.analysisResult ? (
+              <Select
+                value={values.targetColumn}
+                onValueChange={(v) => setField("targetColumn", v)}
+              >
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="Select target column" />
                 </SelectTrigger>
                 <SelectContent>
-                  {analysisResult.column_names.map((columnName) => (
+                  {values.analysisResult.column_names.map((columnName) => (
                     <SelectItem key={columnName} value={columnName}>
                       {columnName}
                     </SelectItem>
@@ -329,8 +315,8 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
             ) : (
               <DraggableInput
                 id="targetColumn"
-                value={targetColumn}
-                onChange={(e) => setTargetColumn(e.target.value)}
+                value={values.targetColumn}
+                onChange={(e) => setField("targetColumn", e.target.value)}
                 placeholder="Enter target column name"
                 className="w-full"
               />
@@ -343,14 +329,15 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
           {/* Feature Columns */}
           <div className="space-y-2">
             <Label>Feature Columns *</Label>
-            {analysisResult ? (
+            {values.analysisResult ? (
               /* Badge view when column names are available */
               <div className="space-y-3">
                 <div className="flex flex-wrap gap-2 max-h-64 overflow-y-auto p-2 border rounded">
-                  {analysisResult.column_names
-                    .filter((columnName) => columnName !== targetColumn)
+                  {values.analysisResult.column_names
+                    .filter((columnName) => columnName !== values.targetColumn)
                     .map((columnName) => {
-                      const isSelected = featureColumns.includes(columnName);
+                      const isSelected =
+                        values.featureColumns.includes(columnName);
                       return (
                         <Badge
                           key={columnName}
@@ -364,9 +351,9 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
                     })}
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  {featureColumns.length} of{" "}
-                  {analysisResult.column_names.filter(
-                    (col) => col !== targetColumn
+                  {values.featureColumns.length} of{" "}
+                  {values.analysisResult.column_names.filter(
+                    (col) => col !== values.targetColumn
                   ).length}{" "}
                   columns selected. Click badges to toggle selection.
                 </p>
@@ -388,17 +375,17 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
                 </div>
                 <div className="space-y-2">
                   <RichInput
-                    value={featureColumns.join(", ")}
+                    value={values.featureColumns.join(", ")}
                     onChange={(e) =>
                       handleCommaSeparatedInputChange(e.target.value)
                     }
                     placeholder="Enter column names separated by commas (e.g., col1, col2, col3)"
                     className="w-full"
                   />
-                  {featureColumns.length > 0 && (
+                  {values.featureColumns.length > 0 && (
                     <>
                       <div className="flex flex-wrap gap-2 p-2 border rounded bg-muted">
-                        {featureColumns.map((column, index) => (
+                        {values.featureColumns.map((column, index) => (
                           <div key={index} className="flex items-center gap-1">
                             <Badge variant="default">{column}</Badge>
                             <Button
@@ -413,12 +400,12 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
                         ))}
                       </div>
                       <p className="text-xs text-muted-foreground">
-                        {featureColumns.length} column
-                        {featureColumns.length !== 1 ? "s" : ""} added
+                        {values.featureColumns.length} column
+                        {values.featureColumns.length !== 1 ? "s" : ""} added
                       </p>
                     </>
                   )}
-                  {featureColumns.length === 0 && (
+                  {values.featureColumns.length === 0 && (
                     <p className="text-sm text-muted-foreground italic">
                       No feature columns defined. Add columns to specify which
                       features to use for training.
@@ -435,11 +422,11 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
           {/* Validation Split */}
           <div className="space-y-2">
             <Label>
-              Validation Split: {Math.round(validationSplit * 100)}%
+              Validation Split: {Math.round(values.validationSplit * 100)}%
             </Label>
             <Slider
-              value={[validationSplit]}
-              onValueChange={(value) => setValidationSplit(value[0])}
+              value={[values.validationSplit]}
+              onValueChange={(value) => setField("validationSplit", value[0])}
               max={0.5}
               min={0.1}
               step={0.05}

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/useNodeDialogState.ts
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/useNodeDialogState.ts
@@ -1,0 +1,99 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { NodeData } from "../types/nodes";
+import { BaseNodeDialogProps } from "./base";
+
+export interface NodeDialogState<T extends NodeData, V extends object> {
+  /** Current in-progress field values (local edit state). */
+  values: V;
+  /** Replace the whole values object (use for multi-field updates in one handler). */
+  setValues: React.Dispatch<React.SetStateAction<V>>;
+  /** Update a single field by key. */
+  setField: <K extends keyof V>(key: K, value: V[K]) => void;
+  /**
+   * Original node `data` overlaid with the in-progress edits (after `toPayload`, when
+   * provided). Pass this as `NodeConfigPanel`'s `data` prop AND it is what `handleSave`
+   * persists — keeping unsaved-changes detection and the save payload in lockstep.
+   */
+  merged: T;
+  /** Persist `merged` via `onUpdate`, then `onClose`. */
+  handleSave: () => void;
+}
+
+/**
+ * Shared state/lifecycle for node configuration dialogs.
+ *
+ * Every node dialog repeats the same wrapper boilerplate:
+ *   - seed local field state from `data`
+ *   - re-seed whenever the panel (re)opens or the node data changes (`[isOpen, data]`)
+ *   - build a live "merged" object ({ ...data, ...edits }) used both as the save payload
+ *     and as `NodeConfigPanel`'s `data` prop (which powers unsaved-changes detection — so
+ *     every editable field must be represented there)
+ *   - save via `onUpdate(merged)` then `onClose()`
+ *
+ * This hook centralizes that behavior. It is opt-in and behavior-preserving: dialogs
+ * migrate one at a time.
+ *
+ * Two forms:
+ *   1. `useNodeDialogState(props, seed)` — `values` is a subset of the node data
+ *      (`Partial<T>`); `merged = { ...data, ...values }`. Use when the save payload is a
+ *      plain field merge.
+ *   2. `useNodeDialogState(props, seed, toPayload)` — `values` may be any local edit shape
+ *      (extra/intermediate keys, different names); `toPayload(values, data)` maps it to the
+ *      persisted `Partial<T>`, and `merged = { ...data, ...toPayload(values, data) }`. Use
+ *      for save-time transforms (empty→undefined, renamed keys, derived/parsed fields).
+ *
+ * @param props     Standard node-dialog props ({ isOpen, onClose, data, onUpdate, ... }).
+ * @param seed      Returns the initial field values from the current `data`. Re-invoked on
+ *                  every (re)open; the latest closure is always used, so it may read fresh
+ *                  props/context without being memoized by the caller.
+ * @param toPayload Optional: maps `values` to the node-data patch to merge & persist.
+ */
+export function useNodeDialogState<T extends NodeData, V extends Partial<T>>(
+  props: BaseNodeDialogProps<T, T>,
+  seed: () => V
+): NodeDialogState<T, V>;
+export function useNodeDialogState<T extends NodeData, V extends object>(
+  props: BaseNodeDialogProps<T, T>,
+  seed: () => V,
+  toPayload: (values: V, data: T) => Partial<T>
+): NodeDialogState<T, V>;
+export function useNodeDialogState<T extends NodeData, V extends object>(
+  props: BaseNodeDialogProps<T, T>,
+  seed: () => V,
+  toPayload?: (values: V, data: T) => Partial<T>
+): NodeDialogState<T, V> {
+  const { isOpen, data, onUpdate, onClose } = props;
+
+  // Hold the latest closures so the re-seed effect can keep `[isOpen, data]` deps without
+  // listing `seed`/`toPayload` (which get a new identity on every render).
+  const seedRef = useRef(seed);
+  seedRef.current = seed;
+  const toPayloadRef = useRef(toPayload);
+  toPayloadRef.current = toPayload;
+
+  const [values, setValues] = useState<V>(() => seedRef.current());
+
+  // Mirror the historical `useEffect(() => { if (isOpen) { ...re-seed... } }, [isOpen, data])`
+  // present in every node dialog: re-seed on open and whenever the node data changes.
+  useEffect(() => {
+    if (isOpen) {
+      setValues(seedRef.current());
+    }
+  }, [isOpen, data]);
+
+  const setField = useCallback(<K extends keyof V>(key: K, value: V[K]) => {
+    setValues((prev) => ({ ...prev, [key]: value }) as V);
+  }, []);
+
+  const patch = toPayloadRef.current
+    ? toPayloadRef.current(values, data)
+    : (values as unknown as Partial<T>);
+  const merged = { ...data, ...patch } as T;
+
+  const handleSave = () => {
+    onUpdate(merged);
+    onClose();
+  };
+
+  return { values, setValues, setField, merged, handleSave };
+}


### PR DESCRIPTION
## Description

feat: refactor node dialog state management with useNodeDialogState hook

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- Introduced a new custom hook `useNodeDialogState` to centralize state management for node dialogs.
- Simplified state updates and handling of input changes by using `setField` and `setValues` methods from the hook.
- Updated Node Dialogs across web to utilize the new hook for managing local state and merging with props.
- Improved code readability and maintainability by reducing repetitive state management logic across dialogs.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
