### PR TITLE
fix: replace blocking requests with httpx.AsyncClient in Gmail/Office365 async paths

### DIFF
--- a/backend/app/api/v1/routes/office365.py
+++ b/backend/app/api/v1/routes/office365.py
@@ -10,7 +10,7 @@ from app.services.app_settings import AppSettingsService
 from app.services.datasources import DataSourceService
 from app.core.utils.encryption_utils import decrypt_key
 from fastapi_injector import Injected
-import requests
+import httpx
 from datetime import datetime, timedelta
 
 from app.tasks.sharepoint_tasks import import_sharepoint_files_to_kb_async_with_scope
@@ -170,8 +170,9 @@ async def get_office365_access_token(
 
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
-        response = requests.post(
-            token_url, data=payload, headers=headers, timeout=30)
+        async with httpx.AsyncClient(timeout=30) as client:
+            response = await client.post(
+                token_url, data=payload, headers=headers)
         response.raise_for_status()
         token_data = response.json()
 
@@ -188,7 +189,7 @@ async def get_office365_access_token(
             "scope": token_data.get("scope", ""),
         }
 
-    except requests.exceptions.RequestException as e:
+    except httpx.HTTPError as e:
         logger.error(f"Office365 token exchange failed: {e}")
         if hasattr(e, "response") and e.response is not None:
             logger.error(f"Response content: {e.response.text}")
@@ -212,8 +213,9 @@ async def get_office365_user_email(access_token: str) -> str:
             "Authorization": f"Bearer {access_token}",
             "Accept": "application/json"
         }
-        response = requests.get(
-            "https://graph.microsoft.com/v1.0/me", headers=headers, timeout=15)
+        async with httpx.AsyncClient(timeout=15) as client:
+            response = await client.get(
+                "https://graph.microsoft.com/v1.0/me", headers=headers)
 
         if response.status_code != 200:
             logger.error(

--- a/backend/app/core/utils/gmail.py
+++ b/backend/app/core/utils/gmail.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 from uuid import UUID
 from fastapi import HTTPException
 from fastapi_injector import Injected
-import requests
+import httpx
 
 from app.core.utils.encryption_utils import decrypt_key
 from app.services.app_settings import AppSettingsService
@@ -54,8 +54,9 @@ async def get_access_token(
             'Content-Type': 'application/x-www-form-urlencoded'
         }
 
-        response = requests.post(
-            token_url, data=payload, headers=headers, timeout=30)
+        async with httpx.AsyncClient(timeout=30) as client:
+            response = await client.post(
+                token_url, data=payload, headers=headers)
         response.raise_for_status()
 
         token_data = response.json()
@@ -76,7 +77,7 @@ async def get_access_token(
             'app_settings_id': app_settings_id
         }
 
-    except requests.exceptions.RequestException as e:
+    except httpx.HTTPError as e:
         logger.error(f"Token exchange request failed: {e}")
         if hasattr(e, 'response') and e.response is not None:
             logger.error(f"Response content: {e.response.text}")
@@ -103,7 +104,8 @@ async def get_user_email(access_token: str) -> str:
         headers = {
             "Authorization": f"Bearer {access_token}"
         }
-        response = requests.request("GET", user_info_url, headers=headers)
+        async with httpx.AsyncClient(timeout=30) as client:
+            response = await client.get(user_info_url, headers=headers)
         if response.status_code != 200:
             logger.error(
                 f"Failed to retrieve user info: {response.status_code} - {response.text}")

--- a/backend/app/modules/integration/office365_connector.py
+++ b/backend/app/modules/integration/office365_connector.py
@@ -2,7 +2,6 @@ from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Optional
 import httpx
-import requests
 import logging
 from msal import ConfidentialClientApplication
 from urllib.parse import quote, urlparse, unquote
@@ -44,9 +43,8 @@ class Office365Connector:
         }
         self.for_sharepoint = for_sharepoint
         self._client: httpx.AsyncClient | None = None
-
-        if (self.site_id is None or self.drive_id is None) and self.for_sharepoint:
-            self.resolve_sharepoint_url(self.sharepoint_url)
+        # SharePoint site/drive resolution issues blocking HTTP calls, so it is
+        # done lazily from the async paths (list_files) instead of __init__.
 
     def refresh_access_token(self) -> str:
 
@@ -105,22 +103,25 @@ class Office365Connector:
         # logger.info("Successfully refreshed access token.")
         # return new_token
 
-    def list_files(self, folder_path: Optional[str] = None) -> dict:
+    async def list_files(self, folder_path: Optional[str] = None) -> dict:
         """
         Recursively list all files in the specified SharePoint folder.
         folder_path = "Shared Documents/MyFolder"
         """
+        if (self.site_id is None or self.drive_id is None) and self.for_sharepoint:
+            await self.resolve_sharepoint_url(self.sharepoint_url)
         if folder_path==None:
             folder_path=self.folder_path
         logger.info(f"Listing files from folder (recursively): {folder_path}")
         files = []
-        self._list_files_recursive(folder_path, files)
+        await self._list_files_recursive(folder_path, files)
         return {"files": files}
 
-    def _list_files_recursive(self, folder_path: str, files_accumulator: list):
+    async def _list_files_recursive(self, folder_path: str, files_accumulator: list):
         url=f"{self.base_url}/sites/{self.site_id}/drives/{self.drive_id}/root:/{folder_path}:/children"
 
-        response = requests.get(url, headers=self.headers)
+        async with self._session() as client:
+            response = await client.get(url, headers=self.headers)
 
         if response.status_code != 200:
             raise Exception(f"Error listing folder {folder_path}: {response.text}")
@@ -128,7 +129,7 @@ class Office365Connector:
         for item in response.json().get("value", []):
             if "folder" in item:
                 sub_path = f"{folder_path}/{item['name']}"
-                self._list_files_recursive(sub_path, files_accumulator)
+                await self._list_files_recursive(sub_path, files_accumulator)
             elif "file" in item:
                 files_accumulator.append({
                     "name": item["name"],
@@ -136,14 +137,15 @@ class Office365Connector:
                     "download_url": item["@microsoft.graph.downloadUrl"]
                 })
 
-    def get_file_content(self, download_url: str):
-        response = requests.get(download_url)
+    async def get_file_content(self, download_url: str):
+        async with self._session() as client:
+            response = await client.get(download_url)
         if response.status_code != 200:
             raise Exception(f"Error downloading file: {response.status_code} - {response.text}")
         return response.content
 
 
-    def resolve_sharepoint_url(self, sharepoint_url: str):
+    async def resolve_sharepoint_url(self, sharepoint_url: str):
         """
         Resolves a SharePoint folder URL to Microsoft Graph-compatible site_id, drive_id, and folder_path.
         """
@@ -164,18 +166,20 @@ class Office365Connector:
             raise Exception("Invalid SharePoint URL: cannot find 'sites/<site-name>' path.")
 
         # Step 1: Get site ID
-        site_resp = requests.get(
-            f"https://graph.microsoft.com/v1.0/sites/{hostname}:/{site_path}",
-            headers=headers
-        )
+        async with self._session() as client:
+            site_resp = await client.get(
+                f"https://graph.microsoft.com/v1.0/sites/{hostname}:/{site_path}",
+                headers=headers
+            )
         site_resp.raise_for_status()
         self.site_id = site_resp.json()["id"]
 
         # Step 2: Get drive ID (default is 'Documents' or 'Shared Documents')
-        drives_resp = requests.get(
-            f"https://graph.microsoft.com/v1.0/sites/{self.site_id}/drives",
-            headers=headers
-        )
+        async with self._session() as client:
+            drives_resp = await client.get(
+                f"https://graph.microsoft.com/v1.0/sites/{self.site_id}/drives",
+                headers=headers
+            )
         drives_resp.raise_for_status()
 
         drives = drives_resp.json()["value"]

--- a/backend/app/tasks/sharepoint_tasks.py
+++ b/backend/app/tasks/sharepoint_tasks.py
@@ -157,7 +157,7 @@ async def import_sharepoint_files_to_kb_async(kb_id: Optional[UUID] = None):
 
             # ---- enumerate files ----
             try:
-                result = sp_client.list_files()
+                result = await sp_client.list_files()
             except Exception as e:
                 logger.error(f"Failed to list files: {e}")
                 errors.append(f"{kb.id} file listing failed: {str(e)}")
@@ -190,7 +190,7 @@ async def import_sharepoint_files_to_kb_async(kb_id: Optional[UUID] = None):
             # ---- add new files ----
             for file_info in new_files:
                 try:
-                    file_content = sp_client.get_file_content(
+                    file_content = await sp_client.get_file_content(
                         file_info["download_url"])
                     if len(file_content) == 0:
                         logger.warning(


### PR DESCRIPTION

## Description

A single synchronous requests call inside an async def stalls the FastAPI event loop (timeouts up to ~30s). Swap to httpx.AsyncClient and await the calls, reusing a shared client where practical and preserving timeouts.

- gmail.py: get_access_token / get_user_email now await httpx calls; catch httpx.HTTPError instead of requests.exceptions.RequestException.
- office365.py: get_office365_access_token / get_office365_user_email now await httpx calls; catch httpx.HTTPError.
- office365_connector.py: list_files, _list_files_recursive, get_file_content and resolve_sharepoint_url are now async and reuse the shared _session() AsyncClient. SharePoint site/drive resolution moved out of __init__ (which cannot await) and is done lazily from list_files.
- sharepoint_tasks.py: await the now-async connector methods.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
