### PR TITLE
fix: align dashboard and agent conversation counts

### DIFF
--- a/backend/app/api/v1/routes/analytics.py
+++ b/backend/app/api/v1/routes/analytics.py
@@ -27,6 +27,42 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _validate_activity_bounds(
+    from_date: date | None,
+    to_date: date | None,
+    activity_from_datetime: datetime | None,
+    activity_to_datetime: datetime | None,
+    compare: bool = False,
+) -> None:
+    if activity_from_datetime is None and activity_to_datetime is None:
+        return
+    if compare:
+        raise HTTPException(
+            status_code=422,
+            detail="compare cannot be combined with exact activity boundaries",
+        )
+    if activity_from_datetime is None or activity_to_datetime is None:
+        raise HTTPException(
+            status_code=422,
+            detail="activity_from_datetime and activity_to_datetime must be supplied together",
+        )
+    if activity_from_datetime.utcoffset() is None or activity_to_datetime.utcoffset() is None:
+        raise HTTPException(
+            status_code=422,
+            detail="activity_from_datetime and activity_to_datetime must include a timezone offset",
+        )
+    if activity_from_datetime >= activity_to_datetime:
+        raise HTTPException(
+            status_code=422,
+            detail="activity_from_datetime must be earlier than activity_to_datetime",
+        )
+    if from_date is None or to_date is None:
+        raise HTTPException(
+            status_code=422,
+            detail="exact activity boundaries require both from_date and to_date",
+        )
+
+
 @router.get(
     "/agents",
     response_model=AgentDailyStatsListResponse,
@@ -106,14 +142,29 @@ async def get_agent_stats_summary(
     from_date: date | None = Query(default=None),
     to_date: date | None = Query(default=None),
     compare: bool = Query(default=False),
+    activity_from_datetime: datetime | None = Query(
+        default=None,
+        description="Inclusive start of the exact conversation-activity interval",
+    ),
+    activity_to_datetime: datetime | None = Query(
+        default=None,
+        description="Exclusive end of the exact conversation-activity interval",
+    ),
     service: AnalyticsReadService = Injected(AnalyticsReadService),
 ):
+    _validate_activity_bounds(from_date, to_date, activity_from_datetime, activity_to_datetime, compare)
+
     if compare:
         return await service.get_agent_stats_summary_with_comparison(
             agent_id=agent_id, group_id=group_id, from_date=from_date, to_date=to_date
         )
     return await service.get_agent_stats_summary(
-        agent_id=agent_id, group_id=group_id, from_date=from_date, to_date=to_date
+        agent_id=agent_id,
+        group_id=group_id,
+        from_date=from_date,
+        to_date=to_date,
+        activity_from_datetime=activity_from_datetime,
+        activity_to_datetime=activity_to_datetime,
     )
 
 
@@ -131,14 +182,32 @@ async def export_agent_performance(
     group_id: UUID | None = Query(default=None),
     from_date: date | None = Query(default=None),
     to_date: date | None = Query(default=None),
+    activity_from_datetime: datetime | None = Query(
+        default=None,
+        description="Inclusive start of the exact conversation-activity interval",
+    ),
+    activity_to_datetime: datetime | None = Query(
+        default=None,
+        description="Exclusive end of the exact conversation-activity interval",
+    ),
     service: AnalyticsReadService = Injected(AnalyticsReadService),
     agent_repo: AgentRepository = Injected(AgentRepository),
 ) -> StreamingResponse:
     if fmt not in VALID_FORMATS:
         raise HTTPException(status_code=400, detail=f"format must be one of: {', '.join(sorted(VALID_FORMATS))}")
 
+    _validate_activity_bounds(from_date, to_date, activity_from_datetime, activity_to_datetime)
+
     try:
-        summary, daily = await _fetch_agent_data(service, agent_id, group_id, from_date, to_date)
+        summary, daily = await _fetch_agent_data(
+            service,
+            agent_id,
+            group_id,
+            from_date,
+            to_date,
+            activity_from_datetime,
+            activity_to_datetime,
+        )
         agent_names = await get_agent_names(agent_repo)
 
         node_breakdown = None
@@ -386,10 +455,17 @@ async def _fetch_agent_data(
     group_id: UUID | None,
     from_date: date | None,
     to_date: date | None,
+    activity_from_datetime: datetime | None = None,
+    activity_to_datetime: datetime | None = None,
 ) -> tuple[AgentStatsSummaryResponse, AgentDailyStatsListResponse]:
     # Sequential — same SQLAlchemy session cannot handle concurrent operations
     summary = await service.get_agent_stats_summary(
-        agent_id=agent_id, group_id=group_id, from_date=from_date, to_date=to_date
+        agent_id=agent_id,
+        group_id=group_id,
+        from_date=from_date,
+        to_date=to_date,
+        activity_from_datetime=activity_from_datetime,
+        activity_to_datetime=activity_to_datetime,
     )
     daily = await service.get_agent_daily_stats(
         agent_id=agent_id, group_id=group_id, from_date=from_date, to_date=to_date

--- a/backend/app/api/v1/routes/dashboard.py
+++ b/backend/app/api/v1/routes/dashboard.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Literal
+from typing import Literal, NamedTuple
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi_injector import Injected
@@ -27,6 +27,13 @@ router = APIRouter()
 DEFAULT_SUMMARY_DAYS = 30
 
 
+class SummaryRange(NamedTuple):
+    """Resolved summary bounds"""
+    from_date: datetime | None
+    to_date: datetime | None
+    exact: bool
+
+
 def parse_date_range(days: int = 30) -> tuple[datetime, datetime]:
     """Parse days parameter into date range."""
     to_date = datetime.now(timezone.utc)
@@ -39,7 +46,7 @@ def resolve_summary_range(
     from_datetime: datetime | None,
     to_datetime: datetime | None,
     all_time: bool,
-) -> tuple[datetime | None, datetime | None]:
+) -> SummaryRange:
     """Resolve the summary range into bounds, rejecting mixed modes with a 422"""
     has_exact_boundary = from_datetime is not None or to_datetime is not None
 
@@ -49,7 +56,7 @@ def resolve_summary_range(
                 status_code=422,
                 detail="all_time cannot be combined with days, from_datetime or to_datetime",
             )
-        return None, None
+        return SummaryRange(None, None, exact=False)
 
     if has_exact_boundary:
         if days is not None:
@@ -72,9 +79,10 @@ def resolve_summary_range(
                 status_code=422,
                 detail="from_datetime must be earlier than to_datetime",
             )
-        return from_datetime, to_datetime
+        return SummaryRange(from_datetime, to_datetime, exact=True)
 
-    return parse_date_range(days if days is not None else DEFAULT_SUMMARY_DAYS)
+    rolling_from, rolling_to = parse_date_range(days if days is not None else DEFAULT_SUMMARY_DAYS)
+    return SummaryRange(rolling_from, rolling_to, exact=False)
 
 
 @router.get(
@@ -150,8 +158,10 @@ async def get_summary_stats(
     - Average response time in milliseconds
     - Total cost in USD
     """
-    from_date, to_date = resolve_summary_range(days, from_datetime, to_datetime, all_time)
-    return await dashboard_service.get_summary_stats(from_date, to_date)
+    summary_range = resolve_summary_range(days, from_datetime, to_datetime, all_time)
+    return await dashboard_service.get_summary_stats(
+        summary_range.from_date, summary_range.to_date, exact=summary_range.exact
+    )
 
 
 @router.get(

--- a/backend/app/api/v1/routes/dashboard.py
+++ b/backend/app/api/v1/routes/dashboard.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Literal
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi_injector import Injected
 
 from app.auth.dependencies import auth, permissions
@@ -24,11 +24,57 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+DEFAULT_SUMMARY_DAYS = 30
+
+
 def parse_date_range(days: int = 30) -> tuple[datetime, datetime]:
     """Parse days parameter into date range."""
     to_date = datetime.now(timezone.utc)
     from_date = to_date - timedelta(days=days)
     return from_date, to_date
+
+
+def resolve_summary_range(
+    days: int | None,
+    from_datetime: datetime | None,
+    to_datetime: datetime | None,
+    all_time: bool,
+) -> tuple[datetime | None, datetime | None]:
+    """Resolve the summary range into bounds, rejecting mixed modes with a 422"""
+    has_exact_boundary = from_datetime is not None or to_datetime is not None
+
+    if all_time:
+        if days is not None or has_exact_boundary:
+            raise HTTPException(
+                status_code=422,
+                detail="all_time cannot be combined with days, from_datetime or to_datetime",
+            )
+        return None, None
+
+    if has_exact_boundary:
+        if days is not None:
+            raise HTTPException(
+                status_code=422,
+                detail="days cannot be combined with from_datetime or to_datetime",
+            )
+        if from_datetime is None or to_datetime is None:
+            raise HTTPException(
+                status_code=422,
+                detail="from_datetime and to_datetime must be supplied together",
+            )
+        if from_datetime.utcoffset() is None or to_datetime.utcoffset() is None:
+            raise HTTPException(
+                status_code=422,
+                detail="from_datetime and to_datetime must include a timezone offset",
+            )
+        if from_datetime >= to_datetime:
+            raise HTTPException(
+                status_code=422,
+                detail="from_datetime must be earlier than to_datetime",
+            )
+        return from_datetime, to_datetime
+
+    return parse_date_range(days if days is not None else DEFAULT_SUMMARY_DAYS)
 
 
 @router.get(
@@ -50,7 +96,7 @@ async def get_dashboard(
 ) -> DashboardResponse:
     """
     Get complete dashboard data including:
-    - Summary statistics (active agents, workflow runs, avg response time)
+    - Summary statistics (active agents, conversations with agent activity, avg response time)
     - Active conversations with feedback counts (paginated)
     - Agent statistics (conversations today, resolution rate, etc.)
     - Active integrations
@@ -71,20 +117,40 @@ async def get_dashboard(
         Depends(permissions(P.Dashboard.READ)),
     ],
     summary="Get dashboard summary statistics",
-    description="Returns summary statistics: active agents count, workflow runs, and average response time.",
+    description=(
+        "Returns summary statistics: active agents count, conversations with agent activity, "
+        "and average response time."
+    ),
 )
 async def get_summary_stats(
-    days: int = Query(default=30, ge=1, le=365, description="Number of days to look back"),
+    days: int | None = Query(
+        default=None,
+        ge=1,
+        le=365,
+        description="Number of days to look back, defaults to 30 when no other range is supplied",
+    ),
+    from_datetime: datetime | None = Query(
+        default=None,
+        description="Inclusive start of an exact range, requires to_datetime and a timezone offset",
+    ),
+    to_datetime: datetime | None = Query(
+        default=None,
+        description="Exclusive end of an exact range, requires from_datetime and a timezone offset",
+    ),
+    all_time: bool = Query(
+        default=False,
+        description="Drop all date filtering, cannot be combined with days or an exact boundary",
+    ),
     dashboard_service: DashboardService = Injected(DashboardService),
 ) -> DashboardSummaryStats:
     """
     Get dashboard summary statistics:
     - Number of active agents
-    - Total workflow runs in the period
+    - Conversations with agent activity in the period
     - Average response time in milliseconds
     - Total cost in USD
     """
-    from_date, to_date = parse_date_range(days)
+    from_date, to_date = resolve_summary_range(days, from_datetime, to_datetime, all_time)
     return await dashboard_service.get_summary_stats(from_date, to_date)
 
 

--- a/backend/app/core/utils/date_time_utils.py
+++ b/backend/app/core/utils/date_time_utils.py
@@ -24,6 +24,21 @@ def utc_day_start(value: date | datetime) -> datetime:
         value = (value if value.tzinfo else value.replace(tzinfo=timezone.utc)).astimezone(timezone.utc).date()
     return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
 
+def exact_interval_bucket_dates(start: datetime, end_exclusive: datetime) -> tuple[date, date]:
+    """Returns the first and last UTC calendar day the interval overlaps"""
+    first = start.astimezone(timezone.utc).date()
+    last = (end_exclusive - timedelta(microseconds=1)).astimezone(timezone.utc).date()
+    return first, last
+
+
+def rolling_window_bucket_dates(start: datetime, end: datetime) -> tuple[date, date]:
+    """Kept for old callers: stat dates whose UTC midnight lands inside [start, end]"""
+    first = utc_day_start(start)
+    if start > first:
+        first += timedelta(days=1)
+    return first.date(), utc_day_start(end).date()
+
+
 def shift_datetime(unit: str, amount: int, operation: str = 'add', base_time: datetime = None) -> datetime:
     """
     Shift the given datetime by a specified amount of time units.

--- a/backend/app/repositories/analytics_read.py
+++ b/backend/app/repositories/analytics_read.py
@@ -97,15 +97,24 @@ class AnalyticsReadRepository:
         from_date: date | None,
         to_date: date | None,
         group_id: UUID | None = None,
+        activity_from_datetime: datetime | None = None,
+        activity_to_datetime: datetime | None = None,
     ):
-        """One row per (conversation, agent) with activity in the date range."""
+        """One row per (conversation, agent) with activity in the range."""
+        if (activity_from_datetime is None) != (activity_to_datetime is None):
+            raise ValueError("activity bounds must be supplied together")
+
         conditions = [AgentResponseLogModel.is_deleted == 0]
-        if from_date is not None:
-            start = datetime.combine(from_date, time.min, tzinfo=timezone.utc)
-            conditions.append(AgentResponseLogModel.logged_at >= start)
-        if to_date is not None:
-            end = datetime.combine(to_date, time.max, tzinfo=timezone.utc)
-            conditions.append(AgentResponseLogModel.logged_at <= end)
+        if activity_from_datetime is not None and activity_to_datetime is not None:
+            conditions.append(AgentResponseLogModel.logged_at >= activity_from_datetime)
+            conditions.append(AgentResponseLogModel.logged_at < activity_to_datetime)
+        else:
+            if from_date is not None:
+                start = datetime.combine(from_date, time.min, tzinfo=timezone.utc)
+                conditions.append(AgentResponseLogModel.logged_at >= start)
+            if to_date is not None:
+                end = datetime.combine(to_date, time.max, tzinfo=timezone.utc)
+                conditions.append(AgentResponseLogModel.logged_at <= end)
 
         stmt = (
             select(
@@ -142,6 +151,8 @@ class AnalyticsReadRepository:
         to_date: date | None = None,
         *,
         group_by_agent: bool = False,
+        activity_from_datetime: datetime | None = None,
+        activity_to_datetime: datetime | None = None,
     ) -> list[dict]:
         """
         Distinct conversations with agent activity in the period, split by current status.
@@ -167,7 +178,12 @@ class AnalyticsReadRepository:
             ConversationStatus.TAKE_OVER.value,
         )
         activity = self._conversations_with_activity_subquery(
-            agent_ids, from_date, to_date, group_id=group_id
+            agent_ids,
+            from_date,
+            to_date,
+            group_id=group_id,
+            activity_from_datetime=activity_from_datetime,
+            activity_to_datetime=activity_to_datetime,
         )
 
         if group_by_agent:
@@ -223,6 +239,9 @@ class AnalyticsReadRepository:
         group_id: UUID | None = None,
         from_date: date | None = None,
         to_date: date | None = None,
+        *,
+        activity_from_datetime: datetime | None = None,
+        activity_to_datetime: datetime | None = None,
     ) -> dict:
         agent_ids = await resolve_authorized_agent_ids(self.db, agent_id, group_id)
         if agent_ids is not None and not agent_ids and group_id is None:
@@ -285,6 +304,8 @@ class AnalyticsReadRepository:
             from_date=from_date,
             to_date=to_date,
             group_by_agent=False,
+            activity_from_datetime=activity_from_datetime,
+            activity_to_datetime=activity_to_datetime,
         )
         row.update(conv_rows[0])
         return row

--- a/backend/app/repositories/dashboard.py
+++ b/backend/app/repositories/dashboard.py
@@ -362,18 +362,27 @@ class DashboardRepository:
         return list(result.scalars().all())
 
     async def get_total_cost_usd(
-        self, from_date: datetime, to_date: datetime, *, agent_ids: list[UUID] | None
+        self,
+        from_date: Optional[datetime] = None,
+        to_date: Optional[datetime] = None,
+        *,
+        agent_ids: list[UUID] | None,
     ) -> float:
         """Total priced LLM cost over the range from the usage ledger"""
+        if (from_date is None) != (to_date is None):
+            raise ValueError("get_total_cost_usd needs both bounds or neither")
         if agent_ids is not None and not agent_ids:
             return 0.0
 
-        window_start, window_end = _ledger_window(from_date, to_date)
         query = select(func.coalesce(func.sum(LlmUsageEventModel.cost_usd), 0)).where(
             LlmUsageEventModel.is_deleted == 0,
-            LlmUsageEventModel.occurred_at >= window_start,
-            LlmUsageEventModel.occurred_at < window_end,
         )
+        if from_date is not None and to_date is not None:
+            window_start, window_end = _ledger_window(from_date, to_date)
+            query = query.where(
+                LlmUsageEventModel.occurred_at >= window_start,
+                LlmUsageEventModel.occurred_at < window_end,
+            )
         if agent_ids is not None:
             query = query.where(LlmUsageEventModel.agent_id.in_(agent_ids))
         result = await self.db.execute(query)

--- a/backend/app/repositories/dashboard.py
+++ b/backend/app/repositories/dashboard.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Optional
 from uuid import UUID
 
@@ -41,36 +41,14 @@ class DashboardRepository:
         result = await self.db.execute(query)
         return result.scalar() or 0
 
-    async def get_workflow_runs_count(
-        self,
-        from_date: Optional[datetime] = None,
-        to_date: Optional[datetime] = None
-    ) -> int:
-        """
-        Get count of workflow runs (conversations) within date range.
-        Workflow runs are tracked via conversations since each conversation
-        typically triggers a workflow execution.
-        """
-        query = select(func.count(ConversationModel.id)).where(
-            ConversationModel.is_deleted == 0
-        )
-
-        if from_date:
-            query = query.where(ConversationModel.conversation_date >= from_date)
-        if to_date:
-            query = query.where(ConversationModel.conversation_date <= to_date)
-
-        result = await self.db.execute(query)
-        return result.scalar() or 0
-
     async def resolve_visible_agent_ids(self) -> list[UUID] | None:
         """Caller's agent scope for the summary aggregates (None = unrestricted admin)"""
         return await resolve_authorized_agent_ids(self.db)
 
     async def get_avg_response_time(
         self,
-        from_date: Optional[datetime] = None,
-        to_date: Optional[datetime] = None,
+        from_date: Optional[date] = None,
+        to_date: Optional[date] = None,
         *,
         agent_ids: list[UUID] | None,
     ) -> int:
@@ -82,6 +60,8 @@ class DashboardRepository:
 
         ``agent_ids`` is required because the stats table is not group-scoped: ``None``
         is an explicit tenant-wide (admin) scope, ``[]`` short-circuits to zero.
+
+        Bounds are UTC bucket dates, matching the ``stat_date`` column.
         """
         if agent_ids is not None and not agent_ids:
             return 0
@@ -367,6 +347,7 @@ class DashboardRepository:
         to_date: Optional[datetime] = None,
         *,
         agent_ids: list[UUID] | None,
+        exact: bool = False,
     ) -> float:
         """Total priced LLM cost over the range from the usage ledger"""
         if (from_date is None) != (to_date is None):
@@ -378,7 +359,9 @@ class DashboardRepository:
             LlmUsageEventModel.is_deleted == 0,
         )
         if from_date is not None and to_date is not None:
-            window_start, window_end = _ledger_window(from_date, to_date)
+            window_start, window_end = (
+                (from_date, to_date) if exact else _ledger_window(from_date, to_date)
+            )
             query = query.where(
                 LlmUsageEventModel.occurred_at >= window_start,
                 LlmUsageEventModel.occurred_at < window_end,

--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -3,17 +3,25 @@ from decimal import Decimal
 from typing import Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, computed_field
 
 
 class DashboardSummaryStats(BaseModel):
     """Summary statistics for the dashboard header."""
     active_agents: int
-    workflow_runs: int
+    conversations: int
     avg_response_time_ms: int
     total_cost_usd: float
 
     model_config = ConfigDict(from_attributes=True)
+
+    @computed_field(
+        description="Deprecated alias of conversations.",
+        json_schema_extra={"deprecated": True},
+    )
+    @property
+    def workflow_runs(self) -> int:
+        return self.conversations
 
 
 class ActiveConversationItem(BaseModel):

--- a/backend/app/services/analytics_read.py
+++ b/backend/app/services/analytics_read.py
@@ -46,9 +46,17 @@ class AnalyticsReadService:
         group_id: UUID | None = None,
         from_date: date | None = None,
         to_date: date | None = None,
+        *,
+        activity_from_datetime: datetime | None = None,
+        activity_to_datetime: datetime | None = None,
     ) -> AgentStatsSummaryResponse:
         summary = await self.repo.get_agent_stats_summary(
-            agent_id=agent_id, group_id=group_id, from_date=from_date, to_date=to_date
+            agent_id=agent_id,
+            group_id=group_id,
+            from_date=from_date,
+            to_date=to_date,
+            activity_from_datetime=activity_from_datetime,
+            activity_to_datetime=activity_to_datetime,
         )
         by_agent: list[AgentConversationStatusByAgent] = []
         if agent_id is None:
@@ -58,6 +66,8 @@ class AnalyticsReadService:
                 from_date=from_date,
                 to_date=to_date,
                 group_by_agent=True,
+                activity_from_datetime=activity_from_datetime,
+                activity_to_datetime=activity_to_datetime,
             )
             by_agent = [AgentConversationStatusByAgent.model_validate(r) for r in rows]
         return self._dict_to_summary(

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 from injector import inject
 
+from app.core.utils.date_time_utils import exact_interval_bucket_dates, rolling_window_bucket_dates
+from app.repositories.analytics_read import AnalyticsReadRepository
 from app.repositories.dashboard import DashboardRepository
 from app.schemas.dashboard import (
     ActiveConversationItem,
@@ -35,8 +37,9 @@ INTEGRATION_DESCRIPTIONS = {
 @inject
 class DashboardService:
 
-    def __init__(self, dashboard_repo: DashboardRepository):
+    def __init__(self, dashboard_repo: DashboardRepository, analytics_repo: AnalyticsReadRepository):
         self.dashboard_repo = dashboard_repo
+        self.analytics_repo = analytics_repo
 
     def _get_date_range(self, days: int = 30) -> tuple[datetime, datetime]:
         """Get date range from now going back specified days."""
@@ -70,17 +73,25 @@ class DashboardService:
     async def get_summary_stats(
         self,
         from_date: Optional[datetime] = None,
-        to_date: Optional[datetime] = None
+        to_date: Optional[datetime] = None,
+        *,
+        exact: bool = False,
     ) -> DashboardSummaryStats:
         """Get summary statistics for the dashboard header."""
         active_agents = await self.dashboard_repo.get_active_agents_count()
-        conversations = await self.dashboard_repo.get_workflow_runs_count(from_date, to_date)
+        conversations = await self._count_conversations(from_date, to_date, exact=exact)
         visible_agent_ids = await self.dashboard_repo.resolve_visible_agent_ids()
+
+        bucket_from, bucket_to = None, None
+        if from_date is not None and to_date is not None:
+            converter = exact_interval_bucket_dates if exact else rolling_window_bucket_dates
+            bucket_from, bucket_to = converter(from_date, to_date)
+
         avg_response_time = await self.dashboard_repo.get_avg_response_time(
-            from_date, to_date, agent_ids=visible_agent_ids
+            bucket_from, bucket_to, agent_ids=visible_agent_ids
         )
         total_cost_usd = await self.dashboard_repo.get_total_cost_usd(
-            from_date, to_date, agent_ids=visible_agent_ids
+            from_date, to_date, agent_ids=visible_agent_ids, exact=exact
         )
 
         return DashboardSummaryStats(
@@ -89,6 +100,26 @@ class DashboardService:
             avg_response_time_ms=avg_response_time,
             total_cost_usd=total_cost_usd,
         )
+
+    async def _count_conversations(
+        self,
+        from_date: Optional[datetime],
+        to_date: Optional[datetime],
+        *,
+        exact: bool,
+    ) -> int:
+        bounds: dict = {}
+        if from_date is not None and to_date is not None:
+            if exact:
+                bounds = {"activity_from_datetime": from_date, "activity_to_datetime": to_date}
+            else:
+                bounds = {
+                    "from_date": from_date.astimezone(timezone.utc).date(),
+                    "to_date": to_date.astimezone(timezone.utc).date(),
+                }
+
+        rows = await self.analytics_repo.get_conversation_status_counts(group_by_agent=False, **bounds)
+        return rows[0]["total_unique_conversations"] if rows else 0
 
     async def get_active_conversations(
         self,

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -69,12 +69,12 @@ class DashboardService:
 
     async def get_summary_stats(
         self,
-        from_date: datetime,
-        to_date: datetime
+        from_date: Optional[datetime] = None,
+        to_date: Optional[datetime] = None
     ) -> DashboardSummaryStats:
         """Get summary statistics for the dashboard header."""
         active_agents = await self.dashboard_repo.get_active_agents_count()
-        workflow_runs = await self.dashboard_repo.get_workflow_runs_count(from_date, to_date)
+        conversations = await self.dashboard_repo.get_workflow_runs_count(from_date, to_date)
         visible_agent_ids = await self.dashboard_repo.resolve_visible_agent_ids()
         avg_response_time = await self.dashboard_repo.get_avg_response_time(
             from_date, to_date, agent_ids=visible_agent_ids
@@ -85,7 +85,7 @@ class DashboardService:
 
         return DashboardSummaryStats(
             active_agents=active_agents,
-            workflow_runs=workflow_runs,
+            conversations=conversations,
             avg_response_time_ms=avg_response_time,
             total_cost_usd=total_cost_usd,
         )

--- a/backend/tests/integration/analytics/test_conversation_activity_counts.py
+++ b/backend/tests/integration/analytics/test_conversation_activity_counts.py
@@ -1,0 +1,344 @@
+"""Integration tests pinning the canonical conversation-activity counts against the database"""
+
+from contextlib import contextmanager
+from datetime import date, datetime, timedelta, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from starlette_context import context, request_cycle_context
+
+from app.core.config.settings import settings
+from app.db.models.agent import AgentModel
+from app.db.models.agent_response_log import AgentResponseLogModel
+from app.db.models.conversation import ConversationModel
+from app.db.models.message_model import TranscriptMessageModel
+from app.db.models.operator import OperatorModel, OperatorStatisticsModel
+from app.db.models.user import UserModel
+from app.db.models.user_group import UserGroupModel
+from app.db.models.workflow import WorkflowModel
+from app.repositories.analytics_read import AnalyticsReadRepository
+from app.repositories.dashboard import DashboardRepository
+from app.services.dashboard import DashboardService
+
+PROBE_START = date(2097, 3, 1)
+WINDOW_START_HOUR = 6
+WINDOW_END_HOUR = 18
+
+CONVERSATIONS = (
+    ("multi_log", "a1", "finalized", 0, ((7, 0), (8, 0), (9, 0))),
+    ("at_start", "a1", "in_progress", 0, ((WINDOW_START_HOUR, 0),)),
+    ("at_end", "a1", "finalized", 0, ((WINDOW_END_HOUR, 0),)),
+    ("silent", "a1", "finalized", 0, ()),
+    ("deleted_log", "a1", "finalized", 0, ((10, 1),)),
+    ("soft_deleted", "a1", "finalized", 1, ((11, 0),)),
+    ("other_agent", "a2", "finalized", 0, ((12, 0),)),
+)
+
+IN_EXACT_WINDOW = {"multi_log", "at_start", "other_agent"}
+IN_WHOLE_DAY = IN_EXACT_WINDOW | {"at_end"}
+PER_AGENT_IN_WINDOW = {"a1": 2, "a2": 1}
+
+
+@contextmanager
+def caller(*, user_id=None, group_id=None, supervised=(), admin=False):
+    with request_cycle_context():
+        context["user_id"] = user_id
+        context["group_id"] = group_id
+        context["supervised_group_ids"] = list(supervised)
+        context["user_roles"] = [SimpleNamespace(name="admin" if admin else "operator")]
+        yield
+
+
+@contextmanager
+def acting_as(user_id):
+    with caller(user_id=user_id, admin=True):
+        yield
+
+
+async def _free_day(session) -> date:
+    day = PROBE_START
+    for _ in range(365):
+        start = datetime.combine(day, datetime.min.time(), tzinfo=timezone.utc)
+        stmt = select(func.count()).select_from(AgentResponseLogModel).where(
+            AgentResponseLogModel.logged_at >= start,
+            AgentResponseLogModel.logged_at < start + timedelta(days=1),
+        )
+        if not (await session.execute(stmt)).scalar():
+            return day
+        day += timedelta(days=1)
+    raise AssertionError("no collision-free window found")
+
+
+class World:
+
+    def __init__(self, maker):
+        self.maker = maker
+        self.group = None
+        self.user = None
+        self.agents: dict[str, AgentModel] = {}
+        self.workflow_ids: list = []
+        self.operator_ids: list = []
+        self.statistics_ids: list = []
+        self.conversation_ids: dict[str, object] = {}
+        self.message_ids: list = []
+        self.day: date = PROBE_START
+
+    def agent_id(self, key):
+        return self.agents[key].id
+
+    def at(self, hour: int, **delta) -> datetime:
+        midnight = datetime.combine(self.day, datetime.min.time(), tzinfo=timezone.utc)
+        return midnight + timedelta(hours=hour, **delta)
+
+    @property
+    def window_start(self) -> datetime:
+        return self.at(WINDOW_START_HOUR)
+
+    @property
+    def window_end(self) -> datetime:
+        return self.at(WINDOW_END_HOUR)
+
+
+@pytest_asyncio.fixture(loop_scope="module")
+async def world(app_def):
+    engine = create_async_engine(settings.DATABASE_URL)
+    maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    built = World(maker)
+
+    async with maker() as session:
+        built.day = await _free_day(session)
+        user_type_id = (await session.execute(select(UserModel.user_type_id).limit(1))).scalar_one()
+
+        built.group = UserGroupModel(id=uuid4(), name=f"convcount-{uuid4().hex[:8]}", is_deleted=0)
+        session.add(built.group)
+        suffix = uuid4().hex[:12]
+        built.user = UserModel(
+            id=uuid4(),
+            username=f"convcount-{suffix}",
+            email=f"convcount-{suffix}@example.test",
+            hashed_password="x",
+            user_type_id=user_type_id,
+            is_active=1,
+            group_id=built.group.id,
+            is_deleted=0,
+        )
+        session.add(built.user)
+        await session.flush()
+
+        for agent_key in ("a1", "a2"):
+            with acting_as(built.user.id):
+                statistics = OperatorStatisticsModel(id=uuid4(), is_deleted=0)
+                session.add(statistics)
+                built.statistics_ids.append(statistics.id)
+                operator = OperatorModel(
+                    id=uuid4(),
+                    first_name="Conv",
+                    last_name=agent_key,
+                    statistics_id=statistics.id,
+                    is_active=1,
+                    user_id=built.user.id,
+                    is_deleted=0,
+                )
+                session.add(operator)
+                built.operator_ids.append(operator.id)
+                workflow = WorkflowModel(
+                    id=uuid4(),
+                    name=f"convcount-{agent_key}",
+                    version="1",
+                    nodes=[],
+                    edges=[],
+                    user_id=built.user.id,
+                    is_deleted=0,
+                )
+                session.add(workflow)
+                built.workflow_ids.append(workflow.id)
+                agent = AgentModel(
+                    id=uuid4(),
+                    name=f"convcount-{agent_key}",
+                    is_active=1,
+                    operator_id=operator.id,
+                    welcome_message="Welcome",
+                    workflow_id=workflow.id,
+                    is_deleted=0,
+                )
+                built.agents[agent_key] = agent
+                session.add(agent)
+                await session.flush()
+
+        for key, agent_key, status, conversation_deleted, logs in CONVERSATIONS:
+            conversation_id = uuid4()
+            built.conversation_ids[key] = conversation_id
+            session.add(
+                ConversationModel(
+                    id=conversation_id,
+                    operator_id=built.agents[agent_key].operator_id,
+                    group_id=built.group.id,
+                    conversation_type="chat",
+                    conversation_date=built.at(12),
+                    status=status,
+                    is_deleted=conversation_deleted,
+                )
+            )
+            await session.flush()
+
+            for index, (hour, log_deleted) in enumerate(logs):
+                message_id = uuid4()
+                built.message_ids.append(message_id)
+                session.add(
+                    TranscriptMessageModel(
+                        id=message_id,
+                        conversation_id=conversation_id,
+                        start_time=float(index),
+                        end_time=float(index + 1),
+                        speaker="agent",
+                        text=f"convcount {key} {index}",
+                        type="text",
+                        sequence_number=index + 1,
+                        is_deleted=0,
+                    )
+                )
+                await session.flush()
+                session.add(
+                    AgentResponseLogModel(
+                        id=uuid4(),
+                        transcript_message_id=message_id,
+                        conversation_id=conversation_id,
+                        raw_response="{}",
+                        logged_at=built.at(hour),
+                        is_deleted=log_deleted,
+                    )
+                )
+        await session.commit()
+
+    try:
+        yield built
+    finally:
+        conversation_ids = list(built.conversation_ids.values())
+        agent_ids = [a.id for a in built.agents.values()]
+        async with maker() as session:
+            await session.execute(
+                delete(AgentResponseLogModel).where(AgentResponseLogModel.conversation_id.in_(conversation_ids))
+            )
+            await session.execute(
+                delete(TranscriptMessageModel).where(TranscriptMessageModel.id.in_(built.message_ids))
+            )
+            await session.execute(delete(ConversationModel).where(ConversationModel.id.in_(conversation_ids)))
+            await session.execute(delete(AgentModel).where(AgentModel.id.in_(agent_ids)))
+            await session.execute(delete(OperatorModel).where(OperatorModel.id.in_(built.operator_ids)))
+            await session.execute(
+                delete(OperatorStatisticsModel).where(OperatorStatisticsModel.id.in_(built.statistics_ids))
+            )
+            await session.execute(delete(WorkflowModel).where(WorkflowModel.id.in_(built.workflow_ids)))
+            await session.execute(delete(UserModel).where(UserModel.id == built.user.id))
+            await session.execute(delete(UserGroupModel).where(UserGroupModel.id == built.group.id))
+            await session.commit()
+        await engine.dispose()
+
+
+async def _counts(world, **kwargs) -> dict:
+    async with world.maker() as session:
+        with caller(user_id=uuid4(), admin=True):
+            rows = await AnalyticsReadRepository(session).get_conversation_status_counts(**kwargs)
+    return rows[0]
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_repeated_logs_count_their_conversation_once(world):
+    row = await _counts(
+        world,
+        activity_from_datetime=world.window_start,
+        activity_to_datetime=world.window_end,
+    )
+    assert row["total_unique_conversations"] == len(IN_EXACT_WINDOW)
+    assert row["total_finalized_conversations"] == 2
+    assert row["total_in_progress_conversations"] == 1
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_exact_start_is_inclusive(world):
+    row = await _counts(
+        world,
+        activity_from_datetime=world.at(WINDOW_START_HOUR, microseconds=1),
+        activity_to_datetime=world.window_end,
+    )
+    assert row["total_unique_conversations"] == len(IN_EXACT_WINDOW) - 1
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_exact_end_is_exclusive(world):
+    row = await _counts(
+        world,
+        activity_from_datetime=world.window_start,
+        activity_to_datetime=world.at(WINDOW_END_HOUR, microseconds=1),
+    )
+    assert row["total_unique_conversations"] == len(IN_EXACT_WINDOW) + 1
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_a_conversation_without_response_activity_is_excluded(world):
+    row = await _counts(world, from_date=world.day, to_date=world.day)
+    assert row["total_unique_conversations"] == len(IN_WHOLE_DAY)
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_deleted_response_logs_do_not_count(world):
+    row = await _counts(
+        world,
+        activity_from_datetime=world.at(10),
+        activity_to_datetime=world.at(10, minutes=1),
+    )
+    assert row["total_unique_conversations"] == 0
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_soft_deleted_conversations_drop_out_via_the_global_filter(world):
+    row = await _counts(
+        world,
+        activity_from_datetime=world.at(11),
+        activity_to_datetime=world.at(11, minutes=1),
+    )
+    assert row["total_unique_conversations"] == 0
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_per_agent_rows_sum_to_the_summary_total(world):
+    async with world.maker() as session:
+        repo = AnalyticsReadRepository(session)
+        bounds = {
+            "activity_from_datetime": world.window_start,
+            "activity_to_datetime": world.window_end,
+        }
+        with caller(user_id=uuid4(), admin=True):
+            grouped = await repo.get_conversation_status_counts(group_by_agent=True, **bounds)
+            ungrouped = await repo.get_conversation_status_counts(**bounds)
+
+    by_agent = {row["agent_id"]: row["unique_conversations"] for row in grouped}
+    assert by_agent == {world.agent_id(key): count for key, count in PER_AGENT_IN_WINDOW.items()}
+    assert sum(by_agent.values()) == ungrouped[0]["total_unique_conversations"]
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_dashboard_and_agent_performance_agree_for_the_same_caller_and_interval(world):
+    bounds = {
+        "activity_from_datetime": world.window_start,
+        "activity_to_datetime": world.window_end,
+    }
+    for principal in (
+        {"user_id": uuid4(), "admin": True},
+        {"user_id": world.user.id, "group_id": world.group.id},
+    ):
+        async with world.maker() as session:
+            with caller(**principal):
+                dashboard = DashboardService(DashboardRepository(session), AnalyticsReadRepository(session))
+                summary = await dashboard.get_summary_stats(world.window_start, world.window_end, exact=True)
+                performance = await AnalyticsReadRepository(session).get_agent_stats_summary(
+                    from_date=world.day, to_date=world.day, **bounds
+                )
+
+        assert summary.conversations == performance["total_unique_conversations"] == len(IN_EXACT_WINDOW)
+        assert summary.workflow_runs == summary.conversations

--- a/backend/tests/integration/analytics/test_group_authorization.py
+++ b/backend/tests/integration/analytics/test_group_authorization.py
@@ -29,6 +29,7 @@ from app.repositories.agent import AgentRepository
 from app.repositories.analytics_read import AnalyticsReadRepository
 from app.repositories.dashboard import DashboardRepository
 from app.repositories.llm_usage_read import LlmUsageReadRepository
+from app.repositories.workflow import WorkflowRepository
 from app.schemas.llm_usage import LlmUsageQueryParams
 from app.services.llm_usage_read import LlmUsageReadService
 
@@ -516,7 +517,9 @@ async def test_custom_attribute_keys_are_limited_to_visible_workflows(world):
 @pytest.mark.asyncio(loop_scope="module")
 async def test_llm_usage_filter_options_expose_only_visible_providers_models_and_agents(world):
     async with world.maker() as session:
-        service = LlmUsageReadService(LlmUsageReadRepository(session), AgentRepository(session))
+        service = LlmUsageReadService(
+            LlmUsageReadRepository(session), AgentRepository(session), WorkflowRepository(session)
+        )
         with caller(user_id=world.user_id("u1"), group_id=world.group_id("g1")):
             options = await service.get_filter_options(world.params)
 
@@ -543,18 +546,20 @@ async def test_dashboard_cost_and_response_time_follow_the_visible_scope(world):
     start, end = world.window
     async with world.maker() as session:
         dashboard = DashboardRepository(session)
-        service = LlmUsageReadService(LlmUsageReadRepository(session), AgentRepository(session))
+        service = LlmUsageReadService(
+            LlmUsageReadRepository(session), AgentRepository(session), WorkflowRepository(session)
+        )
 
         with caller(user_id=uuid4(), admin=True):
             admin_scope = await dashboard.resolve_visible_agent_ids()
             admin_cost = await dashboard.get_total_cost_usd(start, end, agent_ids=admin_scope)
-            admin_ms = await dashboard.get_avg_response_time(start, end, agent_ids=admin_scope)
+            admin_ms = await dashboard.get_avg_response_time(world.day, world.day, agent_ids=admin_scope)
             admin_explorer = (await service.get_summary(world.params)).total_cost_usd
 
         with caller(user_id=world.user_id("u1"), group_id=world.group_id("g1")):
             user_scope = await dashboard.resolve_visible_agent_ids()
             user_cost = await dashboard.get_total_cost_usd(start, end, agent_ids=user_scope)
-            user_ms = await dashboard.get_avg_response_time(start, end, agent_ids=user_scope)
+            user_ms = await dashboard.get_avg_response_time(world.day, world.day, agent_ids=user_scope)
             user_explorer = (await service.get_summary(world.params)).total_cost_usd
 
     assert admin_scope is None and user_scope == [world.agent_id("a1")]

--- a/backend/tests/unit/test_analytics_activity_bounds.py
+++ b/backend/tests/unit/test_analytics_activity_bounds.py
@@ -1,0 +1,116 @@
+"""Unit tests for the Agent Performance exact-activity validation"""
+
+from datetime import date, datetime, timezone
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.v1.routes.analytics import _validate_activity_bounds
+
+FROM_DATE = date(2026, 8, 1)
+TO_DATE = date(2026, 8, 7)
+ACTIVITY_FROM = datetime(2026, 8, 1, tzinfo=timezone.utc)
+ACTIVITY_TO = datetime(2026, 8, 8, tzinfo=timezone.utc)
+NAIVE = datetime(2026, 8, 1)
+
+
+def _expect_422(**kwargs):
+    with pytest.raises(HTTPException) as excinfo:
+        _validate_activity_bounds(**kwargs)
+    assert excinfo.value.status_code == 422
+
+
+def test_date_only_requests_pass_untouched():
+    _validate_activity_bounds(FROM_DATE, TO_DATE, None, None)
+    _validate_activity_bounds(None, None, None, None)
+
+
+def test_date_only_comparison_stays_valid():
+    _validate_activity_bounds(FROM_DATE, TO_DATE, None, None, compare=True)
+
+
+def test_complete_aware_pair_with_a_full_date_range_passes():
+    _validate_activity_bounds(FROM_DATE, TO_DATE, ACTIVITY_FROM, ACTIVITY_TO)
+
+
+@pytest.mark.parametrize(
+    "activity_from, activity_to",
+    [
+        pytest.param(ACTIVITY_FROM, None, id="start_only"),
+        pytest.param(None, ACTIVITY_TO, id="end_only"),
+    ],
+)
+def test_incomplete_activity_pairs_are_rejected(activity_from, activity_to):
+    _expect_422(
+        from_date=FROM_DATE,
+        to_date=TO_DATE,
+        activity_from_datetime=activity_from,
+        activity_to_datetime=activity_to,
+    )
+
+
+@pytest.mark.parametrize(
+    "activity_from, activity_to",
+    [
+        pytest.param(NAIVE, ACTIVITY_TO, id="naive_start"),
+        pytest.param(ACTIVITY_FROM, NAIVE, id="naive_end"),
+    ],
+)
+def test_naive_activity_bounds_are_rejected(activity_from, activity_to):
+    _expect_422(
+        from_date=FROM_DATE,
+        to_date=TO_DATE,
+        activity_from_datetime=activity_from,
+        activity_to_datetime=activity_to,
+    )
+
+
+@pytest.mark.parametrize(
+    "activity_from, activity_to",
+    [
+        pytest.param(ACTIVITY_TO, ACTIVITY_FROM, id="reversed"),
+        pytest.param(ACTIVITY_FROM, ACTIVITY_FROM, id="zero_length"),
+    ],
+)
+def test_non_increasing_activity_bounds_are_rejected(activity_from, activity_to):
+    _expect_422(
+        from_date=FROM_DATE,
+        to_date=TO_DATE,
+        activity_from_datetime=activity_from,
+        activity_to_datetime=activity_to,
+    )
+
+
+@pytest.mark.parametrize(
+    "from_date, to_date",
+    [
+        pytest.param(None, TO_DATE, id="missing_from_date"),
+        pytest.param(FROM_DATE, None, id="missing_to_date"),
+        pytest.param(None, None, id="missing_both"),
+    ],
+)
+def test_exact_bounds_require_a_complete_bucket_date_range(from_date, to_date):
+    _expect_422(
+        from_date=from_date,
+        to_date=to_date,
+        activity_from_datetime=ACTIVITY_FROM,
+        activity_to_datetime=ACTIVITY_TO,
+    )
+
+
+@pytest.mark.parametrize(
+    "activity_from, activity_to",
+    [
+        pytest.param(ACTIVITY_FROM, ACTIVITY_TO, id="complete_pair"),
+        pytest.param(ACTIVITY_FROM, None, id="start_only"),
+        pytest.param(None, ACTIVITY_TO, id="end_only"),
+    ],
+)
+def test_compare_with_any_activity_boundary_is_rejected(activity_from, activity_to):
+    _expect_422(
+        from_date=FROM_DATE,
+        to_date=TO_DATE,
+        activity_from_datetime=activity_from,
+        activity_to_datetime=activity_to,
+        compare=True,
+    )

--- a/backend/tests/unit/test_analytics_read_repo_scope.py
+++ b/backend/tests/unit/test_analytics_read_repo_scope.py
@@ -1,5 +1,7 @@
 """Unit tests proving the analytics reads are wired to the authorization resolver"""
 
+import re
+from datetime import date, datetime, timezone
 from uuid import uuid4
 
 import pytest
@@ -21,6 +23,9 @@ class _Result:
 
     def mappings(self):
         return self
+
+    def one(self):
+        return {}
 
 
 class CapturingDb:
@@ -45,6 +50,20 @@ def _repo_with_scope(monkeypatch, scope):
 
     monkeypatch.setattr(analytics_read, "resolve_authorized_agent_ids", _resolver)
     return AnalyticsReadRepository(db), db
+
+
+def _repo_with_conversation_scope(monkeypatch, scope):
+    db = CapturingDb()
+
+    async def _resolver(_db, agent_id=None, group_id=None):
+        return scope
+
+    monkeypatch.setattr(analytics_read, "resolve_scoped_agent_ids", _resolver)
+    return AnalyticsReadRepository(db), db
+
+
+def _logged_at_predicates(sql: str) -> list[str]:
+    return sorted(re.findall(r"agent_response_logs\.logged_at [<>=]+ '[^']+'", sql))
 
 
 @pytest.mark.asyncio
@@ -128,7 +147,7 @@ async def test_agent_stats_summary_keeps_the_conversation_tier_on_a_group_reques
     repo, db = _repo_with_scope(monkeypatch, [])
     seen = {}
 
-    async def _conversation_counts(agent_id=None, group_id=None, from_date=None, to_date=None, *, group_by_agent=False):
+    async def _conversation_counts(agent_id=None, group_id=None, from_date=None, to_date=None, **kwargs):
         seen.update(agent_id=agent_id, group_id=group_id)
         return [
             {
@@ -155,3 +174,96 @@ async def test_agent_stats_summary_zeroes_everything_when_no_group_was_requested
     assert summary["total_executions"] == 0
     assert summary["total_unique_conversations"] == 0
     assert db.statements == []
+
+
+ACTIVITY_FROM = datetime(2026, 8, 1, 15, 0, tzinfo=timezone.utc)
+ACTIVITY_TO = datetime(2026, 8, 8, tzinfo=timezone.utc)
+LEGACY_FROM = date(2026, 8, 1)
+LEGACY_TO = date(2026, 8, 7)
+
+
+@pytest.mark.asyncio
+async def test_conversation_counts_apply_the_exact_activity_window_half_open(monkeypatch):
+    repo, db = _repo_with_conversation_scope(monkeypatch, None)
+    await repo.get_conversation_status_counts(
+        activity_from_datetime=ACTIVITY_FROM, activity_to_datetime=ACTIVITY_TO
+    )
+    sql = _sql(db.statements[0])
+    assert "logged_at >= '2026-08-01 15:00:00+00:00'" in sql
+    assert "logged_at < '2026-08-08 00:00:00+00:00'" in sql
+
+
+@pytest.mark.asyncio
+async def test_conversation_counts_keep_the_legacy_inclusive_utc_day_window(monkeypatch):
+    repo, db = _repo_with_conversation_scope(monkeypatch, None)
+    await repo.get_conversation_status_counts(from_date=LEGACY_FROM, to_date=LEGACY_TO)
+    sql = _sql(db.statements[0])
+    assert "logged_at >= '2026-08-01 00:00:00+00:00'" in sql
+    assert "logged_at <= '2026-08-07 23:59:59.999999+00:00'" in sql
+
+
+@pytest.mark.asyncio
+async def test_exact_activity_bounds_replace_the_legacy_dates(monkeypatch):
+    repo, db = _repo_with_conversation_scope(monkeypatch, None)
+    await repo.get_conversation_status_counts(
+        from_date=LEGACY_FROM,
+        to_date=LEGACY_TO,
+        activity_from_datetime=ACTIVITY_FROM,
+        activity_to_datetime=ACTIVITY_TO,
+    )
+    sql = _sql(db.statements[0])
+    assert "logged_at >= '2026-08-01 15:00:00+00:00'" in sql
+    assert "logged_at < '2026-08-08 00:00:00+00:00'" in sql
+    assert "23:59:59.999999" not in sql
+
+
+@pytest.mark.asyncio
+async def test_grouped_and_ungrouped_counts_share_the_same_activity_bounds(monkeypatch):
+    repo, db = _repo_with_conversation_scope(monkeypatch, None)
+    bounds = {"activity_from_datetime": ACTIVITY_FROM, "activity_to_datetime": ACTIVITY_TO}
+    await repo.get_conversation_status_counts(group_by_agent=False, **bounds)
+    await repo.get_conversation_status_counts(group_by_agent=True, **bounds)
+    ungrouped, grouped = (_sql(stmt) for stmt in db.statements)
+    assert _logged_at_predicates(ungrouped) == _logged_at_predicates(grouped)
+    assert "GROUP BY" in grouped
+
+
+@pytest.mark.asyncio
+async def test_conversation_counts_only_exclude_deleted_response_logs(monkeypatch):
+    repo, db = _repo_with_conversation_scope(monkeypatch, None)
+    await repo.get_conversation_status_counts(
+        activity_from_datetime=ACTIVITY_FROM, activity_to_datetime=ACTIVITY_TO
+    )
+    sql = _sql(db.statements[0])
+    assert "agent_response_logs.is_deleted = 0" in sql
+    for table in ("conversations", "agents", "operators"):
+        assert f"{table}.is_deleted" not in sql
+
+
+@pytest.mark.asyncio
+async def test_conversation_counts_reject_a_half_supplied_activity_range(monkeypatch):
+    repo, db = _repo_with_conversation_scope(monkeypatch, None)
+    with pytest.raises(ValueError):
+        await repo.get_conversation_status_counts(activity_from_datetime=ACTIVITY_FROM)
+    assert db.statements == []
+
+
+@pytest.mark.asyncio
+async def test_agent_stats_summary_forwards_activity_bounds_to_the_conversation_query(monkeypatch):
+    repo, _ = _repo_with_scope(monkeypatch, None)
+    seen = {}
+
+    async def _conversation_counts(**kwargs):
+        seen.update(kwargs)
+        return [{"total_unique_conversations": 2}]
+
+    monkeypatch.setattr(repo, "get_conversation_status_counts", _conversation_counts)
+    await repo.get_agent_stats_summary(
+        from_date=LEGACY_FROM,
+        to_date=LEGACY_TO,
+        activity_from_datetime=ACTIVITY_FROM,
+        activity_to_datetime=ACTIVITY_TO,
+    )
+    assert seen["activity_from_datetime"] == ACTIVITY_FROM
+    assert seen["activity_to_datetime"] == ACTIVITY_TO
+    assert (seen["from_date"], seen["to_date"]) == (LEGACY_FROM, LEGACY_TO)

--- a/backend/tests/unit/test_dashboard_service.py
+++ b/backend/tests/unit/test_dashboard_service.py
@@ -1,6 +1,6 @@
 """Unit tests for DashboardService reading cost straight from the ledger repository"""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from uuid import uuid4
 
 import pytest
@@ -10,6 +10,7 @@ from app.services.dashboard import DashboardService
 TOTAL_COST = 99.99
 AGENT_COST = 2.22
 PER_CONVERSATION = 0.55
+CONVERSATIONS = 7
 
 FROM_DATE = datetime(2026, 1, 1, tzinfo=timezone.utc)
 TO_DATE = datetime(2026, 1, 31, tzinfo=timezone.utc)
@@ -25,17 +26,13 @@ class FakeDashboardRepo:
         self.scope_calls = 0
         self.response_time_scope = _UNSET
         self.total_cost_scope = _UNSET
-        self.workflow_runs_bounds = _UNSET
         self.response_time_bounds = _UNSET
         self.total_cost_bounds = _UNSET
+        self.total_cost_exact = _UNSET
         self.agents_kwargs = None
 
     async def get_active_agents_count(self):
         return 3
-
-    async def get_workflow_runs_count(self, from_date, to_date):
-        self.workflow_runs_bounds = (from_date, to_date)
-        return 7
 
     async def resolve_visible_agent_ids(self):
         self.scope_calls += 1
@@ -46,10 +43,11 @@ class FakeDashboardRepo:
         self.response_time_bounds = (from_date, to_date)
         return 0 if agent_ids == [] else 250
 
-    async def get_total_cost_usd(self, from_date, to_date, *, agent_ids):
+    async def get_total_cost_usd(self, from_date, to_date, *, agent_ids, exact=False):
         self.total_cost_calls += 1
         self.total_cost_scope = agent_ids
         self.total_cost_bounds = (from_date, to_date)
+        self.total_cost_exact = exact
         return 0.0 if agent_ids == [] else TOTAL_COST
 
     async def get_agents_with_stats(self, from_date, to_date, limit):
@@ -68,29 +66,50 @@ class FakeDashboardRepo:
         ]
 
 
+class FakeAnalyticsRepo:
+    def __init__(self):
+        self.conversation_kwargs = None
+
+    async def get_conversation_status_counts(self, **kwargs):
+        self.conversation_kwargs = kwargs
+        return [{"total_unique_conversations": CONVERSATIONS}]
+
+
 def _service(visible_agent_ids=None):
     repo = FakeDashboardRepo(uuid4(), visible_agent_ids)
-    return DashboardService(repo), repo
+    analytics_repo = FakeAnalyticsRepo()
+    return DashboardService(repo, analytics_repo), repo, analytics_repo
 
 
-def test_service_takes_only_the_dashboard_repository():
-    service, repo = _service()
+def test_service_takes_the_dashboard_and_analytics_repositories():
+    service, repo, analytics_repo = _service()
     assert service.dashboard_repo is repo
+    assert service.analytics_repo is analytics_repo
 
 
 @pytest.mark.asyncio
 async def test_summary_reads_the_ledger_total():
-    service, repo = _service()
+    service, repo, _ = _service()
     summary = await service.get_summary_stats(FROM_DATE, TO_DATE)
     assert summary.total_cost_usd == TOTAL_COST
     assert repo.total_cost_calls == 1
-    assert (summary.active_agents, summary.workflow_runs, summary.avg_response_time_ms) == (3, 7, 250)
+    assert (summary.active_agents, summary.conversations, summary.avg_response_time_ms) == (3, 7, 250)
+
+
+@pytest.mark.asyncio
+async def test_summary_counts_conversations_with_the_canonical_query():
+    service, _, analytics_repo = _service()
+    summary = await service.get_summary_stats(FROM_DATE, TO_DATE)
+    assert summary.conversations == CONVERSATIONS
+    assert analytics_repo.conversation_kwargs["group_by_agent"] is False
+    assert "agent_id" not in analytics_repo.conversation_kwargs
+    assert "group_id" not in analytics_repo.conversation_kwargs
 
 
 @pytest.mark.asyncio
 async def test_summary_resolves_visible_scope_once_and_passes_it_to_both_reads():
     scope = [uuid4()]
-    service, repo = _service(visible_agent_ids=scope)
+    service, repo, _ = _service(visible_agent_ids=scope)
     await service.get_summary_stats(FROM_DATE, TO_DATE)
     assert repo.scope_calls == 1
     assert repo.response_time_scope == scope
@@ -99,34 +118,50 @@ async def test_summary_resolves_visible_scope_once_and_passes_it_to_both_reads()
 
 @pytest.mark.asyncio
 async def test_summary_serialises_workflow_runs_as_a_mirror_of_conversations():
-    service, _ = _service()
+    service, _, _ = _service()
     summary = await service.get_summary_stats(FROM_DATE, TO_DATE)
-    assert summary.conversations == summary.workflow_runs == 7
-    assert summary.model_dump()["workflow_runs"] == 7
+    assert summary.conversations == summary.workflow_runs == CONVERSATIONS
+    assert summary.model_dump()["workflow_runs"] == CONVERSATIONS
 
 
 @pytest.mark.asyncio
-async def test_summary_forwards_the_requested_bounds_to_every_read():
-    service, repo = _service()
+async def test_legacy_mode_sends_utc_dates_to_conversations_and_rolling_buckets_to_stats():
+    service, repo, analytics_repo = _service()
     await service.get_summary_stats(FROM_DATE, TO_DATE)
-    bounds = (FROM_DATE, TO_DATE)
-    assert repo.workflow_runs_bounds == bounds
-    assert repo.response_time_bounds == bounds
-    assert repo.total_cost_bounds == bounds
+    assert analytics_repo.conversation_kwargs["from_date"] == date(2026, 1, 1)
+    assert analytics_repo.conversation_kwargs["to_date"] == date(2026, 1, 31)
+    assert "activity_from_datetime" not in analytics_repo.conversation_kwargs
+    assert repo.response_time_bounds == (date(2026, 1, 1), date(2026, 1, 31))
+    assert repo.total_cost_bounds == (FROM_DATE, TO_DATE)
+    assert repo.total_cost_exact is False
+
+
+@pytest.mark.asyncio
+async def test_exact_mode_sends_activity_instants_and_intersecting_buckets():
+    service, repo, analytics_repo = _service()
+    start = datetime(2026, 8, 1, 15, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 8, 8, tzinfo=timezone.utc)
+    await service.get_summary_stats(start, end, exact=True)
+    assert analytics_repo.conversation_kwargs["activity_from_datetime"] == start
+    assert analytics_repo.conversation_kwargs["activity_to_datetime"] == end
+    assert "from_date" not in analytics_repo.conversation_kwargs
+    assert repo.response_time_bounds == (date(2026, 8, 1), date(2026, 8, 7))
+    assert repo.total_cost_bounds == (start, end)
+    assert repo.total_cost_exact is True
 
 
 @pytest.mark.asyncio
 async def test_summary_without_bounds_reads_all_time():
-    service, repo = _service()
+    service, repo, analytics_repo = _service()
     await service.get_summary_stats()
-    assert repo.workflow_runs_bounds == (None, None)
+    assert analytics_repo.conversation_kwargs == {"group_by_agent": False}
     assert repo.response_time_bounds == (None, None)
     assert repo.total_cost_bounds == (None, None)
 
 
 @pytest.mark.asyncio
 async def test_summary_passes_empty_scope_to_both_reads():
-    service, repo = _service(visible_agent_ids=[])
+    service, repo, _ = _service(visible_agent_ids=[])
     summary = await service.get_summary_stats(FROM_DATE, TO_DATE)
     assert repo.response_time_scope == [] and repo.total_cost_scope == []
     assert (summary.avg_response_time_ms, summary.total_cost_usd) == (0, 0.0)
@@ -134,7 +169,7 @@ async def test_summary_passes_empty_scope_to_both_reads():
 
 @pytest.mark.asyncio
 async def test_agents_stats_surface_ledger_cost_and_per_conversation():
-    service, repo = _service()
+    service, repo, _ = _service()
     response = await service.get_agents_stats(FROM_DATE, TO_DATE)
     agent = response.agents[0]
     assert float(agent.cost) == AGENT_COST

--- a/backend/tests/unit/test_dashboard_service.py
+++ b/backend/tests/unit/test_dashboard_service.py
@@ -25,12 +25,16 @@ class FakeDashboardRepo:
         self.scope_calls = 0
         self.response_time_scope = _UNSET
         self.total_cost_scope = _UNSET
+        self.workflow_runs_bounds = _UNSET
+        self.response_time_bounds = _UNSET
+        self.total_cost_bounds = _UNSET
         self.agents_kwargs = None
 
     async def get_active_agents_count(self):
         return 3
 
     async def get_workflow_runs_count(self, from_date, to_date):
+        self.workflow_runs_bounds = (from_date, to_date)
         return 7
 
     async def resolve_visible_agent_ids(self):
@@ -39,11 +43,13 @@ class FakeDashboardRepo:
 
     async def get_avg_response_time(self, from_date, to_date, *, agent_ids):
         self.response_time_scope = agent_ids
+        self.response_time_bounds = (from_date, to_date)
         return 0 if agent_ids == [] else 250
 
     async def get_total_cost_usd(self, from_date, to_date, *, agent_ids):
         self.total_cost_calls += 1
         self.total_cost_scope = agent_ids
+        self.total_cost_bounds = (from_date, to_date)
         return 0.0 if agent_ids == [] else TOTAL_COST
 
     async def get_agents_with_stats(self, from_date, to_date, limit):
@@ -89,6 +95,33 @@ async def test_summary_resolves_visible_scope_once_and_passes_it_to_both_reads()
     assert repo.scope_calls == 1
     assert repo.response_time_scope == scope
     assert repo.total_cost_scope == scope
+
+
+@pytest.mark.asyncio
+async def test_summary_serialises_workflow_runs_as_a_mirror_of_conversations():
+    service, _ = _service()
+    summary = await service.get_summary_stats(FROM_DATE, TO_DATE)
+    assert summary.conversations == summary.workflow_runs == 7
+    assert summary.model_dump()["workflow_runs"] == 7
+
+
+@pytest.mark.asyncio
+async def test_summary_forwards_the_requested_bounds_to_every_read():
+    service, repo = _service()
+    await service.get_summary_stats(FROM_DATE, TO_DATE)
+    bounds = (FROM_DATE, TO_DATE)
+    assert repo.workflow_runs_bounds == bounds
+    assert repo.response_time_bounds == bounds
+    assert repo.total_cost_bounds == bounds
+
+
+@pytest.mark.asyncio
+async def test_summary_without_bounds_reads_all_time():
+    service, repo = _service()
+    await service.get_summary_stats()
+    assert repo.workflow_runs_bounds == (None, None)
+    assert repo.response_time_bounds == (None, None)
+    assert repo.total_cost_bounds == (None, None)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_dashboard_summary_range.py
+++ b/backend/tests/unit/test_dashboard_summary_range.py
@@ -1,0 +1,70 @@
+"""Unit tests for the /dashboard/summary range contract"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.v1.routes.dashboard import DEFAULT_SUMMARY_DAYS, resolve_summary_range
+
+EXACT_FROM = datetime(2026, 8, 1, tzinfo=timezone.utc)
+EXACT_TO = datetime(2026, 8, 8, tzinfo=timezone.utc)
+OFFSET_FROM = datetime(2026, 8, 1, tzinfo=timezone(timedelta(hours=2)))
+NAIVE_FROM = datetime(2026, 8, 1)
+NAIVE_TO = datetime(2026, 8, 8)
+
+
+def _rolling_days(bounds: tuple[datetime, datetime]) -> float:
+    from_date, to_date = bounds
+    return (to_date - from_date) / timedelta(days=1)
+
+
+def test_no_range_arguments_fall_back_to_the_legacy_rolling_window():
+    bounds = resolve_summary_range(None, None, None, False)
+    assert _rolling_days(bounds) == DEFAULT_SUMMARY_DAYS
+    assert all(bound.utcoffset() is not None for bound in bounds)
+
+
+def test_days_keeps_the_legacy_rolling_duration():
+    assert _rolling_days(resolve_summary_range(7, None, None, False)) == 7
+
+
+def test_exact_pair_passes_through_unchanged():
+    assert resolve_summary_range(None, EXACT_FROM, EXACT_TO, False) == (EXACT_FROM, EXACT_TO)
+
+
+def test_exact_pair_keeps_a_non_utc_offset():
+    assert resolve_summary_range(None, OFFSET_FROM, EXACT_TO, False) == (OFFSET_FROM, EXACT_TO)
+
+
+def test_all_time_drops_both_bounds():
+    assert resolve_summary_range(None, None, None, True) == (None, None)
+
+
+def test_all_time_false_stays_inactive_beside_another_mode():
+    assert resolve_summary_range(None, EXACT_FROM, EXACT_TO, False) == (EXACT_FROM, EXACT_TO)
+    assert _rolling_days(resolve_summary_range(7, None, None, False)) == 7
+
+
+@pytest.mark.parametrize(
+    "days, from_datetime, to_datetime, all_time",
+    [
+        pytest.param(None, EXACT_FROM, None, False, id="start_only"),
+        pytest.param(None, None, EXACT_TO, False, id="end_only"),
+        pytest.param(None, NAIVE_FROM, EXACT_TO, False, id="naive_start"),
+        pytest.param(None, EXACT_FROM, NAIVE_TO, False, id="naive_end"),
+        pytest.param(None, EXACT_TO, EXACT_FROM, False, id="reversed"),
+        pytest.param(None, EXACT_FROM, EXACT_FROM, False, id="zero_length"),
+        pytest.param(7, EXACT_FROM, None, False, id="days_with_start"),
+        pytest.param(7, None, EXACT_TO, False, id="days_with_end"),
+        pytest.param(7, EXACT_FROM, EXACT_TO, False, id="days_with_exact_pair"),
+        pytest.param(7, None, None, True, id="all_time_with_days"),
+        pytest.param(None, EXACT_FROM, None, True, id="all_time_with_start"),
+        pytest.param(None, None, EXACT_TO, True, id="all_time_with_end"),
+        pytest.param(None, EXACT_FROM, EXACT_TO, True, id="all_time_with_exact_pair"),
+    ],
+)
+def test_invalid_mode_combinations_are_rejected(days, from_datetime, to_datetime, all_time):
+    with pytest.raises(HTTPException) as excinfo:
+        resolve_summary_range(days, from_datetime, to_datetime, all_time)
+    assert excinfo.value.status_code == 422

--- a/backend/tests/unit/test_dashboard_summary_range.py
+++ b/backend/tests/unit/test_dashboard_summary_range.py
@@ -14,35 +14,37 @@ NAIVE_FROM = datetime(2026, 8, 1)
 NAIVE_TO = datetime(2026, 8, 8)
 
 
-def _rolling_days(bounds: tuple[datetime, datetime]) -> float:
-    from_date, to_date = bounds
-    return (to_date - from_date) / timedelta(days=1)
+def _rolling_days(resolved) -> float:
+    return (resolved.to_date - resolved.from_date) / timedelta(days=1)
 
 
 def test_no_range_arguments_fall_back_to_the_legacy_rolling_window():
-    bounds = resolve_summary_range(None, None, None, False)
-    assert _rolling_days(bounds) == DEFAULT_SUMMARY_DAYS
-    assert all(bound.utcoffset() is not None for bound in bounds)
+    resolved = resolve_summary_range(None, None, None, False)
+    assert _rolling_days(resolved) == DEFAULT_SUMMARY_DAYS
+    assert resolved.exact is False
+    assert resolved.from_date.utcoffset() is not None and resolved.to_date.utcoffset() is not None
 
 
 def test_days_keeps_the_legacy_rolling_duration():
-    assert _rolling_days(resolve_summary_range(7, None, None, False)) == 7
+    resolved = resolve_summary_range(7, None, None, False)
+    assert _rolling_days(resolved) == 7
+    assert resolved.exact is False
 
 
 def test_exact_pair_passes_through_unchanged():
-    assert resolve_summary_range(None, EXACT_FROM, EXACT_TO, False) == (EXACT_FROM, EXACT_TO)
+    assert resolve_summary_range(None, EXACT_FROM, EXACT_TO, False) == (EXACT_FROM, EXACT_TO, True)
 
 
 def test_exact_pair_keeps_a_non_utc_offset():
-    assert resolve_summary_range(None, OFFSET_FROM, EXACT_TO, False) == (OFFSET_FROM, EXACT_TO)
+    assert resolve_summary_range(None, OFFSET_FROM, EXACT_TO, False) == (OFFSET_FROM, EXACT_TO, True)
 
 
 def test_all_time_drops_both_bounds():
-    assert resolve_summary_range(None, None, None, True) == (None, None)
+    assert resolve_summary_range(None, None, None, True) == (None, None, False)
 
 
 def test_all_time_false_stays_inactive_beside_another_mode():
-    assert resolve_summary_range(None, EXACT_FROM, EXACT_TO, False) == (EXACT_FROM, EXACT_TO)
+    assert resolve_summary_range(None, EXACT_FROM, EXACT_TO, False) == (EXACT_FROM, EXACT_TO, True)
     assert _rolling_days(resolve_summary_range(7, None, None, False)) == 7
 
 

--- a/backend/tests/unit/test_date_time_bucket_helpers.py
+++ b/backend/tests/unit/test_date_time_bucket_helpers.py
@@ -1,0 +1,49 @@
+"""Unit tests for the UTC daily-stat bucket conversions"""
+
+from datetime import date, datetime, timedelta, timezone
+
+from app.core.utils.date_time_utils import exact_interval_bucket_dates, rolling_window_bucket_dates
+
+TZ_PLUS_2 = timezone(timedelta(hours=2))
+TZ_MINUS_7 = timezone(timedelta(hours=-7))
+
+
+def test_exact_interval_covers_every_touched_utc_day():
+    assert exact_interval_bucket_dates(
+        datetime(2026, 8, 1, 15, 0, tzinfo=timezone.utc),
+        datetime(2026, 8, 8, tzinfo=timezone.utc),
+    ) == (date(2026, 8, 1), date(2026, 8, 7))
+
+
+def test_exact_interval_of_one_day_is_a_single_bucket():
+    start = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    assert exact_interval_bucket_dates(start, start + timedelta(days=1)) == (
+        date(2026, 8, 1),
+        date(2026, 8, 1),
+    )
+
+
+def test_exact_interval_converts_local_offsets_to_utc_days():
+    assert exact_interval_bucket_dates(
+        datetime(2026, 8, 2, tzinfo=TZ_PLUS_2),
+        datetime(2026, 8, 3, tzinfo=TZ_PLUS_2),
+    ) == (date(2026, 8, 1), date(2026, 8, 2))
+
+    assert exact_interval_bucket_dates(
+        datetime(2026, 8, 2, tzinfo=TZ_MINUS_7),
+        datetime(2026, 8, 3, tzinfo=TZ_MINUS_7),
+    ) == (date(2026, 8, 2), date(2026, 8, 3))
+
+
+def test_rolling_window_keeps_whole_utc_days():
+    assert rolling_window_bucket_dates(
+        datetime(2026, 1, 1, tzinfo=timezone.utc),
+        datetime(2026, 1, 31, tzinfo=timezone.utc),
+    ) == (date(2026, 1, 1), date(2026, 1, 31))
+
+
+def test_rolling_window_rounds_a_mid_day_start_up():
+    assert rolling_window_bucket_dates(
+        datetime(2026, 1, 1, 13, 30, tzinfo=timezone.utc),
+        datetime(2026, 1, 31, 13, 30, tzinfo=timezone.utc),
+    ) == (date(2026, 1, 2), date(2026, 1, 31))

--- a/backend/tests/unit/test_llm_usage_read_repo_sql.py
+++ b/backend/tests/unit/test_llm_usage_read_repo_sql.py
@@ -15,6 +15,8 @@ from app.services.llm_usage_read import _DIMENSION_COLUMNS, _EXTRA_BREAKDOWN_CON
 
 WINDOW_START = datetime(2026, 1, 1, tzinfo=timezone.utc)
 WINDOW_END = datetime(2026, 1, 31, tzinfo=timezone.utc)
+BUCKET_FROM = date(2026, 1, 1)
+BUCKET_TO = date(2026, 1, 31)
 
 
 class _Result:
@@ -216,6 +218,20 @@ async def test_dashboard_ledger_total_restricts_to_the_visible_agents():
 
 
 @pytest.mark.asyncio
+async def test_dashboard_ledger_total_in_exact_mode_keeps_the_caller_instants():
+    db = CapturingDb()
+    await DashboardRepository(db).get_total_cost_usd(
+        datetime(2026, 1, 1, 15, 30, tzinfo=timezone.utc),
+        datetime(2026, 1, 31, 9, 0, tzinfo=timezone.utc),
+        agent_ids=None,
+        exact=True,
+    )
+    sql = _sql(db.statements[0])
+    assert "occurred_at >= '2026-01-01 15:30:00+00:00'" in sql
+    assert "occurred_at < '2026-01-31 09:00:00+00:00'" in sql
+
+
+@pytest.mark.asyncio
 async def test_dashboard_ledger_total_without_bounds_has_no_date_predicate():
     db = CapturingDb()
     await DashboardRepository(db).get_total_cost_usd(agent_ids=None)
@@ -243,22 +259,39 @@ async def test_dashboard_ledger_total_short_circuits_on_an_empty_scope():
 @pytest.mark.asyncio
 async def test_dashboard_response_time_without_a_scope_has_no_agent_predicate():
     db = CapturingDb()
-    await DashboardRepository(db).get_avg_response_time(WINDOW_START, WINDOW_END, agent_ids=None)
+    await DashboardRepository(db).get_avg_response_time(BUCKET_FROM, BUCKET_TO, agent_ids=None)
     assert "agent_id" not in _sql(db.statements[0])
+
+
+@pytest.mark.asyncio
+async def test_dashboard_response_time_filters_on_inclusive_bucket_dates():
+    db = CapturingDb()
+    await DashboardRepository(db).get_avg_response_time(BUCKET_FROM, BUCKET_TO, agent_ids=None)
+    sql = _sql(db.statements[0])
+    assert "stat_date >= '2026-01-01'" in sql
+    assert "stat_date <= '2026-01-31'" in sql
+    assert "is_deleted = 0" in sql
+
+
+@pytest.mark.asyncio
+async def test_dashboard_response_time_without_bounds_has_no_date_predicate():
+    db = CapturingDb()
+    await DashboardRepository(db).get_avg_response_time(agent_ids=None)
+    assert "stat_date" not in _sql(db.statements[0])
 
 
 @pytest.mark.asyncio
 async def test_dashboard_response_time_restricts_to_the_visible_agents():
     db = CapturingDb()
     scope = [uuid4(), uuid4()]
-    await DashboardRepository(db).get_avg_response_time(WINDOW_START, WINDOW_END, agent_ids=scope)
+    await DashboardRepository(db).get_avg_response_time(BUCKET_FROM, BUCKET_TO, agent_ids=scope)
     assert "agent_id IN" in _sql(db.statements[0])
 
 
 @pytest.mark.asyncio
 async def test_dashboard_response_time_short_circuits_on_an_empty_scope():
     db = CapturingDb()
-    avg = await DashboardRepository(db).get_avg_response_time(WINDOW_START, WINDOW_END, agent_ids=[])
+    avg = await DashboardRepository(db).get_avg_response_time(BUCKET_FROM, BUCKET_TO, agent_ids=[])
     assert avg == 0
     assert db.statements == []
 

--- a/backend/tests/unit/test_llm_usage_read_repo_sql.py
+++ b/backend/tests/unit/test_llm_usage_read_repo_sql.py
@@ -216,6 +216,23 @@ async def test_dashboard_ledger_total_restricts_to_the_visible_agents():
 
 
 @pytest.mark.asyncio
+async def test_dashboard_ledger_total_without_bounds_has_no_date_predicate():
+    db = CapturingDb()
+    await DashboardRepository(db).get_total_cost_usd(agent_ids=None)
+    sql = _sql(db.statements[0])
+    assert "occurred_at" not in sql
+    assert "is_deleted = 0" in sql
+
+
+@pytest.mark.asyncio
+async def test_dashboard_ledger_total_rejects_a_half_supplied_range():
+    db = CapturingDb()
+    with pytest.raises(ValueError):
+        await DashboardRepository(db).get_total_cost_usd(WINDOW_START, None, agent_ids=None)
+    assert db.statements == []
+
+
+@pytest.mark.asyncio
 async def test_dashboard_ledger_total_short_circuits_on_an_empty_scope():
     db = CapturingDb()
     total = await DashboardRepository(db).get_total_cost_usd(WINDOW_START, WINDOW_END, agent_ids=[])

--- a/frontend/src/helpers/analyticsParams.ts
+++ b/frontend/src/helpers/analyticsParams.ts
@@ -28,10 +28,7 @@ function localEndOfDayUTC(d: Date): string {
 }
 
 /**
- * Convert a local date range to expanded UTC date strings (yyyy-MM-dd).
- * Used for daily-stats endpoints that filter on a Date column bucketed by UTC.
- * The local start/end-of-day may span two UTC dates, so we take the date
- * component of each converted boundary.
+ * Legacy date-string params (yyyy-MM-dd) for the menus that still send day filters.
  */
 export function toExpandedUTCDateRange(
   dateRange: DateRange | undefined,

--- a/frontend/src/helpers/dateRange.test.ts
+++ b/frontend/src/helpers/dateRange.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeDateRange,
+  toExactActivityParams,
+  toExactInterval,
+  toUtcBucketDateParams,
+} from "./dateRange";
+
+const day = (y: number, m: number, d: number, h = 0) => new Date(y, m - 1, d, h);
+
+const offsetMinutes = (d: Date) => d.getTimezoneOffset();
+
+describe("normalizeDateRange", () => {
+  it("leaves a complete range untouched", () => {
+    const range = { from: day(2026, 8, 1), to: day(2026, 8, 8) };
+    expect(normalizeDateRange(range)).toEqual(range);
+  });
+
+  it("treats a from-only range as a single day", () => {
+    const from = day(2026, 8, 1);
+    expect(normalizeDateRange({ from, to: undefined })).toEqual({ from, to: from });
+  });
+
+  it("keeps an empty range undefined for all-time", () => {
+    expect(normalizeDateRange(undefined)).toBeUndefined();
+    expect(normalizeDateRange({ from: undefined, to: undefined })).toBeUndefined();
+  });
+});
+
+describe("toExactInterval", () => {
+  it("spans whole local days, end exclusive", () => {
+    const interval = toExactInterval({ from: day(2026, 8, 1, 13), to: day(2026, 8, 3, 9) })!;
+    expect(interval.start).toEqual(day(2026, 8, 1));
+    expect(interval.endExclusive).toEqual(day(2026, 8, 4));
+  });
+
+  it("covers exactly one day for a from-only range", () => {
+    const interval = toExactInterval({ from: day(2026, 8, 1), to: undefined })!;
+    expect(interval.start).toEqual(day(2026, 8, 1));
+    expect(interval.endExclusive).toEqual(day(2026, 8, 2));
+  });
+
+  it("keeps local midnight across a DST transition", () => {
+    for (const [from, to] of [
+      [day(2026, 3, 28), day(2026, 3, 30)],
+      [day(2026, 11, 1), day(2026, 11, 3)],
+    ]) {
+      const interval = toExactInterval({ from, to })!;
+      expect(interval.start.getHours()).toBe(0);
+      expect(interval.endExclusive.getHours()).toBe(0);
+      expect(interval.endExclusive.getDate()).toBe(to.getDate() + 1);
+    }
+  });
+});
+
+describe("toExactActivityParams", () => {
+  it("emits both boundaries as UTC ISO strings", () => {
+    const params = toExactActivityParams({ from: day(2026, 8, 1), to: day(2026, 8, 7) });
+    expect(params.activity_from_datetime).toBe(day(2026, 8, 1).toISOString());
+    expect(params.activity_to_datetime).toBe(day(2026, 8, 8).toISOString());
+  });
+
+  it("emits a complete one-day interval for a from-only range", () => {
+    const params = toExactActivityParams({ from: day(2026, 8, 1), to: undefined });
+    expect(params.activity_from_datetime).toBeDefined();
+    expect(params.activity_to_datetime).toBeDefined();
+    const spanMs =
+      new Date(params.activity_to_datetime!).getTime() -
+      new Date(params.activity_from_datetime!).getTime();
+    expect(spanMs).toBeGreaterThan(0);
+    expect(spanMs).toBeLessThanOrEqual(25 * 60 * 60 * 1000);
+  });
+
+  it("returns nothing for an empty range so callers can fall back to all-time", () => {
+    expect(toExactActivityParams(undefined)).toEqual({});
+  });
+});
+
+describe("toUtcBucketDateParams", () => {
+  it("always returns both bounds for a from-only range", () => {
+    const params = toUtcBucketDateParams({ from: day(2026, 8, 1), to: undefined });
+    expect(params.from_date).toBeDefined();
+    expect(params.to_date).toBeDefined();
+  });
+
+  it("expands to the UTC dates the local interval touches", () => {
+    const range = { from: day(2026, 8, 1), to: day(2026, 8, 7) };
+    const params = toUtcBucketDateParams(range);
+    const west = offsetMinutes(range.from) > 0;
+    const east = offsetMinutes(range.from) < 0;
+    expect(params.from_date).toBe(east ? "2026-07-31" : "2026-08-01");
+    expect(params.to_date).toBe(west ? "2026-08-08" : "2026-08-07");
+  });
+
+  it("matches the exact interval it is derived from", () => {
+    const range = { from: day(2026, 8, 1), to: day(2026, 8, 7) };
+    const interval = toExactInterval(range)!;
+    const params = toUtcBucketDateParams(range);
+    expect(params.from_date).toBe(interval.start.toISOString().slice(0, 10));
+    expect(params.to_date).toBe(
+      new Date(interval.endExclusive.getTime() - 1).toISOString().slice(0, 10),
+    );
+  });
+
+  it("returns nothing for an empty range", () => {
+    expect(toUtcBucketDateParams(undefined)).toEqual({});
+  });
+});
+
+describe("agent performance parameter families", () => {
+  it("builds a complete request from a first picker click", () => {
+    const params = {
+      ...toUtcBucketDateParams({ from: day(2026, 8, 1), to: undefined }),
+      ...toExactActivityParams({ from: day(2026, 8, 1), to: undefined }),
+    };
+    for (const key of [
+      "from_date",
+      "to_date",
+      "activity_from_datetime",
+      "activity_to_datetime",
+    ] as const) {
+      expect(params[key]).toBeDefined();
+    }
+    expect(new Date(params.activity_from_datetime!).getTime()).toBeLessThan(
+      new Date(params.activity_to_datetime!).getTime(),
+    );
+  });
+});

--- a/frontend/src/helpers/dateRange.ts
+++ b/frontend/src/helpers/dateRange.ts
@@ -1,0 +1,70 @@
+import type { DateRange } from "react-day-picker";
+
+/** A picker range with both ends resolved. */
+export type NormalizedDateRange = { from: Date; to: Date };
+
+/** Half-open interval of whole local days, ready for UTC conversion. */
+export type ExactInterval = { start: Date; endExclusive: Date };
+
+export type ExactActivityParams = {
+  activity_from_datetime?: string;
+  activity_to_datetime?: string;
+};
+
+export type UtcBucketDateParams = {
+  from_date?: string;
+  to_date?: string;
+};
+
+/**
+ * Turns a picker selection into a date range. A single click (`{ from, to: undefined }`)
+ * means just that one day; no selection at all stays undefined, meaning all-time.
+ */
+export function normalizeDateRange(
+  range: DateRange | undefined,
+): NormalizedDateRange | undefined {
+  if (!range?.from) return undefined;
+  return { from: range.from, to: range.to ?? range.from };
+}
+
+function localMidnight(day: Date): Date {
+  return new Date(day.getFullYear(), day.getMonth(), day.getDate());
+}
+
+function utcDateString(instant: Date): string {
+  return instant.toISOString().slice(0, 10);
+}
+
+export function toExactInterval(
+  range: DateRange | undefined,
+): ExactInterval | undefined {
+  const normalized = normalizeDateRange(range);
+  if (!normalized) return undefined;
+  const start = localMidnight(normalized.from);
+  const endExclusive = localMidnight(normalized.to);
+  endExclusive.setDate(endExclusive.getDate() + 1);
+  return { start, endExclusive };
+}
+
+/** Exact conversation-activity boundaries as UTC ISO strings. */
+export function toExactActivityParams(
+  range: DateRange | undefined,
+): ExactActivityParams {
+  const interval = toExactInterval(range);
+  if (!interval) return {};
+  return {
+    activity_from_datetime: interval.start.toISOString(),
+    activity_to_datetime: interval.endExclusive.toISOString(),
+  };
+}
+
+export function toUtcBucketDateParams(
+  range: DateRange | undefined,
+): UtcBucketDateParams {
+  const interval = toExactInterval(range);
+  if (!interval) return {};
+  return {
+    from_date: utcDateString(interval.start),
+    to_date: utcDateString(new Date(interval.endExclusive.getTime() - 1)),
+  };
+}

--- a/frontend/src/hooks/usePersistedDateRange.test.ts
+++ b/frontend/src/hooks/usePersistedDateRange.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { parseStoredDateRange } from "./usePersistedDateRange";
+
+describe("parseStoredDateRange", () => {
+  it("reports nothing stored for a missing entry", () => {
+    expect(parseStoredDateRange(null)).toBeNull();
+    expect(parseStoredDateRange("")).toBeNull();
+  });
+
+  it("reports nothing stored for unparseable content", () => {
+    expect(parseStoredDateRange("not json")).toBeNull();
+  });
+
+  it("reads a legacy ISO range", () => {
+    const parsed = parseStoredDateRange(
+      JSON.stringify({ from: "2026-08-01T00:00:00.000Z", to: "2026-08-08T00:00:00.000Z" }),
+    );
+    expect(parsed?.value?.from).toEqual(new Date("2026-08-01T00:00:00.000Z"));
+    expect(parsed?.value?.to).toEqual(new Date("2026-08-08T00:00:00.000Z"));
+  });
+
+  it("keeps a from-only range", () => {
+    const parsed = parseStoredDateRange(JSON.stringify({ from: "2026-08-01T00:00:00.000Z" }));
+    expect(parsed?.value?.from).toEqual(new Date("2026-08-01T00:00:00.000Z"));
+    expect(parsed?.value?.to).toBeUndefined();
+  });
+
+  it("distinguishes a cleared range from nothing stored", () => {
+    const cleared = parseStoredDateRange("{}");
+    expect(cleared).not.toBeNull();
+    expect(cleared?.value).toBeUndefined();
+  });
+
+  it("treats invalid dates as nothing stored", () => {
+    expect(parseStoredDateRange(JSON.stringify({ from: "nonsense", to: "nonsense" }))?.value).toBeUndefined();
+  });
+});

--- a/frontend/src/hooks/usePersistedDateRange.ts
+++ b/frontend/src/hooks/usePersistedDateRange.ts
@@ -48,24 +48,24 @@ function parseDate(value: string | undefined): Date | undefined {
   return Number.isNaN(date.getTime()) ? undefined : date;
 }
 
-function deserialize(raw: string | null): DateRange | undefined {
-  if (!raw) return undefined;
+export function parseStoredDateRange(raw: string | null): { value: DateRange | undefined } | null {
+  if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as StoredDateRange;
     const from = parseDate(parsed.from);
     const to = parseDate(parsed.to);
-    if (!from && !to) return undefined;
-    return { from, to };
+    if (!from && !to) return { value: undefined };
+    return { value: { from, to } };
   } catch {
-    return undefined;
+    return null;
   }
 }
 
-function readStored(storageKey: string): DateRange | undefined {
+function readStored(storageKey: string): { value: DateRange | undefined } | null {
   try {
-    return deserialize(localStorage.getItem(storageKey));
+    return parseStoredDateRange(localStorage.getItem(storageKey));
   } catch {
-    return undefined;
+    return null;
   }
 }
 
@@ -75,7 +75,7 @@ export function usePersistedDateRange(
 ): [DateRange | undefined, (value: DateRange | undefined) => void] {
   const [value, setValue] = useState<DateRange | undefined>(() => {
     const stored = readStored(storageKey);
-    return stored ?? defaultValue;
+    return stored ? stored.value : defaultValue;
   });
 
   const setPersisted = useCallback(
@@ -97,7 +97,7 @@ export function usePersistedDateRange(
   // Keep this instance in sync when its range is changed elsewhere — either in
   // another tab (`storage`) or by another consumer in this tab (custom event).
   useEffect(() => {
-    const sync = () => setValue(readStored(storageKey) ?? undefined);
+    const sync = () => setValue(readStored(storageKey)?.value);
 
     const onStorage = (event: StorageEvent) => {
       if (event.key === storageKey) sync();

--- a/frontend/src/interfaces/analyticsReports.interface.ts
+++ b/frontend/src/interfaces/analyticsReports.interface.ts
@@ -101,6 +101,8 @@ export interface AnalyticsFilterParams {
   from_date?: string;
   to_date?: string;
   node_type?: string;
+  activity_from_datetime?: string;
+  activity_to_datetime?: string;
 }
 
 export interface GroupAgentItem {

--- a/frontend/src/interfaces/dashboard.interface.ts
+++ b/frontend/src/interfaces/dashboard.interface.ts
@@ -1,5 +1,8 @@
 export interface DashboardSummaryStats {
   active_agents: number;
+  /** Unique chat sessions with agent activity in the selected period. */
+  conversations: number;
+  /** @deprecated Alias of `conversations`; always the same value. */
   workflow_runs: number;
   avg_response_time_ms: number;
   total_cost_usd: number;

--- a/frontend/src/services/analyticsReports.ts
+++ b/frontend/src/services/analyticsReports.ts
@@ -40,7 +40,10 @@ export const fetchAgentDailyStats = async (
 };
 
 export const fetchAgentStatsSummary = async (
-  params?: Pick<AnalyticsFilterParams, "agent_id" | "group_id" | "from_date" | "to_date">
+  params?: Pick<
+    AnalyticsFilterParams,
+    "agent_id" | "group_id" | "from_date" | "to_date" | "activity_from_datetime" | "activity_to_datetime"
+  >
 ): Promise<AgentStatsSummaryResponse | null> => {
   try {
     const qs = buildQueryString({
@@ -48,6 +51,8 @@ export const fetchAgentStatsSummary = async (
       group_id: params?.group_id,
       from_date: params?.from_date,
       to_date: params?.to_date,
+      activity_from_datetime: params?.activity_from_datetime,
+      activity_to_datetime: params?.activity_to_datetime,
     });
     return await apiRequest<AgentStatsSummaryResponse>("get", `/analytics/agents/summary${qs}`);
   } catch (error) {

--- a/frontend/src/services/dashboard.ts
+++ b/frontend/src/services/dashboard.ts
@@ -27,21 +27,35 @@ export const fetchDashboard = async (
   }
 };
 
+/** The mutually exclusive range modes accepted by /dashboard/summary */
+export type DashboardSummaryRange =
+  | { days: number }
+  | { from_datetime: string; to_datetime: string }
+  | { all_time: true };
+
+function summaryQueryString(range: DashboardSummaryRange): string {
+  const params = new URLSearchParams();
+  if ("days" in range) {
+    params.set("days", String(range.days));
+  } else if ("all_time" in range) {
+    params.set("all_time", "true");
+  } else {
+    params.set("from_datetime", range.from_datetime);
+    params.set("to_datetime", range.to_datetime);
+  }
+  return params.toString();
+}
+
 /**
  * Fetch dashboard summary statistics
  */
 export const fetchDashboardSummary = async (
-  days: number = 30
+  range: DashboardSummaryRange = { days: 30 }
 ): Promise<DashboardSummaryStats | null> => {
-  try {
-    return await apiRequest<DashboardSummaryStats>(
-      "get",
-      `/dashboard/summary?days=${days}`
-    );
-  } catch (error) {
-    console.error("Error fetching dashboard summary:", error);
-    return null;
-  }
+  return await apiRequest<DashboardSummaryStats>(
+    "get",
+    `/dashboard/summary?${summaryQueryString(range)}`
+  );
 };
 
 /**

--- a/frontend/src/views/Analytics/components/KPISection.tsx
+++ b/frontend/src/views/Analytics/components/KPISection.tsx
@@ -1,15 +1,17 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
+import type { DateRange } from "react-day-picker";
 import { StatsOverviewCard } from "./StatsOverviewCard";
 
 import { usePermissions, useIsLoadingPermissions } from "@/context/PermissionContext";
-import { fetchDashboardSummary } from "@/services/dashboard";
+import { fetchDashboardSummary, type DashboardSummaryRange } from "@/services/dashboard";
 import type { DashboardSummaryStats } from "@/interfaces/dashboard.interface";
 import { useFeatureFlagVisible } from "@/components/featureFlag";
 import { FeatureFlags } from "@/config/featureFlags";
 import { formatUsd } from "@/helpers/formatCurrency";
+import { toExactActivityParams } from "@/helpers/dateRange";
 
 interface KPISectionProps {
-  days: number;
+  dateRange: DateRange | undefined;
 }
 
 const formatResponseTime = (ms: number): string => {
@@ -22,8 +24,14 @@ const formatResponseTime = (ms: number): string => {
 const formatNumber = (num: number): string => {
   return num.toLocaleString();
 };
+/** No dates picked means show all-time, otherwise use the exact local-day range picked */ 
+function toSummaryRange(dateRange: DateRange | undefined): DashboardSummaryRange {
+  const { activity_from_datetime, activity_to_datetime } = toExactActivityParams(dateRange);
+  if (!activity_from_datetime || !activity_to_datetime) return { all_time: true };
+  return { from_datetime: activity_from_datetime, to_datetime: activity_to_datetime };
+}
 
-export function KPISection({ days }: KPISectionProps) {
+export function KPISection({ dateRange }: KPISectionProps) {
   const permissions = usePermissions();
   const isLoadingPermissions = useIsLoadingPermissions();
   const showCostPerConversation = useFeatureFlagVisible(
@@ -31,6 +39,11 @@ export function KPISection({ days }: KPISectionProps) {
   );
   const [summaryStats, setSummaryStats] = useState<DashboardSummaryStats | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const requestId = useRef(0);
+
+  const fromTime = dateRange?.from?.getTime();
+  const toTime = dateRange?.to?.getTime();
 
   useEffect(() => {
     const fetchStats = async () => {
@@ -40,14 +53,20 @@ export function KPISection({ days }: KPISectionProps) {
 
       // Check for dashboard permission or wildcard
       if (permissions.includes("read:dashboard") || permissions.includes("*")) {
+        const currentRequest = ++requestId.current;
         setLoading(true);
         try {
-          const data = await fetchDashboardSummary(days);
+          const data = await fetchDashboardSummary(toSummaryRange(dateRange));
+          if (currentRequest !== requestId.current) return; // a newer range won
           setSummaryStats(data);
+          setError(data ? null : "Summary unavailable");
         } catch (err) {
           console.error("Error fetching dashboard summary:", err);
+          if (currentRequest !== requestId.current) return;
+          setSummaryStats(null);
+          setError("Summary unavailable");
         } finally {
-          setLoading(false);
+          if (currentRequest === requestId.current) setLoading(false);
         }
       } else {
         setLoading(false);
@@ -55,25 +74,25 @@ export function KPISection({ days }: KPISectionProps) {
     };
 
     fetchStats();
-  }, [isLoadingPermissions, permissions, days]);
+  }, [isLoadingPermissions, permissions, fromTime, toTime]);
 
   // Transform summary stats for the stats overview card
   const statsMetrics = [
     {
       label: "Active Agents",
-      value: summaryStats?.active_agents?.toString() || "0",
+      value: (summaryStats?.active_agents ?? 0).toString(),
       change: 0,
       changeType: "neutral" as const,
     },
     {
-      label: "Workflow Runs",
-      value: formatNumber(summaryStats?.workflow_runs || 0),
+      label: "Conversations",
+      value: formatNumber(summaryStats?.conversations ?? 0),
       change: 0,
       changeType: "neutral" as const,
     },
     {
       label: "Avg Response Time",
-      value: formatResponseTime(summaryStats?.avg_response_time_ms || 0),
+      value: formatResponseTime(summaryStats?.avg_response_time_ms ?? 0),
       change: 0,
       changeType: "neutral" as const,
     },
@@ -91,7 +110,7 @@ export function KPISection({ days }: KPISectionProps) {
 
   return (
     <section className="mb-5">
-      <StatsOverviewCard metrics={statsMetrics} loading={loading} />
+      <StatsOverviewCard metrics={statsMetrics} loading={loading} error={error} />
     </section>
   );
 }

--- a/frontend/src/views/Analytics/components/StatsOverviewCard.tsx
+++ b/frontend/src/views/Analytics/components/StatsOverviewCard.tsx
@@ -13,9 +13,10 @@ interface StatMetric {
 interface StatsOverviewCardProps {
   metrics: StatMetric[];
   loading?: boolean;
+  error?: string | null;
 }
 
-export const StatsOverviewCard = ({ metrics, loading = false }: StatsOverviewCardProps) => {
+export const StatsOverviewCard = ({ metrics, loading = false, error = null }: StatsOverviewCardProps) => {
   const getChangeIcon = (changeType: "increase" | "decrease" | "neutral") => {
     switch (changeType) {
       case "increase":
@@ -45,6 +46,19 @@ export const StatsOverviewCard = ({ metrics, loading = false }: StatsOverviewCar
               )}
             </div>
           ))}
+        </div>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="w-full px-4 py-4 sm:px-6 sm:py-6 shadow-sm bg-card dark:bg-zinc-900 animate-fade-up">
+        <div className="flex flex-col gap-1 py-2">
+          <div className="text-sm sm:text-base font-medium text-foreground">
+            Statistics unavailable
+          </div>
+          <div className="text-xs text-muted-foreground">{error}</div>
         </div>
       </Card>
     );

--- a/frontend/src/views/Analytics/components/reports/SummaryStatsCards.tsx
+++ b/frontend/src/views/Analytics/components/reports/SummaryStatsCards.tsx
@@ -95,7 +95,7 @@ function buildMetrics(
         summary.total_finalized_conversations + summary.total_in_progress_conversations > 0
           ? `${summary.total_finalized_conversations} completed · ${summary.total_in_progress_conversations} in progress`
           : undefined,
-      description: "Unique chat sessions in the selected period.",
+      description: "Unique chat sessions with agent activity in the selected period.",
       delta: previous
         ? pctChange(summary.total_unique_conversations, previous.total_unique_conversations)
         : null,

--- a/frontend/src/views/Analytics/helpers/agentRows.test.ts
+++ b/frontend/src/views/Analytics/helpers/agentRows.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import type { AgentDailyStatsItem } from "@/interfaces/analyticsReports.interface";
+import { aggregateAgentRows, toConversationCountsByAgent } from "./agentRows";
+
+const dailyRow = (
+  agent_id: string,
+  overrides: Partial<AgentDailyStatsItem> = {},
+): AgentDailyStatsItem => ({
+  id: `${agent_id}-${overrides.stat_date ?? "2026-08-01"}`,
+  agent_id,
+  stat_date: "2026-08-01",
+  execution_count: 10,
+  success_count: 9,
+  error_count: 1,
+  avg_response_ms: 500,
+  min_response_ms: 100,
+  max_response_ms: 900,
+  total_nodes_executed: 20,
+  avg_success_rate: 0.9,
+  rag_used_count: 2,
+  unique_conversations: 4,
+  finalized_conversations: 3,
+  in_progress_conversations: 1,
+  thumbs_up_count: 1,
+  thumbs_down_count: 0,
+  last_aggregated_at: "2026-08-01T00:00:00Z",
+  ...overrides,
+});
+
+const canonical = (
+  agent_id: string,
+  unique_conversations: number,
+  finalized_conversations = unique_conversations,
+  in_progress_conversations = 0,
+) => ({
+  agent_id,
+  unique_conversations,
+  finalized_conversations,
+  in_progress_conversations,
+});
+
+describe("toConversationCountsByAgent", () => {
+  it("returns null when the summary carried no rows", () => {
+    expect(toConversationCountsByAgent(undefined)).toBeNull();
+  });
+
+  it("returns an empty map for an empty row list", () => {
+    expect(toConversationCountsByAgent([])?.size).toBe(0);
+  });
+});
+
+describe("aggregateAgentRows", () => {
+  it("sums execution metrics across daily buckets", () => {
+    const rows = aggregateAgentRows(
+      [
+        dailyRow("a", { execution_count: 10, success_count: 9, error_count: 1 }),
+        dailyRow("a", { stat_date: "2026-08-02", execution_count: 5, success_count: 5, error_count: 0 }),
+      ],
+      null,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].execution_count).toBe(15);
+    expect(rows[0].success_count).toBe(14);
+    expect(rows[0].error_count).toBe(1);
+  });
+
+  it("weights avg response time by execution count", () => {
+    const rows = aggregateAgentRows(
+      [
+        dailyRow("a", { execution_count: 10, avg_response_ms: 100 }),
+        dailyRow("a", { stat_date: "2026-08-02", execution_count: 30, avg_response_ms: 200 }),
+      ],
+      null,
+    );
+    expect(rows[0].avg_response_ms).toBe((10 * 100 + 30 * 200) / 40);
+  });
+
+  it("keeps daily conversation counts when no canonical rows exist", () => {
+    const rows = aggregateAgentRows([dailyRow("a", { unique_conversations: 4 })], null);
+    expect(rows[0].unique_conversations).toBe(4);
+  });
+
+  it("prefers canonical counts over the daily bucket count", () => {
+    const rows = aggregateAgentRows(
+      [dailyRow("a", { unique_conversations: 4 })],
+      toConversationCountsByAgent([canonical("a", 2, 1, 1)]),
+    );
+    expect(rows[0].unique_conversations).toBe(2);
+    expect(rows[0].finalized_conversations).toBe(1);
+    expect(rows[0].in_progress_conversations).toBe(1);
+  });
+
+  it("zeroes an agent whose daily buckets fall outside the exact activity interval", () => {
+    const rows = aggregateAgentRows(
+      [dailyRow("a", { unique_conversations: 4 }), dailyRow("b", { unique_conversations: 7 })],
+      toConversationCountsByAgent([canonical("a", 4)]),
+    );
+    const b = rows.find((row) => row.agent_id === "b")!;
+    expect(b.unique_conversations).toBe(0);
+    expect(b.execution_count).toBe(10);
+  });
+
+  it("adds a row for an agent that only the canonical counts know about", () => {
+    const rows = aggregateAgentRows(
+      [dailyRow("a", { unique_conversations: 4 })],
+      toConversationCountsByAgent([canonical("a", 4), canonical("b", 3, 2, 1)]),
+    );
+    const b = rows.find((row) => row.agent_id === "b")!;
+    expect(b).toMatchObject({
+      agent_id: "b",
+      unique_conversations: 3,
+      finalized_conversations: 2,
+      in_progress_conversations: 1,
+      execution_count: 0,
+      avg_response_ms: null,
+    });
+  });
+
+  it("makes the rows sum to the canonical summary total", () => {
+    const canonicalRows = [canonical("a", 4), canonical("b", 3), canonical("c", 5)];
+    const summaryTotal = canonicalRows.reduce((sum, row) => sum + row.unique_conversations, 0);
+    const rows = aggregateAgentRows(
+      [
+        dailyRow("a", { unique_conversations: 9 }),
+        dailyRow("b", { unique_conversations: 1 }),
+        dailyRow("d", { unique_conversations: 6 }),
+      ],
+      toConversationCountsByAgent(canonicalRows),
+    );
+    const rowTotal = rows.reduce((sum, row) => sum + row.unique_conversations, 0);
+    expect(rowTotal).toBe(summaryTotal);
+    expect(rows.map((row) => row.agent_id).sort()).toEqual(["a", "b", "c", "d"]);
+  });
+});

--- a/frontend/src/views/Analytics/helpers/agentRows.ts
+++ b/frontend/src/views/Analytics/helpers/agentRows.ts
@@ -1,0 +1,133 @@
+import type {
+  AgentConversationStatusByAgent,
+  AgentDailyStatsItem,
+} from "@/interfaces/analyticsReports.interface";
+
+export interface AgentAggregated {
+  id: string;
+  agent_id: string;
+  unique_conversations: number;
+  finalized_conversations: number;
+  in_progress_conversations: number;
+  execution_count: number;
+  success_count: number;
+  error_count: number;
+  avg_response_ms: number | null;
+  total_nodes_executed: number;
+  rag_used_count: number;
+  thumbs_up_count: number;
+  thumbs_down_count: number;
+}
+
+export type ConversationCounts = Pick<
+  AgentAggregated,
+  "unique_conversations" | "finalized_conversations" | "in_progress_conversations"
+>;
+
+type Accumulator = AgentAggregated & { _totalMs: number; _msCount: number };
+
+const NO_CONVERSATIONS: ConversationCounts = {
+  unique_conversations: 0,
+  finalized_conversations: 0,
+  in_progress_conversations: 0,
+};
+
+/** Canonical per-agent counts, or null when the summary carried none. */
+export function toConversationCountsByAgent(
+  rows: AgentConversationStatusByAgent[] | undefined,
+): Map<string, ConversationCounts> | null {
+  if (!rows) return null;
+  return new Map(
+    rows.map((row) => [
+      row.agent_id,
+      {
+        unique_conversations: row.unique_conversations,
+        finalized_conversations: row.finalized_conversations,
+        in_progress_conversations: row.in_progress_conversations,
+      },
+    ]),
+  );
+}
+
+function emptyRow(agentId: string): Accumulator {
+  return {
+    id: agentId,
+    agent_id: agentId,
+    ...NO_CONVERSATIONS,
+    execution_count: 0,
+    success_count: 0,
+    error_count: 0,
+    avg_response_ms: null,
+    total_nodes_executed: 0,
+    rag_used_count: 0,
+    thumbs_up_count: 0,
+    thumbs_down_count: 0,
+    _totalMs: 0,
+    _msCount: 0,
+  };
+}
+
+/**
+ * One row per agent: execution metrics from the UTC daily buckets, conversation
+ * counts from the canonical rows when available (they cover the exact activity
+ * window, not just whole UTC days). Canonical-only agents still get a row, so
+ * totals keep matching the summary. No canonical rows → daily counts are used as-is.
+ */
+export function aggregateAgentRows(
+  items: AgentDailyStatsItem[],
+  conversationsByAgent: Map<string, ConversationCounts> | null,
+): AgentAggregated[] {
+  const map = new Map<string, Accumulator>();
+
+  for (const item of items) {
+    const existing = map.get(item.agent_id);
+    if (existing) {
+      existing.execution_count += item.execution_count;
+      existing.success_count += item.success_count;
+      existing.error_count += item.error_count;
+      existing.total_nodes_executed += item.total_nodes_executed;
+      existing.rag_used_count += item.rag_used_count;
+      existing.thumbs_up_count += item.thumbs_up_count;
+      existing.thumbs_down_count += item.thumbs_down_count;
+      if (item.avg_response_ms != null) {
+        existing._totalMs += item.avg_response_ms * item.execution_count;
+        existing._msCount += item.execution_count;
+      }
+    } else {
+      map.set(item.agent_id, {
+        id: item.agent_id,
+        agent_id: item.agent_id,
+        unique_conversations: item.unique_conversations,
+        finalized_conversations: item.finalized_conversations,
+        in_progress_conversations: item.in_progress_conversations,
+        execution_count: item.execution_count,
+        success_count: item.success_count,
+        error_count: item.error_count,
+        avg_response_ms: item.avg_response_ms,
+        total_nodes_executed: item.total_nodes_executed,
+        rag_used_count: item.rag_used_count,
+        thumbs_up_count: item.thumbs_up_count,
+        thumbs_down_count: item.thumbs_down_count,
+        _totalMs: item.avg_response_ms != null ? item.avg_response_ms * item.execution_count : 0,
+        _msCount: item.avg_response_ms != null ? item.execution_count : 0,
+      });
+    }
+  }
+
+  for (const agentId of conversationsByAgent?.keys() ?? []) {
+    if (!map.has(agentId)) map.set(agentId, emptyRow(agentId));
+  }
+
+  return Array.from(map.values()).map((row) => {
+    const counts = conversationsByAgent
+      ? (conversationsByAgent.get(row.agent_id) ?? NO_CONVERSATIONS)
+      : row;
+    return {
+      ...row,
+      unique_conversations: counts.unique_conversations,
+      finalized_conversations: counts.finalized_conversations,
+      in_progress_conversations: counts.in_progress_conversations,
+      avg_response_ms: row._msCount > 0 ? row._totalMs / row._msCount : null,
+    };
+  });
+}

--- a/frontend/src/views/Analytics/pages/AgentPerformancePage.tsx
+++ b/frontend/src/views/Analytics/pages/AgentPerformancePage.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useRef } from "react";
 import { subDays } from "date-fns";
-import { toExpandedUTCDateRange } from "@/helpers/analyticsParams";
+import { toExactActivityParams, toUtcBucketDateParams } from "@/helpers/dateRange";
 import { Settings2, TrendingDown, ShieldCheck, ThumbsUp, ThumbsDown } from "lucide-react";
 import { DateRange } from "react-day-picker";
 import {
@@ -25,6 +25,11 @@ import {
 import { AgentPerformancePageSkeleton } from "../components/skeletons";
 import { cn } from "@/helpers/utils";
 import { useAnalyticsFilters } from "../hooks/useAnalyticsFilters";
+import {
+  aggregateAgentRows,
+  toConversationCountsByAgent,
+  type AgentAggregated,
+} from "../helpers/agentRows";
 import { usePersistedDateRange, COMPARE_DATE_RANGE_STORAGE_KEY } from "@/hooks/usePersistedDateRange";
 import {
   fetchAgentStatsSummary,
@@ -49,22 +54,6 @@ function getResponseTimeColor(ms: number): string {
 function formatResponseTime(ms: number | null): string {
   if (ms == null) return "—";
   return ms < 1000 ? `${Math.round(ms)} ms` : `${(ms / 1000).toFixed(1)}s`;
-}
-
-interface AgentAggregated {
-  id: string;
-  agent_id: string;
-  unique_conversations: number;
-  finalized_conversations: number;
-  in_progress_conversations: number;
-  execution_count: number;
-  success_count: number;
-  error_count: number;
-  avg_response_ms: number | null;
-  total_nodes_executed: number;
-  rag_used_count: number;
-  thumbs_up_count: number;
-  thumbs_down_count: number;
 }
 
 const AgentPerformancePage = () => {
@@ -99,23 +88,28 @@ const AgentPerformancePage = () => {
   const [nodeBreakdown, setNodeBreakdown] = useState<NodeTypeBreakdownItem[]>([]);
   const [escalationNode, setEscalationNode] = useState<string>("");
 
+  const dataRequestId = useRef(0);
+  const breakdownRequestId = useRef(0);
+
   const loadData = async (
     range: DateRange | undefined,
     filters: { agent_id?: string; group_id?: string },
     compareRange: DateRange | undefined,
   ) => {
+    // The picker can fire again before the last request finishes
+    const request = ++dataRequestId.current;
     setLoading(true);
     setError(null);
     try {
-      const { from_date, to_date } = toExpandedUTCDateRange(range);
       const params = {
-        from_date,
-        to_date,
+        ...toUtcBucketDateParams(range),
+        ...toExactActivityParams(range),
         ...filters,
       };
-      const compareParams = compareRange?.from && compareRange?.to
+      const compareParams = compareRange?.from
         ? {
-            ...toExpandedUTCDateRange(compareRange),
+            ...toUtcBucketDateParams(compareRange),
+            ...toExactActivityParams(compareRange),
             ...filters,
           }
         : undefined;
@@ -125,34 +119,49 @@ const AgentPerformancePage = () => {
         compareParams ? fetchAgentStatsSummary(compareParams) : Promise.resolve(null),
         fetchAgentDailyStats(params),
       ]);
+      if (request !== dataRequestId.current) return;
       setSummary(currentData);
       setPreviousSummary(previousData);
       setItems(dailyData?.items ?? []);
     } catch {
+      if (request !== dataRequestId.current) return;
       setError("Failed to load analytics data.");
     } finally {
-      setLoading(false);
+      if (request === dataRequestId.current) setLoading(false);
     }
   };
+
+  const fromTime = dateRange?.from?.getTime();
+  const toTime = dateRange?.to?.getTime();
+  const compareFromTime = compareDateRange?.from?.getTime();
+  const compareToTime = compareDateRange?.to?.getTime();
 
   useEffect(() => {
     loadData(dateRange, filterParams, compareDateRange);
 
     if (agentFilter !== "all") {
+      const request = ++breakdownRequestId.current;
       setEscalationNode(localStorage.getItem(LS_KEY(agentFilter)) ?? "");
-      fetchAgentNodeBreakdown(agentFilter, toExpandedUTCDateRange(dateRange))
-        .then((data) => setNodeBreakdown(data?.items ?? []))
-        .catch(() => setNodeBreakdown([]));
+      fetchAgentNodeBreakdown(agentFilter, toUtcBucketDateParams(dateRange))
+        .then((data) => {
+          if (request === breakdownRequestId.current) setNodeBreakdown(data?.items ?? []);
+        })
+        .catch(() => {
+          if (request === breakdownRequestId.current) setNodeBreakdown([]);
+        });
     } else {
+      breakdownRequestId.current++;
       setEscalationNode("");
       setNodeBreakdown([]);
     }
   }, [
-    dateRange,
+    fromTime,
+    toTime,
     agentFilter,
     filterParams.agent_id,
     filterParams.group_id,
-    compareDateRange,
+    compareFromTime,
+    compareToTime,
   ]);
 
   const handleEscalationNodeChange = (value: string) => {
@@ -185,73 +194,23 @@ const AgentPerformancePage = () => {
       : null;
   const containmentRate = escalationRate !== null ? 1 - escalationRate : null;
 
-  const conversationStatusByAgent = useMemo(() => {
-    const map = new Map<string, { unique_conversations: number; finalized_conversations: number; in_progress_conversations: number }>();
-    for (const row of summary?.conversation_status_by_agent ?? []) {
-      map.set(row.agent_id, {
-        unique_conversations: row.unique_conversations,
-        finalized_conversations: row.finalized_conversations,
-        in_progress_conversations: row.in_progress_conversations,
-      });
-    }
-    return map;
-  }, [summary?.conversation_status_by_agent]);
+  const conversationStatusByAgent = useMemo(
+    () => toConversationCountsByAgent(summary?.conversation_status_by_agent),
+    [summary?.conversation_status_by_agent],
+  );
 
-  // When all agents shown: aggregate daily rows into one row per agent
-  const aggregatedItems = useMemo<AgentAggregated[]>(() => {
-    const map = new Map<string, AgentAggregated & { _totalMs: number; _msCount: number }>();
-    for (const item of items) {
-      const existing = map.get(item.agent_id);
-      if (existing) {
-        existing.execution_count += item.execution_count;
-        existing.success_count += item.success_count;
-        existing.error_count += item.error_count;
-        existing.total_nodes_executed += item.total_nodes_executed;
-        existing.rag_used_count += item.rag_used_count;
-        existing.thumbs_up_count += item.thumbs_up_count;
-        existing.thumbs_down_count += item.thumbs_down_count;
-        if (item.avg_response_ms != null) {
-          existing._totalMs += item.avg_response_ms * item.execution_count;
-          existing._msCount += item.execution_count;
-        }
-      } else {
-        map.set(item.agent_id, {
-          id: item.agent_id,
-          agent_id: item.agent_id,
-          unique_conversations: item.unique_conversations,
-          finalized_conversations: item.finalized_conversations,
-          in_progress_conversations: item.in_progress_conversations,
-          execution_count: item.execution_count,
-          success_count: item.success_count,
-          error_count: item.error_count,
-          avg_response_ms: item.avg_response_ms,
-          total_nodes_executed: item.total_nodes_executed,
-          rag_used_count: item.rag_used_count,
-          thumbs_up_count: item.thumbs_up_count,
-          thumbs_down_count: item.thumbs_down_count,
-          _totalMs: item.avg_response_ms != null ? item.avg_response_ms * item.execution_count : 0,
-          _msCount: item.avg_response_ms != null ? item.execution_count : 0,
-        });
-      }
-    }
-    return Array.from(map.values()).map((a) => {
-      const conv = conversationStatusByAgent.get(a.agent_id);
-      return {
-        ...a,
-        unique_conversations: conv?.unique_conversations ?? a.unique_conversations,
-        finalized_conversations: conv?.finalized_conversations ?? a.finalized_conversations,
-        in_progress_conversations: conv?.in_progress_conversations ?? a.in_progress_conversations,
-        avg_response_ms: a._msCount > 0 ? a._totalMs / a._msCount : null,
-      };
-    });
-  }, [items, conversationStatusByAgent]);
+  // When all agents shown
+  const aggregatedItems = useMemo(
+    () => aggregateAgentRows(items, conversationStatusByAgent),
+    [items, conversationStatusByAgent],
+  );
 
   const statsColumns = useMemo(() => {
     const statCols: Column<AgentAggregated>[] = [
       {
         header: "Conversations",
         key: "unique_conversations",
-        description: "Unique chat sessions in the period.",
+        description: "Unique chat sessions with agent activity in the selected period.",
         cell: (item: AgentAggregated) => (
           <div className="flex flex-col gap-0.5">
             <span className="font-medium">{item.unique_conversations.toLocaleString()}</span>
@@ -348,7 +307,8 @@ const AgentPerformancePage = () => {
 
   const exportParams = {
     ...filterParams,
-    ...toExpandedUTCDateRange(dateRange),
+    ...toUtcBucketDateParams(dateRange),
+    ...toExactActivityParams(dateRange),
   };
 
   const hasSummary = summary != null;
@@ -549,8 +509,8 @@ const AgentPerformancePage = () => {
           agentId={selectedItem.agent_id}
           agentName={agentNameMap[selectedItem.agent_id] ?? selectedItem.agent_id.slice(0, 8) + "…"}
           totalExecutions={selectedItem.execution_count}
-          fromDate={toExpandedUTCDateRange(dateRange).from_date}
-          toDate={toExpandedUTCDateRange(dateRange).to_date}
+          fromDate={toUtcBucketDateParams(dateRange).from_date}
+          toDate={toUtcBucketDateParams(dateRange).to_date}
         />
       )}
     </>

--- a/frontend/src/views/Index.tsx
+++ b/frontend/src/views/Index.tsx
@@ -1,5 +1,5 @@
 import { DateRangePicker } from "@/components/date-range-picker";
-import { subDays, differenceInCalendarDays } from "date-fns";
+import { subDays } from "date-fns";
 import { usePersistedDateRange } from "@/hooks/usePersistedDateRange";
 import { KPISection } from "./Analytics";
 import { ActiveConversations } from "./ActiveConversations/pages/ActiveConversations";
@@ -9,12 +9,6 @@ const Index = () => {
     from: subDays(new Date(), 30),
     to: new Date(),
   });
-
-  const selectedDays = (() => {
-    if (!dateRange?.from) return 30;
-    const toDate = dateRange.to ?? new Date();
-    return Math.max(1, differenceInCalendarDays(toDate, dateRange.from) + 1);
-  })();
 
   return (
     <>
@@ -36,7 +30,7 @@ const Index = () => {
                 </p>
               </header>
 
-              <KPISection days={selectedDays} />
+              <KPISection dateRange={dateRange} />
               <ActiveConversations />
             </div>
           </div>


### PR DESCRIPTION
## Description

Replaces the misleading Dashboard “Workflow Runs” KPI with “Conversations,” calculated as distinct conversations with agent response activity during the selected period. This aligns the Dashboard with Agent Performance by reusing the canonical server-side conversation calculation, supporting exact date boundaries, preserving tenant and group scoping, and retaining `workflow_runs` as a deprecated compatibility field.


## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [x] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

- Replaced the Dashboard “Workflow Runs” KPI with “Conversations.”
- Calculated conversations as distinct chat sessions with non-deleted agent response activity.
- Reused the canonical analytics conversation query across Dashboard and Agent Performance.
- Added exact half-open date intervals with inclusive start and exclusive end boundaries.
- Added legacy rolling-days and all-time range modes for the Dashboard summary endpoint.
- Added validation for incomplete, timezone-naive, reversed, and conflicting range parameters.
- Applied the same activity boundaries to Agent Performance summary and per-agent counts.
- Added normalized handling for incomplete single-day date-picker selections.
- Updated LLM-cost filtering to support exact and all-time intervals.


## Testing

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues


Closes #

## Screenshots (if applicable)


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
