### PR TITLE
feat: add option to ignore IDs when comparing versions

### DIFF
--- a/frontend/src/interfaces/workflow-diff.interface.ts
+++ b/frontend/src/interfaces/workflow-diff.interface.ts
@@ -11,6 +11,12 @@ import { Workflow } from '@/interfaces/workflow.interface';
 /** How a node changed between the two compared versions. */
 export type NodeDiffStatus = 'added' | 'removed' | 'modified' | 'unchanged';
 
+/** Rules for what counts as a meaningful change. */
+export interface DiffOptions {
+  /** Drop record-reference ids (provider, KB, connector, data source) from both sides. */
+  ignoreIdReferences?: boolean;
+}
+
 /** A single configuration field that differs between base and target for a modified node. */
 export interface FieldChange {
   /** Field key within the node's `data` (or the synthetic `type` key when the node type changed). */

--- a/frontend/src/views/AIAgents/Workflows/components/diff/VersionDiffDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/diff/VersionDiffDialog.tsx
@@ -3,6 +3,7 @@ import { ArrowRight, Loader2, AlertTriangle, RefreshCw, List, Network } from 'lu
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/dialog';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/tabs';
 import { Button } from '@/components/button';
+import { Switch } from '@/components/switch';
 import { cn } from '@/helpers/utils';
 import { Workflow } from '@/interfaces/workflow.interface';
 import { getWorkflowById } from '@/services/workflows';
@@ -33,6 +34,7 @@ const VersionDiffDialog: React.FC<VersionDiffDialogProps> = ({ open, onClose, ba
   const [resolvedTarget, setResolvedTarget] = useState<Workflow | undefined>();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [ignoreIdReferences, setIgnoreIdReferences] = useState(false);
 
   const loadVersions = useCallback(async () => {
     setLoading(true);
@@ -58,13 +60,14 @@ const VersionDiffDialog: React.FC<VersionDiffDialogProps> = ({ open, onClose, ba
       setResolvedBase(undefined);
       setResolvedTarget(undefined);
       setError(null);
+      setIgnoreIdReferences(false);
     }
   }, [open, loadVersions]);
 
   const diff = useMemo(() => {
     if (!resolvedBase || !resolvedTarget) return null;
-    return computeWorkflowDiff(resolvedBase, resolvedTarget);
-  }, [resolvedBase, resolvedTarget]);
+    return computeWorkflowDiff(resolvedBase, resolvedTarget, { ignoreIdReferences });
+  }, [resolvedBase, resolvedTarget, ignoreIdReferences]);
 
   const versionChip = (workflow: Workflow, side: 'base' | 'target') => {
     const isTarget = side === 'target';
@@ -137,16 +140,32 @@ const VersionDiffDialog: React.FC<VersionDiffDialogProps> = ({ open, onClose, ba
 
         {!loading && !error && diff && (
           <Tabs defaultValue="list" className="flex min-h-0 flex-1 flex-col pt-3">
-            <TabsList className="w-fit">
-              <TabsTrigger value="list" className="gap-1.5">
-                <List className="h-4 w-4" aria-hidden="true" />
-                List
-              </TabsTrigger>
-              <TabsTrigger value="graph" className="gap-1.5">
-                <Network className="h-4 w-4" aria-hidden="true" />
-                Graph
-              </TabsTrigger>
-            </TabsList>
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <TabsList className="w-fit">
+                <TabsTrigger value="list" className="gap-1.5">
+                  <List className="h-4 w-4" aria-hidden="true" />
+                  List
+                </TabsTrigger>
+                <TabsTrigger value="graph" className="gap-1.5">
+                  <Network className="h-4 w-4" aria-hidden="true" />
+                  Graph
+                </TabsTrigger>
+              </TabsList>
+
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="ignore-id-references"
+                  checked={ignoreIdReferences}
+                  onCheckedChange={setIgnoreIdReferences}
+                />
+                <label
+                  htmlFor="ignore-id-references"
+                  className="cursor-pointer select-none text-sm font-medium text-muted-foreground"
+                >
+                  Ignore ID references
+                </label>
+              </div>
+            </div>
             <TabsContent value="list" className="min-h-0 flex-1 pt-3 data-[state=inactive]:hidden">
               <DiffListView diff={diff} />
             </TabsContent>

--- a/frontend/src/views/AIAgents/Workflows/utils/versionDiff.ts
+++ b/frontend/src/views/AIAgents/Workflows/utils/versionDiff.ts
@@ -2,6 +2,7 @@ import { isEqual } from 'lodash';
 import { Edge, Node } from 'reactflow';
 import { Workflow } from '@/interfaces/workflow.interface';
 import {
+  DiffOptions,
   DiffSummary,
   EdgeDiff,
   FieldChange,
@@ -31,8 +32,82 @@ export interface NormalizedWorkflow {
   edges: Edge[];
 }
 
-const asRecord = (value: unknown): UnknownRecord =>
-  value && typeof value === 'object' && !Array.isArray(value) ? (value as UnknownRecord) : {};
+const isRecord = (value: unknown): value is UnknownRecord =>
+  !!value && typeof value === 'object' && !Array.isArray(value);
+
+const asRecord = (value: unknown): UnknownRecord => (isRecord(value) ? value : {});
+
+// Ids of records created inside genassist. External ids stay compared.
+const INTERNAL_ID_KEYS = new Set([
+  'providerId',
+  'llm_provider_id',
+  'fallbackChainId',
+  'audioProviderId',
+  'voiceProviderId',
+  'selectedBases',
+  'app_settings_id',
+  'dataSourceId',
+  'modelId',
+  'workflowId',
+  'agentId',
+  'fileId',
+  'csvFileId',
+]);
+
+// Upload locators → the id that must sit alongside; null = node keeps no id.
+const LOCATOR_KEYS: Record<string, string | null> = {
+  filePath: 'fileId',
+  fileUrl: 'fileId',
+  csvFilePath: 'csvFileId',
+  csvFileUrl: 'csvFileId',
+  serverFilePath: null,
+  serverFileUrl: null,
+};
+
+const isIgnorable = (key: string, base: UnknownRecord, target: UnknownRecord): boolean => {
+  if (INTERNAL_ID_KEYS.has(key)) return true;
+  if (!(key in LOCATOR_KEYS)) return false;
+  const idKey = LOCATOR_KEYS[key];
+  return idKey === null || idKey in base || idKey in target;
+};
+
+const dropReferences = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(dropReferences);
+  if (!isRecord(value)) return value;
+  const out: UnknownRecord = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (!isIgnorable(key, value, value)) out[key] = dropReferences(item);
+  }
+  return out;
+};
+
+// Both sides walked together so a key ignored on one is ignored on the other.
+const dropReferencePair = (base: unknown, target: unknown): [unknown, unknown] => {
+  if (isRecord(base) && isRecord(target)) {
+    const outBase: UnknownRecord = {};
+    const outTarget: UnknownRecord = {};
+    for (const key of Array.from(new Set([...Object.keys(base), ...Object.keys(target)]))) {
+      if (isIgnorable(key, base, target)) continue;
+      const [nextBase, nextTarget] = dropReferencePair(base[key], target[key]);
+      if (key in base) outBase[key] = nextBase;
+      if (key in target) outTarget[key] = nextTarget;
+    }
+    return [outBase, outTarget];
+  }
+
+  if (Array.isArray(base) && Array.isArray(target)) {
+    const outBase: unknown[] = [];
+    const outTarget: unknown[] = [];
+    for (let index = 0; index < Math.max(base.length, target.length); index += 1) {
+      const [nextBase, nextTarget] = dropReferencePair(base[index], target[index]);
+      if (index < base.length) outBase.push(nextBase);
+      if (index < target.length) outTarget.push(nextTarget);
+    }
+    return [outBase, outTarget];
+  }
+
+  return [dropReferences(base), dropReferences(target)];
+};
 
 /**
  * Deep-clones a workflow and strips all non-meaningful/cosmetic fields:
@@ -77,15 +152,19 @@ export const getNodeLabel = (node: Node): string => {
  * either node via `isEqual`. If the node's `type` itself changed, that is surfaced as a synthetic
  * `type` field change so the user sees the node was re-typed.
  */
-export const diffNodeData = (baseNode: Node, targetNode: Node): FieldChange[] => {
+export const diffNodeData = (baseNode: Node, targetNode: Node, options: DiffOptions = {}): FieldChange[] => {
   const changes: FieldChange[] = [];
 
   if (baseNode.type !== targetNode.type) {
     changes.push({ key: 'type', before: baseNode.type, after: targetNode.type });
   }
 
-  const baseData = asRecord(baseNode.data);
-  const targetData = asRecord(targetNode.data);
+  const [comparableBase, comparableTarget] = options.ignoreIdReferences
+    ? dropReferencePair(asRecord(baseNode.data), asRecord(targetNode.data))
+    : [baseNode.data, targetNode.data];
+
+  const baseData = asRecord(comparableBase);
+  const targetData = asRecord(comparableTarget);
   const keys = Array.from(new Set([...Object.keys(baseData), ...Object.keys(targetData)]));
 
   for (const key of keys) {
@@ -162,7 +241,7 @@ export const diffEdges = (base: Workflow, target: Workflow): EdgeDiff[] => {
  * changes ⇒ `modified`, in both with none ⇒ `unchanged`. The returned `base`/`target` are the
  * original (un-normalized) workflows so callers can display their name/version/timestamps.
  */
-export const computeWorkflowDiff = (base: Workflow, target: Workflow): WorkflowDiff => {
+export const computeWorkflowDiff = (base: Workflow, target: Workflow, options: DiffOptions = {}): WorkflowDiff => {
   const baseNorm = normalizeForDiff(base);
   const targetNorm = normalizeForDiff(target);
 
@@ -193,7 +272,7 @@ export const computeWorkflowDiff = (base: Workflow, target: Workflow): WorkflowD
       pushNode(targetNode, 'added', []);
       continue;
     }
-    const fieldChanges = diffNodeData(baseNode, targetNode);
+    const fieldChanges = diffNodeData(baseNode, targetNode, options);
     pushNode(targetNode, fieldChanges.length ? 'modified' : 'unchanged', fieldChanges);
   }
 


### PR DESCRIPTION
## Description

When comparing two workflow versions, user has the option to ignore changes in ID.
This would ignore changes in selected KBs, data sources, LLM providers, etc.
Meaningful when comparing workflows downloaded from different enviroments.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
