### PR TITLE
feat: move raw SQLAlchemy out of services into repositories

### DIFF
--- a/backend/app/repositories/analytics_aggregation.py
+++ b/backend/app/repositories/analytics_aggregation.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import date, datetime, time, timezone
+from uuid import UUID
 
 from injector import inject
 from sqlalchemy import func, select
@@ -8,8 +9,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.utils.date_time_utils import utc_now
 from app.db.base import generate_sequential_uuid
+from app.db.models.agent import AgentModel
 from app.db.models.agent_execution_daily_stats import AgentExecutionDailyStatsModel
 from app.db.models.agent_response_log import AgentResponseLogModel
+from app.db.models.conversation import ConversationModel
 from app.db.models.node_execution_daily_stats import NodeExecutionDailyStatsModel
 
 logger = logging.getLogger(__name__)
@@ -24,6 +27,272 @@ class AnalyticsAggregationRepository:
     @inject
     def __init__(self, db: AsyncSession):
         self.db = db
+
+    # ───────────── real-time incremental upserts ─────────────
+    # Single-execution counterparts of the batch aggregation below. Each issues one
+    # INSERT ... ON CONFLICT DO UPDATE with atomic += increments. They do NOT commit;
+    # the caller owns the transaction boundary (one commit per unit of work).
+    async def increment_agent_daily_stats(self, data: dict) -> None:
+        """Upsert a single execution's contribution into agent_execution_daily_stats."""
+        now = datetime.now(timezone.utc)
+        response_ms = data["response_ms"]
+        nodes = data["nodes"]
+
+        # Compute per-execution node success rate
+        node_success_rate = None
+        if nodes:
+            success_nodes = sum(1 for n in nodes if n["is_success"])
+            node_success_rate = success_nodes / len(nodes)
+
+        input_tokens = data.get("input_tokens")
+        output_tokens = data.get("output_tokens")
+        cost_usd = data.get("cost_usd") or 0.0
+
+        row = {
+            "id": generate_sequential_uuid(),
+            "agent_id": data["agent_id"],
+            "stat_date": data["stat_date"],
+            "execution_count": 1,
+            "success_count": 1 if data["is_success"] else 0,
+            "error_count": 0 if data["is_success"] else 1,
+            "avg_response_ms": response_ms,
+            "min_response_ms": response_ms,
+            "max_response_ms": response_ms,
+            "total_response_ms": response_ms,
+            "total_nodes_executed": data["total_nodes_executed"],
+            "avg_success_rate": node_success_rate,
+            "total_success_rate_sum": node_success_rate,
+            "rag_used_count": 1 if data["rag_used"] else 0,
+            "unique_conversations": 0,
+            "finalized_conversations": 0,
+            "in_progress_conversations": 0,
+            "thumbs_up_count": 0,
+            "thumbs_down_count": 0,
+            "total_input_tokens": input_tokens or 0,
+            "total_output_tokens": output_tokens or 0,
+            "total_cost_usd": cost_usd,
+            "last_aggregated_at": now,
+            "is_deleted": 0,
+            "created_at": now,
+            "updated_at": now,
+        }
+
+        stmt = insert(AgentExecutionDailyStatsModel).values(row)
+        tbl = AgentExecutionDailyStatsModel.__table__
+
+        update_set = {
+            "execution_count": tbl.c.execution_count + stmt.excluded.execution_count,
+            "success_count": tbl.c.success_count + stmt.excluded.success_count,
+            "error_count": tbl.c.error_count + stmt.excluded.error_count,
+            "total_nodes_executed": tbl.c.total_nodes_executed + stmt.excluded.total_nodes_executed,
+            "rag_used_count": tbl.c.rag_used_count + stmt.excluded.rag_used_count,
+            "total_input_tokens": func.coalesce(tbl.c.total_input_tokens, 0) + (input_tokens or 0),
+            "total_output_tokens": func.coalesce(tbl.c.total_output_tokens, 0) + (output_tokens or 0),
+            "total_cost_usd": func.coalesce(tbl.c.total_cost_usd, 0.0) + cost_usd,
+            "last_aggregated_at": stmt.excluded.last_aggregated_at,
+            "updated_at": stmt.excluded.updated_at,
+        }
+
+        if response_ms is not None:
+            update_set["total_response_ms"] = (
+                func.coalesce(tbl.c.total_response_ms, 0.0) + response_ms
+            )
+            update_set["avg_response_ms"] = (
+                (func.coalesce(tbl.c.total_response_ms, 0.0) + response_ms)
+                / (tbl.c.execution_count + 1)
+            )
+            update_set["min_response_ms"] = func.least(
+                func.coalesce(tbl.c.min_response_ms, response_ms), response_ms
+            )
+            update_set["max_response_ms"] = func.greatest(
+                func.coalesce(tbl.c.max_response_ms, response_ms), response_ms
+            )
+
+        if node_success_rate is not None:
+            update_set["total_success_rate_sum"] = (
+                func.coalesce(tbl.c.total_success_rate_sum, 0.0) + node_success_rate
+            )
+            update_set["avg_success_rate"] = (
+                (func.coalesce(tbl.c.total_success_rate_sum, 0.0) + node_success_rate)
+                / (tbl.c.execution_count + 1)
+            )
+
+        stmt = stmt.on_conflict_do_update(
+            constraint="uq_agent_execution_daily_stats_agent_date",
+            set_=update_set,
+        )
+        await self.db.execute(stmt)
+
+    async def increment_node_daily_stats(self, data: dict) -> None:
+        """Upsert each node's contribution into node_execution_daily_stats."""
+        now = datetime.now(timezone.utc)
+
+        for node in data["nodes"]:
+            exec_ms = node["execution_ms"]
+
+            row = {
+                "id": generate_sequential_uuid(),
+                "agent_id": data["agent_id"],
+                "node_type": node["type"],
+                "stat_date": data["stat_date"],
+                "execution_count": 1,
+                "success_count": 1 if node["is_success"] else 0,
+                "failure_count": 0 if node["is_success"] else 1,
+                "avg_execution_ms": exec_ms,
+                "min_execution_ms": exec_ms,
+                "max_execution_ms": exec_ms,
+                "total_execution_ms": exec_ms,
+                "is_deleted": 0,
+                "created_at": now,
+                "updated_at": now,
+            }
+
+            stmt = insert(NodeExecutionDailyStatsModel).values(row)
+            tbl = NodeExecutionDailyStatsModel.__table__
+
+            update_set = {
+                "execution_count": tbl.c.execution_count + stmt.excluded.execution_count,
+                "success_count": tbl.c.success_count + stmt.excluded.success_count,
+                "failure_count": tbl.c.failure_count + stmt.excluded.failure_count,
+                "updated_at": stmt.excluded.updated_at,
+            }
+
+            if exec_ms is not None:
+                update_set["total_execution_ms"] = (
+                    func.coalesce(tbl.c.total_execution_ms, 0.0) + exec_ms
+                )
+                update_set["avg_execution_ms"] = (
+                    (func.coalesce(tbl.c.total_execution_ms, 0.0) + exec_ms)
+                    / (tbl.c.execution_count + 1)
+                )
+                update_set["min_execution_ms"] = func.least(
+                    func.coalesce(tbl.c.min_execution_ms, exec_ms), exec_ms
+                )
+                update_set["max_execution_ms"] = func.greatest(
+                    func.coalesce(tbl.c.max_execution_ms, exec_ms), exec_ms
+                )
+
+            stmt = stmt.on_conflict_do_update(
+                constraint="uq_node_execution_daily_stats_agent_node_date",
+                set_=update_set,
+            )
+            await self.db.execute(stmt)
+
+    async def increment_conversation_counts(self, agent_id: UUID, event: str) -> None:
+        """Increment conversation counters on agent_execution_daily_stats.
+
+        event: "start"    → unique_conversations += 1, in_progress_conversations += 1
+        event: "finalize" → finalized_conversations += 1, in_progress_conversations -= 1
+        """
+        now = datetime.now(timezone.utc)
+        stat_date = now.date()
+
+        row = {
+            "id": generate_sequential_uuid(),
+            "agent_id": agent_id,
+            "stat_date": stat_date,
+            "execution_count": 0,
+            "success_count": 0,
+            "error_count": 0,
+            "total_nodes_executed": 0,
+            "avg_success_rate": None,
+            "rag_used_count": 0,
+            "unique_conversations": 1 if event == "start" else 0,
+            "finalized_conversations": 1 if event == "finalize" else 0,
+            "in_progress_conversations": 1 if event == "start" else 0,
+            "thumbs_up_count": 0,
+            "thumbs_down_count": 0,
+            "last_aggregated_at": now,
+            "is_deleted": 0,
+            "created_at": now,
+            "updated_at": now,
+        }
+
+        stmt = insert(AgentExecutionDailyStatsModel).values(row)
+        tbl = AgentExecutionDailyStatsModel.__table__
+
+        if event == "start":
+            update_set = {
+                "unique_conversations": tbl.c.unique_conversations + 1,
+                "in_progress_conversations": tbl.c.in_progress_conversations + 1,
+                "updated_at": stmt.excluded.updated_at,
+            }
+        else:  # finalize
+            update_set = {
+                "finalized_conversations": tbl.c.finalized_conversations + 1,
+                "in_progress_conversations": func.greatest(
+                    tbl.c.in_progress_conversations - 1, 0
+                ),
+                "updated_at": stmt.excluded.updated_at,
+            }
+
+        stmt = stmt.on_conflict_do_update(
+            constraint="uq_agent_execution_daily_stats_agent_date",
+            set_=update_set,
+        )
+        await self.db.execute(stmt)
+
+    async def get_agent_id_for_conversation(self, conversation_id: UUID) -> UUID | None:
+        """Look up the agent_id for a conversation via its operator_id."""
+        result = await self.db.execute(
+            select(ConversationModel.operator_id).where(
+                ConversationModel.id == conversation_id
+            )
+        )
+        operator_id = result.scalar_one_or_none()
+        if not operator_id:
+            return None
+
+        result = await self.db.execute(
+            select(AgentModel.id).where(AgentModel.operator_id == operator_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def increment_thumbs(self, agent_id: UUID, is_thumbs_up: bool) -> None:
+        """Increment thumbs_up_count or thumbs_down_count on agent_execution_daily_stats."""
+        now = datetime.now(timezone.utc)
+        stat_date = now.date()
+
+        row = {
+            "id": generate_sequential_uuid(),
+            "agent_id": agent_id,
+            "stat_date": stat_date,
+            "execution_count": 0,
+            "success_count": 0,
+            "error_count": 0,
+            "total_nodes_executed": 0,
+            "avg_success_rate": None,
+            "rag_used_count": 0,
+            "unique_conversations": 0,
+            "finalized_conversations": 0,
+            "in_progress_conversations": 0,
+            "thumbs_up_count": 1 if is_thumbs_up else 0,
+            "thumbs_down_count": 0 if is_thumbs_up else 1,
+            "last_aggregated_at": now,
+            "is_deleted": 0,
+            "created_at": now,
+            "updated_at": now,
+        }
+
+        stmt = insert(AgentExecutionDailyStatsModel).values(row)
+        tbl = AgentExecutionDailyStatsModel.__table__
+
+        if is_thumbs_up:
+            update_set = {
+                "thumbs_up_count": tbl.c.thumbs_up_count + 1,
+                "updated_at": stmt.excluded.updated_at,
+            }
+        else:
+            update_set = {
+                "thumbs_down_count": tbl.c.thumbs_down_count + 1,
+                "updated_at": stmt.excluded.updated_at,
+            }
+
+        stmt = stmt.on_conflict_do_update(
+            constraint="uq_agent_execution_daily_stats_agent_date",
+            set_=update_set,
+        )
+        await self.db.execute(stmt)
 
     async def get_last_aggregation_timestamp(self) -> datetime | None:
         """Return the latest last_aggregated_at across all agent daily stats rows."""

--- a/backend/app/repositories/user_groups.py
+++ b/backend/app/repositories/user_groups.py
@@ -1,7 +1,14 @@
+from typing import List
+from uuid import UUID
+
 from injector import inject
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.db.models.role import RoleModel
 from app.db.models.user_group import UserGroupModel
+from app.db.models.user_role import UserRoleModel
+from app.db.models.user_supervised_group import UserSupervisedGroupModel
 from app.repositories.db_repository import DbRepository
 
 
@@ -9,3 +16,52 @@ from app.repositories.db_repository import DbRepository
 class UserGroupRepository(DbRepository[UserGroupModel]):
     def __init__(self, db: AsyncSession):
         super().__init__(UserGroupModel, db)
+
+    # ───────────── supervisor assignments ─────────────
+    async def user_has_supervisor_role(self, user_id: UUID) -> bool:
+        """Return True if the user is assigned the "supervisor" role."""
+        result = await self.db.execute(
+            select(UserRoleModel)
+            .join(RoleModel, RoleModel.id == UserRoleModel.role_id)
+            .where(
+                UserRoleModel.user_id == user_id,
+                RoleModel.name == "supervisor",
+            )
+        )
+        return result.scalars().first() is not None
+
+    async def is_supervisor(self, group_id: UUID, user_id: UUID) -> bool:
+        """Return True if the user is already a supervisor of the group."""
+        result = await self.db.execute(
+            select(UserSupervisedGroupModel).where(
+                UserSupervisedGroupModel.group_id == group_id,
+                UserSupervisedGroupModel.user_id == user_id,
+            )
+        )
+        return result.scalars().first() is not None
+
+    async def add_supervisor(self, group_id: UUID, user_id: UUID) -> UserSupervisedGroupModel:
+        """Assign the user as a supervisor of the group and persist it."""
+        link = UserSupervisedGroupModel(group_id=group_id, user_id=user_id)
+        self.db.add(link)
+        await self.db.commit()
+        return link
+
+    async def remove_supervisor(self, group_id: UUID, user_id: UUID) -> None:
+        """Remove the user's supervisor assignment from the group."""
+        await self.db.execute(
+            delete(UserSupervisedGroupModel).where(
+                UserSupervisedGroupModel.group_id == group_id,
+                UserSupervisedGroupModel.user_id == user_id,
+            )
+        )
+        await self.db.commit()
+
+    async def get_supervisor_user_ids(self, group_id: UUID) -> List[UUID]:
+        """Return the user IDs of all supervisors of the group."""
+        result = await self.db.execute(
+            select(UserSupervisedGroupModel.user_id).where(
+                UserSupervisedGroupModel.group_id == group_id
+            )
+        )
+        return list(result.scalars().all())

--- a/backend/app/services/analytics_realtime.py
+++ b/backend/app/services/analytics_realtime.py
@@ -3,21 +3,16 @@ Real-time incremental analytics update.
 
 Fired as a background asyncio.create_task after each agent_response_log is saved.
 If this fails, the Celery worker's next run does a full recount — no data is lost.
+
+Data access lives in AnalyticsAggregationRepository; this module handles parsing
+of the raw agent_response payload and orchestration (tenant scope + commit).
 """
 
 import logging
 from datetime import datetime, timezone
 from uuid import UUID
 
-from sqlalchemy import func, select
-from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
-
-from app.db.base import generate_sequential_uuid
-from app.db.models.agent import AgentModel
-from app.db.models.agent_execution_daily_stats import AgentExecutionDailyStatsModel
-from app.db.models.conversation import ConversationModel
-from app.db.models.node_execution_daily_stats import NodeExecutionDailyStatsModel
 
 logger = logging.getLogger(__name__)
 
@@ -110,237 +105,6 @@ def parse_agent_response_for_stats(agent_response: dict) -> dict | None:
     }
 
 
-async def _increment_agent_daily_stats(session: AsyncSession, data: dict) -> None:
-    """
-    Upsert a single execution's contribution into agent_execution_daily_stats
-    using INSERT ... ON CONFLICT DO UPDATE with atomic += increments.
-    """
-    now = datetime.now(timezone.utc)
-    response_ms = data["response_ms"]
-    nodes = data["nodes"]
-
-    # Compute per-execution node success rate
-    node_success_rate = None
-    if nodes:
-        success_nodes = sum(1 for n in nodes if n["is_success"])
-        node_success_rate = success_nodes / len(nodes)
-
-    input_tokens = data.get("input_tokens")
-    output_tokens = data.get("output_tokens")
-    cost_usd = data.get("cost_usd") or 0.0
-
-    row = {
-        "id": generate_sequential_uuid(),
-        "agent_id": data["agent_id"],
-        "stat_date": data["stat_date"],
-        "execution_count": 1,
-        "success_count": 1 if data["is_success"] else 0,
-        "error_count": 0 if data["is_success"] else 1,
-        "avg_response_ms": response_ms,
-        "min_response_ms": response_ms,
-        "max_response_ms": response_ms,
-        "total_response_ms": response_ms,
-        "total_nodes_executed": data["total_nodes_executed"],
-        "avg_success_rate": node_success_rate,
-        "total_success_rate_sum": node_success_rate,
-        "rag_used_count": 1 if data["rag_used"] else 0,
-        "unique_conversations": 0,
-        "finalized_conversations": 0,
-        "in_progress_conversations": 0,
-        "thumbs_up_count": 0,
-        "thumbs_down_count": 0,
-        "total_input_tokens": input_tokens or 0,
-        "total_output_tokens": output_tokens or 0,
-        "total_cost_usd": cost_usd,
-        "last_aggregated_at": now,
-        "is_deleted": 0,
-        "created_at": now,
-        "updated_at": now,
-    }
-
-    stmt = insert(AgentExecutionDailyStatsModel).values(row)
-    tbl = AgentExecutionDailyStatsModel.__table__
-
-    update_set = {
-        "execution_count": tbl.c.execution_count + stmt.excluded.execution_count,
-        "success_count": tbl.c.success_count + stmt.excluded.success_count,
-        "error_count": tbl.c.error_count + stmt.excluded.error_count,
-        "total_nodes_executed": tbl.c.total_nodes_executed + stmt.excluded.total_nodes_executed,
-        "rag_used_count": tbl.c.rag_used_count + stmt.excluded.rag_used_count,
-        "total_input_tokens": func.coalesce(tbl.c.total_input_tokens, 0) + (input_tokens or 0),
-        "total_output_tokens": func.coalesce(tbl.c.total_output_tokens, 0) + (output_tokens or 0),
-        "total_cost_usd": func.coalesce(tbl.c.total_cost_usd, 0.0) + cost_usd,
-        "last_aggregated_at": stmt.excluded.last_aggregated_at,
-        "updated_at": stmt.excluded.updated_at,
-    }
-
-    if response_ms is not None:
-        update_set["total_response_ms"] = (
-            func.coalesce(tbl.c.total_response_ms, 0.0) + response_ms
-        )
-        update_set["avg_response_ms"] = (
-            (func.coalesce(tbl.c.total_response_ms, 0.0) + response_ms)
-            / (tbl.c.execution_count + 1)
-        )
-        update_set["min_response_ms"] = func.least(
-            func.coalesce(tbl.c.min_response_ms, response_ms), response_ms
-        )
-        update_set["max_response_ms"] = func.greatest(
-            func.coalesce(tbl.c.max_response_ms, response_ms), response_ms
-        )
-
-    if node_success_rate is not None:
-        update_set["total_success_rate_sum"] = (
-            func.coalesce(tbl.c.total_success_rate_sum, 0.0) + node_success_rate
-        )
-        update_set["avg_success_rate"] = (
-            (func.coalesce(tbl.c.total_success_rate_sum, 0.0) + node_success_rate)
-            / (tbl.c.execution_count + 1)
-        )
-
-    stmt = stmt.on_conflict_do_update(
-        constraint="uq_agent_execution_daily_stats_agent_date",
-        set_=update_set,
-    )
-    await session.execute(stmt)
-
-
-async def _increment_node_daily_stats(session: AsyncSession, data: dict) -> None:
-    """
-    Upsert each node's contribution into node_execution_daily_stats
-    using INSERT ... ON CONFLICT DO UPDATE with atomic += increments.
-    """
-    now = datetime.now(timezone.utc)
-
-    for node in data["nodes"]:
-        exec_ms = node["execution_ms"]
-
-        row = {
-            "id": generate_sequential_uuid(),
-            "agent_id": data["agent_id"],
-            "node_type": node["type"],
-            "stat_date": data["stat_date"],
-            "execution_count": 1,
-            "success_count": 1 if node["is_success"] else 0,
-            "failure_count": 0 if node["is_success"] else 1,
-            "avg_execution_ms": exec_ms,
-            "min_execution_ms": exec_ms,
-            "max_execution_ms": exec_ms,
-            "total_execution_ms": exec_ms,
-            "is_deleted": 0,
-            "created_at": now,
-            "updated_at": now,
-        }
-
-        stmt = insert(NodeExecutionDailyStatsModel).values(row)
-        tbl = NodeExecutionDailyStatsModel.__table__
-
-        update_set = {
-            "execution_count": tbl.c.execution_count + stmt.excluded.execution_count,
-            "success_count": tbl.c.success_count + stmt.excluded.success_count,
-            "failure_count": tbl.c.failure_count + stmt.excluded.failure_count,
-            "updated_at": stmt.excluded.updated_at,
-        }
-
-        if exec_ms is not None:
-            update_set["total_execution_ms"] = (
-                func.coalesce(tbl.c.total_execution_ms, 0.0) + exec_ms
-            )
-            update_set["avg_execution_ms"] = (
-                (func.coalesce(tbl.c.total_execution_ms, 0.0) + exec_ms)
-                / (tbl.c.execution_count + 1)
-            )
-            update_set["min_execution_ms"] = func.least(
-                func.coalesce(tbl.c.min_execution_ms, exec_ms), exec_ms
-            )
-            update_set["max_execution_ms"] = func.greatest(
-                func.coalesce(tbl.c.max_execution_ms, exec_ms), exec_ms
-            )
-
-        stmt = stmt.on_conflict_do_update(
-            constraint="uq_node_execution_daily_stats_agent_node_date",
-            set_=update_set,
-        )
-        await session.execute(stmt)
-
-
-async def _increment_conversation_counts(
-    session: AsyncSession, agent_id: UUID, event: str,
-) -> None:
-    """
-    Increment conversation counters on agent_execution_daily_stats.
-
-    event: "start" → unique_conversations += 1, in_progress_conversations += 1
-    event: "finalize" → finalized_conversations += 1, in_progress_conversations -= 1
-    """
-    now = datetime.now(timezone.utc)
-    stat_date = now.date()
-
-    row = {
-        "id": generate_sequential_uuid(),
-        "agent_id": agent_id,
-        "stat_date": stat_date,
-        "execution_count": 0,
-        "success_count": 0,
-        "error_count": 0,
-        "total_nodes_executed": 0,
-        "avg_success_rate": None,
-        "rag_used_count": 0,
-        "unique_conversations": 1 if event == "start" else 0,
-        "finalized_conversations": 1 if event == "finalize" else 0,
-        "in_progress_conversations": 1 if event == "start" else 0,
-        "thumbs_up_count": 0,
-        "thumbs_down_count": 0,
-        "last_aggregated_at": now,
-        "is_deleted": 0,
-        "created_at": now,
-        "updated_at": now,
-    }
-
-    stmt = insert(AgentExecutionDailyStatsModel).values(row)
-    tbl = AgentExecutionDailyStatsModel.__table__
-
-    if event == "start":
-        update_set = {
-            "unique_conversations": tbl.c.unique_conversations + 1,
-            "in_progress_conversations": tbl.c.in_progress_conversations + 1,
-            "updated_at": stmt.excluded.updated_at,
-        }
-    else:  # finalize
-        update_set = {
-            "finalized_conversations": tbl.c.finalized_conversations + 1,
-            "in_progress_conversations": func.greatest(
-                tbl.c.in_progress_conversations - 1, 0
-            ),
-            "updated_at": stmt.excluded.updated_at,
-        }
-
-    stmt = stmt.on_conflict_do_update(
-        constraint="uq_agent_execution_daily_stats_agent_date",
-        set_=update_set,
-    )
-    await session.execute(stmt)
-
-
-async def _get_agent_id_for_conversation(
-    session: AsyncSession, conversation_id: UUID,
-) -> UUID | None:
-    """Look up the agent_id for a conversation via its operator_id."""
-    result = await session.execute(
-        select(ConversationModel.operator_id).where(
-            ConversationModel.id == conversation_id
-        )
-    )
-    operator_id = result.scalar_one_or_none()
-    if not operator_id:
-        return None
-
-    result = await session.execute(
-        select(AgentModel.id).where(AgentModel.operator_id == operator_id)
-    )
-    return result.scalar_one_or_none()
-
-
 # ---------------------------------------------------------------------------
 # Public entry points (called via asyncio.create_task)
 # ---------------------------------------------------------------------------
@@ -354,6 +118,7 @@ async def update_stats_incrementally(agent_response: dict) -> None:
     try:
         from app.core.utils.db_connection_utils import create_tenant_request_scope
         from app.dependencies.injector import injector
+        from app.repositories.analytics_aggregation import AnalyticsAggregationRepository
 
         data = parse_agent_response_for_stats(agent_response)
         if data is None:
@@ -362,8 +127,9 @@ async def update_stats_incrementally(agent_response: dict) -> None:
         async with create_tenant_request_scope():
             session = injector.get(AsyncSession)
             try:
-                await _increment_agent_daily_stats(session, data)
-                await _increment_node_daily_stats(session, data)
+                repo = AnalyticsAggregationRepository(session)
+                await repo.increment_agent_daily_stats(data)
+                await repo.increment_node_daily_stats(data)
                 await session.commit()
                 logger.debug(
                     "Incremental analytics update for agent %s", data["agent_id"]
@@ -383,11 +149,13 @@ async def update_conversation_started(agent_id: UUID) -> None:
     try:
         from app.core.utils.db_connection_utils import create_tenant_request_scope
         from app.dependencies.injector import injector
+        from app.repositories.analytics_aggregation import AnalyticsAggregationRepository
 
         async with create_tenant_request_scope():
             session = injector.get(AsyncSession)
             try:
-                await _increment_conversation_counts(session, agent_id, "start")
+                repo = AnalyticsAggregationRepository(session)
+                await repo.increment_conversation_counts(agent_id, "start")
                 await session.commit()
                 logger.debug("Conversation started for agent %s", agent_id)
             finally:
@@ -405,20 +173,18 @@ async def update_conversation_finalized(conversation_id: UUID) -> None:
     try:
         from app.core.utils.db_connection_utils import create_tenant_request_scope
         from app.dependencies.injector import injector
+        from app.repositories.analytics_aggregation import AnalyticsAggregationRepository
 
         async with create_tenant_request_scope():
             session = injector.get(AsyncSession)
             try:
-                agent_id = await _get_agent_id_for_conversation(
-                    session, conversation_id
-                )
+                repo = AnalyticsAggregationRepository(session)
+                agent_id = await repo.get_agent_id_for_conversation(conversation_id)
                 if agent_id is None:
                     return
-                await _increment_conversation_counts(session, agent_id, "finalize")
+                await repo.increment_conversation_counts(agent_id, "finalize")
                 await session.commit()
-                logger.debug(
-                    "Conversation finalized for agent %s", agent_id
-                )
+                logger.debug("Conversation finalized for agent %s", agent_id)
             finally:
                 await session.close()
 
@@ -429,74 +195,21 @@ async def update_conversation_finalized(conversation_id: UUID) -> None:
         )
 
 
-async def _increment_thumbs(
-    session: AsyncSession, agent_id: UUID, is_thumbs_up: bool,
-) -> None:
-    """
-    Increment thumbs_up_count or thumbs_down_count on agent_execution_daily_stats.
-    """
-    now = datetime.now(timezone.utc)
-    stat_date = now.date()
-
-    row = {
-        "id": generate_sequential_uuid(),
-        "agent_id": agent_id,
-        "stat_date": stat_date,
-        "execution_count": 0,
-        "success_count": 0,
-        "error_count": 0,
-        "total_nodes_executed": 0,
-        "avg_success_rate": None,
-        "rag_used_count": 0,
-        "unique_conversations": 0,
-        "finalized_conversations": 0,
-        "in_progress_conversations": 0,
-        "thumbs_up_count": 1 if is_thumbs_up else 0,
-        "thumbs_down_count": 0 if is_thumbs_up else 1,
-        "last_aggregated_at": now,
-        "is_deleted": 0,
-        "created_at": now,
-        "updated_at": now,
-    }
-
-    stmt = insert(AgentExecutionDailyStatsModel).values(row)
-    tbl = AgentExecutionDailyStatsModel.__table__
-
-    if is_thumbs_up:
-        update_set = {
-            "thumbs_up_count": tbl.c.thumbs_up_count + 1,
-            "updated_at": stmt.excluded.updated_at,
-        }
-    else:
-        update_set = {
-            "thumbs_down_count": tbl.c.thumbs_down_count + 1,
-            "updated_at": stmt.excluded.updated_at,
-        }
-
-    stmt = stmt.on_conflict_do_update(
-        constraint="uq_agent_execution_daily_stats_agent_date",
-        set_=update_set,
-    )
-    await session.execute(stmt)
-
-
-async def update_feedback_given(
-    conversation_id: UUID, is_thumbs_up: bool,
-) -> None:
+async def update_feedback_given(conversation_id: UUID, is_thumbs_up: bool) -> None:
     """Fired when feedback is given on a message. Increments thumbs counters."""
     try:
         from app.core.utils.db_connection_utils import create_tenant_request_scope
         from app.dependencies.injector import injector
+        from app.repositories.analytics_aggregation import AnalyticsAggregationRepository
 
         async with create_tenant_request_scope():
             session = injector.get(AsyncSession)
             try:
-                agent_id = await _get_agent_id_for_conversation(
-                    session, conversation_id
-                )
+                repo = AnalyticsAggregationRepository(session)
+                agent_id = await repo.get_agent_id_for_conversation(conversation_id)
                 if agent_id is None:
                     return
-                await _increment_thumbs(session, agent_id, is_thumbs_up)
+                await repo.increment_thumbs(agent_id, is_thumbs_up)
                 await session.commit()
                 logger.debug(
                     "Feedback (%s) recorded for agent %s",

--- a/backend/app/services/user_groups.py
+++ b/backend/app/services/user_groups.py
@@ -1,14 +1,10 @@
 from uuid import UUID
 
 from injector import inject
-from sqlalchemy import delete, select
 
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
-from app.db.models.role import RoleModel
 from app.db.models.user_group import UserGroupModel
-from app.db.models.user_role import UserRoleModel
-from app.db.models.user_supervised_group import UserSupervisedGroupModel
 from app.repositories.user_groups import UserGroupRepository
 from app.schemas.user_group import UserGroupCreate, UserGroupRead, UserGroupUpdate
 
@@ -54,51 +50,26 @@ class UserGroupService:
         if not group:
             raise AppException(error_key=ErrorKey.NOT_FOUND, status_code=404)
         # Verify the user has the supervisor role
-        role_check = await self.repository.db.execute(
-            select(UserRoleModel).join(RoleModel, RoleModel.id == UserRoleModel.role_id).where(
-                UserRoleModel.user_id == user_id,
-                RoleModel.name == "supervisor",
-            )
-        )
-        if not role_check.scalars().first():
+        if not await self.repository.user_has_supervisor_role(user_id):
             raise AppException(
                 error_key=ErrorKey.NOT_AUTHORIZED_ACCESS_RESOURCE,
                 status_code=400,
             )
         # Check not already assigned
-        existing = await self.repository.db.execute(
-            select(UserSupervisedGroupModel).where(
-                UserSupervisedGroupModel.group_id == group_id,
-                UserSupervisedGroupModel.user_id == user_id,
-            )
-        )
-        if existing.scalars().first():
+        if await self.repository.is_supervisor(group_id, user_id):
             return {"message": "User is already a supervisor of this group"}
-        obj = UserSupervisedGroupModel(group_id=group_id, user_id=user_id)
-        self.repository.db.add(obj)
-        await self.repository.db.commit()
+        await self.repository.add_supervisor(group_id, user_id)
         return {"message": f"User {user_id} added as supervisor of group {group_id}"}
 
     async def remove_supervisor(self, group_id: UUID, user_id: UUID) -> dict:
         group = await self.repository.get_by_id(group_id)
         if not group:
             raise AppException(error_key=ErrorKey.NOT_FOUND, status_code=404)
-        await self.repository.db.execute(
-            delete(UserSupervisedGroupModel).where(
-                UserSupervisedGroupModel.group_id == group_id,
-                UserSupervisedGroupModel.user_id == user_id,
-            )
-        )
-        await self.repository.db.commit()
+        await self.repository.remove_supervisor(group_id, user_id)
         return {"message": f"User {user_id} removed as supervisor of group {group_id}"}
 
     async def get_supervisors(self, group_id: UUID) -> list[UUID]:
         group = await self.repository.get_by_id(group_id)
         if not group:
             raise AppException(error_key=ErrorKey.NOT_FOUND, status_code=404)
-        result = await self.repository.db.execute(
-            select(UserSupervisedGroupModel.user_id).where(
-                UserSupervisedGroupModel.group_id == group_id
-            )
-        )
-        return list(result.scalars().all())
+        return await self.repository.get_supervisor_user_ids(group_id)

--- a/backend/tests/unit/test_analytics_realtime_parse.py
+++ b/backend/tests/unit/test_analytics_realtime_parse.py
@@ -1,0 +1,103 @@
+"""Unit tests for analytics_realtime.parse_agent_response_for_stats.
+
+Pure parsing logic (no DB) that turns a raw agent_response payload into the
+data dict the incremental-stats repository methods consume.
+"""
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from app.services.analytics_realtime import parse_agent_response_for_stats
+
+_AGENT_ID = "019f60f3-5c20-715c-850b-ffc8f458ee30"
+
+
+def test_returns_none_when_agent_id_missing():
+    assert parse_agent_response_for_stats({}) is None
+    assert parse_agent_response_for_stats({"status": "success"}) is None
+
+
+def test_returns_none_when_agent_id_invalid():
+    assert parse_agent_response_for_stats({"agent_id": "not-a-uuid"}) is None
+
+
+def test_minimal_success_payload():
+    data = parse_agent_response_for_stats({"agent_id": _AGENT_ID, "status": "success"})
+    assert data is not None
+    assert data["agent_id"] == UUID(_AGENT_ID)
+    assert data["is_success"] is True
+    assert data["response_ms"] is None
+    assert data["rag_used"] is False
+    assert data["nodes"] == []
+    assert data["total_nodes_executed"] == 0
+    assert data["stat_date"] == datetime.now(timezone.utc).date()
+
+
+def test_failed_status_is_not_success():
+    data = parse_agent_response_for_stats({"agent_id": _AGENT_ID, "status": "failed"})
+    assert data is not None
+    assert data["is_success"] is False
+
+
+def test_completed_status_counts_as_success():
+    data = parse_agent_response_for_stats({"agent_id": _AGENT_ID, "status": "completed"})
+    assert data["is_success"] is True
+
+
+def test_parses_response_time_and_rag():
+    payload = {
+        "agent_id": _AGENT_ID,
+        "status": "success",
+        "rag_used": True,
+        "row_agent_response": {
+            "performance_metrics": {"totalExecutionTime": "1234.5"},
+        },
+    }
+    data = parse_agent_response_for_stats(payload)
+    assert data["response_ms"] == 1234.5
+    assert data["rag_used"] is True
+
+
+def test_parses_nodes_from_dict_status_map():
+    payload = {
+        "agent_id": _AGENT_ID,
+        "status": "success",
+        "row_agent_response": {
+            "state": {
+                "nodeExecutionStatus": {
+                    "n1": {"type": "llm", "status": "success", "time_taken": "50"},
+                    "n2": {"type": "tool", "status": "failed", "execution_time_ms": 20},
+                }
+            }
+        },
+    }
+    data = parse_agent_response_for_stats(payload)
+    assert data["total_nodes_executed"] == 2
+    by_type = {n["type"]: n for n in data["nodes"]}
+    assert by_type["llm"]["is_success"] is True
+    assert by_type["llm"]["execution_ms"] == 50.0
+    assert by_type["tool"]["is_success"] is False
+    assert by_type["tool"]["execution_ms"] == 20.0
+
+
+def test_parses_tokens_and_cost():
+    payload = {
+        "agent_id": _AGENT_ID,
+        "status": "success",
+        "token_usage": {"input_tokens": 10, "output_tokens": 20},
+        "cost_usd": 0.0031,
+    }
+    data = parse_agent_response_for_stats(payload)
+    assert data["input_tokens"] == 10
+    assert data["output_tokens"] == 20
+    assert data["cost_usd"] == 0.0031
+
+
+def test_bad_response_time_is_ignored():
+    payload = {
+        "agent_id": _AGENT_ID,
+        "status": "success",
+        "row_agent_response": {"performance_metrics": {"totalExecutionTime": "abc"}},
+    }
+    data = parse_agent_response_for_stats(payload)
+    assert data["response_ms"] is None


### PR DESCRIPTION
## Description

Restores the intended layering (routes → services → repositories → schemas) for two services that reached past their repositories and issued `select()` / `session.execute()` / inline `commit()` directly. From the internal Backend Architecture Audit (§03–§04). Pure refactor — **no behavior change**; SQL was moved verbatim.

**`user_groups`** — `UserGroupService` bypassed its repository via `self.repository.db.execute(...)` for the supervisor operations. Moved those into `UserGroupRepository`:
- `user_has_supervisor_role`, `is_supervisor`, `add_supervisor`, `remove_supervisor`, `get_supervisor_user_ids`

The service now contains only business logic (not-found checks, "already a supervisor" message) and no longer imports `sqlalchemy`.

**`analytics_realtime`** — a module of functions that each took a `session` and ran PostgreSQL upserts (`INSERT ... ON CONFLICT DO UPDATE`) inline. Moved the five DB helpers into `AnalyticsAggregationRepository`, which already owns those exact tables and the same upsert idiom (reuse):
- `increment_agent_daily_stats`, `increment_node_daily_stats`, `increment_conversation_counts`, `get_agent_id_for_conversation`, `increment_thumbs`

The service keeps the pure `parse_agent_response_for_stats` parsing and the tenant-scope + `commit()` orchestration. The four public entry points keep their names/signatures, so `conversations.py` and `chat_as_client_use_case.py` are unaffected.

**Transaction boundary:** repository methods do **not** commit — the caller keeps one commit per unit of work (e.g. `update_stats_incrementally` does two increments then a single commit). This preserves behavior and lines up with the future service-level transaction work.

## Type of Change

- [x] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 🧪 Test update

## Changes Made

- [x] Move supervisor queries into `UserGroupRepository` (5 methods); slim `UserGroupService`
- [x] Move incremental-stats DB helpers into `AnalyticsAggregationRepository` (5 methods)
- [x] Reduce `analytics_realtime` service to parsing + orchestration (no SQL construction)
- [x] Add unit tests for `parse_agent_response_for_stats`

## Testing

- [x] Unit tests — `tests/unit/test_analytics_realtime_parse.py` (9 tests) passing
- [x] Integration tests — all five analytics upserts + the lookup executed against real Postgres (FKs / unique constraints / `ON CONFLICT` valid), rolled back with nothing persisted
- [x] Manual testing — full user-groups supervisor flow end-to-end over HTTP (create → list → add → list → duplicate-add message → remove → list → delete), throwaway data cleaned up; `GET /api/user-groups` returns `200`
- [x] Wiring — all 10 repo methods present and async; services free of raw SQLAlchemy; consumer routes import cleanly

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] Multi-tenant considerations addressed (if applicable)

## Related Issues

Closes #<!-- Ticket 66663 -->

## Notes for reviewers

- SQL relocated verbatim; diff is mostly move-not-modify. Repository methods intentionally omit `commit()`.
- Out of scope: while testing I noticed `DELETE /api/user-groups/{id}` returns `200` but leaves the row with `is_deleted=0` (the delete path, untouched here). Flagging separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)