### PR TITLE
fix: import opik lazily to prevent prefork worker segfault

### DIFF
--- a/backend/app/services/gpt_questions.py
+++ b/backend/app/services/gpt_questions.py
@@ -4,9 +4,12 @@ import os
 from dotenv import load_dotenv
 from langchain_core.messages import HumanMessage, SystemMessage
 
+# NOTE: `opik` (and opik.integrations.langchain) transitively import the ML stack
+# (sklearn / torch / transformers) at import time. This service is eagerly instantiated
+# by the DI container at Celery boot, so importing opik at module top level loads those
+# native-thread libs into the prefork *master* -> fork() SIGSEGV (see run_celery.py and
+# the two-pool split). Import opik lazily, only when USE_OPIK is actually enabled.
 # from opik.integrations.openai import track_openai
-from opik import track
-from opik.integrations.langchain import OpikTracer
 
 from app.core.config.settings import settings
 from app.core.exceptions.error_messages import ErrorKey
@@ -34,6 +37,8 @@ class QuestionAnswerer:
             from langchain_openai import ChatOpenAI
 
             if USE_OPIK:
+                from opik.integrations.langchain import OpikTracer
+
                 self.opik_tracer = OpikTracer()
                 self._llm = ChatOpenAI(model=self.llm_model, temperature=self.temperature, stream_usage=True, callbacks=[self.opik_tracer])
             else:
@@ -72,6 +77,8 @@ class QuestionAnswerer:
 
 # Conditionally assign the method after class definition
 if USE_OPIK:
+    from opik import track
+
     QuestionAnswerer.answer_question = track(QuestionAnswerer.answer_question)
 else:
     QuestionAnswerer.answer_question = QuestionAnswerer.answer_question


### PR DESCRIPTION
opik pulls in torch/sklearn/transformers at import. gpt_questions is built by the DI container at boot, so the prefork worker loaded ML libs into its master and crashed on fork(). Import opik only when USE_OPIK.

## Description

## What
Move the two `opik` imports in `gpt_questions.py` to load lazily, only when `USE_OPIK` is enabled.

## Why
`opik` transitively imports torch/sklearn/transformers. This service is instantiated at Celery boot, so the prefork "default" worker loaded ML libs into its master process and SIGSEGV'd on fork() — the crash #819 was meant to prevent.

## Test
`test_celery_worker_boot_clean` now passes (was failing: `LOADED: sklearn, torch, transformers`). Verified in a real prefork worker run — boots clean, forked children run tasks with no crash.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
