### PR TITLE
perf: optimize Agent Performance initial load

### DIFF
--- a/backend/alembic/versions/00106_add_agent_response_logs_logged_at_index.py
+++ b/backend/alembic/versions/00106_add_agent_response_logs_logged_at_index.py
@@ -1,0 +1,49 @@
+"""add agent response logs logged at index
+
+Adds a partial index on ``agent_response_logs.logged_at`` covering non-deleted
+rows. The conversations-with-activity query behind ``/analytics/agents/summary``
+and the dashboard conversation count both filter that column, and it had no
+index: every first load of the Agent Performance screen scanned the table's
+whole history.
+
+Revision ID: db1cbdf682c5
+Revises: 639dcc861c9c
+Create Date: 2026-08-13 14:00:29.457251
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "db1cbdf682c5"
+down_revision: Union[str, None] = "639dcc861c9c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX = "ix_agent_response_logs_logged_at"
+_TABLE = "agent_response_logs"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        left_invalid = op.get_bind().scalar(
+            sa.text("SELECT NOT indisvalid FROM pg_index WHERE indexrelid = to_regclass(:name)"),
+            {"name": _INDEX},
+        )
+        if left_invalid:
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX}")
+
+        op.execute(
+            f"""
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS {_INDEX}
+            ON {_TABLE} (logged_at)
+            WHERE is_deleted = 0
+            """
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX}")

--- a/backend/app/db/models/agent_response_log.py
+++ b/backend/app/db/models/agent_response_log.py
@@ -19,14 +19,19 @@ class AgentResponseLogModel(Base):
 
     __tablename__ = "agent_response_logs"
 
-    # Declared here so Alembic autogenerate knows this
-    # partial unique index belongs to the model and does not try to drop it
+    # Declared here so Alembic autogenerate knows these
+    # partial indexes belong to the model and does not try to drop them
     __table_args__ = (
         Index(
             "uq_agent_response_logs_workflow_execution_id",
             "workflow_execution_id",
             unique=True,
             postgresql_where="workflow_execution_id IS NOT NULL",
+        ),
+        Index(
+            "ix_agent_response_logs_logged_at",
+            "logged_at",
+            postgresql_where="is_deleted = 0",
         ),
     )
 

--- a/backend/app/repositories/analytics_read.py
+++ b/backend/app/repositories/analytics_read.py
@@ -242,7 +242,9 @@ class AnalyticsReadRepository:
         *,
         activity_from_datetime: datetime | None = None,
         activity_to_datetime: datetime | None = None,
+        include_conversation_counts: bool = True,
     ) -> dict:
+        """Daily-stat totals for the period, plus the conversation counts for the same window"""
         agent_ids = await resolve_authorized_agent_ids(self.db, agent_id, group_id)
         if agent_ids is not None and not agent_ids and group_id is None:
             return {
@@ -298,16 +300,17 @@ class AnalyticsReadRepository:
             result = await self.db.execute(stmt)
             row = dict(result.mappings().one())
 
-        conv_rows = await self.get_conversation_status_counts(
-            agent_id=agent_id,
-            group_id=group_id,
-            from_date=from_date,
-            to_date=to_date,
-            group_by_agent=False,
-            activity_from_datetime=activity_from_datetime,
-            activity_to_datetime=activity_to_datetime,
-        )
-        row.update(conv_rows[0])
+        if include_conversation_counts:
+            conv_rows = await self.get_conversation_status_counts(
+                agent_id=agent_id,
+                group_id=group_id,
+                from_date=from_date,
+                to_date=to_date,
+                group_by_agent=False,
+                activity_from_datetime=activity_from_datetime,
+                activity_to_datetime=activity_to_datetime,
+            )
+            row.update(conv_rows[0])
         return row
 
     async def get_agent_stats_summary_with_comparison(

--- a/backend/app/services/analytics_read.py
+++ b/backend/app/services/analytics_read.py
@@ -57,6 +57,7 @@ class AnalyticsReadService:
             to_date=to_date,
             activity_from_datetime=activity_from_datetime,
             activity_to_datetime=activity_to_datetime,
+            include_conversation_counts=agent_id is not None,
         )
         by_agent: list[AgentConversationStatusByAgent] = []
         if agent_id is None:
@@ -70,6 +71,13 @@ class AnalyticsReadService:
                 activity_to_datetime=activity_to_datetime,
             )
             by_agent = [AgentConversationStatusByAgent.model_validate(r) for r in rows]
+            derived = {
+                "total_unique_conversations": sum(r["unique_conversations"] for r in rows),
+                "total_finalized_conversations": sum(r["finalized_conversations"] for r in rows),
+                "total_in_progress_conversations": sum(r["in_progress_conversations"] for r in rows),
+            }
+            for key, value in derived.items():
+                summary.setdefault(key, value)
         return self._dict_to_summary(
             summary, agent_id, from_date, to_date, conversation_status_by_agent=by_agent
         )

--- a/backend/tests/integration/analytics/test_conversation_activity_counts.py
+++ b/backend/tests/integration/analytics/test_conversation_activity_counts.py
@@ -23,6 +23,7 @@ from app.db.models.user_group import UserGroupModel
 from app.db.models.workflow import WorkflowModel
 from app.repositories.analytics_read import AnalyticsReadRepository
 from app.repositories.dashboard import DashboardRepository
+from app.services.analytics_read import AnalyticsReadService
 from app.services.dashboard import DashboardService
 
 PROBE_START = date(2097, 3, 1)
@@ -42,6 +43,12 @@ CONVERSATIONS = (
 IN_EXACT_WINDOW = {"multi_log", "at_start", "other_agent"}
 IN_WHOLE_DAY = IN_EXACT_WINDOW | {"at_end"}
 PER_AGENT_IN_WINDOW = {"a1": 2, "a2": 1}
+
+COUNTER_KEYS = (
+    ("unique_conversations", "total_unique_conversations"),
+    ("finalized_conversations", "total_finalized_conversations"),
+    ("in_progress_conversations", "total_in_progress_conversations"),
+)
 
 
 @contextmanager
@@ -319,7 +326,27 @@ async def test_per_agent_rows_sum_to_the_summary_total(world):
 
     by_agent = {row["agent_id"]: row["unique_conversations"] for row in grouped}
     assert by_agent == {world.agent_id(key): count for key, count in PER_AGENT_IN_WINDOW.items()}
-    assert sum(by_agent.values()) == ungrouped[0]["total_unique_conversations"]
+    for per_agent_key, total_key in COUNTER_KEYS:
+        assert sum(row[per_agent_key] for row in grouped) == ungrouped[0][total_key]
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_the_summary_totals_match_the_ungrouped_counts_they_replaced(world):
+    bounds = {
+        "activity_from_datetime": world.window_start,
+        "activity_to_datetime": world.window_end,
+    }
+    async with world.maker() as session:
+        repo = AnalyticsReadRepository(session)
+        with caller(user_id=uuid4(), admin=True):
+            ungrouped = await repo.get_conversation_status_counts(**bounds)
+            summary = await AnalyticsReadService(repo).get_agent_stats_summary(
+                from_date=world.day, to_date=world.day, **bounds
+            )
+
+    for _, total_key in COUNTER_KEYS:
+        assert getattr(summary, total_key) == ungrouped[0][total_key]
+    assert summary.total_unique_conversations == len(IN_EXACT_WINDOW)
 
 
 @pytest.mark.asyncio(loop_scope="module")

--- a/backend/tests/unit/test_analytics_read_repo_scope.py
+++ b/backend/tests/unit/test_analytics_read_repo_scope.py
@@ -62,6 +62,17 @@ def _repo_with_conversation_scope(monkeypatch, scope):
     return AnalyticsReadRepository(db), db
 
 
+def _repo_with_both_scopes(monkeypatch, scope):
+    db = CapturingDb()
+
+    async def _resolver(_db, agent_id=None, group_id=None):
+        return scope
+
+    monkeypatch.setattr(analytics_read, "resolve_authorized_agent_ids", _resolver)
+    monkeypatch.setattr(analytics_read, "resolve_scoped_agent_ids", _resolver)
+    return AnalyticsReadRepository(db), db
+
+
 def _logged_at_predicates(sql: str) -> list[str]:
     return sorted(re.findall(r"agent_response_logs\.logged_at [<>=]+ '[^']+'", sql))
 
@@ -267,3 +278,33 @@ async def test_agent_stats_summary_forwards_activity_bounds_to_the_conversation_
     assert seen["activity_from_datetime"] == ACTIVITY_FROM
     assert seen["activity_to_datetime"] == ACTIVITY_TO
     assert (seen["from_date"], seen["to_date"]) == (LEGACY_FROM, LEGACY_TO)
+
+
+@pytest.mark.asyncio
+async def test_agent_stats_summary_reads_the_response_logs_by_default(monkeypatch):
+    repo, db = _repo_with_both_scopes(monkeypatch, None)
+    await repo.get_agent_stats_summary()
+    statements = [_sql(stmt) for stmt in db.statements]
+    assert any("agent_execution_daily_stats" in sql for sql in statements)
+    assert any("agent_response_logs" in sql for sql in statements)
+
+
+@pytest.mark.asyncio
+async def test_agent_stats_summary_skips_the_response_logs_when_counts_are_excluded(monkeypatch):
+    repo, db = _repo_with_both_scopes(monkeypatch, None)
+    summary = await repo.get_agent_stats_summary(include_conversation_counts=False)
+    statements = [_sql(stmt) for stmt in db.statements]
+    assert len(statements) == 1
+    assert "agent_execution_daily_stats" in statements[0]
+    assert "agent_response_logs" not in statements[0]
+    assert "total_unique_conversations" not in summary
+
+
+@pytest.mark.asyncio
+async def test_denied_caller_keeps_hard_zero_totals_without_conversation_counts(monkeypatch):
+    repo, db = _repo_with_both_scopes(monkeypatch, [])
+    summary = await repo.get_agent_stats_summary(agent_id=uuid4(), include_conversation_counts=False)
+    assert summary["total_unique_conversations"] == 0
+    assert summary["total_finalized_conversations"] == 0
+    assert summary["total_in_progress_conversations"] == 0
+    assert db.statements == []

--- a/backend/tests/unit/test_analytics_read_service.py
+++ b/backend/tests/unit/test_analytics_read_service.py
@@ -1,0 +1,169 @@
+"""Unit tests for AnalyticsReadService deriving the summary totals from the per-agent rows"""
+
+from datetime import date, datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from app.services.analytics_read import AnalyticsReadService
+
+AGENT_A = uuid4()
+AGENT_B = uuid4()
+
+FROM_DATE = date(2026, 8, 1)
+TO_DATE = date(2026, 8, 7)
+ACTIVITY_FROM = datetime(2026, 8, 1, 15, 0, tzinfo=timezone.utc)
+ACTIVITY_TO = datetime(2026, 8, 8, tzinfo=timezone.utc)
+
+DAILY = {
+    "total_executions": 12,
+    "total_success": 10,
+    "total_errors": 2,
+    "avg_response_ms": 250.0,
+    "avg_success_rate": 0.83,
+    "total_rag_used": 4,
+    "total_thumbs_up": 3,
+    "total_thumbs_down": 1,
+}
+
+TOTALS = {
+    "total_unique_conversations": 9,
+    "total_finalized_conversations": 6,
+    "total_in_progress_conversations": 3,
+}
+
+ZERO_TOTALS = {key: 0 for key in TOTALS}
+
+GROUPED = [
+    {
+        "agent_id": AGENT_A,
+        "unique_conversations": 5,
+        "finalized_conversations": 4,
+        "in_progress_conversations": 1,
+    },
+    {
+        "agent_id": AGENT_B,
+        "unique_conversations": 4,
+        "finalized_conversations": 2,
+        "in_progress_conversations": 2,
+    },
+]
+
+
+class FakeAnalyticsReadRepo:
+    def __init__(self, summary=None, grouped=None, comparison=None):
+        self._summary = summary if summary is not None else {**DAILY, **TOTALS}
+        self._grouped = grouped if grouped is not None else GROUPED
+        self._comparison = comparison
+        self.summary_kwargs = None
+        self.comparison_kwargs = None
+        self.grouped_calls = []
+
+    async def get_agent_stats_summary(self, **kwargs):
+        self.summary_kwargs = kwargs
+        return dict(self._summary)
+
+    async def get_conversation_status_counts(self, **kwargs):
+        self.grouped_calls.append(kwargs)
+        return [dict(row) for row in self._grouped]
+
+    async def get_agent_stats_summary_with_comparison(self, **kwargs):
+        self.comparison_kwargs = kwargs
+        return self._comparison
+
+
+def _service(**kwargs):
+    repo = FakeAnalyticsReadRepo(**kwargs)
+    return AnalyticsReadService(repo), repo
+
+
+BOUNDS = {
+    "from_date": FROM_DATE,
+    "to_date": TO_DATE,
+    "activity_from_datetime": ACTIVITY_FROM,
+    "activity_to_datetime": ACTIVITY_TO,
+}
+
+
+@pytest.mark.asyncio
+async def test_all_agents_summary_stops_the_repository_counting_conversations():
+    service, repo = _service()
+    await service.get_agent_stats_summary(**BOUNDS)
+    assert repo.summary_kwargs["include_conversation_counts"] is False
+
+
+@pytest.mark.asyncio
+async def test_all_agents_summary_runs_one_grouped_query_over_the_same_window():
+    service, repo = _service()
+    await service.get_agent_stats_summary(**BOUNDS)
+    assert len(repo.grouped_calls) == 1
+    assert repo.grouped_calls[0] == {
+        "agent_id": None,
+        "group_id": None,
+        "group_by_agent": True,
+        **BOUNDS,
+    }
+    for key, value in BOUNDS.items():
+        assert repo.summary_kwargs[key] == value
+
+
+@pytest.mark.asyncio
+async def test_all_agents_totals_are_the_sum_of_the_per_agent_rows():
+    service, _ = _service(summary={**DAILY})
+    summary = await service.get_agent_stats_summary(**BOUNDS)
+    assert summary.total_unique_conversations == 9
+    assert summary.total_finalized_conversations == 6
+    assert summary.total_in_progress_conversations == 3
+    assert [row.agent_id for row in summary.conversation_status_by_agent] == [AGENT_A, AGENT_B]
+    assert (summary.total_executions, summary.total_errors) == (12, 2)
+    assert summary.avg_response_ms == 250.0
+
+
+@pytest.mark.asyncio
+async def test_no_agent_activity_leaves_every_total_at_zero():
+    service, _ = _service(summary={**DAILY}, grouped=[])
+    summary = await service.get_agent_stats_summary(**BOUNDS)
+    assert summary.total_unique_conversations == 0
+    assert summary.total_finalized_conversations == 0
+    assert summary.total_in_progress_conversations == 0
+    assert summary.conversation_status_by_agent == []
+
+
+@pytest.mark.asyncio
+async def test_a_single_agent_summary_still_takes_its_totals_from_the_repository():
+    service, repo = _service()
+    summary = await service.get_agent_stats_summary(agent_id=AGENT_A, **BOUNDS)
+    assert repo.summary_kwargs["include_conversation_counts"] is True
+    assert repo.grouped_calls == []
+    assert summary.total_unique_conversations == 9
+    assert summary.conversation_status_by_agent == []
+
+
+@pytest.mark.asyncio
+async def test_a_group_scoped_summary_without_totals_is_built_from_the_grouped_rows():
+    service, _ = _service(summary={**DAILY})
+    summary = await service.get_agent_stats_summary(group_id=uuid4(), **BOUNDS)
+    assert summary.total_unique_conversations == 9
+    assert summary.total_finalized_conversations == 6
+    assert summary.total_in_progress_conversations == 3
+
+
+@pytest.mark.asyncio
+async def test_a_denied_caller_keeps_the_hard_zero_totals_it_was_given():
+    service, _ = _service(summary={**DAILY, **ZERO_TOTALS})
+    summary = await service.get_agent_stats_summary(**BOUNDS)
+    assert summary.total_unique_conversations == 0
+    assert summary.total_finalized_conversations == 0
+    assert summary.total_in_progress_conversations == 0
+
+
+@pytest.mark.asyncio
+async def test_the_comparison_path_still_lets_the_repository_count_conversations():
+    comparison = {"current": {**DAILY, **TOTALS}, "previous": {**DAILY, **TOTALS}}
+    service, repo = _service(comparison=comparison)
+    result = await service.get_agent_stats_summary_with_comparison(from_date=FROM_DATE, to_date=TO_DATE)
+    assert "include_conversation_counts" not in repo.comparison_kwargs
+    assert repo.summary_kwargs is None
+    assert len(repo.grouped_calls) == 1
+    assert result["current"].total_unique_conversations == 9
+    assert result["previous"].total_unique_conversations == 9


### PR DESCRIPTION
## Description

Improves the initial loading performance of the Agent Performance screen. The conversation activity query previously scanned historical `agent_response_logs` without an index on `logged_at`. The all-agent summary also performed the same expensive conversation aggregation twice: once for overall totals and again for per-agent totals. This change adds an appropriate partial index and reuses the grouped conversation results to derive overall totals, reducing the loading path to one activity aggregation without changing the API response.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

- Added a partial index on `agent_response_logs.logged_at` for non-deleted rows.
- Added recovery for an invalid index left by an interrupted concurrent migration.
- Removed the duplicate conversation activity aggregation from all-agent summaries.
- Derived overall conversation totals from the grouped per-agent results.
- Added unit and integration coverage for query deduplication, totals, date boundaries, and denied callers.

## Testing

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues


Closes #

## Screenshots (if applicable)


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
