### PR TITLE
feat: open conversations inside the Reported Feedback dialog

### DIFF
--- a/frontend/src/views/ReportedFeedback/components/ConversationPanel.tsx
+++ b/frontend/src/views/ReportedFeedback/components/ConversationPanel.tsx
@@ -1,0 +1,183 @@
+import { useQuery } from "@tanstack/react-query";
+import { ExternalLink, MessageCircle, RefreshCw, ShieldAlert } from "lucide-react";
+
+import { apiRequest } from "@/config/api";
+import { Button } from "@/components/button";
+import { BackendTranscript, Transcript } from "@/interfaces/transcript.interface";
+import { transformTranscript } from "@/views/Transcripts/helpers/transformers";
+import { TranscriptThread } from "@/views/Transcripts/components/TranscriptThread";
+import { formatDateTime } from "@/helpers/utils";
+
+const conversationTranscriptKey = (conversationId: string) =>
+  ["conversation", conversationId, "transcript"] as const;
+
+/**
+ * Same request the `/transcripts?conversation=<id>` deep link makes, so the embedded
+ * thread shows exactly what the full Transcripts view would.
+ */
+async function fetchConversationTranscript(
+  conversationId: string,
+): Promise<Transcript> {
+  // apiRequest resolves to null on 403 instead of throwing, so a scoped-out
+  // conversation lands here rather than in the catch.
+  const backend = await apiRequest<BackendTranscript>(
+    "get",
+    `conversations/${encodeURIComponent(conversationId)}?include_feedback=true`,
+  );
+  if (!backend) {
+    throw new Error(
+      "This conversation may not exist or you may not have access to it.",
+    );
+  }
+
+  // transformTranscript swallows its own errors and returns an "error" stub.
+  const transformed = transformTranscript(backend);
+  if (!transformed || transformed.id === "error") {
+    throw new Error("This conversation could not be read.");
+  }
+
+  return transformed;
+}
+
+function ThreadSkeleton() {
+  // Alternating bubble widths so the placeholder reads as a conversation.
+  const rows = [
+    { self: false, width: "w-2/3" },
+    { self: true, width: "w-1/2" },
+    { self: false, width: "w-3/5" },
+    { self: true, width: "w-2/3" },
+    { self: false, width: "w-1/2" },
+  ];
+
+  return (
+    <div className="space-y-4 p-4" aria-hidden>
+      {rows.map((row, index) => (
+        <div
+          key={index}
+          className={`flex flex-col gap-1.5 ${row.self ? "items-end" : "items-start"}`}
+        >
+          <div className="h-2.5 w-14 animate-pulse rounded bg-muted" />
+          <div
+            className={`h-12 animate-pulse rounded-lg bg-muted ${row.width}`}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+type ConversationPanelProps = {
+  conversationId: string;
+  /** The reported message — ringed and scrolled into view once the thread loads. */
+  highlightMessageId?: string | null;
+  topic?: string | null;
+  conversationDate?: string | null;
+  /** Opens the full Transcripts view (stats, costs, Ask GenAI) in a new tab. */
+  onOpenFullTranscript: () => void;
+};
+
+/**
+ * The conversation behind a reported comment, rendered inside the Reported Feedback dialog
+ * so reviewers keep their place in the list instead of navigating to Transcripts.
+ *
+ * The thread is deliberately read-only (`variant="compact"`): the dialog's detail pane already
+ * owns the comment and its status, and offering a second place to edit the same comment inside
+ * one dialog is ambiguous. Full editing stays one click away via "Open full transcript".
+ */
+export function ConversationPanel({
+  conversationId,
+  highlightMessageId,
+  topic,
+  conversationDate,
+  onOpenFullTranscript,
+}: ConversationPanelProps) {
+  const {
+    data: transcript,
+    isPending,
+    isError,
+    error,
+    refetch,
+    isFetching,
+  } = useQuery({
+    queryKey: conversationTranscriptKey(conversationId),
+    queryFn: () => fetchConversationTranscript(conversationId),
+    enabled: Boolean(conversationId),
+    staleTime: 30_000,
+    retry: false,
+  });
+
+  const isCall =
+    Boolean(transcript?.recording_id) || Boolean(transcript?.metadata?.isCall);
+
+  return (
+    <div className="flex min-h-0 flex-col bg-muted/20">
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b bg-background/60 px-5 py-3">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            <MessageCircle className="h-4 w-4" />
+          </div>
+          <div className="min-w-0">
+            <div className="truncate text-sm font-medium text-foreground">
+              {topic || "Untitled conversation"}
+            </div>
+            {conversationDate && (
+              <div className="truncate text-xs text-muted-foreground">
+                {formatDateTime(conversationDate)}
+              </div>
+            )}
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="shrink-0 gap-1.5 rounded-full text-xs"
+          onClick={onOpenFullTranscript}
+          title="Open the full transcript — stats, costs and Ask GenAI — in a new tab"
+        >
+          Full transcript
+          <ExternalLink className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+
+      {isPending ? (
+        <ThreadSkeleton />
+      ) : isError ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 py-12 text-center">
+          <div className="rounded-full bg-destructive/10 p-3">
+            <ShieldAlert className="h-7 w-7 text-destructive" />
+          </div>
+          <div>
+            <h4 className="text-sm font-medium">Couldn't load the conversation</h4>
+            <p className="mx-auto mt-1 max-w-xs text-xs text-muted-foreground">
+              {error instanceof Error
+                ? error.message
+                : "Something went wrong loading this conversation."}
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="gap-1.5 rounded-full"
+            disabled={isFetching}
+            onClick={() => void refetch()}
+          >
+            <RefreshCw
+              className={`h-3.5 w-3.5 ${isFetching ? "animate-spin" : ""}`}
+            />
+            Try again
+          </Button>
+        </div>
+      ) : (
+        <TranscriptThread
+          transcript={transcript}
+          isCall={isCall}
+          variant="compact"
+          highlightMessageId={highlightMessageId}
+          className="min-h-0 flex-1 px-4 py-3"
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/views/ReportedFeedback/components/ReportedFeedbackDialog.tsx
+++ b/frontend/src/views/ReportedFeedback/components/ReportedFeedbackDialog.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, ReactNode } from "react";
+import { ComponentType, ReactNode, useEffect, useState } from "react";
 import {
   Flag,
   Quote,
@@ -6,6 +6,8 @@ import {
   Workflow,
   Clock,
   User,
+  ChevronLeft,
+  PanelRightClose,
 } from "lucide-react";
 
 import {
@@ -20,14 +22,16 @@ import {
   FeedbackStatus,
   ReportedFeedbackItem,
 } from "@/services/reportedFeedback";
-import { formatDateTime } from "@/helpers/utils";
+import { cn, formatDateTime } from "@/helpers/utils";
 import { StatusSelect } from "./StatusSelect";
+import { ConversationPanel } from "./ConversationPanel";
 
 type ReportedFeedbackDialogProps = {
   issue: ReportedFeedbackItem | null;
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   onStatusChange: (issue: ReportedFeedbackItem, next: FeedbackStatus) => void;
+  /** Escape hatch to the full Transcripts view — the dialog embeds the thread itself. */
   onOpenConversation: (conversationId: string) => void;
   onOpenWorkflow: (agentId: string | null) => void;
 };
@@ -79,13 +83,42 @@ export function ReportedFeedbackDialog({
   onOpenConversation,
   onOpenWorkflow,
 }: ReportedFeedbackDialogProps) {
+  // The conversation expands the dialog in place rather than navigating, so reviewers
+  // keep their page, filters and scroll position in the list behind it.
+  const [showConversation, setShowConversation] = useState(false);
+
+  const issueId = issue?.feedback_id;
+  useEffect(() => {
+    setShowConversation(false);
+  }, [issueId]);
+
   if (!issue) return null;
+
+  const canOpenConversation = Boolean(issue.conversation_id);
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl gap-0 overflow-hidden p-0">
-        <DialogHeader className="space-y-0 border-b px-6 py-4">
+      <DialogContent
+        className={cn(
+          "flex flex-col gap-0 overflow-hidden p-0 transition-[max-width] duration-300 ease-out",
+          showConversation ? "h-[85vh] max-w-6xl" : "max-w-2xl",
+        )}
+      >
+        <DialogHeader className="shrink-0 space-y-0 border-b px-6 py-4">
           <div className="flex items-center gap-3">
+            {showConversation && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="-ml-2 h-8 w-8 shrink-0 p-0"
+                title="Back to feedback details"
+                aria-label="Back to feedback details"
+                onClick={() => setShowConversation(false)}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+            )}
             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-amber-50 text-amber-600 dark:bg-amber-500/15 dark:text-amber-400">
               <Flag className="h-5 w-5" />
             </div>
@@ -98,58 +131,94 @@ export function ReportedFeedbackDialog({
           </div>
         </DialogHeader>
 
-        <div className="max-h-[65vh] space-y-5 overflow-y-auto px-6 py-5">
-          <div className="flex items-center justify-between gap-3">
-            <SectionLabel icon={Flag}>Status</SectionLabel>
-            <StatusSelect
-              value={issue.status}
-              onChange={(next) => onStatusChange(issue, next)}
-            />
+        <div
+          className={cn(
+            "min-h-0",
+            showConversation
+              ? "grid flex-1 grid-cols-1 lg:grid-cols-[minmax(0,380px)_minmax(0,1fr)]"
+              : "flex flex-col",
+          )}
+        >
+          {/* Detail pane. Hidden on narrow screens once the conversation is showing —
+              the header's back control brings it back. */}
+          <div
+            className={cn(
+              "min-h-0 space-y-5 overflow-y-auto px-6 py-5",
+              showConversation
+                ? "hidden lg:block lg:border-r"
+                : "max-h-[65vh]",
+            )}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <SectionLabel icon={Flag}>Status</SectionLabel>
+              <StatusSelect
+                value={issue.status}
+                onChange={(next) => onStatusChange(issue, next)}
+              />
+            </div>
+
+            <section>
+              <SectionLabel icon={Quote}>Comment</SectionLabel>
+              <div className="rounded-lg border bg-muted/40 p-3 text-sm leading-relaxed whitespace-pre-wrap break-words">
+                {issue.comment}
+              </div>
+            </section>
+
+            <section>
+              <SectionLabel icon={MessageCircle}>
+                Flagged message · {issue.speaker}
+              </SectionLabel>
+              <div className="max-h-48 overflow-y-auto rounded-lg border bg-background p-3 text-sm leading-relaxed text-muted-foreground whitespace-pre-wrap break-words">
+                {issue.text}
+              </div>
+            </section>
+
+            <section
+              className={cn(
+                "grid grid-cols-1 gap-x-6 gap-y-4 border-t pt-5",
+                !showConversation && "sm:grid-cols-2",
+              )}
+            >
+              <Meta
+                icon={Workflow}
+                label="Workflow"
+                value={issue.workflow_name || "—"}
+              />
+              <Meta
+                icon={User}
+                label="Reported by"
+                value={issue.reported_by ?? "—"}
+              />
+              <Meta
+                icon={Clock}
+                label="Reported at"
+                value={formatDateTime(issue.reported_at)}
+              />
+              <Meta
+                icon={MessageCircle}
+                label="Conversation"
+                value={`${issue.conversation_topic || "Untitled"} · ${formatDateTime(
+                  issue.conversation_date,
+                )}`}
+              />
+            </section>
           </div>
 
-          <section>
-            <SectionLabel icon={Quote}>Comment</SectionLabel>
-            <div className="rounded-lg border bg-muted/40 p-3 text-sm leading-relaxed whitespace-pre-wrap break-words">
-              {issue.comment}
-            </div>
-          </section>
-
-          <section>
-            <SectionLabel icon={MessageCircle}>
-              Flagged message · {issue.speaker}
-            </SectionLabel>
-            <div className="max-h-48 overflow-y-auto rounded-lg border bg-background p-3 text-sm leading-relaxed text-muted-foreground whitespace-pre-wrap break-words">
-              {issue.text}
-            </div>
-          </section>
-
-          <section className="grid grid-cols-1 gap-x-6 gap-y-4 border-t pt-5 sm:grid-cols-2">
-            <Meta
-              icon={Workflow}
-              label="Workflow"
-              value={issue.workflow_name || "—"}
+          {showConversation && canOpenConversation && (
+            <ConversationPanel
+              key={issue.conversation_id}
+              conversationId={issue.conversation_id}
+              highlightMessageId={issue.message_id}
+              topic={issue.conversation_topic}
+              conversationDate={issue.conversation_date}
+              onOpenFullTranscript={() =>
+                onOpenConversation(issue.conversation_id)
+              }
             />
-            <Meta
-              icon={User}
-              label="Reported by"
-              value={issue.reported_by ?? "—"}
-            />
-            <Meta
-              icon={Clock}
-              label="Reported at"
-              value={formatDateTime(issue.reported_at)}
-            />
-            <Meta
-              icon={MessageCircle}
-              label="Conversation"
-              value={`${issue.conversation_topic || "Untitled"} · ${formatDateTime(
-                issue.conversation_date,
-              )}`}
-            />
-          </section>
+          )}
         </div>
 
-        <div className="flex flex-wrap justify-end gap-2 border-t bg-muted/30 px-6 py-4">
+        <div className="flex shrink-0 flex-wrap justify-end gap-2 border-t bg-muted/30 px-6 py-4">
           <Button
             type="button"
             variant="outline"
@@ -157,7 +226,7 @@ export function ReportedFeedbackDialog({
             disabled={!issue.agent_id}
             title={
               issue.agent_id
-                ? "Open the agent's workflow"
+                ? "Open the agent's workflow in a new tab"
                 : "No workflow linked to this conversation"
             }
             onClick={() => onOpenWorkflow(issue.agent_id)}
@@ -167,9 +236,25 @@ export function ReportedFeedbackDialog({
           <Button
             type="button"
             className="rounded-full"
-            onClick={() => onOpenConversation(issue.conversation_id)}
+            disabled={!canOpenConversation}
+            title={
+              canOpenConversation
+                ? showConversation
+                  ? "Collapse the conversation"
+                  : "Read the conversation without leaving this page"
+                : "No conversation linked to this feedback"
+            }
+            onClick={() => setShowConversation((current) => !current)}
           >
-            <MessageCircle className="h-4 w-4" /> Open conversation
+            {showConversation ? (
+              <>
+                <PanelRightClose className="h-4 w-4" /> Hide conversation
+              </>
+            ) : (
+              <>
+                <MessageCircle className="h-4 w-4" /> Open conversation
+              </>
+            )}
           </Button>
         </div>
       </DialogContent>

--- a/frontend/src/views/ReportedFeedback/pages/ReportedFeedback.tsx
+++ b/frontend/src/views/ReportedFeedback/pages/ReportedFeedback.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { MessageSquareDot } from "lucide-react";
 import { format } from "date-fns";
 import type { DateRange } from "react-day-picker";
@@ -35,7 +34,6 @@ import { formatDateTime } from "@/helpers/utils";
 const PAGE_SIZE = 20;
 
 export default function ReportedFeedback() {
-  const navigate = useNavigate();
   const [currentPage, setCurrentPage] = useState(1);
   const [statusFilter, setStatusFilter] = useState<FeedbackStatus | "all">(
     "all",
@@ -81,14 +79,21 @@ export default function ReportedFeedback() {
     setIsDialogOpen(true);
   };
 
+  // The dialog embeds the conversation itself; these are the "see everything" escape
+  // hatches. They open in a new tab so the reviewer keeps their filters, page and
+  // scroll position — and the open dialog — on this one.
+  const openInNewTab = (path: string) => {
+    window.open(`${window.location.origin}${path}`, "_blank", "noopener,noreferrer");
+  };
+
   const openConversation = (conversationId: string) => {
     if (!conversationId) return;
-    navigate(`/transcripts?conversation=${encodeURIComponent(conversationId)}`);
+    openInNewTab(`/transcripts?conversation=${encodeURIComponent(conversationId)}`);
   };
 
   const openWorkflow = (agentId: string | null) => {
     if (!agentId) return;
-    navigate(`/ai-agents/workflow/${agentId}`);
+    openInNewTab(`/ai-agents/workflow/${agentId}`);
   };
 
   const handleStatusChange = async (

--- a/frontend/src/views/Transcripts/components/TranscriptDialog.tsx
+++ b/frontend/src/views/Transcripts/components/TranscriptDialog.tsx
@@ -4,7 +4,6 @@ import {
   ThumbsDown,
   BotMessageSquare,
   MessageSquare,
-  User,
   Pencil,
   Coins,
   Megaphone,
@@ -12,7 +11,7 @@ import {
   Check,
 } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/dialog';
-import { useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   getAudioUrl,
   submitConversationFeedback,
@@ -27,12 +26,11 @@ import { askAIQuestion } from '@/services/aiChat';
 import { Tabs, TabsList, TabsTrigger } from '@/components/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/useToast';
-import { formatMessageTime, formatCallTimestamp, formatDateTime, getEffectiveSentiment } from '../helpers/formatting';
+import { getEffectiveSentiment } from '../helpers/formatting';
 import { MetricCards } from './MetricCard';
 import { ScoreCards } from './ScoreCard';
 import { TranscriptAudioPlayer } from './TranscriptAudioPlayer';
-import { MessageFeedbackPopover } from './MessageFeedbackPopover';
-import { ConversationEntryWrapper } from '@/views/ActiveConversations/common/ConversationEntryWrapper';
+import { TranscriptThread } from './TranscriptThread';
 import { AgentResponseLogDialog } from '@/components/AgentResponseLogDialog';
 import { Switch } from '@/components/switch';
 import { DollarSign } from 'lucide-react';
@@ -118,97 +116,6 @@ const isCallTranscript = (transcript: Transcript | null) => {
   return Boolean(transcript.recording_id) || Boolean(transcript.metadata?.isCall);
 };
 
-function MessageFeedbackButton({
-  messageId,
-  localTranscript,
-  setLocalTranscript,
-  onOpenChange,
-}: {
-  messageId: string;
-  localTranscript: Transcript | null;
-  setLocalTranscript: Dispatch<SetStateAction<Transcript | null>>;
-  onOpenChange?: (open: boolean) => void;
-}) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [text, setText] = useState('');
-  const { toast } = useToast();
-
-  const handleOpenChange = (open: boolean) => {
-    setIsOpen(open);
-    onOpenChange?.(open);
-
-    if (open) {
-      const collection = (localTranscript?.messages ?? localTranscript?.messages) || [];
-      const message = collection.find((entry) => entry.message_id === messageId);
-      const feedbackArr = Array.isArray(message?.feedback) ? (message?.feedback as ConversationFeedbackEntry[]) : [];
-      const lastFeedback = feedbackArr.length > 0 ? feedbackArr[feedbackArr.length - 1] : null;
-      setText(lastFeedback?.feedback_message || '');
-    }
-  };
-
-  const message = (localTranscript?.messages ?? localTranscript?.messages)?.find(
-    (entry) => entry.message_id === messageId
-  );
-  const feedbackArr = Array.isArray(message?.feedback) ? (message?.feedback as ConversationFeedbackEntry[]) : [];
-  const lastFeedback = feedbackArr.length > 0 ? feedbackArr[feedbackArr.length - 1] : null;
-  const hasFeedbackMessage = Boolean(lastFeedback?.feedback_message?.trim());
-
-  const handleClose = () => {
-    handleOpenChange(false);
-    setText('');
-  };
-
-  const handleSave = async () => {
-    if (!messageId || !localTranscript) return;
-
-    // A comment must never create or change a thumbs rating, so don't send one.
-    const success = await submitMessageFeedback(messageId, undefined, text);
-
-    if (success) {
-      setLocalTranscript((currentTranscript) => {
-        if (!currentTranscript) return null;
-        const b = currentTranscript.messages || [];
-        const newTranscriptEntries = b.map((entry) => {
-          if (entry.message_id !== messageId) return entry;
-          const arr = Array.isArray(entry.feedback) ? [...entry.feedback] : [];
-          if (arr.length > 0) {
-            // Attach the comment to the latest feedback entry, keeping its rating.
-            const idx = arr.length - 1;
-            arr[idx] = { ...arr[idx], feedback_message: text };
-          } else {
-            // Comment with no rating yet (feedback "" => no thumbs).
-            arr.push({
-              feedback: '',
-              feedback_message: text,
-              feedback_timestamp: new Date().toISOString(),
-              feedback_user_id: '',
-            });
-          }
-          return { ...entry, feedback: arr };
-        });
-        return { ...currentTranscript, messages: newTranscriptEntries, transcript: newTranscriptEntries };
-      });
-
-      toast({ title: 'Success', description: 'Feedback message saved.' });
-      handleClose();
-    } else {
-      toast({ title: 'Error', description: 'Failed to save feedback.', variant: 'destructive' });
-    }
-  };
-
-  return (
-    <MessageFeedbackPopover
-      isOpen={isOpen}
-      hasFeedbackMessage={hasFeedbackMessage}
-      text={text}
-      onOpenChange={handleOpenChange}
-      onTextChange={setText}
-      onSave={handleSave}
-      onCancel={handleClose}
-    />
-  );
-}
-
 export function TranscriptDialog({ transcript, isOpen, onOpenChange, agentName: agentNameProp }: TranscriptDialogProps) {
   const [audioSrc, setAudioSrc] = useState<string>('');
   const [chatInput, setChatInput] = useState<string>('');
@@ -225,7 +132,6 @@ export function TranscriptDialog({ transcript, isOpen, onOpenChange, agentName: 
   const [isEditing, setIsEditing] = useState(false);
   const [userFeedback, setUserFeedback] = useState<ConversationFeedbackEntry | null>(null);
   const [localTranscript, setLocalTranscript] = useState<Transcript | null>(transcript);
-  const [openPopoverMessageId, setOpenPopoverMessageId] = useState<string | null>(null);
   const [debugLogOpen, setDebugLogOpen] = useState(false);
   const [debugMessageId, setDebugMessageId] = useState<string | null>(null);
   const [showCosts, setShowCosts] = useState(false);
@@ -734,177 +640,19 @@ export function TranscriptDialog({ transcript, isOpen, onOpenChange, agentName: 
             </Tabs>
             <div className="flex-1 flex flex-col bg-secondary/30 rounded-lg overflow-hidden">
               {activeTab === 'transcript' ? (
-                <div
-                  className="p-3 overflow-y-auto text-[13px] sm:text-[12px]"
+                <TranscriptThread
+                  transcript={localTranscript}
+                  isCall={isCall}
+                  showCosts={showCosts}
+                  costsByMessageId={costsByMessageId}
+                  onMessageFeedback={handleMessageFeedback}
+                  onTranscriptChange={setLocalTranscript}
+                  onDebugMessage={(messageId) => {
+                    setDebugMessageId(messageId);
+                    setDebugLogOpen(true);
+                  }}
                   style={{ height: isCall ? '550px' : '460px' }}
-                >
-                  <div className="space-y-2">
-                    {localTranscript.timestamp && (
-                      <div className="flex justify-center mb-3">
-                        <div className="px-3 py-1 rounded-full bg-muted text-muted-foreground text-xs">
-                          {formatDateTime(localTranscript.timestamp)}
-                        </div>
-                      </div>
-                    )}
-                    {(localTranscript.messages ?? localTranscript.messages)?.map((entry, index) => {
-                      const entryObj = typeof entry === 'string' ? JSON.parse(entry) : entry;
-                      const entryType = entryObj.type || '';
-
-                      if (
-                        entryType === 'takeover' ||
-                        (entryObj.speaker === 'Unknown' && entryObj.text === '' && entryObj.start_time === 0)
-                      ) {
-                        return (
-                          <div
-                            className="flex justify-center my-3"
-                            key={`takeover-${index}-${entryObj.create_time || index}`}
-                          >
-                            <div className="px-3 py-1.5 rounded-full bg-blue-100 dark:bg-blue-500/20 text-blue-800 dark:text-blue-400 text-xs font-medium flex items-center">
-                              <User className="w-3 h-3 mr-1" />
-                              Supervisor took over
-                            </div>
-                          </div>
-                        );
-                      }
-
-                      // Skip empty messages
-                      if ((entryObj.text === '' || !entryObj.text) && (entryObj.speaker === '' || !entryObj.speaker)) {
-                        return null;
-                      }
-
-                      const isAgent = ['Agent', 'agent'].includes(entryObj.speaker);
-                      const messageId = entryObj.message_id as string | undefined;
-                      const messageFeedbackArr = Array.isArray(entryObj.feedback)
-                        ? (entryObj.feedback as ConversationFeedbackEntry[])
-                        : [];
-                      const hasGood = messageFeedbackArr.some((f) => f.feedback === 'good');
-                      const hasBad = messageFeedbackArr.some((f) => f.feedback === 'bad');
-                      const hasComment = messageFeedbackArr.some(
-                        (f) => Boolean(f.feedback_message && f.feedback_message.trim())
-                      );
-                      // Keep the controls pinned once there's any feedback (rating or comment),
-                      // so the comment indicator doesn't vanish when the hover ends.
-                      const hasFeedback = hasGood || hasBad || hasComment;
-                      const speakerName = isAgent ? 'Operator' : 'Customer';
-
-                      return (
-                        <div
-                          key={index}
-                          className={`flex flex-col ${isAgent ? 'items-end' : 'items-start'} group relative`}
-                        >
-                          <span className="text-[11px] text-foreground font-medium mb-1">{speakerName}</span>
-                          <div className="relative">
-                            {isAgent && messageId && (
-                              <div
-                                className={`absolute right-full mr-2 top-1/2 -translate-y-1/2 ${
-                                  hasFeedback || openPopoverMessageId === messageId
-                                    ? 'flex'
-                                    : 'hidden group-hover:flex'
-                                } items-center gap-2 z-10`}
-                              >
-                                {hasGood ? (
-                                  <div className="flex items-center bg-card rounded-lg shadow-sm border border-green-200 dark:border-green-500/30 p-2">
-                                    <ThumbsUp className="w-4 h-4 text-green-600 dark:text-green-400" />
-                                  </div>
-                                ) : hasBad ? (
-                                  <div className="flex items-center bg-card rounded-lg shadow-sm border border-red-200 dark:border-red-500/30 p-2">
-                                    <ThumbsDown className="w-4 h-4 text-red-600 dark:text-red-400" />
-                                  </div>
-                                ) : (
-                                  <div className="flex items-center bg-card rounded-lg shadow-sm border border-border">
-                                    <button
-                                      className="p-2 hover:bg-muted rounded-l-lg"
-                                      title="Good response"
-                                      onClick={() => handleMessageFeedback(messageId, 'good')}
-                                    >
-                                      <ThumbsUp className="w-4 h-4 text-yellow-500" />
-                                    </button>
-                                    <div className="h-4 w-px bg-muted" />
-                                    <button
-                                      className="p-2 hover:bg-muted rounded-r-lg"
-                                      title="Bad response"
-                                      onClick={() => handleMessageFeedback(messageId, 'bad')}
-                                    >
-                                      <ThumbsDown className="w-4 h-4 text-yellow-500" />
-                                    </button>
-                                  </div>
-                                )}
-                                <MessageFeedbackButton
-                                  messageId={messageId}
-                                  localTranscript={localTranscript}
-                                  setLocalTranscript={setLocalTranscript}
-                                  onOpenChange={(open) => setOpenPopoverMessageId(open ? messageId : null)}
-                                />
-                              </div>
-                            )}
-                            <div className={`p-2 flex flex-col gap-1`} style={{ maxWidth: '400px' }}>
-                              <div
-                                className={`p-2 rounded-lg leading-tight break-words inline-block z-10 ${
-                                  isAgent
-                                    ? 'bg-blue-600 text-white rounded-tl-lg rounded-tr-none'
-                                    : 'bg-muted text-foreground rounded-tr-lg rounded-tl-none'
-                                }`}
-                              >
-                                <ConversationEntryWrapper entry={entryObj} conversationId={localTranscript.id} />
-
-                                <div className="flex items-center justify-end">
-                                  <span
-                                    className={`block text-[10px] text-right mt-1 ${
-                                      isAgent ? 'text-white/80' : 'text-muted-foreground'
-                                    }`}
-                                  >
-                                    {isCall
-                                      ? formatCallTimestamp(entryObj.start_time)
-                                      : formatMessageTime(entryObj.create_time)}
-                                  </span>
-                                </div>
-                              </div>
-
-                              {isAgent && messageId && (
-                                <div className="flex flex-row gap-1 px-3 py-2 pt-3 rounded-b-lg justify-between w-full bg-gray-300/50 text-black/80 -mt-3 z-9">
-                                  <button
-                                    type="button"
-                                    className="text-[10px] underline self-end"
-                                    onClick={() => {
-                                      setDebugMessageId(messageId);
-                                      setDebugLogOpen(true);
-                                    }}
-                                  >
-                                    Debug response
-                                  </button>
-                                  {showCosts && costsByMessageId[messageId] && (
-                                    <div className={`mt-1 text-[10px] ${isAgent ? 'text-black/80' : 'text-gray-600'}`}>
-                                      Tokens Input/Output:
-                                      <span className="font-bold">
-                                        {costsByMessageId[messageId].input_tokens ?? '—'}
-                                      </span>
-                                      /
-                                      <span className="font-bold">
-                                        {costsByMessageId[messageId].output_tokens ?? '—'}
-                                      </span>
-                                      ,
-                                      <Coins className="w-2 h-2 inline-block" /> Cost:{' '}
-                                      <span className="font-bold">
-                                        ${(costsByMessageId[messageId].cost_usd ?? 0).toFixed(6)}
-                                      </span>
-                                    </div>
-                                  )}
-                                </div>
-                              )}
-                            </div>
-                          </div>
-                        </div>
-                      );
-                    })}
-                    {localTranscript.status === 'finalized' && (
-                      <div className="flex justify-center my-3">
-                        <div className="px-3 py-1.5 rounded-full bg-blue-100 dark:bg-blue-500/20 text-blue-800 dark:text-blue-400 text-xs font-medium flex items-center">
-                          Conversation Finalized
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                </div>
+                />
               ) : (
                 <div
                   ref={chatContainerRef}

--- a/frontend/src/views/Transcripts/components/TranscriptThread.tsx
+++ b/frontend/src/views/Transcripts/components/TranscriptThread.tsx
@@ -1,0 +1,349 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
+import { ThumbsUp, ThumbsDown, User, Coins, Flag } from 'lucide-react';
+
+import { Transcript, ConversationFeedbackEntry } from '@/interfaces/transcript.interface';
+import { submitMessageFeedback, type AgentResponseLogSummary } from '@/services/transcripts';
+import { useToast } from '@/hooks/useToast';
+import { cn } from '@/helpers/utils';
+import { ConversationEntryWrapper } from '@/views/ActiveConversations/common/ConversationEntryWrapper';
+import { MessageFeedbackPopover } from './MessageFeedbackPopover';
+import { formatMessageTime, formatCallTimestamp, formatDateTime } from '../helpers/formatting';
+
+function MessageFeedbackButton({
+  messageId,
+  localTranscript,
+  setLocalTranscript,
+  onOpenChange,
+}: {
+  messageId: string;
+  localTranscript: Transcript | null;
+  setLocalTranscript: Dispatch<SetStateAction<Transcript | null>>;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [text, setText] = useState('');
+  const { toast } = useToast();
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    onOpenChange?.(open);
+
+    if (open) {
+      const collection = localTranscript?.messages || [];
+      const message = collection.find((entry) => entry.message_id === messageId);
+      const feedbackArr = Array.isArray(message?.feedback) ? (message?.feedback as ConversationFeedbackEntry[]) : [];
+      const lastFeedback = feedbackArr.length > 0 ? feedbackArr[feedbackArr.length - 1] : null;
+      setText(lastFeedback?.feedback_message || '');
+    }
+  };
+
+  const message = localTranscript?.messages?.find((entry) => entry.message_id === messageId);
+  const feedbackArr = Array.isArray(message?.feedback) ? (message?.feedback as ConversationFeedbackEntry[]) : [];
+  const lastFeedback = feedbackArr.length > 0 ? feedbackArr[feedbackArr.length - 1] : null;
+  const hasFeedbackMessage = Boolean(lastFeedback?.feedback_message?.trim());
+
+  const handleClose = () => {
+    handleOpenChange(false);
+    setText('');
+  };
+
+  const handleSave = async () => {
+    if (!messageId || !localTranscript) return;
+
+    // A comment must never create or change a thumbs rating, so don't send one.
+    const success = await submitMessageFeedback(messageId, undefined, text);
+
+    if (success) {
+      setLocalTranscript((currentTranscript) => {
+        if (!currentTranscript) return null;
+        const b = currentTranscript.messages || [];
+        const newTranscriptEntries = b.map((entry) => {
+          if (entry.message_id !== messageId) return entry;
+          const arr = Array.isArray(entry.feedback) ? [...entry.feedback] : [];
+          if (arr.length > 0) {
+            // Attach the comment to the latest feedback entry, keeping its rating.
+            const idx = arr.length - 1;
+            arr[idx] = { ...arr[idx], feedback_message: text };
+          } else {
+            // Comment with no rating yet (feedback "" => no thumbs).
+            arr.push({
+              feedback: '',
+              feedback_message: text,
+              feedback_timestamp: new Date().toISOString(),
+              feedback_user_id: '',
+            });
+          }
+          return { ...entry, feedback: arr };
+        });
+        return { ...currentTranscript, messages: newTranscriptEntries, transcript: newTranscriptEntries };
+      });
+
+      toast({ title: 'Success', description: 'Feedback message saved.' });
+      handleClose();
+    } else {
+      toast({ title: 'Error', description: 'Failed to save feedback.', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <MessageFeedbackPopover
+      isOpen={isOpen}
+      hasFeedbackMessage={hasFeedbackMessage}
+      text={text}
+      onOpenChange={handleOpenChange}
+      onTextChange={setText}
+      onSave={handleSave}
+      onCancel={handleClose}
+    />
+  );
+}
+
+export type TranscriptThreadVariant = 'full' | 'compact';
+
+type TranscriptThreadProps = {
+  transcript: Transcript;
+  /** Call transcripts stamp each message with a call offset instead of a wall-clock time. */
+  isCall?: boolean;
+  /**
+   * 'compact' renders the thread read-only — no rating controls, no comment popover and no
+   * debug/cost row — for embedding inside a dialog that owns those actions itself.
+   */
+  variant?: TranscriptThreadVariant;
+  /** Ringed, labelled "Reported" and scrolled to the middle of the pane on mount. */
+  highlightMessageId?: string | null;
+  showCosts?: boolean;
+  costsByMessageId?: Record<string, AgentResponseLogSummary>;
+  onMessageFeedback?: (messageId: string, feedback: 'good' | 'bad') => void;
+  /** Lets the comment popover write its result back into the owner's transcript state. */
+  onTranscriptChange?: Dispatch<SetStateAction<Transcript | null>>;
+  onDebugMessage?: (messageId: string) => void;
+  /** Applied to the scroll container, so the caller decides how tall the thread is. */
+  className?: string;
+  style?: CSSProperties;
+};
+
+/**
+ * The conversation thread on its own — message bubbles, per-message feedback controls and the
+ * takeover/finalized markers. Extracted from `TranscriptDialog` so other surfaces (e.g. the
+ * Reported Feedback dialog) can embed the same thread instead of navigating to Transcripts.
+ */
+export function TranscriptThread({
+  transcript,
+  isCall = false,
+  variant = 'full',
+  highlightMessageId = null,
+  showCosts = false,
+  costsByMessageId,
+  onMessageFeedback,
+  onTranscriptChange,
+  onDebugMessage,
+  className,
+  style,
+}: TranscriptThreadProps) {
+  const [openPopoverMessageId, setOpenPopoverMessageId] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const messageRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+  const isInteractive = variant === 'full';
+  const messages = useMemo(() => transcript.messages ?? [], [transcript.messages]);
+  const costs = costsByMessageId ?? {};
+
+  // Centre the flagged message inside this pane only — scrollIntoView() would walk up the
+  // ancestor chain and drag the surrounding dialog along with it.
+  useEffect(() => {
+    if (!highlightMessageId) return;
+
+    const raf = requestAnimationFrame(() => {
+      const container = scrollRef.current;
+      const node = messageRefs.current.get(highlightMessageId);
+      if (!container || !node) return;
+
+      const top = node.offsetTop - container.clientHeight / 2 + node.offsetHeight / 2;
+      container.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+    });
+
+    return () => cancelAnimationFrame(raf);
+  }, [highlightMessageId, transcript.id, messages.length]);
+
+  return (
+    <div
+      ref={scrollRef}
+      className={cn('relative overflow-y-auto p-3 text-[13px] sm:text-[12px]', className)}
+      style={style}
+    >
+      <div className="space-y-2">
+        {transcript.timestamp && (
+          <div className="flex justify-center mb-3">
+            <div className="px-3 py-1 rounded-full bg-muted text-muted-foreground text-xs">
+              {formatDateTime(transcript.timestamp)}
+            </div>
+          </div>
+        )}
+        {messages.map((entry, index) => {
+          const entryObj = typeof entry === 'string' ? JSON.parse(entry) : entry;
+          const entryType = entryObj.type || '';
+
+          if (
+            entryType === 'takeover' ||
+            (entryObj.speaker === 'Unknown' && entryObj.text === '' && entryObj.start_time === 0)
+          ) {
+            return (
+              <div className="flex justify-center my-3" key={`takeover-${index}-${entryObj.create_time || index}`}>
+                <div className="px-3 py-1.5 rounded-full bg-blue-100 dark:bg-blue-500/20 text-blue-800 dark:text-blue-400 text-xs font-medium flex items-center">
+                  <User className="w-3 h-3 mr-1" />
+                  Supervisor took over
+                </div>
+              </div>
+            );
+          }
+
+          // Skip empty messages
+          if ((entryObj.text === '' || !entryObj.text) && (entryObj.speaker === '' || !entryObj.speaker)) {
+            return null;
+          }
+
+          const isAgent = ['Agent', 'agent'].includes(entryObj.speaker);
+          const messageId = entryObj.message_id as string | undefined;
+          const messageFeedbackArr = Array.isArray(entryObj.feedback)
+            ? (entryObj.feedback as ConversationFeedbackEntry[])
+            : [];
+          const hasGood = messageFeedbackArr.some((f) => f.feedback === 'good');
+          const hasBad = messageFeedbackArr.some((f) => f.feedback === 'bad');
+          const hasComment = messageFeedbackArr.some((f) => Boolean(f.feedback_message && f.feedback_message.trim()));
+          // Keep the controls pinned once there's any feedback (rating or comment),
+          // so the comment indicator doesn't vanish when the hover ends.
+          const hasFeedback = hasGood || hasBad || hasComment;
+          const speakerName = isAgent ? 'Operator' : 'Customer';
+          const isHighlighted = Boolean(messageId && messageId === highlightMessageId);
+
+          return (
+            <div
+              key={index}
+              ref={(node) => {
+                if (!messageId) return;
+                if (node) messageRefs.current.set(messageId, node);
+                else messageRefs.current.delete(messageId);
+              }}
+              className={`flex flex-col ${isAgent ? 'items-end' : 'items-start'} group relative`}
+            >
+              <span className="flex items-center gap-1.5 text-[11px] text-foreground font-medium mb-1">
+                {speakerName}
+                {isHighlighted && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-700 dark:bg-amber-500/20 dark:text-amber-400">
+                    <Flag className="h-2.5 w-2.5" />
+                    Reported
+                  </span>
+                )}
+              </span>
+              <div className="relative">
+                {isInteractive && isAgent && messageId && (
+                  <div
+                    className={`absolute right-full mr-2 top-1/2 -translate-y-1/2 ${
+                      hasFeedback || openPopoverMessageId === messageId ? 'flex' : 'hidden group-hover:flex'
+                    } items-center gap-2 z-10`}
+                  >
+                    {hasGood ? (
+                      <div className="flex items-center bg-card rounded-lg shadow-sm border border-green-200 dark:border-green-500/30 p-2">
+                        <ThumbsUp className="w-4 h-4 text-green-600 dark:text-green-400" />
+                      </div>
+                    ) : hasBad ? (
+                      <div className="flex items-center bg-card rounded-lg shadow-sm border border-red-200 dark:border-red-500/30 p-2">
+                        <ThumbsDown className="w-4 h-4 text-red-600 dark:text-red-400" />
+                      </div>
+                    ) : (
+                      <div className="flex items-center bg-card rounded-lg shadow-sm border border-border">
+                        <button
+                          className="p-2 hover:bg-muted rounded-l-lg"
+                          title="Good response"
+                          onClick={() => onMessageFeedback?.(messageId, 'good')}
+                        >
+                          <ThumbsUp className="w-4 h-4 text-yellow-500" />
+                        </button>
+                        <div className="h-4 w-px bg-muted" />
+                        <button
+                          className="p-2 hover:bg-muted rounded-r-lg"
+                          title="Bad response"
+                          onClick={() => onMessageFeedback?.(messageId, 'bad')}
+                        >
+                          <ThumbsDown className="w-4 h-4 text-yellow-500" />
+                        </button>
+                      </div>
+                    )}
+                    {onTranscriptChange && (
+                      <MessageFeedbackButton
+                        messageId={messageId}
+                        localTranscript={transcript}
+                        setLocalTranscript={onTranscriptChange}
+                        onOpenChange={(open) => setOpenPopoverMessageId(open ? messageId : null)}
+                      />
+                    )}
+                  </div>
+                )}
+                <div className={`p-2 flex flex-col gap-1`} style={{ maxWidth: '400px' }}>
+                  <div
+                    className={cn(
+                      'p-2 rounded-lg leading-tight break-words inline-block z-10',
+                      isAgent
+                        ? 'bg-blue-600 text-white rounded-tl-lg rounded-tr-none'
+                        : 'bg-muted text-foreground rounded-tr-lg rounded-tl-none',
+                      isHighlighted &&
+                        'ring-2 ring-amber-400 ring-offset-2 ring-offset-background dark:ring-amber-500'
+                    )}
+                  >
+                    <ConversationEntryWrapper entry={entryObj} conversationId={transcript.id} />
+
+                    <div className="flex items-center justify-end">
+                      <span
+                        className={`block text-[10px] text-right mt-1 ${
+                          isAgent ? 'text-white/80' : 'text-muted-foreground'
+                        }`}
+                      >
+                        {isCall ? formatCallTimestamp(entryObj.start_time) : formatMessageTime(entryObj.create_time)}
+                      </span>
+                    </div>
+                  </div>
+
+                  {isInteractive && isAgent && messageId && (
+                    <div className="flex flex-row gap-1 px-3 py-2 pt-3 rounded-b-lg justify-between w-full bg-gray-300/50 text-black/80 -mt-3 z-9">
+                      <button
+                        type="button"
+                        className="text-[10px] underline self-end"
+                        onClick={() => onDebugMessage?.(messageId)}
+                      >
+                        Debug response
+                      </button>
+                      {showCosts && costs[messageId] && (
+                        <div className={`mt-1 text-[10px] ${isAgent ? 'text-black/80' : 'text-gray-600'}`}>
+                          Tokens Input/Output:
+                          <span className="font-bold">{costs[messageId].input_tokens ?? '—'}</span>/
+                          <span className="font-bold">{costs[messageId].output_tokens ?? '—'}</span>,
+                          <Coins className="w-2 h-2 inline-block" /> Cost:{' '}
+                          <span className="font-bold">${(costs[messageId].cost_usd ?? 0).toFixed(6)}</span>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+        {transcript.status === 'finalized' && (
+          <div className="flex justify-center my-3">
+            <div className="px-3 py-1.5 rounded-full bg-blue-100 dark:bg-blue-500/20 text-blue-800 dark:text-blue-400 text-xs font-medium flex items-center">
+              Conversation Finalized
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/views/Transcripts/index.tsx
+++ b/frontend/src/views/Transcripts/index.tsx
@@ -1,6 +1,7 @@
 import Transcripts from './pages/Transcripts';
 import { RecentTranscripts } from './components/RecentTranscripts';
 import { TranscriptDialog } from './components/TranscriptDialog';
+import { TranscriptThread } from './components/TranscriptThread';
 import { TranscriptCard } from './components/TranscriptCard';
 import { useTranscriptData } from './hooks/useTranscriptData';
 import { useTranscripts } from './hooks/useTranscripts';
@@ -9,6 +10,7 @@ import { useTranscript } from './hooks/useTranscript';
 export {
   RecentTranscripts,
   TranscriptDialog,
+  TranscriptThread,
   TranscriptCard,
   useTranscriptData,
   useTranscripts,


### PR DESCRIPTION
## Description

Clicking "Open conversation" navigated to /transcripts, which lost the reviewer's page, filters, selected issue and scroll position and gave no indication which message was flagged. 

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- The dialog now expands in place into a two-pane view with the reported message ringed and scrolled to
- Extracts the message thread out of TranscriptDialog into a reusable TranscriptThread so both surfaces render the same markup. Frontend only; no API or schema changes

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
