### PR TITLE
fix: retire versions of deleted agents

### DIFF
--- a/backend/alembic/versions/00107_retire_versions_of_deleted_agents.py
+++ b/backend/alembic/versions/00107_retire_versions_of_deleted_agents.py
@@ -1,0 +1,33 @@
+"""retire versions of deleted agents
+
+Revision ID: b8454171e700
+Revises: db1cbdf682c5
+Create Date: 2026-08-19 15:59:06.713081
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'b8454171e700'
+down_revision: Union[str, None] = 'db1cbdf682c5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE workflows w
+        SET is_deleted = 1
+        FROM agents a
+        WHERE w.agent_id = a.id
+          AND a.is_deleted = 1
+          AND w.is_deleted = 0
+        """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/repositories/db_repository.py
+++ b/backend/app/repositories/db_repository.py
@@ -177,11 +177,13 @@ class DbRepository(Generic[OrmModelT]):
         await self.db.delete(obj)
         await self.db.commit()
 
-    async def soft_delete(self, obj: OrmModelT) -> None:
+    async def soft_delete(self, obj: OrmModelT, commit: bool = True) -> None:
+        """Skip the commit to batch this delete with later writes."""
         await self.db.execute(
                 update(obj.__class__)
                 .where(obj.__class__.id == obj.id)
                 .values(is_deleted=1)
                 .execution_options(synchronize_session="fetch")
                 )
-        await self.db.commit()
+        if commit:
+            await self.db.commit()

--- a/backend/app/repositories/workflow.py
+++ b/backend/app/repositories/workflow.py
@@ -47,11 +47,11 @@ class WorkflowRepository(DbRepository[WorkflowModel]):
         result = await self.db.execute(stmt)
         return result.all()
 
-    async def soft_delete_by_agent(self, agent_id: UUID) -> None:
+    async def soft_delete_by_agent(self, agent_id: UUID, commit: bool = True) -> None:
         """Retire every version of an agent's workflow.
 
         Each version is a separate row, so deleting the agent leaves them all
-        behind.
+        behind. Skip the commit to batch this with the agent's own delete.
         """
         await self.db.execute(
             update(WorkflowModel)
@@ -59,7 +59,8 @@ class WorkflowRepository(DbRepository[WorkflowModel]):
             .values(is_deleted=1)
             .execution_options(synchronize_session="fetch")
         )
-        await self.db.commit()
+        if commit:
+            await self.db.commit()
 
     async def get_summaries_by_agent(self, agent_id: UUID) -> List:
         stmt = (

--- a/backend/app/repositories/workflow.py
+++ b/backend/app/repositories/workflow.py
@@ -2,7 +2,7 @@ from typing import List
 from uuid import UUID
 
 from injector import inject
-from sqlalchemy import case, select
+from sqlalchemy import case, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.db.events.group_scope import GROUP_SCOPE_BYPASS_FLAG
 from app.db.models.agent import AgentModel
@@ -46,6 +46,20 @@ class WorkflowRepository(DbRepository[WorkflowModel]):
         stmt = self._minimal_select().where(WorkflowModel.id.in_(ids))
         result = await self.db.execute(stmt)
         return result.all()
+
+    async def soft_delete_by_agent(self, agent_id: UUID) -> None:
+        """Retire every version of an agent's workflow.
+
+        Each version is a separate row, so deleting the agent leaves them all
+        behind.
+        """
+        await self.db.execute(
+            update(WorkflowModel)
+            .where(WorkflowModel.agent_id == agent_id)
+            .values(is_deleted=1)
+            .execution_options(synchronize_session="fetch")
+        )
+        await self.db.commit()
 
     async def get_summaries_by_agent(self, agent_id: UUID) -> List:
         stmt = (

--- a/backend/app/services/agent_config.py
+++ b/backend/app/services/agent_config.py
@@ -291,9 +291,10 @@ class AgentConfigService:
         agent_delete = await self.repository.get_by_id_full(agent_id)
         if not agent_delete:
             raise AppException(ErrorKey.AGENT_NOT_FOUND, status_code=404)
-        await self.repository.soft_delete(agent_delete)
-        # Retire every agent workflow
-        await self.workflow_service.soft_delete_by_agent(agent_id)
+        # One transaction: a live workflow must never outlive its deleted agent.
+        await self.repository.soft_delete(agent_delete, commit=False)
+        await self.workflow_service.soft_delete_by_agent(agent_id, commit=False)
+        await self.db.commit()
 
         # Invalidate cache entries for this agent
         await invalidate_agent_cache(agent_id, agent_delete.operator.user.id)

--- a/backend/app/services/agent_config.py
+++ b/backend/app/services/agent_config.py
@@ -292,6 +292,8 @@ class AgentConfigService:
         if not agent_delete:
             raise AppException(ErrorKey.AGENT_NOT_FOUND, status_code=404)
         await self.repository.soft_delete(agent_delete)
+        # Retire every agent workflow
+        await self.workflow_service.soft_delete_by_agent(agent_id)
 
         # Invalidate cache entries for this agent
         await invalidate_agent_cache(agent_id, agent_delete.operator.user.id)

--- a/backend/app/services/workflow.py
+++ b/backend/app/services/workflow.py
@@ -208,9 +208,9 @@ class WorkflowService:
             await self._invalidate_agent_caches(orm_obj.agent.id)
         await self.repository.delete(orm_obj)
 
-    async def soft_delete_by_agent(self, agent_id: UUID) -> None:
+    async def soft_delete_by_agent(self, agent_id: UUID, commit: bool = True) -> None:
         """Retire every version of an agent's workflow when the agent is deleted."""
-        await self.repository.soft_delete_by_agent(agent_id)
+        await self.repository.soft_delete_by_agent(agent_id, commit=commit)
 
     async def _invalidate_agent_caches(self, agent_id: UUID) -> None:
         """Best-effort bust of every agent cache that embeds the workflow.

--- a/backend/app/services/workflow.py
+++ b/backend/app/services/workflow.py
@@ -208,6 +208,10 @@ class WorkflowService:
             await self._invalidate_agent_caches(orm_obj.agent.id)
         await self.repository.delete(orm_obj)
 
+    async def soft_delete_by_agent(self, agent_id: UUID) -> None:
+        """Retire every version of an agent's workflow when the agent is deleted."""
+        await self.repository.soft_delete_by_agent(agent_id)
+
     async def _invalidate_agent_caches(self, agent_id: UUID) -> None:
         """Best-effort bust of every agent cache that embeds the workflow.
 


### PR DESCRIPTION
## Description

When soft deleting a workflow, soft delete all of its versions as well.
Plus: Alembic migration to soft delete versions of already deleted workflows.

## Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
