### PR TITLE
perf: paginate operators menu

### DIFF
--- a/backend/app/api/v1/routes/operators.py
+++ b/backend/app/api/v1/routes/operators.py
@@ -1,12 +1,15 @@
 from uuid import UUID
+
 from fastapi import APIRouter, Depends
 from fastapi_injector import Injected
-from app.core.permissions.constants import Permissions as P
+
 from app.auth.dependencies import auth, permissions
 from app.auth.utils import generate_password
-from app.schemas.operator import OperatorCreate, OperatorRead, OperatorReadAfterCreate
+from app.core.permissions.constants import Permissions as P
+from app.schemas.common import PaginatedResponse
+from app.schemas.filter import OperatorListFilter
+from app.schemas.operator import OperatorCreate, OperatorListItem, OperatorRead, OperatorReadAfterCreate
 from app.services.operators import OperatorService
-
 
 router = APIRouter()
 
@@ -22,7 +25,6 @@ async def create(operator: OperatorCreate, operator_service: OperatorService = I
     operator_read_after_create = OperatorReadAfterCreate.model_validate(created_operator)
     operator_read_after_create.user.password = generated_password
 
-    await operator_service.set_operator_latest_call(operator_read_after_create)
     return operator_read_after_create
 
 @router.get("", response_model=list[OperatorRead],
@@ -31,16 +33,19 @@ async def create(operator: OperatorCreate, operator_service: OperatorService = I
                          Depends(permissions(P.Operator.READ))
                          ])
 async def get_all(operator_service: OperatorService = Injected(OperatorService)):
-    operators =  await operator_service.get_all()
-    enriched = []
-    for operator in operators:
-        # Add the latest call only if operator has more than 1 call to not duplicate data in frontend
-        operator_read = OperatorRead.model_validate(operator)
-        await operator_service.set_operator_latest_call(operator_read)
+    return await operator_service.get_all()
 
-        enriched.append(operator)
 
-    return enriched
+# Declared before /{operator_id} so "list" is not matched as a UUID path param.
+@router.get("/list", response_model=PaginatedResponse[OperatorListItem],
+                     dependencies=[
+                         Depends(auth),
+                         Depends(permissions(P.Operator.READ))
+                         ])
+async def get_list(filter_obj: OperatorListFilter = Depends(),
+                   operator_service: OperatorService = Injected(OperatorService)):
+    """Paginated operator list ordered by positive sentiment, then score"""
+    return await operator_service.get_list_paginated(filter_obj)
 
 
 @router.get("/{operator_id}", response_model=OperatorRead,
@@ -49,6 +54,4 @@ async def get_all(operator_service: OperatorService = Injected(OperatorService))
                          Depends(permissions(P.Operator.READ))
                          ])
 async def get(operator_id: UUID, operator_service: OperatorService = Injected(OperatorService)):
-    operator = operator_service.get_by_id(operator_id)
-    operator_read = OperatorRead.model_validate(operator)
-    await operator_service.set_operator_latest_call(operator_read)
+    return await operator_service.get_by_id(operator_id)

--- a/backend/app/db/seed/seed.py
+++ b/backend/app/db/seed/seed.py
@@ -33,7 +33,7 @@ from app.db.models.user import UserModel
 from app.db.models.user_role import UserRoleModel
 from app.db.models.user_type import UserTypeModel
 from app.db.seed.seed_data_config import seed_test_data
-from app.schemas.agent import AgentCreate
+from app.schemas.agent import AgentCreate, AgentRead
 from app.schemas.agent_knowledge import KBCreate, KBRead
 from app.schemas.agent_tool import ToolConfigBase
 from app.schemas.app_settings import AppSettingsCreate
@@ -1588,7 +1588,7 @@ async def seed_workflow_builder_agent(
     config_service = injector.get(AgentConfigService)
     agent_model = await config_service.create(builder_agent, user_id=owner_user_id)
     agent_model.is_system = True
-    full_agent: AgentModel = await config_service.get_by_id_full(agent_model.id)
+    full_agent: AgentRead = await config_service.get_by_id_full(agent_model.id)
 
     workflow_update_data = WorkflowUpdate(
         name=workflow_model.name,
@@ -1603,7 +1603,6 @@ async def seed_workflow_builder_agent(
     await workflow_service.update(workflow_model.id, workflow_update_data)
 
     # Create operator role
-    await session.refresh(full_agent.operator, ["user"])
     await session.refresh(agent_role)
 
     urm = UserRoleModel(role_id=agent_role.id, user_id=full_agent.operator.user.id)

--- a/backend/app/repositories/conversations.py
+++ b/backend/app/repositories/conversations.py
@@ -1,34 +1,35 @@
 import datetime
 from typing import List, Optional, Sequence, Tuple
 from uuid import UUID
+
 from injector import inject
-from sqlalchemy import asc, cast, desc, distinct, func, and_, or_, nulls_last, String, update
+from sqlalchemy import String, and_, asc, cast, desc, distinct, func, nulls_last, or_, update
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import contains_eager, joinedload, selectinload
+from starlette_context import context
+from starlette_context.errors import ContextDoesNotExistError
+
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
+from app.core.utils.bi_utils import (
+    filter_conversation_date,
+    filter_conversation_messages_create_time,
+)
 from app.core.utils.enums.conversation_status_enum import ConversationStatus
 from app.core.utils.enums.sentiment_enum import Sentiment
 from app.core.utils.enums.sort_direction_enum import SortDirection
 from app.core.utils.sql_alchemy_utils import add_dynamic_ordering, add_pagination
 from app.db.events.group_scope import GROUP_SCOPE_BYPASS_FLAG, get_group_scope_clause
-from app.db.models.conversation import ConversationModel
-from starlette_context import context
-from starlette_context.errors import ContextDoesNotExistError
-from app.db.models.message_model import TranscriptMessageModel
-from app.schemas.conversation import ConversationCreate
-from app.schemas.filter import ConversationFilter
-from app.core.utils.bi_utils import (
-    filter_conversation_date,
-    filter_conversation_messages_create_time,
-)
-from app.db.models.conversation import ConversationAnalysisModel
-from app.db.models.operator import OperatorModel
 from app.db.models import AgentModel
+from app.db.models.conversation import ConversationAnalysisModel, ConversationModel
+from app.db.models.message_model import TranscriptMessageModel
+from app.db.models.operator import OperatorModel
 from app.db.models.user import UserModel
 from app.repositories.db_repository import DbRepository
+from app.schemas.conversation import ConversationCreate
+from app.schemas.filter import ConversationFilter
 
 # KPI score fields on ConversationAnalysisModel (0-10 scale).
 # Used for sorting, filtering, and join detection.
@@ -212,22 +213,6 @@ class ConversationRepository(DbRepository[ConversationModel]):
                 )
             )
 
-        result = await self.db.execute(query)
-        return result.scalars().first()
-
-    async def get_latest_conversation_with_analysis_for_operator(
-        self, operator_id: UUID
-    ) -> Optional[ConversationModel]:
-        query = (
-            select(ConversationModel)
-            .options(
-                joinedload(ConversationModel.analysis),
-                joinedload(ConversationModel.recording),  # ← Load recording too
-            )
-            .where(ConversationModel.operator_id == operator_id)
-            .order_by(ConversationModel.created_at.desc())
-            .limit(1)
-        )
         result = await self.db.execute(query)
         return result.scalars().first()
 

--- a/backend/app/repositories/operators.py
+++ b/backend/app/repositories/operators.py
@@ -1,16 +1,18 @@
+from typing import List, Optional, Tuple
 from uuid import UUID
+
 from injector import inject
+from sqlalchemy import func, or_
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload
 from sqlalchemy.future import select
-from typing import List
+from sqlalchemy.orm import contains_eager, joinedload
+
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
-from app.db.models.operator import OperatorModel
+from app.db.models.operator import OperatorModel, OperatorStatisticsModel
 from app.repositories.db_repository import DbRepository
-from typing import Optional
+from app.schemas.filter import OperatorListFilter
 
-from sqlalchemy.ext.asyncio import async_sessionmaker
 
 @inject
 class OperatorRepository(DbRepository[OperatorModel]):
@@ -94,3 +96,48 @@ class OperatorRepository(DbRepository[OperatorModel]):
         #     )
         #     result = await session.execute(query)
         #     return result.scalars().all()
+
+    def _search_condition(self, search: Optional[str]):
+        """Case-insensitive substring match on first or last name"""
+        if not search or not search.strip():
+            return None
+
+        term = search.strip().lower()
+        escaped = term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        pattern = f"%{escaped}%"
+        return or_(
+            func.lower(OperatorModel.first_name).like(pattern, escape="\\"),
+            func.lower(OperatorModel.last_name).like(pattern, escape="\\"),
+        )
+
+    async def get_list_paginated(self, filter_obj: OperatorListFilter) -> Tuple[List[OperatorModel], int]:
+        """Return one page of operators plus the unpaginated total"""
+        search_condition = self._search_condition(filter_obj.search)
+
+        count_stmt = (
+            select(func.count(OperatorModel.id))
+            .join(OperatorModel.operator_statistics)
+            .where(OperatorModel.is_deleted == 0)
+        )
+        if search_condition is not None:
+            count_stmt = count_stmt.where(search_condition)
+        total = (await self.db.execute(count_stmt)).scalar() or 0
+
+        data_stmt = (
+            select(OperatorModel)
+            .join(OperatorModel.operator_statistics)
+            .options(contains_eager(OperatorModel.operator_statistics))
+            .where(OperatorModel.is_deleted == 0)
+        )
+        if search_condition is not None:
+            data_stmt = data_stmt.where(search_condition)
+
+        data_stmt = data_stmt.order_by(
+            OperatorStatisticsModel.avg_positive_sentiment.desc(),
+            OperatorStatisticsModel.score.desc(),
+            OperatorModel.id.desc(),
+        )
+        data_stmt = self._apply_pagination(data_stmt, filter_obj)
+
+        result = await self.db.execute(data_stmt)
+        return result.scalars().all(), total

--- a/backend/app/repositories/operators.py
+++ b/backend/app/repositories/operators.py
@@ -102,12 +102,12 @@ class OperatorRepository(DbRepository[OperatorModel]):
         if not search or not search.strip():
             return None
 
-        term = search.strip().lower()
+        term = search.strip()
         escaped = term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         pattern = f"%{escaped}%"
         return or_(
-            func.lower(OperatorModel.first_name).like(pattern, escape="\\"),
-            func.lower(OperatorModel.last_name).like(pattern, escape="\\"),
+            OperatorModel.first_name.ilike(pattern, escape="\\"),
+            OperatorModel.last_name.ilike(pattern, escape="\\"),
         )
 
     async def get_list_paginated(self, filter_obj: OperatorListFilter) -> Tuple[List[OperatorModel], int]:

--- a/backend/app/schemas/filter.py
+++ b/backend/app/schemas/filter.py
@@ -108,6 +108,13 @@ class RecordingFilter(BaseFilterModel):
     operator_id: Optional[UUID] = None
 
 
+class OperatorListFilter(BaseModel):
+    """Query params for the paginated operator list"""
+    skip: int = Field(0, ge=0, description="The number of rows to skip before returning results")
+    limit: int = Field(20, ge=1, le=100, description="The number of rows to return per page")
+    search: Optional[str] = Field(None, description="Case-insensitive substring match on operator first or last name")
+
+
 class AgentResponseLogFilter(BaseModel):
     conversation_id: UUID
     node_type: Optional[str] = Field(None, description="Filter by node type found in state.nodeExecutionStatus[*].type")

--- a/backend/app/schemas/operator.py
+++ b/backend/app/schemas/operator.py
@@ -1,9 +1,11 @@
-from uuid import UUID, uuid4
-from pydantic import BaseModel, Field, ConfigDict
-from typing import Optional
 from datetime import datetime
+from typing import Optional
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
 from app.schemas.conversation import ConversationRead
-from app.schemas.operator_statistics import OperatorStatisticsRead, OperatorStatisticsCreate
+from app.schemas.operator_statistics import OperatorStatisticsCreate, OperatorStatisticsRead
 from app.schemas.user_minimal import UserCreateMinimal, UserReadMinimal
 
 
@@ -43,3 +45,18 @@ class OperatorReadMinimal(BaseModel):
 
 class OperatorReadAfterCreate(OperatorRead):
     user: UserReadMinimal
+
+
+class OperatorListItem(BaseModel):
+    """Row of the paginated operator list"""
+    id: UUID
+    first_name: str = Field(..., alias="firstName")
+    last_name: str = Field(..., alias="lastName")
+    avatar: Optional[bytes] = None
+    created_at: datetime
+    operator_statistics: Optional[OperatorStatisticsRead] = None
+
+    model_config = ConfigDict(
+            from_attributes=True,
+            populate_by_name=True
+            )

--- a/backend/app/services/operators.py
+++ b/backend/app/services/operators.py
@@ -1,19 +1,19 @@
 from datetime import datetime, timezone
 from uuid import UUID
-from fastapi import Depends
-from fastapi_injector import Injected
+
 from injector import inject
 
 from app.auth.utils import generate_unique_username, get_password_hash
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.db.models import OperatorModel, OperatorStatisticsModel, UserModel, UserRoleModel
-from app.repositories.conversations import ConversationRepository
 from app.repositories.operators import OperatorRepository
 from app.repositories.roles import RolesRepository
 from app.repositories.user_types import UserTypesRepository
 from app.repositories.users import UserRepository
-from app.schemas.operator import OperatorCreate, OperatorRead
+from app.schemas.common import PaginatedResponse
+from app.schemas.filter import OperatorListFilter
+from app.schemas.operator import OperatorCreate, OperatorListItem
 
 
 @inject
@@ -23,11 +23,9 @@ class OperatorService:
                  operator_repository: OperatorRepository,
                  user_repository: UserRepository,
                  user_types_repository: UserTypesRepository,
-                 roles_repository: RolesRepository,
-                 conversation_repository: ConversationRepository
+                 roles_repository: RolesRepository
                  ):  # Auto-inject repository
         self.operator_repo = operator_repository
-        self.conversation_repo = conversation_repository
         self.user_repository = user_repository
         self.user_types_repository = user_types_repository
         self.roles_repository = roles_repository
@@ -126,10 +124,10 @@ class OperatorService:
     async def get_all(self) -> list[OperatorModel]:
         return  await self.operator_repo.get_all()
 
-    async def set_operator_latest_call(self, operator: OperatorRead):
-        latest_conversation = await self.conversation_repo.get_latest_conversation_with_analysis_for_operator(
-                operator.id)
-        operator.latest_conversation_analysis = latest_conversation
+    async def get_list_paginated(self, filter_obj: OperatorListFilter) -> PaginatedResponse[OperatorListItem]:
+        rows, total = await self.operator_repo.get_list_paginated(filter_obj)
+        items = [OperatorListItem.model_validate(operator) for operator in rows]
+        return PaginatedResponse.from_filter(items, total, filter_obj)
 
     async def get_by_id(self, operator_id: UUID) -> OperatorModel:
         # Step 1: Fetch operator with stats

--- a/backend/tests/integration/operators/test_operators.py
+++ b/backend/tests/integration/operators/test_operators.py
@@ -1,10 +1,61 @@
 import pytest
-import logging
 
-logger = logging.getLogger(__name__)
+HEADERS = {"X-API-Key": "test123"}
+
 
 @pytest.mark.asyncio
 async def test_list_operators(client):
-    response = client.get("/api/operators/", headers={"X-API-Key": "test123"})
-    logger.info("operators: %s", response.json())
+    response = client.get("/api/operators/", headers=HEADERS)
     assert response.status_code == 200
+
+    body = response.json()
+    assert isinstance(body, list)
+    assert body, "seeded operators expected"
+    assert "id" in body[0]
+    assert "firstName" in body[0]
+    assert body[0]["latest_conversation_analysis"] is None
+
+
+@pytest.mark.asyncio
+async def test_paginated_list(client):
+    response = client.get("/api/operators/list?limit=5", headers=HEADERS)
+    assert response.status_code == 200
+
+    body = response.json()
+    assert set(body) >= {"items", "total", "page", "page_size", "total_pages"}
+    assert body["page_size"] == 5
+    assert body["page"] == 1
+    assert len(body["items"]) <= 5
+    assert body["items"], "seeded operators expected"
+
+    item = body["items"][0]
+    assert "firstName" in item and "lastName" in item
+    assert item["operator_statistics"] is not None
+    assert "user" not in item
+    assert "latest_conversation_analysis" not in item
+
+
+@pytest.mark.asyncio
+async def test_paginated_search_empty(client):
+    response = client.get("/api/operators/list?search=zz_no_such_operator", headers=HEADERS)
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["total"] == 0
+    assert body["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_get_operator_by_id(client):
+    listing = client.get("/api/operators/", headers=HEADERS)
+    assert listing.status_code == 200
+    operators = listing.json()
+    assert operators, "seeded operators expected"
+    operator_id = operators[0]["id"]
+
+    response = client.get(f"/api/operators/{operator_id}", headers=HEADERS)
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["id"] == operator_id
+    assert body["operator_statistics"] is not None

--- a/backend/tests/integration/operators/test_operators_pagination_db.py
+++ b/backend/tests/integration/operators/test_operators_pagination_db.py
@@ -1,0 +1,267 @@
+"""DB-backed proof that the operator list paginates, orders and searches in SQL"""
+
+import decimal
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config.settings import settings
+from app.db.models import (
+    OperatorModel,
+    OperatorStatisticsModel,
+    UserModel,
+    UserTypeModel,
+    test_suite,  # noqa: F401
+)
+from app.repositories.operators import OperatorRepository
+from app.schemas.filter import OperatorListFilter
+
+RANKED_COUNT = 21
+MATCHING_COUNT = RANKED_COUNT + 3
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(settings.DATABASE_URL)
+    maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _add_operator(session, *, user_id, first_name, last_name, sentiment, score, is_deleted=0, stats_deleted=0):
+    stats = OperatorStatisticsModel(
+        avg_positive_sentiment=sentiment,
+        avg_negative_sentiment=0,
+        avg_neutral_sentiment=0,
+        score=decimal.Decimal(str(score)),
+        call_count=0,
+        is_deleted=stats_deleted,
+    )
+    session.add(stats)
+    await session.flush()
+
+    operator = OperatorModel(
+        first_name=first_name,
+        last_name=last_name,
+        is_active=1,
+        statistics_id=stats.id,
+        user_id=user_id,
+        is_deleted=is_deleted,
+    )
+    session.add(operator)
+    await session.flush()
+    return operator, stats
+
+
+@pytest_asyncio.fixture
+async def seeded_operators(db_session):
+    session = db_session
+    prefix = f"zz_{uuid4().hex[:8]}_"
+
+    user_type_id = (await session.execute(select(UserTypeModel.id).limit(1))).scalar_one()
+    user = UserModel(
+        username=f"{prefix}user",
+        email=f"{prefix}user@example.test",
+        hashed_password="not-a-real-hash",
+        is_active=1,
+        user_type_id=user_type_id,
+    )
+    session.add(user)
+    await session.flush()
+
+    operator_ids, stats_ids, tied_ids = [], [], []
+    try:
+        for i in range(RANKED_COUNT):
+            operator, stats = await _add_operator(
+                session,
+                user_id=user.id,
+                first_name=f"{prefix}op{i:02d}",
+                last_name=f"{prefix}last{i:02d}",
+                sentiment=90 - (i // 2),
+                score=100 - i,
+            )
+            operator_ids.append(operator.id)
+            stats_ids.append(stats.id)
+
+        for name in (f"{prefix}be%ta", f"{prefix}back\\slash", f"{prefix}tie"):
+            tied, tied_stats = await _add_operator(
+                session,
+                user_id=user.id,
+                first_name=name,
+                last_name=f"{prefix}probe",
+                sentiment=0,
+                score=0,
+            )
+            operator_ids.append(tied.id)
+            stats_ids.append(tied_stats.id)
+            tied_ids.append(tied.id)
+
+        deleted, deleted_stats = await _add_operator(
+            session,
+            user_id=user.id,
+            first_name=f"{prefix}op99",
+            last_name=f"{prefix}gone",
+            sentiment=100,
+            score=200,
+            is_deleted=1,
+        )
+        operator_ids.append(deleted.id)
+        stats_ids.append(deleted_stats.id)
+
+        orphan, orphan_stats = await _add_operator(
+            session,
+            user_id=user.id,
+            first_name=f"{prefix}op98",
+            last_name=f"{prefix}orphan",
+            sentiment=95,
+            score=150,
+            stats_deleted=1,
+        )
+        operator_ids.append(orphan.id)
+        stats_ids.append(orphan_stats.id)
+
+        await session.commit()
+        session.expunge_all()
+
+        yield {
+            "prefix": prefix,
+            "deleted_id": deleted.id,
+            "orphan_id": orphan.id,
+            "operator_ids": operator_ids,
+            "tied_ids": tied_ids,
+            "visible_ids": set(operator_ids) - {deleted.id, orphan.id},
+        }
+    finally:
+        await session.execute(delete(OperatorModel).where(OperatorModel.id.in_(operator_ids)))
+        await session.execute(delete(OperatorStatisticsModel).where(OperatorStatisticsModel.id.in_(stats_ids)))
+        await session.execute(delete(UserModel).where(UserModel.id == user.id))
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_total_counts_matching_rows_and_excludes_soft_deleted(db_session, seeded_operators):
+    repo = OperatorRepository(db_session)
+    prefix = seeded_operators["prefix"]
+
+    rows, total = await repo.get_list_paginated(OperatorListFilter(skip=0, limit=100, search=prefix))
+
+    assert total == MATCHING_COUNT
+    assert len(rows) == MATCHING_COUNT
+    assert seeded_operators["deleted_id"] not in {op.id for op in rows}
+
+
+@pytest.mark.asyncio
+async def test_soft_deleted_statistics_leave_count_and_rows_in_step(db_session, seeded_operators):
+    repo = OperatorRepository(db_session)
+    prefix = seeded_operators["prefix"]
+
+    rows, total = await repo.get_list_paginated(OperatorListFilter(skip=0, limit=100, search=prefix))
+
+    assert seeded_operators["orphan_id"] not in {op.id for op in rows}
+    assert total == len(rows)
+
+
+@pytest.mark.asyncio
+async def test_database_returns_only_the_requested_page(db_session, seeded_operators):
+    repo = OperatorRepository(db_session)
+    prefix = seeded_operators["prefix"]
+
+    page1, total1 = await repo.get_list_paginated(OperatorListFilter(skip=0, limit=20, search=prefix))
+    page2, total2 = await repo.get_list_paginated(OperatorListFilter(skip=20, limit=20, search=prefix))
+
+    assert len(page1) == 20
+    assert len(page2) == MATCHING_COUNT - 20
+    assert total1 == total2 == MATCHING_COUNT  # total is unpaginated
+
+    ids1, ids2 = {op.id for op in page1}, {op.id for op in page2}
+    assert ids1.isdisjoint(ids2)
+    assert ids1 | ids2 == seeded_operators["visible_ids"]
+
+
+@pytest.mark.asyncio
+async def test_ordering_is_sentiment_then_score_then_stable(db_session, seeded_operators):
+    repo = OperatorRepository(db_session)
+    prefix = seeded_operators["prefix"]
+
+    rows, _ = await repo.get_list_paginated(OperatorListFilter(skip=0, limit=100, search=prefix))
+
+    ranked = [f"{prefix}op{i:02d}" for i in range(RANKED_COUNT)]
+    assert [op.first_name for op in rows[:RANKED_COUNT]] == ranked
+
+    keys = [(op.operator_statistics.avg_positive_sentiment, op.operator_statistics.score) for op in rows]
+    assert keys == sorted(keys, reverse=True)
+    tail_ids = [op.id for op in rows[RANKED_COUNT:]]
+    assert set(tail_ids) == set(seeded_operators["tied_ids"])
+    assert tail_ids == sorted(tail_ids, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_statistics_are_eagerly_loaded(db_session, seeded_operators):
+    repo = OperatorRepository(db_session)
+    prefix = seeded_operators["prefix"]
+
+    rows, _ = await repo.get_list_paginated(OperatorListFilter(skip=0, limit=5, search=prefix))
+    assert all(op.operator_statistics is not None for op in rows)
+    assert rows[0].operator_statistics.avg_positive_sentiment == 90
+
+
+@pytest.mark.asyncio
+async def test_search_narrows_on_either_name_and_ignores_case(db_session, seeded_operators):
+    repo = OperatorRepository(db_session)
+    prefix = seeded_operators["prefix"]
+
+    by_first, total_first = await repo.get_list_paginated(OperatorListFilter(skip=0, limit=100, search=f"{prefix}op07"))
+    assert total_first == 1 and by_first[0].first_name == f"{prefix}op07"
+
+    _, total_last = await repo.get_list_paginated(OperatorListFilter(skip=0, limit=100, search=f"{prefix}last07"))
+    assert total_last == 1
+
+    _, total_upper = await repo.get_list_paginated(
+        OperatorListFilter(skip=0, limit=100, search=f"{prefix}op07".upper())
+    )
+    assert total_upper == 1
+
+    _, total_none = await repo.get_list_paginated(OperatorListFilter(skip=0, limit=100, search=f"{prefix}nope"))
+    assert total_none == 0
+
+
+@pytest.mark.asyncio
+async def test_like_wildcards_in_the_search_term_stay_literal(db_session, seeded_operators):
+    repo = OperatorRepository(db_session)
+    prefix = seeded_operators["prefix"]
+
+    literal, total_literal = await repo.get_list_paginated(
+        OperatorListFilter(skip=0, limit=100, search=f"{prefix}be%t")
+    )
+    assert total_literal == 1 and literal[0].first_name == f"{prefix}be%ta"
+
+    _, total_wildcard = await repo.get_list_paginated(OperatorListFilter(skip=0, limit=100, search=f"{prefix}op%7"))
+    assert total_wildcard == 0
+
+    _, total_underscore = await repo.get_list_paginated(OperatorListFilter(skip=0, limit=100, search=f"{prefix}op_7"))
+    assert total_underscore == 0
+
+    backslash, total_backslash = await repo.get_list_paginated(
+        OperatorListFilter(skip=0, limit=100, search=f"{prefix}back\\slash")
+    )
+    assert total_backslash == 1 and backslash[0].first_name == f"{prefix}back\\slash"
+
+    _, total_escape_eaten = await repo.get_list_paginated(
+        OperatorListFilter(skip=0, limit=100, search=f"{prefix}backslash")
+    )
+    assert total_escape_eaten == 0
+
+
+@pytest.mark.asyncio
+async def test_blank_search_is_treated_as_no_search(db_session, seeded_operators):
+    repo = OperatorRepository(db_session)
+
+    _, total_blank = await repo.get_list_paginated(OperatorListFilter(skip=0, limit=1, search="   "))
+    _, total_unset = await repo.get_list_paginated(OperatorListFilter(skip=0, limit=1))
+
+    assert total_blank == total_unset >= MATCHING_COUNT

--- a/backend/tests/integration/operators/test_operators_pagination_db.py
+++ b/backend/tests/integration/operators/test_operators_pagination_db.py
@@ -21,7 +21,8 @@ from app.repositories.operators import OperatorRepository
 from app.schemas.filter import OperatorListFilter
 
 RANKED_COUNT = 21
-MATCHING_COUNT = RANKED_COUNT + 3
+MATCHING_COUNT = RANKED_COUNT + 4
+TURKISH_NAME = "İlkay"
 
 
 @pytest_asyncio.fixture
@@ -88,7 +89,13 @@ async def seeded_operators(db_session):
             operator_ids.append(operator.id)
             stats_ids.append(stats.id)
 
-        for name in (f"{prefix}be%ta", f"{prefix}back\\slash", f"{prefix}tie"):
+        tied_names = (
+            f"{prefix}be%ta",
+            f"{prefix}back\\slash",
+            f"{prefix}{TURKISH_NAME}",
+            f"{prefix}tie",
+        )
+        for name in tied_names:
             tied, tied_stats = await _add_operator(
                 session,
                 user_id=user.id,
@@ -255,6 +262,22 @@ async def test_like_wildcards_in_the_search_term_stay_literal(db_session, seeded
         OperatorListFilter(skip=0, limit=100, search=f"{prefix}backslash")
     )
     assert total_escape_eaten == 0
+
+
+@pytest.mark.asyncio
+async def test_search_casefolds_the_way_the_database_does(db_session, seeded_operators):
+    repo = OperatorRepository(db_session)
+    prefix = seeded_operators["prefix"]
+    stored = f"{prefix}{TURKISH_NAME}"
+
+    pasted, total_pasted = await repo.get_list_paginated(OperatorListFilter(skip=0, limit=100, search=stored))
+    assert total_pasted == 1 and pasted[0].first_name == stored
+
+    _, total_lower = await repo.get_list_paginated(OperatorListFilter(skip=0, limit=100, search=f"{prefix}ilkay"))
+    assert total_lower == 1
+
+    _, total_upper = await repo.get_list_paginated(OperatorListFilter(skip=0, limit=100, search=f"{prefix}ILKAY"))
+    assert total_upper == 1
 
 
 @pytest.mark.asyncio

--- a/frontend/src/interfaces/operator.interface.ts
+++ b/frontend/src/interfaces/operator.interface.ts
@@ -64,6 +64,11 @@ export type Operator = {
   };
 };
 
+export type OperatorListItem = Pick<
+  Operator,
+  "firstName" | "lastName" | "avatar" | "created_at" | "operator_statistics"
+> & { id: string };
+
 export interface OperatorDetailsDialogProps {
   operator: Operator | null;
   isOpen: boolean;

--- a/frontend/src/services/operators.ts
+++ b/frontend/src/services/operators.ts
@@ -1,15 +1,40 @@
 import { apiRequest } from "@/config/api";
-import { Operator } from "@/interfaces/operator.interface";
+import { PaginatedResponse } from "@/interfaces/common.interface";
+import { Operator, OperatorListItem } from "@/interfaces/operator.interface";
 
 export const fetchOperators = async (): Promise<Operator[]> => {
   const response = await apiRequest<Operator[]>("get", "/operators/");
   return response && Array.isArray(response) ? response : [];
 };
 
+export const fetchOperatorsPaginated = async (
+  page: number = 1,
+  pageSize: number = 20,
+  search?: string
+): Promise<PaginatedResponse<OperatorListItem>> => {
+  const limit = Math.min(Math.max(1, pageSize), 100);
+  const skip = (Math.max(1, page) - 1) * limit;
+  const params = new URLSearchParams({
+    skip: String(skip),
+    limit: String(limit),
+  });
+  const trimmed = search?.trim();
+  if (trimmed) params.set("search", trimmed);
+
+  const response = await apiRequest<PaginatedResponse<OperatorListItem>>(
+    "get",
+    `/operators/list?${params.toString()}`
+  );
+  // apiRequest returns null on 403; other failures still throw.
+  return (
+    response ?? { items: [], total: 0, page: 1, page_size: limit, total_pages: 0 }
+  );
+};
+
 export const fetchOperatorById = async (
   operatorId: string
 ): Promise<Operator | null> => {
-  const response = await apiRequest<Operator>("get", `/operator/${operatorId}`);
+  const response = await apiRequest<Operator>("get", `/operators/${operatorId}`);
   return response ?? null;
 };
 

--- a/frontend/src/views/Operators/components/OperatorCard.tsx
+++ b/frontend/src/views/Operators/components/OperatorCard.tsx
@@ -99,9 +99,9 @@ export function OperatorsCard({
       const data = await fetchOperatorsPaginated(page, PAGE_SIZE, debouncedSearch);
       if (seq !== requestSeqRef.current) return;
 
-      // A stale ?page= beyond the current range: fall back to the last page.
-      if (data.total > 0 && data.items.length === 0 && page > 1) {
-        goToPageRef.current(Math.max(1, data.total_pages));
+      // A stale ?page= past the end: fall back to the last page.
+      if (data.total > 0 && data.items.length === 0 && page > data.total_pages) {
+        goToPageRef.current(data.total_pages);
         return;
       }
 

--- a/frontend/src/views/Operators/components/OperatorCard.tsx
+++ b/frontend/src/views/Operators/components/OperatorCard.tsx
@@ -1,16 +1,20 @@
-import { useCallback, useState, useEffect } from "react";
+import { useCallback, useRef, useState, useEffect } from "react";
 import { Card } from "@/components/card";
 import { ThumbsUp, Clock, Star, Users } from "lucide-react";
 import { OperatorDetailsDialog } from "./OperatorDetailsDialog";
-import { useLocation, useSearchParams } from "react-router-dom";
-import { fetchOperators } from "@/services/operators";
-import { Operator } from "@/interfaces/operator.interface";
+import { useSearchParams } from "react-router-dom";
+import { fetchOperatorById, fetchOperatorsPaginated } from "@/services/operators";
+import { Operator, OperatorListItem } from "@/interfaces/operator.interface";
 import { formatCallDuration } from "@/helpers/formatters";
-import { CardHeader } from "@/components/CardHeader";
 import { Button } from "@/components/button";
 import { PageListSkeleton } from "@/components/skeletons";
 import { ListEmptyState } from "@/components/ListEmptyState";
 import { ListErrorState } from "@/components/ListErrorState";
+import { PaginationBar } from "@/components/PaginationBar";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+
+const PAGE_SIZE = 20;
+const SEARCH_DEBOUNCE_MS = 300;
 
 interface OperatorsCardProps {
   searchQuery: string;
@@ -23,127 +27,163 @@ export function OperatorsCard({
   refreshKey,
   onCreate,
 }: OperatorsCardProps) {
-  const [operators, setOperators] = useState<Operator[]>([]);
+  const [operators, setOperators] = useState<OperatorListItem[]>([]);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedAgent, setSelectedAgent] = useState<Operator | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [imageErrors, setImageErrors] = useState(new Set<string | number>());
+  // Keyed by operator id, not row index, so ids can't collide across pages.
+  const [imageErrors, setImageErrors] = useState(new Set<string>());
 
-  const location = useLocation();
-  const isDashboard = location.pathname === "/dashboard";
-
-  // Deep link
   const [searchParams, setSearchParams] = useSearchParams();
   const operatorParam = searchParams.get("operator");
+  const page = Math.max(1, parseInt(searchParams.get("page") || "1", 10) || 1);
+  const debouncedSearch = useDebouncedValue(searchQuery, SEARCH_DEBOUNCE_MS).trim();
+
+  const requestSeqRef = useRef(0);
+  const lastResetSigRef = useRef(`${debouncedSearch}|${refreshKey}`);
+
+  // Functional updater so the page edit always applies to the current params
+  // rather than a value captured at render time.
+  const goToPage = useCallback(
+    (next: number) => {
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev);
+          if (next <= 1) params.delete("page");
+          else params.set("page", String(next));
+          return params;
+        },
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
+
+  const goToPageRef = useRef(goToPage);
+  useEffect(() => {
+    goToPageRef.current = goToPage;
+  });
 
   const handleModalOpenChange = (open: boolean) => {
     setIsModalOpen(open);
     if (!open && operatorParam) {
-      searchParams.delete("operator");
-      setSearchParams(searchParams, { replace: true });
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev);
+          params.delete("operator");
+          return params;
+        },
+        { replace: true }
+      );
     }
   };
 
   const loadOperators = useCallback(async () => {
+    const seq = ++requestSeqRef.current;
+
+    const resetSig = `${debouncedSearch}|${refreshKey}`;
+    if (resetSig !== lastResetSigRef.current) {
+      lastResetSigRef.current = resetSig;
+      // A new search or a freshly created operator belongs on page 1.
+      if (page !== 1) {
+        goToPageRef.current(1);
+        return;
+      }
+    }
+
     setLoading(true);
     setError(null);
     try {
-      const rawData = await fetchOperators();
+      const data = await fetchOperatorsPaginated(page, PAGE_SIZE, debouncedSearch);
+      if (seq !== requestSeqRef.current) return;
 
-      const sortedOperators = rawData.sort((a, b) => {
-        const sentimentA = a.operator_statistics?.positive ?? 0;
-        const sentimentB = b.operator_statistics?.positive ?? 0;
+      // A stale ?page= beyond the current range: fall back to the last page.
+      if (data.total > 0 && data.items.length === 0 && page > 1) {
+        goToPageRef.current(Math.max(1, data.total_pages));
+        return;
+      }
 
-        if (sentimentB !== sentimentA) {
-          return sentimentB - sentimentA;
-        }
-        return (
-          (b.operator_statistics?.score ?? 0) -
-          (a.operator_statistics?.score ?? 0)
-        );
-      });
-
-      setOperators(isDashboard ? sortedOperators.slice(0, 5) : sortedOperators);
+      setOperators(data.items);
+      setTotal(data.total);
     } catch (err) {
+      if (seq !== requestSeqRef.current) return;
       console.error("Failed to load operators:", err);
       setError("We couldn't load your operators. Please try again.");
     } finally {
-      setLoading(false);
+      if (seq === requestSeqRef.current) setLoading(false);
     }
-  }, [isDashboard]);
+  }, [page, debouncedSearch, refreshKey]);
 
   useEffect(() => {
     loadOperators();
-  }, [loadOperators, refreshKey]);
+  }, [loadOperators]);
 
-  // Open the profile dialog when a matching ?operator=<id> is present.
+  // Open the profile dialog for ?operator=<id>, fetching it when the id isn't
+  // on the current page.
   useEffect(() => {
-    if (!operatorParam || operators.length === 0) return;
+    if (!operatorParam) return;
+
     const match = operators.find((op) => op.id === operatorParam);
     if (match) {
       setSelectedAgent(match);
       setIsModalOpen(true);
+      return;
     }
-  }, [operatorParam, operators]);
+    if (loading) return;
+
+    let cancelled = false;
+    const requestedId = operatorParam;
+    fetchOperatorById(requestedId)
+      .then((operator) => {
+        if (cancelled || operator?.id !== requestedId) return;
+        setSelectedAgent(operator);
+        setIsModalOpen(true);
+      })
+      .catch(() => {
+        // Invalid or unavailable operator deep links remain a silent no-op.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [operatorParam, operators, loading]);
 
   function getInitials(firstName = "", lastName = "") {
     return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
   }
 
-  const handleImageError = (agentId: string | number) => {
-    setImageErrors((prevErrors) => new Set(prevErrors).add(agentId));
+  const handleImageError = (operatorId: string) => {
+    setImageErrors((prevErrors) => new Set(prevErrors).add(operatorId));
   };
 
-  let filteredAgents = searchQuery
-    ? operators.filter(
-        (agent) =>
-          agent.firstName?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          agent.lastName?.toLowerCase().includes(searchQuery.toLowerCase())
-      )
-    : operators;
-
-  if (isDashboard) {
-    filteredAgents = filteredAgents.slice(0, 5);
-  }
-
-  const isSearchActive = searchQuery.trim() !== "";
+  const isSearchActive = debouncedSearch !== "";
 
   return (
     <>
       <Card className="p-4 shadow-sm animate-fade-up bg-card dark:bg-zinc-900">
-        <CardHeader
-          title={isDashboard ? "Top Performing Operators" : ""}
-          tooltipText={
-            isDashboard
-              ? "Operators ranked by customer satisfaction scores and overall performance metrics"
-              : undefined
-          }
-          linkText={isDashboard ? "View all" : undefined}
-          linkHref={isDashboard ? "/operators" : undefined}
-        />
-
         <div className="space-y-2">
           {loading ? (
             <PageListSkeleton variant="operator" rows={5} bordered={false} />
           ) : error ? (
             <ListErrorState message={error} onRetry={loadOperators} />
-          ) : filteredAgents.length > 0 ? (
-            filteredAgents.map((agent, index) => (
+          ) : operators.length > 0 ? (
+            operators.map((agent) => (
               <div
-                key={agent.id ?? index}
+                key={agent.id}
                 className="flex items-center gap-3 p-2 rounded-lg transition-colors hover:bg-muted/30 cursor-pointer"
                 onClick={() => {
                   setSelectedAgent(agent);
                   setIsModalOpen(true);
                 }}
               >
-                {!imageErrors.has(index) && agent.avatar ? (
+                {!imageErrors.has(agent.id) && agent.avatar ? (
                   <img
                     src={agent.avatar}
                     alt={`${agent.firstName} ${agent.lastName}`}
                     className="w-10 h-10 rounded-full object-cover shrink-0"
-                    onError={() => handleImageError(index)}
+                    onError={() => handleImageError(agent.id)}
                   />
                 ) : (
                   <div className="w-10 h-10 flex items-center justify-center rounded-full bg-muted text-muted-foreground text-sm font-semibold shrink-0">
@@ -194,7 +234,7 @@ export function OperatorsCard({
                   : "Operators are the people who handle escalated conversations. They'll appear here once they're added."
               }
               action={
-                !isDashboard && !isSearchActive && onCreate ? (
+                !isSearchActive && onCreate ? (
                   <Button className="rounded-full" onClick={onCreate}>
                     Create your first operator
                   </Button>
@@ -203,6 +243,16 @@ export function OperatorsCard({
             />
           )}
         </div>
+
+        {!loading && !error && (
+          <PaginationBar
+            total={total}
+            currentPage={page}
+            pageSize={PAGE_SIZE}
+            pageItemCount={operators.length}
+            onPageChange={goToPage}
+          />
+        )}
       </Card>
 
       <OperatorDetailsDialog

--- a/frontend/tests/services/operators.test.ts
+++ b/frontend/tests/services/operators.test.ts
@@ -11,7 +11,12 @@ vi.mock("@/config/api", () => ({
 }));
 
 import { apiRequest } from "@/config/api";
-import { fetchOperators, fetchOperatorById, createOperator } from "@/services/operators";
+import {
+  fetchOperators,
+  fetchOperatorById,
+  fetchOperatorsPaginated,
+  createOperator,
+} from "@/services/operators";
 import type { Operator } from "@/interfaces/operator.interface";
 
 const mockApiRequest = vi.mocked(apiRequest);
@@ -40,19 +45,108 @@ describe("fetchOperators", () => {
 });
 
 describe("fetchOperatorById", () => {
-  it("GETs /operator/:id and returns it", async () => {
+  it("GETs /operators/:id and returns it", async () => {
     const operator = { id: "o1" };
     mockApiRequest.mockResolvedValue(operator as never);
 
     const result = await fetchOperatorById("o1");
 
-    expect(mockApiRequest).toHaveBeenCalledWith("get", "/operator/o1");
+    expect(mockApiRequest).toHaveBeenCalledWith("get", "/operators/o1");
     expect(result).toEqual(operator);
   });
 
   it("returns null when the response is null", async () => {
     mockApiRequest.mockResolvedValue(null as never);
     await expect(fetchOperatorById("o1")).resolves.toBeNull();
+  });
+});
+
+describe("fetchOperatorsPaginated", () => {
+  const page = <T,>(items: T[]) => ({
+    items,
+    total: items.length,
+    page: 1,
+    page_size: 20,
+    total_pages: 1,
+  });
+
+  const requestedUrl = () => String(mockApiRequest.mock.calls[0][1]);
+
+  it("defaults to the first page of 20", async () => {
+    mockApiRequest.mockResolvedValue(page([{ id: "o1" }]) as never);
+
+    await fetchOperatorsPaginated();
+
+    expect(mockApiRequest).toHaveBeenCalledWith("get", "/operators/list?skip=0&limit=20");
+  });
+
+  it("converts page and pageSize into skip and limit", async () => {
+    mockApiRequest.mockResolvedValue(page([]) as never);
+
+    await fetchOperatorsPaginated(3, 10);
+
+    expect(requestedUrl()).toBe("/operators/list?skip=20&limit=10");
+  });
+
+  it("clamps pageSize to the backend maximum of 100", async () => {
+    mockApiRequest.mockResolvedValue(page([]) as never);
+
+    await fetchOperatorsPaginated(1, 500);
+
+    expect(requestedUrl()).toContain("limit=100");
+  });
+
+  it("clamps page and pageSize to their minimums", async () => {
+    mockApiRequest.mockResolvedValue(page([]) as never);
+
+    await fetchOperatorsPaginated(0, 0);
+
+    expect(requestedUrl()).toBe("/operators/list?skip=0&limit=1");
+  });
+
+  it("passes a trimmed search term", async () => {
+    mockApiRequest.mockResolvedValue(page([]) as never);
+
+    await fetchOperatorsPaginated(1, 20, "  ana  ");
+
+    expect(requestedUrl()).toBe("/operators/list?skip=0&limit=20&search=ana");
+  });
+
+  it("omits the search param when it is absent or blank", async () => {
+    mockApiRequest.mockResolvedValue(page([]) as never);
+
+    await fetchOperatorsPaginated(1, 20, "   ");
+    expect(requestedUrl()).not.toContain("search");
+
+    vi.clearAllMocks();
+    mockApiRequest.mockResolvedValue(page([]) as never);
+    await fetchOperatorsPaginated(1, 20, undefined);
+    expect(requestedUrl()).not.toContain("search");
+  });
+
+  it("returns the paginated body unchanged", async () => {
+    const body = page([{ id: "o1" }, { id: "o2" }]);
+    mockApiRequest.mockResolvedValue(body as never);
+
+    await expect(fetchOperatorsPaginated()).resolves.toEqual(body);
+  });
+
+  it("returns an empty page when the response is null (403)", async () => {
+    mockApiRequest.mockResolvedValue(null as never);
+
+    await expect(fetchOperatorsPaginated(2, 50)).resolves.toEqual({
+      items: [],
+      total: 0,
+      page: 1,
+      page_size: 50,
+      total_pages: 0,
+    });
+  });
+
+  it("propagates non-403 errors", async () => {
+    mockApiRequest.mockRejectedValue(new Error("boom"));
+
+    await expect(fetchOperatorsPaginated()).rejects.toThrow("boom");
   });
 });
 


### PR DESCRIPTION
## Description

Improves the Operators menu performance by replacing full-list loading and client-side processing with server-side pagination, ordering, and debounced search. The change adds an additive paginated API while preserving the existing Operators endpoint for current consumers. It also removes discarded per-operator conversation queries, fixes operator-by-ID fetching, handles Unicode searches and stale page URLs, and removes an invalid refresh during Workflow Builder seeding.

## Type of Change


- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

- Added `GET /api/operators/list` with server-side pagination, counting, ordering, and search
- Added literal wildcard escaping and Unicode-safe case-insensitive operator search
- Added a minimal paginated operator response model
- Removed discarded sequential conversation lookups from the legacy endpoint
- Updated the Operators menu to use 20-item server-side pages and debounced search
- Added URL-based page state, stale-request protection, and invalid-page correction
- Preserved operator deep links by fetching an operator by ID when it is not on the current page
- Fixed the frontend operator-by-ID endpoint path and backend by-ID route response
- Removed an invalid Pydantic object refresh from the Workflow Builder seed

## Testing


- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)


## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

Closes #

## Screenshots (if applicable)


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
