### PR TITLE
feat: tidy up workflow node variable UI

### DIFF
--- a/frontend/src/components/richInput.tsx
+++ b/frontend/src/components/richInput.tsx
@@ -16,11 +16,12 @@ const INPUT_BASE_CLASS =
 
 const INPUT_TYPO_CLASS = "text-base md:text-sm leading-normal whitespace-pre"
 const OVERLAY_BASE_CLASS =
-  "block absolute inset-0 pointer-events-none px-3 py-2 select-none z-0 text-foreground"
+  "block absolute inset-0 pointer-events-none px-3 py-2 select-none z-0 overflow-hidden text-foreground"
 
 const RichInput = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  ({ className, type, value, onFocus, onChange, onMouseUp, ...props }, ref) => {
+  ({ className, type, value, onFocus, onChange, onMouseUp, onScroll, ...props }, ref) => {
     const inputRef = React.useRef<HTMLInputElement | null>(null)
+    const overlayRef = React.useRef<HTMLDivElement | null>(null)
     const pendingCursorRef = React.useRef<number | null>(null)
     const useOverlay = hasVariableSyntax(value)
 
@@ -91,6 +92,25 @@ const RichInput = React.forwardRef<HTMLInputElement, React.ComponentProps<"input
       [useOverlay, value, onMouseUp]
     )
 
+    // The overlay is clipped to the field, so it has to follow the input's own
+    // horizontal scroll — otherwise the highlighted text stays pinned to the
+    // start while the caret moves on. Same approach as RichTextarea.
+    const syncScroll = () => {
+      if (!inputRef.current || !overlayRef.current) return
+      overlayRef.current.scrollLeft = inputRef.current.scrollLeft
+    }
+
+    const handleScroll: React.UIEventHandler<HTMLInputElement> = (event) => {
+      syncScroll()
+      onScroll?.(event)
+    }
+
+    // Covers scrolling caused by a value change (typing, paste, drag & drop),
+    // which doesn't emit a scroll event before the re-render.
+    React.useLayoutEffect(() => {
+      syncScroll()
+    })
+
     return (
       <div className="relative w-full">
         <input
@@ -103,6 +123,7 @@ const RichInput = React.forwardRef<HTMLInputElement, React.ComponentProps<"input
           ref={setRef}
           value={value ?? ""}
           onFocus={handleFocus}
+          onScroll={handleScroll}
           onKeyDown={handleKeyDown}
           onKeyUp={handleKeyUp}
           onMouseUp={handleMouseUp}
@@ -111,6 +132,7 @@ const RichInput = React.forwardRef<HTMLInputElement, React.ComponentProps<"input
         />
         {useOverlay && segments.length > 0 && (
           <div
+            ref={overlayRef}
             className={cn(OVERLAY_BASE_CLASS, INPUT_TYPO_CLASS)}
             aria-hidden
           >

--- a/frontend/src/views/AIAgents/Workflows/components/custom/ParameterSection.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/custom/ParameterSection.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useEffect } from "react";
+import { FC, useState, useEffect, useLayoutEffect, useRef } from "react";
 import { Button } from "@/components/button";
 import { Plus, Info } from "lucide-react";
 import { RichInput } from "@/components/richInput";
@@ -71,43 +71,179 @@ interface ParameterDialogProps {
 interface ParameterBadgesProps {
   params: Record<string, { type: string; required?: boolean }>;
   className?: string;
+  /**
+   * Clip the badges to a single row and summarise the rest as a "+N" circle.
+   * Used on canvas nodes, whose width is fixed: a long variable list would
+   * otherwise wrap into several rows and make the node very tall.
+   */
+  collapse?: boolean;
 }
+
+interface BadgeEntry {
+  name: string;
+  suggested: boolean;
+}
+
+// Matches the `gap-2` of the badge row.
+const BADGE_GAP = 8;
+// Fallback width for the "+N" circle if it can't be measured.
+const COUNTER_FALLBACK_WIDTH = 32;
+
+/**
+ * Renders as many badges as fit on the first row, followed by a "+N" circle
+ * standing for the ones left out. The fit is measured from the real layout
+ * (first paint renders every badge, hidden behind a layout effect) so the row
+ * stays full whatever the badge lengths are.
+ */
+const CollapsedParameterBadges: FC<{
+  entries: BadgeEntry[];
+  className?: string;
+}> = ({ entries, className = "" }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const measuredWidthRef = useRef(0);
+  // `null` means "measuring": everything is rendered so the rows can be read.
+  const [visibleCount, setVisibleCount] = useState<number | null>(null);
+  // Bumped to force a fresh measuring pass (see the resize observer below).
+  const [measureKey, setMeasureKey] = useState(0);
+
+  // The parent keys this component on the variable list, so a changed list
+  // remounts it and measuring starts over.
+  useLayoutEffect(() => {
+    if (visibleCount !== null) return;
+    const container = containerRef.current;
+    if (!container || container.clientWidth === 0) return;
+
+    const children = Array.from(container.children) as HTMLElement[];
+    const badges = children.slice(0, entries.length);
+    if (badges.length === 0) return;
+    measuredWidthRef.current = container.clientWidth;
+
+    const firstRowTop = badges[0].offsetTop;
+    let count = badges.filter((badge) => badge.offsetTop === firstRowTop).length;
+
+    if (count < badges.length) {
+      // Something will be hidden, so the row must also fit the "+N" circle
+      // (rendered last during the measuring pass).
+      const counter = children[entries.length];
+      const counterWidth = counter?.offsetWidth || COUNTER_FALLBACK_WIDTH;
+      while (count > 1) {
+        const last = badges[count - 1];
+        const rowEnd = last.offsetLeft + last.offsetWidth;
+        if (rowEnd + BADGE_GAP + counterWidth <= container.clientWidth) break;
+        count -= 1;
+      }
+    }
+
+    setVisibleCount(count);
+  }, [visibleCount, entries.length, measureKey]);
+
+  // The node width is fixed today, but re-measure if it ever changes (or if the
+  // node was laid out while off-screen, i.e. at zero width).
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      const width = containerRef.current?.clientWidth ?? 0;
+      if (width !== 0 && width !== measuredWidthRef.current) {
+        setVisibleCount(null);
+        setMeasureKey((key) => key + 1);
+      }
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  const isMeasuring = visibleCount === null;
+  const visible = isMeasuring ? entries : entries.slice(0, visibleCount);
+  const hidden = entries.slice(visible.length);
+  // During the measuring pass the counter is only there to be measured, so its
+  // label just needs the right order of magnitude.
+  const hiddenCount = isMeasuring ? entries.length - 1 : hidden.length;
+
+  return (
+    <div
+      ref={containerRef}
+      className={`flex gap-2 overflow-hidden ${
+        isMeasuring ? "flex-wrap" : "flex-nowrap"
+      } ${className}`}
+    >
+      {visible.map((entry) => (
+        <Badge
+          key={entry.name}
+          variant="secondary"
+          className={`shrink-0 cursor-pointer hover:bg-secondary/80 ${
+            entry.suggested ? "font-light" : ""
+          }`}
+        >
+          {entry.name}
+        </Badge>
+      ))}
+      {hiddenCount > 0 && (
+        <Badge
+          variant="secondary"
+          className={`shrink-0 h-[22px] min-w-[22px] justify-center px-1.5 ${
+            isMeasuring ? "invisible" : ""
+          }`}
+          title={hidden.map((entry) => entry.name).join("\n")}
+        >
+          +{hiddenCount}
+        </Badge>
+      )}
+    </div>
+  );
+};
 
 export const ParameterBadges: FC<ParameterBadgesProps> = ({
   params,
   className = "",
+  collapse = false,
 }) => {
   const chatInputSchema = useChatInputSchema();
   const suggestedParams = chatInputSchema || {};
-  return (
-    <div className={`flex flex-wrap gap-2 ${className}`}>
-      {Object.entries(params ?? {})
-        .filter(([name, param]) => !suggestedParams[name])
-        .map(([name, param]) => (
-          <Badge
-            key={name}
-            variant="secondary"
-            className="cursor-pointer hover:bg-secondary/80"
-          >
-            {name}
-          </Badge>
-        ))}
-      {Object.entries(params ?? {})
-        .filter(([name, param]) => suggestedParams[name])
-        .map(([name, param]) => (
-          <Badge
-            key={name}
-            variant="secondary"
-            className="cursor-pointer hover:bg-secondary/80 font-light"
-          >
-            {name}
-          </Badge>
-        ))}
-      {Object.keys(params || {}).length === 0 && (
+  const names = Object.keys(params ?? {});
+  // Suggested params keep their place at the end of the list.
+  const entries: BadgeEntry[] = [
+    ...names
+      .filter((name) => !suggestedParams[name])
+      .map((name) => ({ name, suggested: false })),
+    ...names
+      .filter((name) => suggestedParams[name])
+      .map((name) => ({ name, suggested: true })),
+  ];
+
+  if (entries.length === 0) {
+    return (
+      <div className={`flex flex-wrap gap-2 ${className}`}>
         <span className="text-sm text-muted-foreground italic">
           No variables required
         </span>
-      )}
+      </div>
+    );
+  }
+
+  if (collapse) {
+    return (
+      <CollapsedParameterBadges
+        key={entries.map((entry) => entry.name).join("|")}
+        entries={entries}
+        className={className}
+      />
+    );
+  }
+
+  return (
+    <div className={`flex flex-wrap gap-2 ${className}`}>
+      {entries.map((entry) => (
+        <Badge
+          key={entry.name}
+          variant="secondary"
+          className={`cursor-pointer hover:bg-secondary/80 ${
+            entry.suggested ? "font-light" : ""
+          }`}
+        >
+          {entry.name}
+        </Badge>
+      ))}
     </div>
   );
 };

--- a/frontend/src/views/AIAgents/Workflows/nodeTypes/chat/chatInputNode.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeTypes/chat/chatInputNode.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from "react";
-import { NodeProps } from "reactflow";
+import React, { useCallback, useEffect, useState } from "react";
+import { NodeProps, useReactFlow } from "reactflow";
 import { Play } from "lucide-react";
-import { ChatInputNodeData } from "../../types/nodes";
+import { ChatInputNodeData, SetStateNodeData } from "../../types/nodes";
 import { getNodeColor } from "../../utils/nodeColors";
 import { ParameterSection } from "../../components/custom/ParameterSection";
 import { NodeSchema, SchemaField } from "../../types/schemas";
@@ -39,6 +39,7 @@ const ChatInputNode: React.FC<NodeProps<ChatInputNodeData>> = ({
   const nodeDefinition = nodeRegistry.getNodeType(CHAT_INPUT_NODE_TYPE);
   const color = getNodeColor(nodeDefinition.category);
   const nodeActions = useNodeActions();
+  const { setNodes } = useReactFlow();
   const [dynamicParams, setDynamicParams] = useState<NodeSchema>(
     data.inputSchema
   );
@@ -70,6 +71,43 @@ const ChatInputNode: React.FC<NodeProps<ChatInputNodeData>> = ({
     }));
   };
 
+  const removeStateEntriesFor = useCallback(
+    (paramName: string) => {
+      setNodes((nodes) =>
+        nodes.map((node) => {
+          if (node.type !== "setStateNode") return node;
+
+          // Older nodes kept a single entry in stateKey/stateValue, which
+          // SetStateDialog migrates into `states` on open — clear those too, or
+          // the deleted parameter would come back the next time it's opened.
+          const nodeData = node.data as SetStateNodeData & {
+            stateKey?: string;
+            stateValue?: string;
+          };
+          const states = nodeData?.states;
+          const remaining = Array.isArray(states)
+            ? states.filter((state) => state.key !== paramName)
+            : undefined;
+          const dropsEntry = !!remaining && remaining.length !== states.length;
+          const dropsLegacyEntry = nodeData?.stateKey === paramName;
+          if (!dropsEntry && !dropsLegacyEntry) return node;
+
+          return {
+            ...node,
+            data: {
+              ...nodeData,
+              ...(dropsEntry ? { states: remaining } : {}),
+              ...(dropsLegacyEntry
+                ? { stateKey: undefined, stateValue: undefined }
+                : {}),
+            },
+          };
+        })
+      );
+    },
+    [setNodes]
+  );
+
   const removeItem = (
     setter: React.Dispatch<React.SetStateAction<NodeSchema>>,
     name: string
@@ -79,6 +117,7 @@ const ChatInputNode: React.FC<NodeProps<ChatInputNodeData>> = ({
       delete newParams[name];
       return newParams;
     });
+    removeStateEntriesFor(name);
   };
 
   return (

--- a/frontend/src/views/AIAgents/Workflows/nodeTypes/nodeContent.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeTypes/nodeContent.tsx
@@ -61,7 +61,9 @@ export const NodeContent: React.FC<NodeContentProps> = ({ data }) => {
         Object.keys(row.value).length > 0 &&
         !Object.keys(row.value).includes("direct_input")
       ) {
-        return <ParameterBadges params={transformParams(row.value)} />;
+        return (
+          <ParameterBadges params={transformParams(row.value)} collapse />
+        );
       } else {
         return (
           <div className="text-sm text-accent-foreground italic">


### PR DESCRIPTION
## Description

tidy up workflow node variable UI

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- Node cards: keep the VARIABLES row on one line with a "+N" circle for the overflow, measured from the real layout so short names still share the row. Applies to all 13 nodes with a variables row.
- Node settings sheet: clip RichInput's highlight overlay to the field and sync it to the input's scroll, so {{...}} values no longer paint over the neighbouring column.
- Start node: deleting a parameter now also removes the matching entries from Set State nodes instead of leaving them dangling.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
