### PR TITLE
fix: harden raw SQL identifiers and agent CORS origin reflection

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -155,6 +155,13 @@ TENANT_SUBDOMAIN_ENABLED=False
 
 CORS_ALLOWED_ORIGINS=*
 
+# Optional regex an *unknown* (per-agent) Origin must match before AgentCORSMiddleware
+# reflects it with Access-Control-Allow-Credentials. Matched with fullmatch against the
+# whole Origin (scheme://host[:port]). Leave empty to reflect any non-static Origin
+# (current behavior). Set it to close the CSRF vector if agent endpoints ever move to
+# cookie-based auth. Example: https://([a-z0-9-]+\.)*example\.com
+CORS_AGENT_ALLOWED_ORIGIN_REGEX=
+
 # -----------------------------------------------------------------------------
 # Microsoft Entra ID SSO (OIDC, confidential client)
 # -----------------------------------------------------------------------------

--- a/backend/app/core/config/settings.py
+++ b/backend/app/core/config/settings.py
@@ -269,6 +269,11 @@ class ProjectSettings(BaseSettings):
 
     # === CORS Configuration ===
     CORS_ALLOWED_ORIGINS: Optional[str] = None  # Comma-separated list of additional allowed origins
+    # Optional regex an *unknown* (per-agent) Origin must match before AgentCORSMiddleware
+    # will reflect it with Access-Control-Allow-Credentials. When unset, dynamic origins are
+    # reflected unrestricted (current behavior) — set this to close the CSRF vector if agent
+    # endpoints ever move to cookie-based auth. Example: r"https://.*\.example\.com"
+    CORS_AGENT_ALLOWED_ORIGIN_REGEX: Optional[str] = None
 
     # === WebSocket Configuration ===
     USE_WS: bool = True  # Enable/disable WebSocket backend (connect, broadcast, rooms)

--- a/backend/app/middlewares/_middleware.py
+++ b/backend/app/middlewares/_middleware.py
@@ -1,6 +1,7 @@
+import re
 import time
 import uuid
-from typing import Dict
+from typing import Dict, Pattern
 
 from loguru import logger
 from starlette.middleware import Middleware
@@ -73,6 +74,48 @@ def _get_static_origins() -> set[str]:
     return _static_allowed_origins
 
 
+_agent_origin_regex: Pattern[str] | None = None
+_agent_origin_regex_ready: bool = False
+
+
+def _get_agent_origin_regex() -> Pattern[str] | None:
+    """
+    Compile (once) the optional regex that a dynamic per-agent Origin must match
+    before AgentCORSMiddleware will reflect it. Returns None when unconfigured or
+    invalid, in which case dynamic origins are reflected unrestricted.
+    """
+    global _agent_origin_regex, _agent_origin_regex_ready
+    if not _agent_origin_regex_ready:
+        pattern = settings.CORS_AGENT_ALLOWED_ORIGIN_REGEX
+        if pattern:
+            try:
+                _agent_origin_regex = re.compile(pattern)
+            except re.error as exc:
+                logger.error(f"Invalid CORS_AGENT_ALLOWED_ORIGIN_REGEX, ignoring it: {exc}")
+                _agent_origin_regex = None
+        else:
+            logger.info(
+                "CORS_AGENT_ALLOWED_ORIGIN_REGEX is not set; AgentCORSMiddleware will reflect "
+                "any non-static Origin. Set it to restrict dynamic agent origins."
+            )
+        _agent_origin_regex_ready = True
+    return _agent_origin_regex
+
+
+def _is_allowed_dynamic_origin(origin: str) -> bool:
+    """
+    Whether a non-static Origin may be reflected with credentials. When no regex is
+    configured we preserve the historical reflect-any behavior; when one is configured
+    the Origin must match it.
+    """
+    regex = _get_agent_origin_regex()
+    if regex is None:
+        return True
+    # fullmatch (not match) so a pattern for "https://app.example.com" cannot be
+    # bypassed by a suffixed origin like "https://app.example.com.attacker.com".
+    return regex.fullmatch(origin) is not None
+
+
 class AgentCORSMiddleware(BaseHTTPMiddleware):
     """
     Dynamic CORS for origins not in the global static list.
@@ -83,12 +126,22 @@ class AgentCORSMiddleware(BaseHTTPMiddleware):
     otherwise it reflects the Origin so per-agent origins work.
 
     Security: all endpoints authenticate via API key / JWT (not cookies),
-    so reflecting the origin does not enable CSRF.
+    so reflecting the origin does not enable CSRF today. As defense in depth
+    against a future shift to cookie auth, a non-static Origin is only reflected
+    when it passes ``CORS_AGENT_ALLOWED_ORIGIN_REGEX`` (when configured).
     """
 
     async def dispatch(self, request: Request, call_next):
         origin = request.headers.get("origin")
         if not origin or origin in _get_static_origins():
+            return await call_next(request)
+
+        # Unknown (per-agent) origin: only reflect it if it passes the configured
+        # allowlist/regex. Otherwise fall through without credentialed CORS headers
+        # so the browser blocks the cross-origin request.
+        if not _is_allowed_dynamic_origin(origin):
+            if request.method == "OPTIONS":
+                return Response(status_code=400)
             return await call_next(request)
 
         if request.method == "OPTIONS":

--- a/backend/app/middlewares/_middleware.py
+++ b/backend/app/middlewares/_middleware.py
@@ -74,8 +74,9 @@ def _get_static_origins() -> set[str]:
     return _static_allowed_origins
 
 
-_agent_origin_regex: Pattern[str] | None = None
-_agent_origin_regex_ready: bool = False
+# Sentinel distinguishes "not yet compiled" from "compiled to None" (no/invalid regex).
+_UNCOMPILED: object = object()
+_agent_origin_regex: Pattern[str] | None | object = _UNCOMPILED
 
 
 def _get_agent_origin_regex() -> Pattern[str] | None:
@@ -84,22 +85,22 @@ def _get_agent_origin_regex() -> Pattern[str] | None:
     before AgentCORSMiddleware will reflect it. Returns None when unconfigured or
     invalid, in which case dynamic origins are reflected unrestricted.
     """
-    global _agent_origin_regex, _agent_origin_regex_ready
-    if not _agent_origin_regex_ready:
+    global _agent_origin_regex
+    if _agent_origin_regex is _UNCOMPILED:
         pattern = settings.CORS_AGENT_ALLOWED_ORIGIN_REGEX
+        compiled: Pattern[str] | None = None
         if pattern:
             try:
-                _agent_origin_regex = re.compile(pattern)
+                compiled = re.compile(pattern)
             except re.error as exc:
                 logger.error(f"Invalid CORS_AGENT_ALLOWED_ORIGIN_REGEX, ignoring it: {exc}")
-                _agent_origin_regex = None
         else:
             logger.info(
                 "CORS_AGENT_ALLOWED_ORIGIN_REGEX is not set; AgentCORSMiddleware will reflect "
                 "any non-static Origin. Set it to restrict dynamic agent origins."
             )
-        _agent_origin_regex_ready = True
-    return _agent_origin_regex
+        _agent_origin_regex = compiled
+    return _agent_origin_regex  # type: ignore[return-value]
 
 
 def _is_allowed_dynamic_origin(origin: str) -> bool:

--- a/backend/app/modules/data/providers/vector/db/pgvector.py
+++ b/backend/app/modules/data/providers/vector/db/pgvector.py
@@ -172,7 +172,10 @@ class PgVectorDB(BaseVectorDB):
                 return True
 
             async with self.engine.begin() as conn:
-                await conn.execute(text(f"DROP TABLE IF EXISTS {self.table_name}"))
+                # Quote the identifier via the dialect's preparer instead of raw
+                # interpolation to avoid SQL identifier injection.
+                quoted_table = self.engine.dialect.identifier_preparer.quote(self.table_name)
+                await conn.execute(text(f"DROP TABLE IF EXISTS {quoted_table}"))
 
             logger.info(f"Deleted pgvector table: {self.table_name}")
             self.table_name = None

--- a/backend/app/modules/integration/database/database_manager.py
+++ b/backend/app/modules/integration/database/database_manager.py
@@ -686,8 +686,11 @@ class DatabaseManager:
                             continue
                         table_info = {"name": table, "columns": []}
 
-                        # Get column details
-                        result = await conn.execute(text(f"DESCRIBE `{table}`"))
+                        # Get column details. `table` is already restricted to the
+                        # allowlist above; quote via the dialect preparer as defense
+                        # in depth instead of raw backtick interpolation.
+                        quoted_table = self.engine.dialect.identifier_preparer.quote(table)
+                        result = await conn.execute(text(f"DESCRIBE {quoted_table}"))
                         columns = result.fetchall()
 
                         for column in columns:


### PR DESCRIPTION
## Improvement Description

Security-hardening batch for the backend: quote raw-SQL table identifiers and gate the agent CORS middleware's origin reflection behind an allowlist/regex.

Implements **Azure DevOps Task 66629**.

## Motivation

- **Raw SQL identifiers**: `DROP TABLE` (pgvector) and `DESCRIBE` (database_manager) interpolated a table name directly into SQL. Quoting via the dialect's `IdentifierPreparer` removes the identifier-injection surface.
- **Agent CORS**: `AgentCORSMiddleware` reflected any non-static Origin with `Access-Control-Allow-Credentials: true`. Safe today because agent endpoints use API-key/JWT (non-cookie) auth, but a future shift to cookie auth would open a CSRF path. A configurable allowlist/regex is added as defense in depth.

## Changes Made

- **pgvector** (`delete_collection`): quote the `DROP TABLE` identifier via `engine.dialect.identifier_preparer.quote(...)` instead of raw f-string interpolation.
- **database_manager** (`get_schema`, mysql branch): quote the `DESCRIBE` identifier via the dialect preparer; the existing allowlist check above it is retained (defense in depth).
- **AgentCORSMiddleware**: reflect an unknown per-agent Origin only when it passes the new `CORS_AGENT_ALLOWED_ORIGIN_REGEX` setting. Uses `fullmatch` so a suffixed origin (e.g. `https://app.example.com.attacker.com`) cannot bypass it. Invalid regex is logged and ignored.
- **settings**: add `CORS_AGENT_ALLOWED_ORIGIN_REGEX` (Optional[str], default `None`).
- **.env.example**: document the new variable next to `CORS_ALLOWED_ORIGINS`.

### Backward compatibility

`CORS_AGENT_ALLOWED_ORIGIN_REGEX` is unset by default, so the middleware keeps its current reflect-any behavior. **No deployment/pipeline change is required to ship this.** To activate the restriction, set the variable in the environment's `.env` (the `env.cicd` secure file for the Azure DevOps release).

## Testing

- [x] Manual testing completed
- [ ] Automated tests added (see note)

Verified against the real source with isolated harness runs:
- Identifier quoting: legal generated names pass through unquoted (no mismatch with `CREATE TABLE`/`CREATE INDEX`); injection payloads are escaped into inert quoted identifiers for both PostgreSQL and MySQL dialects.
- CORS gate: matching origins reflected; non-matching origins blocked (preflight -> 400, otherwise no credentialed CORS headers); static origins unaffected; suffix-bypass origin blocked by `fullmatch`; invalid regex falls back safely.

> No automated unit tests are added in this PR yet — happy to add them under `tests/` for the middleware + quoting if preferred.

## Related Issues

Azure DevOps Task 66629 — https://dev.azure.com/Ritech/GenAssist/_workitems/edit/66629

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../../CONTRIBUTING.md) or contact the Ritech team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
