### PR TITLE
fix: evaluation workflow picker

### DIFF
--- a/backend/app/api/v1/routes/workflows.py
+++ b/backend/app/api/v1/routes/workflows.py
@@ -137,9 +137,9 @@ async def get_workflows(service: WorkflowService = Injected(WorkflowService)):
 )
 async def get_workflows_minimal(service: WorkflowService = Injected(WorkflowService)):
     """
-    Get a lightweight list of all workflows (id, name, version only).
+    Lightweight list of the workflows the caller can see, matching Agent Studio.
     """
-    return await service.get_all_minimal()
+    return await service.get_visible_minimal()
 
 
 @router.get(

--- a/backend/app/repositories/workflow.py
+++ b/backend/app/repositories/workflow.py
@@ -2,9 +2,9 @@ from typing import List
 from uuid import UUID
 
 from injector import inject
-from sqlalchemy import case, select, update
+from sqlalchemy import and_, case, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
-from app.db.events.group_scope import GROUP_SCOPE_BYPASS_FLAG
+from app.db.events.group_scope import GROUP_SCOPE_BYPASS_FLAG, get_group_scope_clause
 from app.db.models.agent import AgentModel
 from app.db.models.workflow import WorkflowModel
 from app.repositories.db_repository import DbRepository
@@ -14,21 +14,28 @@ class WorkflowRepository(DbRepository[WorkflowModel]):
     def __init__(self, db: AsyncSession):
         super().__init__(WorkflowModel, db)
 
+    @staticmethod
+    def _visible_agent():
+        """An agent the caller may see: live, and inside their groups."""
+        clause = AgentModel.is_deleted == 0
+        scope_clause = get_group_scope_clause(AgentModel)
+        return clause if scope_clause is None else and_(clause, scope_clause)
+
     def _minimal_select(self):
         """Minimal workflow columns, the active-version flag, and the owning
         agent's identity.
 
-        Agents are group-scoped but workflows are not, so the scope filter is
-        bypassed for the join; otherwise the same version would look active to
-        some callers and not to others.
+        The automatic agent scope filter is bypassed so the active-version
+        pointer reads the same for every caller; scoping is applied explicitly
+        instead. The agent's name is a scoped column, so it is nulled for agents
+        outside the caller's groups on every path.
         """
         is_active_version = case(
             (AgentModel.workflow_id == WorkflowModel.id, True), else_=False
         ).label("is_active_version")
-        # A retired agent counts as no agent, matching Agent Studio.
-        agent_name = case(
-            (AgentModel.is_deleted == 0, AgentModel.name), else_=None
-        ).label("agent_name")
+        agent_name = case((self._visible_agent(), AgentModel.name), else_=None).label(
+            "agent_name"
+        )
         stmt = select(
             WorkflowModel.id,
             WorkflowModel.name,
@@ -42,10 +49,25 @@ class WorkflowRepository(DbRepository[WorkflowModel]):
         return stmt.execution_options(**{GROUP_SCOPE_BYPASS_FLAG: True})
 
     async def get_all_minimal(self) -> List[WorkflowModel]:
+        """Every workflow. Internal callers rely on seeing them all, e.g. to find
+        a workflow's sibling versions; user-facing lists use the visible variant."""
         result = await self.db.execute(self._minimal_select())
         return result.all()
 
+    async def get_visible_minimal(self) -> List[WorkflowModel]:
+        """Workflows whose agent the caller can see, as Agent Studio lists them.
+
+        A workflow with no live agent of its own — a row created without one, or
+        a leftover from a deleted agent — is not listed, since there is no agent
+        to see it under.
+        """
+        stmt = self._minimal_select().where(self._visible_agent())
+        result = await self.db.execute(stmt)
+        return result.all()
+
     async def get_minimal_by_ids(self, ids: List[UUID]) -> List:
+        """Point lookup by id — not scoped, so a stored reference still resolves
+        to a name (e.g. labelling an existing run)."""
         if not ids:
             return []
         stmt = self._minimal_select().where(WorkflowModel.id.in_(ids))

--- a/backend/app/repositories/workflow.py
+++ b/backend/app/repositories/workflow.py
@@ -15,22 +15,27 @@ class WorkflowRepository(DbRepository[WorkflowModel]):
         super().__init__(WorkflowModel, db)
 
     def _minimal_select(self):
-        """Minimal workflow columns plus whether this row is its agent's live
-        version — the one the builder marks Active.
+        """Minimal workflow columns, the active-version flag, and the owning
+        agent's identity.
 
         Agents are group-scoped but workflows are not, so the scope filter is
         bypassed for the join; otherwise the same version would look active to
-        some callers and not to others. Only the pointer is read.
+        some callers and not to others.
         """
         is_active_version = case(
             (AgentModel.workflow_id == WorkflowModel.id, True), else_=False
         ).label("is_active_version")
+        # A retired agent counts as no agent, matching Agent Studio.
+        agent_name = case(
+            (AgentModel.is_deleted == 0, AgentModel.name), else_=None
+        ).label("agent_name")
         stmt = select(
             WorkflowModel.id,
             WorkflowModel.name,
             WorkflowModel.version,
             WorkflowModel.agent_id,
             is_active_version,
+            agent_name,
         ).outerjoin(AgentModel, AgentModel.id == WorkflowModel.agent_id)
         if hasattr(WorkflowModel, "is_deleted"):
             stmt = stmt.where(WorkflowModel.is_deleted == 0)

--- a/backend/app/schemas/workflow.py
+++ b/backend/app/schemas/workflow.py
@@ -43,6 +43,8 @@ class WorkflowMinimal(BaseModel):
     # True for the version its agent currently points at — what the builder
     # marks Active and what a plain evaluation run executes.
     is_active_version: bool = False
+    # Null when the agent is gone or retired.
+    agent_name: Optional[str] = None
 
     model_config = ConfigDict(
         from_attributes=True

--- a/backend/app/services/workflow.py
+++ b/backend/app/services/workflow.py
@@ -43,6 +43,11 @@ class WorkflowService:
         rows = await self.repository.get_all_minimal()
         return [WorkflowMinimal.model_validate(r, from_attributes=True) for r in rows]
 
+    async def get_visible_minimal(self) -> List[WorkflowMinimal]:
+        """What the caller may pick from, matching Agent Studio."""
+        rows = await self.repository.get_visible_minimal()
+        return [WorkflowMinimal.model_validate(r, from_attributes=True) for r in rows]
+
     async def get_minimal_by_ids(self, ids: List[UUID]) -> List[WorkflowMinimal]:
         rows = await self.repository.get_minimal_by_ids(ids)
         return [WorkflowMinimal.model_validate(r, from_attributes=True) for r in rows]

--- a/backend/tests/unit/test_workflow_minimal_scope.py
+++ b/backend/tests/unit/test_workflow_minimal_scope.py
@@ -1,0 +1,67 @@
+"""The minimal workflow list must not leak group-scoped agent names."""
+
+from unittest.mock import patch
+
+from sqlalchemy.dialects import postgresql
+
+import app.db.events.group_scope as group_scope
+import app.db.models.test_suite  # noqa: F401 - registers the ORM mappers
+from app.repositories.workflow import WorkflowRepository
+
+
+def _compiled(scoped_list: bool = False, **context) -> str:
+    with patch.object(group_scope, "context", context), patch.object(
+        group_scope, "current_user_is_admin", lambda: False
+    ):
+        statement = WorkflowRepository._minimal_select(WorkflowRepository)
+        if scoped_list:
+            statement = statement.where(WorkflowRepository._visible_agent())
+    return str(statement.compile(dialect=postgresql.dialect()))
+
+
+def test_agent_name_is_group_scoped_for_a_regular_user():
+    sql = _compiled(group_id="g-1", user_id="u-1", supervised_group_ids=[])
+
+    # The name is only read for agents the caller's group owns.
+    assert "agents.created_by IN" in sql
+    assert "THEN agents.name END AS agent_name" in sql
+
+
+def test_agent_name_is_unscoped_without_an_auth_context():
+    """Background jobs have no context; scoping is skipped, as everywhere else."""
+    sql = _compiled()
+
+    assert "agents.created_by IN" not in sql
+    assert "agent_name" in sql
+
+
+def _row_filter(sql: str) -> str:
+    """The statement's own WHERE — not the CASE, and not the scope subquery's."""
+    from_clause = sql[sql.index("FROM workflows"):]
+    return from_clause[from_clause.index("WHERE"):]
+
+
+def test_the_visible_list_only_returns_agents_the_caller_can_see():
+    """get_visible_minimal filters rows, so the picker matches Agent Studio."""
+    sql = _compiled(scoped_list=True, group_id="g-1", user_id="u-1", supervised_group_ids=[])
+
+    where = _row_filter(sql)
+    assert "agents.is_deleted" in where
+    assert "agents.created_by IN" in where
+
+
+def test_the_internal_list_and_lookups_stay_unscoped():
+    """Internal callers need every row — a bundle import resolves a workflow's
+    sibling versions this way — and a stored reference must still resolve."""
+    where = _row_filter(_compiled(group_id="g-1", user_id="u-1", supervised_group_ids=[]))
+
+    assert "agents.created_by IN" not in where
+    assert "agents.is_deleted" not in where
+
+
+def test_active_version_pointer_is_never_scoped():
+    """The pointer must read the same for every caller, or a version would look
+    active to some and not to others."""
+    scoped = _compiled(group_id="g-1", user_id="u-1", supervised_group_ids=[])
+
+    assert "CASE WHEN (agents.workflow_id = workflows.id)" in scoped

--- a/frontend/src/interfaces/workflow.interface.ts
+++ b/frontend/src/interfaces/workflow.interface.ts
@@ -43,6 +43,8 @@ export interface WorkflowMinimal {
   agent_id?: string | null;
   /** True for the version its agent points at — what the builder marks Active. */
   is_active_version?: boolean;
+  /** Null when the agent is gone or retired. */
+  agent_name?: string | null;
 }
 
 export interface WorkflowSummary {

--- a/frontend/src/views/TestSuites/components/EvaluationDetailPanel.tsx
+++ b/frontend/src/views/TestSuites/components/EvaluationDetailPanel.tsx
@@ -234,7 +234,9 @@ export const EvaluationDetailPanel: React.FC<EvaluationDetailPanelProps> = ({
       const workflowData = (workflows ?? []).find(
         (item: WorkflowMinimal) => item.id === evaluation.workflow_id,
       );
-      setWorkflowName(workflowData?.name ?? "Dataset default");
+      setWorkflowName(
+        workflowData?.agent_name || workflowData?.name || "Dataset default",
+      );
       setWorkflowAgentId(workflowData?.agent_id ?? null);
     };
     loadContext();

--- a/frontend/src/views/TestSuites/components/WorkflowEvaluationsPanel.tsx
+++ b/frontend/src/views/TestSuites/components/WorkflowEvaluationsPanel.tsx
@@ -169,7 +169,7 @@ export const WorkflowEvaluationsPanel: React.FC<WorkflowEvaluationsPanelProps> =
   const currentWorkflow = workflows.find((w) => w.id === workflowId);
   const workflowName = isUnassigned
     ? "Unassigned evaluations"
-    : currentWorkflow?.name ?? "Workflow";
+    : currentWorkflow?.agent_name || currentWorkflow?.name || "Workflow";
   const workflowAgentId = isUnassigned ? null : currentWorkflow?.agent_id ?? null;
   // Offered on every workflow; the dialog handles one with no second version.
   const canRunAgainstVersion = Boolean(workflowAgentId);

--- a/frontend/src/views/TestSuites/components/WorkflowVersionPicker.tsx
+++ b/frontend/src/views/TestSuites/components/WorkflowVersionPicker.tsx
@@ -3,7 +3,15 @@ import { Check, ChevronRight } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { WorkflowMinimal } from "@/interfaces/workflow.interface";
-import { groupWorkflowVersions } from "../helpers/workflowVersions";
+import {
+  groupWorkflowVersions,
+  WorkflowGroupKind,
+} from "../helpers/workflowVersions";
+
+const SECTION_LABELS: Record<WorkflowGroupKind, string | null> = {
+  agent: null,
+  unlinked: "Not in Agent Studio",
+};
 
 interface WorkflowVersionPickerProps {
   workflows: WorkflowMinimal[];
@@ -35,8 +43,11 @@ export const WorkflowVersionPicker: React.FC<WorkflowVersionPickerProps> = ({
         <p className="px-2.5 py-2 text-sm text-muted-foreground">{emptyMessage}</p>
       )}
 
-      {groups.map((group) => {
+      {groups.map((group, index) => {
         const isExpanded = expandedKey === group.key;
+        const startsSection =
+          SECTION_LABELS[group.kind] !== null &&
+          group.kind !== groups[index - 1]?.kind;
         const selectedInGroup = group.versions.find(
           (workflow) => workflow.id === selectedWorkflowId,
         );
@@ -45,6 +56,11 @@ export const WorkflowVersionPicker: React.FC<WorkflowVersionPickerProps> = ({
         const defaultForGroup = group.activeVersionId ?? group.versions[0].id;
         return (
           <div key={group.key}>
+            {startsSection && (
+              <p className="px-2.5 pb-1 pt-3 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                {SECTION_LABELS[group.kind]}
+              </p>
+            )}
             <button
               type="button"
               onClick={() => {
@@ -106,9 +122,8 @@ export const WorkflowVersionPicker: React.FC<WorkflowVersionPickerProps> = ({
                           Current
                         </span>
                       )}
-                      {/* A version's own name is what tells two apart once a
-                          workflow has been renamed between saves. */}
-                      {workflow.name !== group.name && (
+                      {/* A version's own name tells two apart after a rename. */}
+                      {workflow.name !== group.workflowName && (
                         <span className="truncate text-xs text-muted-foreground">
                           {workflow.name}
                         </span>

--- a/frontend/src/views/TestSuites/components/WorkflowVersionPicker.tsx
+++ b/frontend/src/views/TestSuites/components/WorkflowVersionPicker.tsx
@@ -3,15 +3,7 @@ import { Check, ChevronRight } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { WorkflowMinimal } from "@/interfaces/workflow.interface";
-import {
-  groupWorkflowVersions,
-  WorkflowGroupKind,
-} from "../helpers/workflowVersions";
-
-const SECTION_LABELS: Record<WorkflowGroupKind, string | null> = {
-  agent: null,
-  unlinked: "Not in Agent Studio",
-};
+import { groupWorkflowVersions } from "../helpers/workflowVersions";
 
 interface WorkflowVersionPickerProps {
   workflows: WorkflowMinimal[];
@@ -43,11 +35,8 @@ export const WorkflowVersionPicker: React.FC<WorkflowVersionPickerProps> = ({
         <p className="px-2.5 py-2 text-sm text-muted-foreground">{emptyMessage}</p>
       )}
 
-      {groups.map((group, index) => {
+      {groups.map((group) => {
         const isExpanded = expandedKey === group.key;
-        const startsSection =
-          SECTION_LABELS[group.kind] !== null &&
-          group.kind !== groups[index - 1]?.kind;
         const selectedInGroup = group.versions.find(
           (workflow) => workflow.id === selectedWorkflowId,
         );
@@ -56,11 +45,6 @@ export const WorkflowVersionPicker: React.FC<WorkflowVersionPickerProps> = ({
         const defaultForGroup = group.activeVersionId ?? group.versions[0].id;
         return (
           <div key={group.key}>
-            {startsSection && (
-              <p className="px-2.5 pb-1 pt-3 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-                {SECTION_LABELS[group.kind]}
-              </p>
-            )}
             <button
               type="button"
               onClick={() => {

--- a/frontend/src/views/TestSuites/helpers/workflowVersions.ts
+++ b/frontend/src/views/TestSuites/helpers/workflowVersions.ts
@@ -15,31 +15,22 @@ export const compareVersions = (a: string, b: string): number => {
   return 0;
 };
 
-/** Agents as Agent Studio lists them, then workflows with no agent left. */
-export type WorkflowGroupKind = "agent" | "unlinked";
-
 export interface WorkflowGroup {
   key: string;
   name: string;
   /** The live version's own name, for spotting renames between saves. */
   workflowName: string;
-  kind: WorkflowGroupKind;
   /** Newest version first. */
   versions: WorkflowMinimal[];
   activeVersionId: string | null;
 }
-
-const KIND_ORDER: Record<WorkflowGroupKind, number> = {
-  agent: 0,
-  unlinked: 1,
-};
 
 /** Group versions by the agent they belong to, newest version first.
  *
  * Versions of one workflow are separate rows sharing an ``agent_id`` and their
  * names can differ (a rename between saves), so grouping by name would split
  * them apart. The group is named after its agent, matching Agent Studio; a
- * workflow whose agent is gone keeps its own name and sorts last.
+ * workflow with no agent name falls back to its own.
  */
 export const groupWorkflowVersions = (
   workflows: WorkflowMinimal[],
@@ -63,13 +54,9 @@ export const groupWorkflowVersions = (
         key,
         name: named.agent_name || named.name,
         workflowName: named.name,
-        kind: named.agent_name ? "agent" : "unlinked",
         versions: ordered,
         activeVersionId: active?.id ?? null,
       };
     })
-    .sort(
-      (a, b) =>
-        KIND_ORDER[a.kind] - KIND_ORDER[b.kind] || a.name.localeCompare(b.name),
-    );
+    .sort((a, b) => a.name.localeCompare(b.name));
 };

--- a/frontend/src/views/TestSuites/helpers/workflowVersions.ts
+++ b/frontend/src/views/TestSuites/helpers/workflowVersions.ts
@@ -15,21 +15,31 @@ export const compareVersions = (a: string, b: string): number => {
   return 0;
 };
 
+/** Agents as Agent Studio lists them, then workflows with no agent left. */
+export type WorkflowGroupKind = "agent" | "unlinked";
+
 export interface WorkflowGroup {
   key: string;
   name: string;
+  /** The live version's own name, for spotting renames between saves. */
+  workflowName: string;
+  kind: WorkflowGroupKind;
   /** Newest version first. */
   versions: WorkflowMinimal[];
   activeVersionId: string | null;
 }
 
-/** Group versions by the workflow they belong to, newest first.
+const KIND_ORDER: Record<WorkflowGroupKind, number> = {
+  agent: 0,
+  unlinked: 1,
+};
+
+/** Group versions by the agent they belong to, newest version first.
  *
- * Versions of one workflow are separate rows sharing an ``agent_id``, and their
+ * Versions of one workflow are separate rows sharing an ``agent_id`` and their
  * names can differ (a rename between saves), so grouping by name would split
- * them apart. The group takes its name from the live version, and the active
- * version is the one its agent points at — the same pointer the builder marks
- * Active and a plain evaluation run executes.
+ * them apart. The group is named after its agent, matching Agent Studio; a
+ * workflow whose agent is gone keeps its own name and sorts last.
  */
 export const groupWorkflowVersions = (
   workflows: WorkflowMinimal[],
@@ -43,17 +53,23 @@ export const groupWorkflowVersions = (
   }
 
   return Array.from(byWorkflow.entries())
-    .map(([key, versions]) => {
+    .map(([key, versions]): WorkflowGroup => {
       const ordered = [...versions].sort((a, b) =>
         compareVersions(b.version, a.version),
       );
       const active = ordered.find((workflow) => workflow.is_active_version);
+      const named = active ?? ordered[0];
       return {
         key,
-        name: (active ?? ordered[0]).name,
+        name: named.agent_name || named.name,
+        workflowName: named.name,
+        kind: named.agent_name ? "agent" : "unlinked",
         versions: ordered,
         activeVersionId: active?.id ?? null,
       };
     })
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .sort(
+      (a, b) =>
+        KIND_ORDER[a.kind] - KIND_ORDER[b.kind] || a.name.localeCompare(b.name),
+    );
 };

--- a/frontend/src/views/TestSuites/pages/DatasetsPage.tsx
+++ b/frontend/src/views/TestSuites/pages/DatasetsPage.tsx
@@ -45,6 +45,26 @@ const getTimeAgo = (date: Date): string => {
   return date.toLocaleDateString();
 };
 
+// Named after the agent, as the workflow picker does; the version keeps two
+// entries apart, and the workflow name settles versions that still collide.
+const workflowFilterOptions = (workflows: WorkflowMinimal[]) => {
+  const options = workflows.map((workflow) => ({
+    id: workflow.id,
+    label: `${workflow.agent_name || workflow.name} · v${workflow.version}`,
+    workflowName: workflow.name,
+  }));
+  const counts = new Map<string, number>();
+  options.forEach((o) => counts.set(o.label, (counts.get(o.label) ?? 0) + 1));
+
+  return options
+    .map((option) =>
+      (counts.get(option.label) ?? 0) > 1
+        ? { ...option, label: `${option.label} (${option.workflowName})` }
+        : option,
+    )
+    .sort((a, b) => a.label.localeCompare(b.label));
+};
+
 const DatasetsPage: React.FC = () => {
   const navigate = useNavigate();
   const [suites, setSuites] = useState<TestSuite[]>([]);
@@ -494,9 +514,9 @@ const DatasetsPage: React.FC = () => {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="__all__">All workflows</SelectItem>
-                  {workflows.map((wf) => (
-                    <SelectItem key={wf.id} value={wf.id ?? ""}>
-                      {wf.name}
+                  {workflowFilterOptions(workflows).map((option) => (
+                    <SelectItem key={option.id} value={option.id ?? ""}>
+                      {option.label}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/frontend/src/views/TestSuites/pages/EvaluationsPage.tsx
+++ b/frontend/src/views/TestSuites/pages/EvaluationsPage.tsx
@@ -41,6 +41,19 @@ interface WorkflowRow {
   isUnassigned: boolean;
 }
 
+// Rows are named after the agent, matching Agent Studio and the workflow picker.
+// Two versions of one agent would then read identically, so those keep a version.
+const nameRows = (rows: WorkflowRow[], workflows: WorkflowMinimal[]): WorkflowRow[] => {
+  const counts = new Map<string, number>();
+  rows.forEach((row) => counts.set(row.name, (counts.get(row.name) ?? 0) + 1));
+
+  return rows.map((row) => {
+    if ((counts.get(row.name) ?? 0) < 2) return row;
+    const version = workflows.find((w) => w.id === row.workflowId)?.version;
+    return version ? { ...row, name: `${row.name} · v${version}` } : row;
+  });
+};
+
 const EvaluationsPage: React.FC = () => {
   const navigate = useNavigate();
   const [workflows, setWorkflows] = useState<WorkflowMinimal[]>([]);
@@ -104,11 +117,13 @@ const EvaluationsPage: React.FC = () => {
   const rows = useMemo<WorkflowRow[]>(() => {
     const nameFor = (workflowId: string | null): string => {
       if (workflowId === null) return "Unassigned evaluations";
-      return workflows.find((w) => w.id === workflowId)?.name ?? "Unknown workflow";
+      const workflow = workflows.find((w) => w.id === workflowId);
+      if (!workflow) return "Unknown workflow";
+      return workflow.agent_name || workflow.name;
     };
     const query = searchQuery.trim().toLowerCase();
-    return summaries
-      .map((summary) => ({
+    const named = nameRows(
+      summaries.map((summary) => ({
         key: summary.workflow_id ?? UNASSIGNED,
         workflowId: summary.workflow_id,
         name: nameFor(summary.workflow_id),
@@ -117,7 +132,10 @@ const EvaluationsPage: React.FC = () => {
         finishedCount: summary.finished_count,
         anyRunning: summary.any_running,
         isUnassigned: summary.workflow_id === null,
-      }))
+      })),
+      workflows,
+    );
+    return named
       .filter((row) => !query || row.name.toLowerCase().includes(query))
       .sort((a, b) => {
         if (a.isUnassigned) return 1;

--- a/frontend/tests/views/TestSuites/helpers/workflowVersions.test.ts
+++ b/frontend/tests/views/TestSuites/helpers/workflowVersions.test.ts
@@ -133,3 +133,37 @@ describe("groupWorkflowVersions", () => {
     expect(groups.map((g) => g.name)).toEqual(["Alpha", "Zebra"]);
   });
 });
+
+describe("groupWorkflowVersions naming and sections", () => {
+  it("names a group after its agent, as Agent Studio does", () => {
+    const groups = groupWorkflowVersions([
+      wf({ id: "w1", name: "Parker Workflow", version: "1.0", agent_id: "a", agent_name: "Parker", is_active_version: true }),
+      wf({ id: "w2", name: "Parker New Workflow", version: "1.1", agent_id: "a", agent_name: "Parker" }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].name).toBe("Parker");
+    expect(groups[0].workflowName).toBe("Parker Workflow");
+    expect(groups[0].kind).toBe("agent");
+  });
+
+  it("falls back to the workflow name when the agent is gone", () => {
+    const groups = groupWorkflowVersions([
+      wf({ id: "w1", name: "Parker 4.1 REPRO", version: "1.1", agent_id: "gone", agent_name: null }),
+    ]);
+    expect(groups[0].name).toBe("Parker 4.1 REPRO");
+    expect(groups[0].kind).toBe("unlinked");
+  });
+
+  it("lists agents alphabetically, then workflows with no agent", () => {
+    const groups = groupWorkflowVersions([
+      wf({ id: "u1", name: "Orphan", version: "1", agent_id: "gone", agent_name: null }),
+      wf({ id: "a1", name: "Zebra WF", version: "1", agent_id: "z", agent_name: "Zebra" }),
+      wf({ id: "a2", name: "Alpha WF", version: "1", agent_id: "b", agent_name: "Alpha" }),
+    ]);
+    expect(groups.map((group) => [group.name, group.kind])).toEqual([
+      ["Alpha", "agent"],
+      ["Zebra", "agent"],
+      ["Orphan", "unlinked"],
+    ]);
+  });
+});

--- a/frontend/tests/views/TestSuites/helpers/workflowVersions.test.ts
+++ b/frontend/tests/views/TestSuites/helpers/workflowVersions.test.ts
@@ -134,7 +134,7 @@ describe("groupWorkflowVersions", () => {
   });
 });
 
-describe("groupWorkflowVersions naming and sections", () => {
+describe("groupWorkflowVersions naming", () => {
   it("names a group after its agent, as Agent Studio does", () => {
     const groups = groupWorkflowVersions([
       wf({ id: "w1", name: "Parker Workflow", version: "1.0", agent_id: "a", agent_name: "Parker", is_active_version: true }),
@@ -143,7 +143,6 @@ describe("groupWorkflowVersions naming and sections", () => {
     expect(groups).toHaveLength(1);
     expect(groups[0].name).toBe("Parker");
     expect(groups[0].workflowName).toBe("Parker Workflow");
-    expect(groups[0].kind).toBe("agent");
   });
 
   it("falls back to the workflow name when the agent is gone", () => {
@@ -151,19 +150,14 @@ describe("groupWorkflowVersions naming and sections", () => {
       wf({ id: "w1", name: "Parker 4.1 REPRO", version: "1.1", agent_id: "gone", agent_name: null }),
     ]);
     expect(groups[0].name).toBe("Parker 4.1 REPRO");
-    expect(groups[0].kind).toBe("unlinked");
   });
 
-  it("lists agents alphabetically, then workflows with no agent", () => {
+  it("sorts by the name it displays, agent or workflow", () => {
     const groups = groupWorkflowVersions([
       wf({ id: "u1", name: "Orphan", version: "1", agent_id: "gone", agent_name: null }),
       wf({ id: "a1", name: "Zebra WF", version: "1", agent_id: "z", agent_name: "Zebra" }),
       wf({ id: "a2", name: "Alpha WF", version: "1", agent_id: "b", agent_name: "Alpha" }),
     ]);
-    expect(groups.map((group) => [group.name, group.kind])).toEqual([
-      ["Alpha", "agent"],
-      ["Zebra", "agent"],
-      ["Orphan", "unlinked"],
-    ]);
+    expect(groups.map((group) => group.name)).toEqual(["Alpha", "Orphan", "Zebra"]);
   });
 });


### PR DESCRIPTION
## Description

- Workflows are named after their agent instead of the saved workflow name, with an agent's versions grouped under one entry.
- The list now shows only workflows whose agent the account can see, following the same access rules as Agent Studio.
- Same naming on the evaluations list, workflow page, evaluation detail and dataset import filter.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
