### PR TITLE
feat: add ML model evaluation service

### DIFF
--- a/backend/app/api/v1/routes/ml_models.py
+++ b/backend/app/api/v1/routes/ml_models.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import os
 import tempfile
@@ -5,7 +6,8 @@ import uuid
 from typing import Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Body, Depends, File, HTTPException, Request, UploadFile
+import pandas as pd
+from fastapi import APIRouter, Body, Depends, File, Form, HTTPException, Request, UploadFile
 from fastapi_injector import Injected
 
 from app.auth.dependencies import auth, permissions
@@ -18,6 +20,7 @@ from app.schemas.file import FileBase, FileUploadResponse
 from app.schemas.ml_model import MLModelCreate, MLModelRead, MLModelUpdate
 from app.services.app_settings import AppSettingsService
 from app.services.file_manager import FileManagerService
+from app.services.ml_model_evaluation import MLModelEvaluationService
 from app.services.ml_model_manager import get_ml_model_manager
 from app.services.ml_models import MLModelsService
 
@@ -173,6 +176,45 @@ async def upload_pkl_file(
             status_code=500,
             detail=f"Error uploading file: {str(e)}"
         ) from e
+
+
+@router.post("/{ml_model_id}/evaluate", dependencies=[
+    Depends(auth),
+    Depends(permissions(P.MlModel.READ))
+])
+async def evaluate_ml_model(
+    ml_model_id: UUID,
+    file: UploadFile = File(...),
+    target_column: Optional[str] = Form(None),
+    service: MLModelEvaluationService = Injected(MLModelEvaluationService),
+):
+    """
+    Evaluate an existing ML model's .pkl file against an uploaded CSV.
+
+    The CSV must contain the model's feature columns plus a target column
+    (defaults to the model's configured target_variable) with the actual
+    values to score predictions against. Returns RMSE/MAE/R2 for regression
+    models or Accuracy/Precision/Recall/F1 for classification models.
+    """
+    try:
+        contents = await file.read()
+        try:
+            df = pd.read_csv(io.BytesIO(contents))
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f"Could not parse uploaded CSV: {e}") from e
+
+        return await service.evaluate_csv(ml_model_id, df, target_column)
+    except HTTPException:
+        raise
+    except AppException as e:
+        if e.error_key == ErrorKey.ML_MODEL_NOT_FOUND:
+            raise HTTPException(status_code=404, detail=str(e))
+        if e.error_key == ErrorKey.FILE_NOT_FOUND:
+            raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error evaluating ML model {ml_model_id}: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Error evaluating model: {str(e)}") from e
 
 
 @router.get("/cache/stats", dependencies=[

--- a/backend/app/modules/workflow/engine/nodes/ml/ml_utils.py
+++ b/backend/app/modules/workflow/engine/nodes/ml/ml_utils.py
@@ -24,6 +24,35 @@ logger = logging.getLogger(__name__)
 _MAX_SANITIZE_DEPTH = 200
 _MAX_SANITIZE_NODES = 1_000_000
 
+# Model types that only support one task type, regardless of the target variable
+_CLASSIFICATION_ONLY_MODEL_TYPES = {"logistic_regression"}
+_REGRESSION_ONLY_MODEL_TYPES = {"linear_regression"}
+
+
+def is_classification_task(y: pd.Series, model_type: str) -> bool:
+    """
+    Determine whether a target column represents a classification or regression task.
+
+    Args:
+        y: Target variable series
+        model_type: Type of model (e.g. "logistic_regression", "linear_regression")
+
+    Returns:
+        True if classification, False if regression
+    """
+    if model_type in _CLASSIFICATION_ONLY_MODEL_TYPES:
+        return True
+    if model_type in _REGRESSION_ONLY_MODEL_TYPES:
+        return False
+
+    # For others (e.g. xgboost, random_forest), infer from target variable
+    if y.dtype in ["int64", "int32"] and y.nunique() <= 20:
+        return True
+    if y.dtype == "object":
+        return True
+
+    return False
+
 
 def sanitize_for_json(obj: Any, _seen: set | None = None, _depth: int = 0, _budget: list | None = None) -> Any:
     """

--- a/backend/app/services/ml_model_evaluation.py
+++ b/backend/app/services/ml_model_evaluation.py
@@ -1,0 +1,166 @@
+"""Service for evaluating an existing ML model's .pkl file against a user-supplied CSV."""
+
+import logging
+import os
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+import pandas as pd
+from injector import inject
+from sklearn.metrics import (
+    accuracy_score,
+    f1_score,
+    mean_absolute_error,
+    mean_squared_error,
+    precision_score,
+    r2_score,
+    recall_score,
+)
+
+from app.core.exceptions.error_messages import ErrorKey
+from app.core.exceptions.exception_classes import AppException
+from app.core.project_path import DATA_VOLUME
+from app.modules.workflow.engine.nodes.ml.ml_model_inference_node import _build_input_array
+from app.modules.workflow.engine.nodes.ml.ml_utils import is_classification_task
+from app.schemas.ml_model import MLModelBase
+from app.services.ml_model_manager import download_pkl_file, get_ml_model_manager
+from app.services.ml_models import MLModelsService
+
+logger = logging.getLogger(__name__)
+
+ML_MODELS_UPLOAD_DIR = str(DATA_VOLUME / "ml_models")
+
+
+@inject
+class MLModelEvaluationService:
+    """Runs an existing model's predict() over an uploaded CSV and scores the result."""
+
+    def __init__(self, ml_models_service: MLModelsService):
+        self.ml_models_service = ml_models_service
+
+    async def evaluate_csv(
+        self, model_id: UUID, df: pd.DataFrame, target_column: Optional[str] = None
+    ) -> Dict[str, Any]:
+        ml_model = await self.ml_models_service.get_by_id(model_id)
+        if not ml_model:
+            raise AppException(error_key=ErrorKey.ML_MODEL_NOT_FOUND)
+
+        target_col = (target_column or ml_model.target_variable or "").strip()
+        if not target_col:
+            raise AppException(
+                error_key=ErrorKey.MISSING_PARAMETER,
+                error_detail="No target column specified and the model has no target_variable configured.",
+            )
+        if target_col not in df.columns:
+            raise AppException(
+                error_key=ErrorKey.INTERNAL_ERROR,
+                error_detail=(
+                    f"Target column '{target_col}' not found in the uploaded CSV. "
+                    f"Available columns: {list(df.columns)}"
+                ),
+            )
+
+        await self._ensure_pkl_file(ml_model)
+
+        model_manager = get_ml_model_manager()
+        try:
+            model_response = await model_manager.get_model(
+                model_id=model_id,
+                pkl_file=ml_model.pkl_file,
+                pkl_file_id=ml_model.pkl_file_id,
+                updated_at=ml_model.updated_at,
+            )
+        except Exception as e:
+            logger.error("Failed to load model %s: %s", model_id, e, exc_info=True)
+            raise AppException(
+                error_key=ErrorKey.INTERNAL_ERROR,
+                error_detail=f"Could not load model: {e}. Ensure all dependencies are installed.",
+            ) from e
+
+        if "version" in model_response and model_response["version"] == "v2.0":
+            model = model_response.get("model", {})
+            metadata = model_response.get("metadata", {})
+            feature_names = list(metadata.get("feature_columns") or ml_model.features or [])
+        else:
+            model = model_response.get("model", {})
+            feature_names = list(getattr(model, "feature_names_in_", []) or ml_model.features or [])
+
+        if not feature_names:
+            feature_names = [c for c in df.columns if c != target_col]
+
+        missing = [f for f in feature_names if f not in df.columns]
+        if missing:
+            raise AppException(
+                error_key=ErrorKey.INTERNAL_ERROR,
+                error_detail=f"The uploaded CSV is missing feature columns required by the model: {missing}",
+            )
+
+        if not hasattr(model, "predict"):
+            raise AppException(
+                error_key=ErrorKey.INTERNAL_ERROR, error_detail="Model does not have a predict method"
+            )
+
+        eval_df = df[df[target_col].notna()]
+        if eval_df.empty:
+            raise AppException(
+                error_key=ErrorKey.INTERNAL_ERROR,
+                error_detail="No rows with a non-empty target value were found in the uploaded CSV.",
+            )
+
+        y_true = eval_df[target_col]
+        normalized_inputs = {feat: eval_df[feat].tolist() for feat in feature_names}
+        input_data = _build_input_array(normalized_inputs, feature_names)
+
+        try:
+            y_pred = model.predict(input_data)
+        except Exception as e:
+            raise AppException(
+                error_key=ErrorKey.INTERNAL_ERROR, error_detail=f"Model prediction failed: {e}"
+            ) from e
+
+        model_type_value = (
+            ml_model.model_type.value if hasattr(ml_model.model_type, "value") else str(ml_model.model_type)
+        )
+        classification = is_classification_task(y_true, model_type_value)
+
+        if classification:
+            task_type = "classification"
+            metrics = {
+                "accuracy": float(accuracy_score(y_true, y_pred)),
+                "precision": float(precision_score(y_true, y_pred, average="weighted", zero_division=0)),
+                "recall": float(recall_score(y_true, y_pred, average="weighted", zero_division=0)),
+                "f1_score": float(f1_score(y_true, y_pred, average="weighted", zero_division=0)),
+            }
+        else:
+            task_type = "regression"
+            mse = float(mean_squared_error(y_true, y_pred))
+            metrics = {
+                "mse": mse,
+                "rmse": mse ** 0.5,
+                "mae": float(mean_absolute_error(y_true, y_pred)),
+                "r2_score": float(r2_score(y_true, y_pred)),
+            }
+
+        return {
+            "task_type": task_type,
+            "row_count": int(len(eval_df)),
+            "target_column": target_col,
+            "metrics": metrics,
+        }
+
+    async def _ensure_pkl_file(self, ml_model: Any) -> None:
+        """Ensure the pkl file exists locally, downloading from file manager if needed."""
+        if ml_model.pkl_file and os.path.exists(ml_model.pkl_file):
+            return
+
+        if ml_model.pkl_file_id:
+            destination_path = os.path.join(ML_MODELS_UPLOAD_DIR, f"{ml_model.name}_{ml_model.id}.pkl")
+            pkl_file_path = await download_pkl_file(ml_model.pkl_file_id, destination_path)
+            await self.ml_models_service.update(ml_model.id, MLModelBase(pkl_file=str(pkl_file_path)))
+            ml_model.pkl_file = str(pkl_file_path)
+            return
+
+        error_msg = f"PKL file not found for model {ml_model.name}"
+        if ml_model.pkl_file:
+            error_msg += f" at path: {ml_model.pkl_file}"
+        raise AppException(error_key=ErrorKey.FILE_NOT_FOUND, error_detail=error_msg)

--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -68,6 +68,7 @@ import EvaluationsPage from "@/views/TestSuites/pages/EvaluationsPage";
 import DatasetDetailPage from "@/views/TestSuites/pages/DatasetDetailPage";
 import EvaluationDetailPage from "@/views/TestSuites/pages/EvaluationDetailPage";
 import WorkflowEvaluationsPage from "@/views/TestSuites/pages/WorkflowEvaluationsPage";
+import MLModelEvaluationsPage from "@/views/TestSuites/pages/MLModelEvaluationsPage";
 import Privacy from "@/views/Privacy";
 import ServerStatusBanner from "@/components/ServerStatusBanner";
 import Onboarding from "@/views/Onboarding/pages/Onboarding";
@@ -543,6 +544,14 @@ export const RoutesProvider = () => {
               element: (
                 <ProtectedRoute requiredPermissions={["test:workflow"]}>
                   <EvaluationDetailPage />
+                </ProtectedRoute>
+              ),
+            },
+            {
+              path: "tests/ml-model-evaluations",
+              element: (
+                <ProtectedRoute requiredPermissions={["test:workflow"]}>
+                  <MLModelEvaluationsPage />
                 </ProtectedRoute>
               ),
             },

--- a/frontend/src/constants/mlModelTypes.ts
+++ b/frontend/src/constants/mlModelTypes.ts
@@ -1,0 +1,29 @@
+export interface MLModelTypeOption {
+  value: string;
+  label: string;
+}
+
+// Keep in sync with backend/app/schemas/ml_model.py::ModelType
+export const ML_MODEL_TYPES: MLModelTypeOption[] = [
+  { value: "xgboost", label: "XGBoost" },
+  { value: "random_forest", label: "Random Forest" },
+  { value: "linear_regression", label: "Linear Regression" },
+  { value: "logistic_regression", label: "Logistic Regression" },
+  { value: "other", label: "Other" },
+];
+
+export const ML_MODEL_TYPE_LABELS: Record<string, string> = ML_MODEL_TYPES.reduce(
+  (labels, { value, label }) => ({ ...labels, [value]: label }),
+  {} as Record<string, string>
+);
+
+export function getMLModelTypeLabel(type: string): string {
+  return ML_MODEL_TYPE_LABELS[type] ?? type;
+}
+
+export type MLModelTypeValue =
+  | "xgboost"
+  | "random_forest"
+  | "linear_regression"
+  | "logistic_regression"
+  | "other";

--- a/frontend/src/interfaces/ml-model.interface.ts
+++ b/frontend/src/interfaces/ml-model.interface.ts
@@ -1,8 +1,10 @@
+import { MLModelTypeValue } from '@/constants/mlModelTypes';
+
 export interface MLModel {
   id: string;
   name: string;
   description: string;
-  model_type: 'xgboost' | 'random_forest' | 'linear_regression' | 'logistic_regression' | 'other';
+  model_type: MLModelTypeValue;
   pkl_file?: string | null;
   pkl_file_id?: string | null;
   features: string[];

--- a/frontend/src/layout/app-sidebar.tsx
+++ b/frontend/src/layout/app-sidebar.tsx
@@ -174,6 +174,11 @@ const navGroups: NavGroup[] = [
             url: "/tests/evaluations",
             permissionsRequired: ["test:workflow"],
           },
+          {
+            title: "Evaluate ML models",
+            url: "/tests/ml-model-evaluations",
+            permissionsRequired: ["test:workflow"],
+          },
         ],
       },
     ],

--- a/frontend/src/views/TestSuites/pages/MLModelEvaluationsPage.tsx
+++ b/frontend/src/views/TestSuites/pages/MLModelEvaluationsPage.tsx
@@ -1,0 +1,566 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { BarChart3, Loader2, Scale, Trash2 } from "lucide-react";
+
+import { PageLayout } from "@/components/PageLayout";
+import { PageHeader } from "@/components/PageHeader";
+import { Badge } from "@/components/badge";
+import { Button } from "@/components/button";
+import { Checkbox } from "@/components/checkbox";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/dialog";
+import { PageListSkeleton } from "@/components/skeletons";
+
+import { deleteMLModel, getAllMLModels } from "@/services/mlModels";
+import { getModelPipelineRuns } from "@/services/mlModelPipelines";
+import { MLModel } from "@/interfaces/ml-model.interface";
+import { getMLModelTypeLabel as getModelTypeLabel } from "@/constants/mlModelTypes";
+
+interface RegressionMetrics {
+  rmse?: number;
+  mae?: number;
+  r2_score?: number;
+  mse?: number;
+}
+
+interface ClassificationMetrics {
+  accuracy?: number;
+  precision?: number;
+  recall?: number;
+  f1_score?: number;
+}
+
+type TaskType = "regression" | "classification";
+
+interface EvaluationResult {
+  model: MLModel;
+  taskType: TaskType | null;
+  metrics: RegressionMetrics & ClassificationMetrics;
+}
+
+function extractMetrics(
+  executionOutput: Record<string, unknown> | undefined
+): { taskType: TaskType | null; metrics: RegressionMetrics & ClassificationMetrics } {
+  const output = (executionOutput?.output ?? {}) as Record<string, unknown>;
+  const metrics = (output.metrics ?? {}) as Record<string, unknown>;
+
+  if (typeof metrics.accuracy === "number") {
+    return {
+      taskType: "classification",
+      metrics: {
+        accuracy: metrics.accuracy as number,
+        precision: metrics.precision as number | undefined,
+        recall: metrics.recall as number | undefined,
+        f1_score: metrics.f1_score as number | undefined,
+      },
+    };
+  }
+
+  if (typeof metrics.mse === "number" || typeof metrics.r2_score === "number") {
+    const mse = metrics.mse as number | undefined;
+    const rmse = typeof metrics.rmse === "number" ? (metrics.rmse as number) : mse !== undefined ? Math.sqrt(mse) : undefined;
+    return {
+      taskType: "regression",
+      metrics: {
+        mse,
+        rmse,
+        mae: metrics.mae as number | undefined,
+        r2_score: metrics.r2_score as number | undefined,
+      },
+    };
+  }
+
+  return { taskType: null, metrics: {} };
+}
+
+function formatMetric(value: number | undefined): string {
+  return value === undefined ? "—" : value.toFixed(4);
+}
+
+type QualityLabel = "Excellent" | "Good" | "Fair" | "Poor";
+
+// R² and F1/accuracy are both unitless 0-1 scores (higher = better), so the same
+// band thresholds give a consistent read across model types — unlike RMSE/MAE,
+// which are in the target variable's own units and can't be compared across models.
+function getQualityRating(
+  taskType: TaskType | null,
+  metrics: RegressionMetrics & ClassificationMetrics
+): { label: QualityLabel; score: number } | null {
+  if (taskType === "regression") {
+    const score = metrics.r2_score;
+    if (score === undefined) return null;
+    if (score >= 0.9) return { label: "Excellent", score };
+    if (score >= 0.7) return { label: "Good", score };
+    if (score >= 0.5) return { label: "Fair", score };
+    return { label: "Poor", score };
+  }
+  if (taskType === "classification") {
+    const score = metrics.f1_score ?? metrics.accuracy;
+    if (score === undefined) return null;
+    if (score >= 0.9) return { label: "Excellent", score };
+    if (score >= 0.75) return { label: "Good", score };
+    if (score >= 0.6) return { label: "Fair", score };
+    return { label: "Poor", score };
+  }
+  return null;
+}
+
+function QualityBadge({ label }: { label: QualityLabel }) {
+  const styles: Record<QualityLabel, string> = {
+    Excellent: "border-transparent bg-green-600 text-white hover:bg-green-600/80",
+    Good: "border-transparent bg-blue-600 text-white hover:bg-blue-600/80",
+    Fair: "border-transparent bg-amber-500 text-white hover:bg-amber-500/80",
+    Poor: "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+  };
+  return <Badge className={styles[label]}>{label}</Badge>;
+}
+
+interface RankedModel {
+  model: MLModel;
+  taskType: TaskType;
+  metrics: RegressionMetrics & ClassificationMetrics;
+  quality: QualityLabel;
+  score: number;
+  rankInGroup: number;
+}
+
+const MLModelEvaluationsPage: React.FC = () => {
+  const [models, setModels] = useState<MLModel[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [isEvaluating, setIsEvaluating] = useState(false);
+  const [result, setResult] = useState<EvaluationResult | null>(null);
+  const [evaluateError, setEvaluateError] = useState<string | null>(null);
+  const [rankings, setRankings] = useState<RankedModel[]>([]);
+  const [isLoadingRankings, setIsLoadingRankings] = useState(false);
+  const [rankingsError, setRankingsError] = useState<string | null>(null);
+  const [modelPendingDelete, setModelPendingDelete] = useState<MLModel | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isCompareOpen, setIsCompareOpen] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setIsLoading(true);
+      setHasError(false);
+      try {
+        const data = await getAllMLModels();
+        if (!cancelled) setModels(data);
+      } catch {
+        if (!cancelled) setHasError(true);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (models.length === 0) return;
+    let cancelled = false;
+
+    const loadRankings = async () => {
+      setIsLoadingRankings(true);
+      setRankingsError(null);
+      try {
+        const perModel = await Promise.all(
+          models.map(async (model) => {
+            const runs = await getModelPipelineRuns(model.id);
+            const latestCompleted = runs.find((run) => run.status === "completed");
+            if (!latestCompleted) return null;
+            const { taskType, metrics } = extractMetrics(latestCompleted.execution_output);
+            if (!taskType) return null;
+            const rating = getQualityRating(taskType, metrics);
+            if (!rating) return null;
+            return { model, taskType, metrics, quality: rating.label, score: rating.score };
+          })
+        );
+        if (cancelled) return;
+
+        const sorted = perModel
+          .filter((r): r is Omit<RankedModel, "rankInGroup"> => r !== null)
+          .sort((a, b) => {
+            if (a.taskType !== b.taskType) return a.taskType.localeCompare(b.taskType);
+            return b.score - a.score;
+          });
+
+        const groupCounts: Partial<Record<TaskType, number>> = {};
+        const ranked: RankedModel[] = sorted.map((entry) => {
+          groupCounts[entry.taskType] = (groupCounts[entry.taskType] ?? 0) + 1;
+          return { ...entry, rankInGroup: groupCounts[entry.taskType]! };
+        });
+        setRankings(ranked);
+      } catch (error) {
+        if (!cancelled) {
+          setRankingsError(error instanceof Error ? error.message : "Failed to load model rankings.");
+        }
+      } finally {
+        if (!cancelled) setIsLoadingRankings(false);
+      }
+    };
+    void loadRankings();
+    return () => {
+      cancelled = true;
+    };
+  }, [models]);
+
+  const filteredModels = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return models;
+    return models.filter((m) => m.name.toLowerCase().includes(query));
+  }, [models, searchQuery]);
+
+  const toggleSelected = (modelId: string) => {
+    setSelectedIds((prev) =>
+      prev.includes(modelId) ? prev.filter((id) => id !== modelId) : [...prev, modelId]
+    );
+  };
+
+  const handleDelete = async () => {
+    if (!modelPendingDelete) return;
+    setIsDeleting(true);
+    try {
+      await deleteMLModel(modelPendingDelete.id);
+      setModels((prev) => prev.filter((m) => m.id !== modelPendingDelete.id));
+      setSelectedIds((prev) => prev.filter((id) => id !== modelPendingDelete.id));
+      setRankings((prev) => prev.filter((r) => r.model.id !== modelPendingDelete.id));
+      if (result?.model.id === modelPendingDelete.id) setResult(null);
+      setModelPendingDelete(null);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleEvaluate = async () => {
+    const model = models.find((m) => m.id === selectedIds[0]);
+    if (!model) return;
+
+    setIsEvaluating(true);
+    setEvaluateError(null);
+    setResult(null);
+    try {
+      const runs = await getModelPipelineRuns(model.id);
+      const latestCompleted = runs.find((run) => run.status === "completed");
+      if (!latestCompleted) {
+        setResult({ model, taskType: null, metrics: {} });
+        return;
+      }
+      const { taskType, metrics } = extractMetrics(latestCompleted.execution_output);
+      setResult({ model, taskType, metrics });
+    } catch (error) {
+      setEvaluateError(error instanceof Error ? error.message : "Failed to fetch pipeline runs for this model.");
+    } finally {
+      setIsEvaluating(false);
+    }
+  };
+
+  return (
+    <PageLayout>
+      <PageHeader
+        title="Evaluate ML models"
+        subtitle="Select a model to view the metrics captured during its last training run."
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        searchPlaceholder="Search models..."
+      />
+
+      <div className="rounded-lg border bg-card dark:bg-zinc-900 overflow-hidden">
+        <div className="px-6 py-3 border-b bg-muted text-sm font-semibold">Model rankings</div>
+        {isLoadingRankings ? (
+          <PageListSkeleton variant="standard" bordered={false} />
+        ) : rankingsError ? (
+          <div className="px-6 py-4 text-sm text-destructive">Couldn't load rankings: {rankingsError}</div>
+        ) : rankings.length === 0 ? (
+          <div className="px-6 py-4 text-sm text-muted-foreground">
+            No models with a completed training run yet — rankings appear once at least one model has trained
+            successfully.
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted text-left text-xs font-medium text-muted-foreground">
+                  <th className="px-6 py-3 font-medium w-10">#</th>
+                  <th className="px-6 py-3 font-medium">Model</th>
+                  <th className="px-6 py-3 font-medium">Task</th>
+                  <th className="px-6 py-3 font-medium">Primary metric</th>
+                  <th className="px-6 py-3 font-medium">Quality</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {rankings.map((entry, index) => {
+                  const isNewGroup = index > 0 && rankings[index - 1].taskType !== entry.taskType;
+                  return (
+                    <tr key={entry.model.id} className={isNewGroup ? "border-t-2 border-border" : ""}>
+                      <td className="px-6 py-4 text-muted-foreground">{entry.rankInGroup}</td>
+                      <td className="px-6 py-4 font-medium">{entry.model.name}</td>
+                      <td className="px-6 py-4">
+                        <Badge variant="secondary">
+                          {entry.taskType === "regression" ? "Regression" : "Classification"}
+                        </Badge>
+                      </td>
+                      <td className="px-6 py-4 text-muted-foreground">
+                        {entry.taskType === "regression"
+                          ? `R² = ${formatMetric(entry.metrics.r2_score)}`
+                          : `F1 = ${formatMetric(entry.metrics.f1_score ?? entry.metrics.accuracy)}`}
+                      </td>
+                      <td className="px-6 py-4">
+                        <QualityBadge label={entry.quality} />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          {selectedIds.length === 0
+            ? "No model selected"
+            : `${selectedIds.length} model${selectedIds.length > 1 ? "s" : ""} selected`}
+        </p>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            onClick={() => setIsCompareOpen(true)}
+            disabled={selectedIds.length < 2}
+          >
+            <Scale className="h-4 w-4 mr-2" />
+            Compare models
+          </Button>
+          <Button onClick={handleEvaluate} disabled={selectedIds.length !== 1 || isEvaluating}>
+            {isEvaluating ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                Evaluating…
+              </>
+            ) : (
+              "Evaluate model"
+            )}
+          </Button>
+        </div>
+      </div>
+
+      <div className="rounded-lg border bg-card dark:bg-zinc-900 overflow-hidden">
+        {isLoading ? (
+          <PageListSkeleton variant="standard" bordered={false} />
+        ) : hasError ? (
+          <div className="py-16 text-center">
+            <p className="text-sm text-muted-foreground mb-3">Couldn't load ML models.</p>
+          </div>
+        ) : filteredModels.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 gap-4 text-center">
+            <div className="rounded-full bg-muted p-4">
+              <BarChart3 className="h-12 w-12 text-muted-foreground" />
+            </div>
+            <h3 className="font-medium text-lg">No ML models found</h3>
+            <p className="text-sm text-muted-foreground max-w-sm">
+              {searchQuery
+                ? "No models match your search."
+                : "Add an ML model under Connect > ML Models to evaluate it here."}
+            </p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted text-left text-xs font-medium text-muted-foreground">
+                  <th className="px-6 py-3 font-medium w-10" />
+                  <th className="px-6 py-3 font-medium">Model</th>
+                  <th className="px-6 py-3 font-medium">Type</th>
+                  <th className="px-6 py-3 font-medium">Target variable</th>
+                  <th className="px-6 py-3 font-medium">Features</th>
+                  <th className="px-6 py-3 font-medium w-10" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {filteredModels.map((model) => (
+                  <tr
+                    key={model.id}
+                    className="hover:bg-muted transition-colors cursor-pointer"
+                    onClick={() => toggleSelected(model.id)}
+                  >
+                    <td className="px-6 py-4" onClick={(e) => e.stopPropagation()}>
+                      <Checkbox
+                        checked={selectedIds.includes(model.id)}
+                        onCheckedChange={() => toggleSelected(model.id)}
+                        id={`model-${model.id}`}
+                      />
+                    </td>
+                    <td className="px-6 py-4 font-medium">{model.name}</td>
+                    <td className="px-6 py-4">
+                      <Badge variant="secondary">{getModelTypeLabel(model.model_type)}</Badge>
+                    </td>
+                    <td className="px-6 py-4 text-muted-foreground">{model.target_variable}</td>
+                    <td className="px-6 py-4 text-muted-foreground">{model.features?.length ?? 0}</td>
+                    <td className="px-6 py-4" onClick={(e) => e.stopPropagation()}>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Delete ${model.name}`}
+                        onClick={() => setModelPendingDelete(model)}
+                      >
+                        <Trash2 className="h-4 w-4 text-destructive" />
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {evaluateError && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 px-6 py-4 text-sm text-destructive">
+          Couldn't evaluate this model: {evaluateError}
+        </div>
+      )}
+
+      {result && (
+        <div className="rounded-lg border bg-card dark:bg-zinc-900 overflow-hidden">
+          <div className="px-6 py-3 border-b bg-muted text-sm font-semibold flex items-center gap-2">
+            {result.model.name}
+            <Badge variant="secondary">{getModelTypeLabel(result.model.model_type)}</Badge>
+            {(() => {
+              const rating = getQualityRating(result.taskType, result.metrics);
+              return rating ? <QualityBadge label={rating.label} /> : null;
+            })()}
+          </div>
+
+          {result.taskType === "regression" && (
+            <div className="grid grid-cols-2 sm:grid-cols-4 divide-x divide-border">
+              <MetricTile label="RMSE" value={formatMetric(result.metrics.rmse)} />
+              <MetricTile label="MAE" value={formatMetric(result.metrics.mae)} />
+              <MetricTile label="R²" value={formatMetric(result.metrics.r2_score)} />
+              <MetricTile label="MSE" value={formatMetric(result.metrics.mse)} />
+            </div>
+          )}
+
+          {result.taskType === "classification" && (
+            <div className="grid grid-cols-2 sm:grid-cols-4 divide-x divide-border">
+              <MetricTile label="Accuracy" value={formatMetric(result.metrics.accuracy)} />
+              <MetricTile label="Precision" value={formatMetric(result.metrics.precision)} />
+              <MetricTile label="Recall" value={formatMetric(result.metrics.recall)} />
+              <MetricTile label="F1" value={formatMetric(result.metrics.f1_score)} />
+            </div>
+          )}
+
+          {result.taskType === null && (
+            <div className="px-6 py-4 text-sm text-muted-foreground">
+              No training metrics available for this model — it has no completed training pipeline run yet.
+            </div>
+          )}
+        </div>
+      )}
+
+      <ConfirmDialog
+        isOpen={!!modelPendingDelete}
+        onOpenChange={(open) => {
+          if (!open) setModelPendingDelete(null);
+        }}
+        onConfirm={handleDelete}
+        isInProgress={isDeleting}
+        itemName={modelPendingDelete?.name ?? ""}
+        title="Delete ML model"
+      />
+
+      <CompareModelsDialog
+        isOpen={isCompareOpen}
+        onOpenChange={setIsCompareOpen}
+        models={models.filter((m) => selectedIds.includes(m.id))}
+        rankings={rankings}
+      />
+    </PageLayout>
+  );
+};
+
+function CompareModelsDialog({
+  isOpen,
+  onOpenChange,
+  models,
+  rankings,
+}: {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  models: MLModel[];
+  rankings: RankedModel[];
+}) {
+  const rows: Array<{ label: string; get: (m: RegressionMetrics & ClassificationMetrics) => string }> = [
+    { label: "RMSE", get: (m) => formatMetric(m.rmse) },
+    { label: "MAE", get: (m) => formatMetric(m.mae) },
+    { label: "R²", get: (m) => formatMetric(m.r2_score) },
+    { label: "MSE", get: (m) => formatMetric(m.mse) },
+    { label: "Accuracy", get: (m) => formatMetric(m.accuracy) },
+    { label: "Precision", get: (m) => formatMetric(m.precision) },
+    { label: "Recall", get: (m) => formatMetric(m.recall) },
+    { label: "F1", get: (m) => formatMetric(m.f1_score) },
+  ];
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Compare models</DialogTitle>
+        </DialogHeader>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-xs font-medium text-muted-foreground">
+                <th className="py-2 pr-4 font-medium">Metric</th>
+                {models.map((model) => (
+                  <th key={model.id} className="py-2 px-4 font-medium">
+                    <div className="flex flex-col gap-1">
+                      <span className="text-foreground">{model.name}</span>
+                      {(() => {
+                        const entry = rankings.find((r) => r.model.id === model.id);
+                        return entry ? <QualityBadge label={entry.quality} /> : <Badge variant="secondary">No data</Badge>;
+                      })()}
+                    </div>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {rows.map((row) => {
+                const values = models.map((model) => {
+                  const entry = rankings.find((r) => r.model.id === model.id);
+                  return entry ? row.get(entry.metrics) : "—";
+                });
+                if (values.every((v) => v === "—")) return null;
+                return (
+                  <tr key={row.label}>
+                    <td className="py-2 pr-4 text-muted-foreground">{row.label}</td>
+                    {values.map((value, i) => (
+                      <td key={models[i].id} className="py-2 px-4 font-medium">
+                        {value}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function MetricTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="px-6 py-4">
+      <div className="text-xs font-medium text-muted-foreground">{label}</div>
+      <div className="text-lg font-semibold">{value}</div>
+    </div>
+  );
+}
+
+export default MLModelEvaluationsPage;


### PR DESCRIPTION
Adds MLModelEvaluationService to score an existing model's .pkl against an uploaded CSV (regression: RMSE/MAE/R2, classification: accuracy/ precision/recall/F1), exposed via POST /ml-models/{id}/evaluate. Adds a new "Evaluate ML models" page for reviewing and ranking trained models based on their latest training-run metrics.

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
   Summary                                                                                                                                                                            
                                                                                                                                                                                     
  Adds the ability to evaluate an existing trained ML model against a new, user-supplied CSV, and a new "Evaluate ML models" page for reviewing and ranking trained models by their  
  latest training-run metrics.                                                                                                                                                       
                                                                                                                                                                                     
  - New POST /ml-models/{ml_model_id}/evaluate endpoint: upload a CSV, get back regression metrics (RMSE/MAE/R²) or classification metrics (accuracy/precision/recall/F1) scored     
  against the model's stored .pkl.                                                                                                                                                   
  - New MLModelEvaluationService backing that endpoint.                                                                                                                              
  - New Evaluate ML models page under Tests, listing all models, ranking them by quality, and letting you inspect/compare metrics from their most recent completed training run.     

**BACKEND**
backend/app/services/ml_model_evaluation.py (new)                                                                                                                                  
  MLModelEvaluationService.evaluate_csv(model_id, df, target_column):                                                                                                                
  - Resolves the target column (explicit param, else the model's stored target_variable); errors if it's missing or not present in the CSV.                                          
  - Ensures the model's .pkl is available locally, downloading it via the file manager if only a pkl_file_id is stored.                                                              
  - Loads the model through the existing model manager (supports both legacy and "v2.0" packaged formats) and resolves the feature columns it expects.                               
  - Validates the CSV has all required feature columns, drops rows with a null target, builds the input array, and calls model.predict().                                            
  - Classifies the task as regression or classification (via is_classification_task, see below) and computes the matching metric set.                                                
  - Returns {task_type, row_count, target_column, metrics}.                                                                                                                          
                                                                                                                                                                                     
  backend/app/api/v1/routes/ml_models.py                                                                                                                                             
  - Adds POST /{ml_model_id}/evaluate (auth + MlModel.READ): accepts a multipart CSV upload and optional target_column form field, parses it with pandas, delegates to the service,  
  and maps errors to HTTP status codes (404 for model/file not found, 400 for validation errors, 500 for unexpected failures).                                                       
                                                                                                                                                                                     
  backend/app/modules/workflow/engine/nodes/ml/ml_utils.py                                                                                                                           
  - Adds is_classification_task(y, model_type): logistic_regression is always classification and linear_regression is always regression; every other model type infers from the      
  target column (integer dtype with ≤20 unique values, or an object/string dty Jump to bottom (click) ↓ cation, otherwise regression).   

**FRONTEND**
frontend/src/views/TestSuites/pages/MLModelEvaluationsPage.tsx (new)                                                                                                               
  New page under Tests:                                                                                                                                                              
  - Lists all ML models with search and multi-select, with delete (confirm dialog).                                                                                                  
  - Rankings panel: for each model, pulls its pipeline runs, takes the latest completed run's output, extracts metrics, computes a quality label (Excellent/Good/Fair/Poor — R² bands
  for regression, F1-or-accuracy bands for classification), and ranks models within each task-type group.                                                                            
  - Single-model view: shows the same metrics/quality badge for one selected model.                                                                                                  
  - Compare dialog: side-by-side comparison across selected models.                                                                                                                  
                                                                                                                                                                                     
  frontend/src/Routes.tsx / frontend/src/layout/app-sidebar.tsx                                                                                                                      
  - Registers the page at /tests/ml-model-evaluations (gated by test:workflow permission) and adds the "Evaluate ML models" nav entry.                                               
                                                                                                                                                                                     
  frontend/src/constants/mlModelTypes.ts (new) / frontend/src/interfaces/ml-model.interface.ts                                                                                       
  - Centralizes the current model type list (xgboost, random_forest, linear_regression, logistic_regression, other) with human-readable labels, and points MLModel.model_type at that
  shared type instead of an inline union.                                                                                                                                            
                                          
                                                                                                                                                                                     
         


## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
