### PR TITLE
feat: service-level TransactionManager — repos flush(), central commi…

### DIFF
--- a/backend/app/core/utils/db_connection_utils.py
+++ b/backend/app/core/utils/db_connection_utils.py
@@ -13,9 +13,39 @@ from fastapi_injector import RequestScopeFactory
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.tenant_scope import get_tenant_context, set_tenant_context
+from app.db.transaction_manager import TransactionManager
 from app.dependencies.injector import injector
 
 logger = logging.getLogger(__name__)
+
+
+async def commit_scope_session(context: Optional[str] = None) -> None:
+    """
+    Commit the current scope's request-scoped session if it has an open transaction.
+
+    Repositories flush instead of commit, so background/Celery/workflow scopes (which do
+    not pass through the HTTP transaction middleware) must commit their own unit of work
+    at the end of a successful scope. Safe to call when no session/transaction exists.
+    """
+    try:
+        tx = injector.get(TransactionManager)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f"No transaction manager to commit ({context}): {e}")
+        return
+    await tx.commit()
+
+
+async def rollback_scope_session(context: Optional[str] = None) -> None:
+    """Roll back the current scope's request-scoped session on error. Safe if none exists."""
+    try:
+        tx = injector.get(TransactionManager)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f"No transaction manager to roll back ({context}): {e}")
+        return
+    try:
+        await tx.rollback()
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f"Scope rollback skipped/failed ({context}): {e}")
 
 
 async def release_db_connection(
@@ -108,6 +138,13 @@ async def create_tenant_request_scope() -> AsyncGenerator[None, None]:
         set_tenant_context(tenant_id)
         try:
             yield
+        except Exception:
+            # Repos only flush; roll back this scope's pending writes on error.
+            await rollback_scope_session(context="create_tenant_request_scope")
+            raise
+        else:
+            # Commit the scope's unit of work (no-op if nothing was written).
+            await commit_scope_session(context="create_tenant_request_scope")
         finally:
-            # Cleanup is handled by the scope context manager
+            # Session close is handled by the scope context manager.
             pass

--- a/backend/app/db/multi_tenant_session.py
+++ b/backend/app/db/multi_tenant_session.py
@@ -210,6 +210,11 @@ class MultiTenantSessionManager:
                     di_session = injector.get(AsyncSession)
                     try:
                         await seed_data(di_session, injector)
+                        # Repositories only flush now; commit the seeded rows explicitly.
+                        await di_session.commit()
+                    except Exception:
+                        await di_session.rollback()
+                        raise
                     finally:
                         try:
                             await di_session.close()
@@ -252,6 +257,8 @@ class MultiTenantSessionManager:
         session_factory = self.get_tenant_session_factory(tenant)
         async with session_factory() as session:
             await seed_data(session, injector)
+            # Repositories only flush now; commit the seeded rows explicitly.
+            await session.commit()
 
     async def get_all_table_names_async(self, tenant: str = "master") -> list[str]:
         """Introspect tables with the *current* session’s bind."""

--- a/backend/app/db/transaction_manager.py
+++ b/backend/app/db/transaction_manager.py
@@ -1,0 +1,67 @@
+"""
+Service-layer transaction management.
+
+Repositories now `flush()` instead of `commit()`, so the transaction boundary is
+owned above them:
+
+* HTTP requests  -> `TransactionMiddleware` commits on success / rolls back on error.
+* Background/Celery/seeding -> the request-scope helpers commit/roll back around the
+  task body (see `app/core/utils/db_connection_utils.py`).
+
+`TransactionManager` is the injectable, request-scoped handle to that boundary. The
+middleware / task boundary call :meth:`commit` and :meth:`rollback`; services that need
+an *explicit* unit of work (e.g. a multi-write operation that must persist immediately,
+or that wants its own partial-rollback scope) use the :meth:`transaction` context
+manager. When a transaction is already open on the session, :meth:`transaction` uses a
+SAVEPOINT (``begin_nested``) so it composes with the outer request boundary instead of
+committing the whole request early.
+"""
+
+import logging
+from contextlib import asynccontextmanager
+
+from injector import inject
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+
+@inject
+class TransactionManager:
+    """Owns the commit/rollback boundary for the shared request-scoped session."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def commit(self) -> None:
+        """Commit the current transaction if one is in progress."""
+        if self.db.in_transaction():
+            await self.db.commit()
+
+    async def rollback(self) -> None:
+        """Roll back the current transaction if one is in progress."""
+        if self.db.in_transaction():
+            await self.db.rollback()
+
+    @asynccontextmanager
+    async def transaction(self):
+        """
+        Explicit unit of work.
+
+        * If no transaction is active, open one and commit it on success.
+        * If a transaction is already active (the common case inside an HTTP request),
+          open a SAVEPOINT so this block can roll back on its own without discarding
+          the surrounding request's pending writes; the outer boundary still owns the
+          final commit.
+
+        On any exception the (nested) transaction is rolled back and the error re-raised.
+        """
+        if self.db.in_transaction():
+            # Nested unit of work -> SAVEPOINT. begin_nested() manages
+            # release/rollback of the savepoint on block exit.
+            async with self.db.begin_nested():
+                yield
+        else:
+            # Top-level unit of work (e.g. a background task that opts in explicitly).
+            async with self.db.begin():
+                yield

--- a/backend/app/dependencies/dependency_injection.py
+++ b/backend/app/dependencies/dependency_injection.py
@@ -20,6 +20,7 @@ from app.core.config.settings import settings
 # Multi-tenant session manager
 from app.core.tenant_scope import tenant_scope
 from app.db.multi_tenant_session import multi_tenant_manager
+from app.db.transaction_manager import TransactionManager
 from app.modules.data.manager import AgentRAGServiceManager
 from app.modules.websockets.socket_connection_manager import SocketConnectionManager
 from app.modules.workflow.llm.provider import LLMProvider
@@ -208,6 +209,11 @@ class Dependencies(Module):
         return session
 
     def configure(self, binder):
+        # Request-scoped transaction boundary shared by the transaction middleware,
+        # the background-task scope helpers, and any service that opts into an
+        # explicit unit of work. Same request-scoped AsyncSession as the repositories.
+        binder.bind(TransactionManager, scope=request_scope)
+
         binder.bind(ToolService, scope=request_scope)
         binder.bind(ToolRepository, scope=request_scope)
 

--- a/backend/app/middlewares/_middleware.py
+++ b/backend/app/middlewares/_middleware.py
@@ -24,6 +24,7 @@ from app.core.config.logging import (
     uid_ctx,
 )
 from app.middlewares.rate_limit_middleware import _request_context
+from app.middlewares.session_cleanup_middleware import TransactionMiddleware
 from app.middlewares.tenant_middleware import TenantMiddleware
 from app.middlewares.tenant_scope_middleware import TenantScopeMiddleware
 
@@ -191,11 +192,9 @@ def build_middlewares() -> list[Middleware]:
         [
             # 3️⃣  Fills Loguru context vars, measures duration, etc.
             Middleware(RequestContextMiddleware),
-            # 4️⃣  Ensures database sessions are closed after each request
-            # Middleware(SessionCleanupMiddleware),
-            # 5️⃣  Agent-route preflight handler (must sit before CORSMiddleware)
+            # 4️⃣  Agent-route preflight handler (must sit before CORSMiddleware)
             Middleware(AgentCORSMiddleware),
-            # 6️⃣  CORS
+            # 5️⃣  CORS
             Middleware(
                 CORSMiddleware,
                 allow_origins=get_allowed_origins(),
@@ -204,6 +203,10 @@ def build_middlewares() -> list[Middleware]:
                 allow_headers=["*"],
             ),
             Middleware(VersionHeaderMiddleware),
+            # 6️⃣  DB transaction boundary — must be the *innermost* user middleware so
+            #     it runs inside the tenant scope (tenant context still active when it
+            #     commits/rolls back the request-scoped session after the endpoint).
+            Middleware(TransactionMiddleware),
         ]
     )
 

--- a/backend/app/middlewares/session_cleanup_middleware.py
+++ b/backend/app/middlewares/session_cleanup_middleware.py
@@ -1,47 +1,83 @@
 """
-Middleware to ensure database sessions are properly closed after each request.
+Request-scoped database transaction boundary.
 
-This middleware ensures that AsyncSession instances created via dependency injection
-are properly closed when the request completes, preventing connection leaks.
+Repositories `flush()` rather than `commit()`, so the commit/rollback decision is made
+once per request here instead of piecemeal inside each repository:
+
+* 2xx/3xx response  -> commit the request's pending writes.
+* >=4xx response     -> roll back (covers ``AppException`` handlers, which turn into an
+  error response *before* this middleware sees it, so no exception propagates).
+* unhandled exception -> roll back and re-raise.
+
+This middleware runs inside the fastapi-injector request scope (``InjectorMiddleware`` is
+the outermost user middleware), so ``injector.get`` resolves the same request-scoped
+``AsyncSession`` the repositories used. Session *close* is still handled by
+fastapi-injector's ``enable_cleanup`` at scope exit; we only own commit/rollback.
 """
 
 import logging
+
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.transaction_manager import TransactionManager
 from app.dependencies.injector import injector
 
 logger = logging.getLogger(__name__)
 
 
-class SessionCleanupMiddleware(BaseHTTPMiddleware):
-    """
-    Middleware that ensures database sessions are closed after each request.
-
-    This is necessary because fastapi-injector's enable_cleanup might not properly
-    handle async cleanup of AsyncSession.close(). This middleware explicitly closes
-    any sessions created during the request.
-    """
+class TransactionMiddleware(BaseHTTPMiddleware):
+    """Commit on success / roll back on error for the request-scoped session."""
 
     async def dispatch(self, request: Request, call_next):
-        """Process request and ensure session cleanup"""
         try:
-            # Process the request
             response = await call_next(request)
-            return response
-        finally:
-            # Always cleanup session, even if request failed
+        except Exception:
+            # Unhandled error escaped the endpoint -> discard all pending writes.
+            await self._rollback()
+            raise
+
+        # AppException & friends are already converted to an error Response by the
+        # inner ExceptionMiddleware, so decide by status code rather than exception.
+        if response.status_code < 400:
+            await self._commit()
+        else:
+            await self._rollback()
+        return response
+
+    async def _commit(self) -> None:
+        tx = self._get_transaction_manager()
+        if tx is not None:
             try:
-                # Try to get the session from the injector
-                # This will only work if a session was created in this request scope
-                try:
-                    session = injector.get(AsyncSession)
-                    if session:
-                        await session.close()
-                        logger.debug("Closed database session after request")
-                except Exception as e:  # pylint: disable=broad-except
-                    # Session might not exist or already closed - this is fine
-                    logger.debug(f"Session cleanup: {e}")
-            except Exception as e:  # pylint: disable=broad-except
-                # Injector might not have a session - this is fine
-                logger.debug(f"Could not cleanup session: {e}")
+                await tx.commit()
+            except Exception:  # pylint: disable=broad-except
+                # A failed commit must not leak a half-open transaction to the next
+                # user of this (pooled) connection.
+                await self._safe_rollback(tx)
+                raise
+
+    async def _rollback(self) -> None:
+        tx = self._get_transaction_manager()
+        if tx is not None:
+            await self._safe_rollback(tx)
+
+    @staticmethod
+    async def _safe_rollback(tx: TransactionManager) -> None:
+        try:
+            await tx.rollback()
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.debug(f"Transaction rollback skipped/failed: {exc}")
+
+    @staticmethod
+    def _get_transaction_manager() -> TransactionManager | None:
+        """Resolve the request-scoped TransactionManager, or None if unavailable.
+
+        Resolving this also resolves the request session; a session that never ran a
+        query holds no connection and no transaction, so commit/rollback are no-ops.
+        """
+        try:
+            return injector.get(TransactionManager)
+        except Exception as exc:  # pylint: disable=broad-except
+            # No active request scope / session (e.g. very early failures) - nothing to do.
+            logger.debug(f"No transaction manager for request: {exc}")
+            return None

--- a/backend/app/modules/workflow/agents/sub_agents/orchestrator.py
+++ b/backend/app/modules/workflow/agents/sub_agents/orchestrator.py
@@ -156,6 +156,11 @@ async def run_child_turn(
         input_data["session"] = canonical
 
     tenant = get_tenant_context()
+    from app.core.utils.db_connection_utils import (
+        commit_scope_session,
+        rollback_scope_session,
+    )
+
     factory = injector.get(RequestScopeFactory)
     async with factory.create_scope():
         set_tenant_context(tenant)
@@ -171,6 +176,13 @@ async def run_child_turn(
                 ),
                 timeout=timeout_seconds,
             )
+        except Exception:
+            # Repos only flush; roll back this child turn's writes on error.
+            await rollback_scope_session(context="orchestrator_child_turn")
+            raise
+        else:
+            # Commit this child turn's unit of work (no-op if nothing was written).
+            await commit_scope_session(context="orchestrator_child_turn")
         finally:
             try:
                 session = injector.get(AsyncSession)

--- a/backend/app/modules/workflow/engine/workflow_engine.py
+++ b/backend/app/modules/workflow/engine/workflow_engine.py
@@ -562,14 +562,27 @@ class WorkflowEngine:
                         next_node_id, state, visited_set
                     )
 
+                from app.core.utils.db_connection_utils import (
+                    commit_scope_session,
+                    rollback_scope_session,
+                )
+
                 request_scope_factory = injector.get(RequestScopeFactory)
                 async with request_scope_factory.create_scope():
                     # Preserve tenant context in the new scope
                     set_tenant_context(tenant)
                     try:
-                        return await self._execute_from_node_recursive(
+                        result = await self._execute_from_node_recursive(
                             next_node_id, state, visited_set
                         )
+                    except Exception:
+                        # Repos only flush; roll back this isolated scope's writes on error.
+                        await rollback_scope_session(context="workflow_node")
+                        raise
+                    else:
+                        # Commit this isolated scope's unit of work (no-op if nothing written).
+                        await commit_scope_session(context="workflow_node")
+                        return result
                     finally:
                         # Ensure any DI-created session is closed for this scope.
                         # (AsyncSession usually doesn't open a connection until first use, so this

--- a/backend/app/repositories/agent_response_log.py
+++ b/backend/app/repositories/agent_response_log.py
@@ -50,7 +50,8 @@ class AgentResponseLogRepository(DbRepository[AgentResponseLogModel]):
         async with self.db.begin_nested():
             self.db.add(entry)
             await self.db.flush()
-        await self.db.commit()
+        # The request/task transaction boundary owns the commit; the savepoint above
+        # has already flushed the row (and isolates the partial-unique-index conflict).
         await self.db.refresh(entry)
         return entry
 

--- a/backend/app/repositories/analytics_aggregation.py
+++ b/backend/app/repositories/analytics_aggregation.py
@@ -425,7 +425,7 @@ class AnalyticsAggregationRepository:
                 },
             )
             await self.db.execute(stmt)
-        await self.db.commit()
+        await self.db.flush()
 
     async def upsert_node_daily_stats(self, stats_list: list[dict]) -> None:
         """
@@ -481,4 +481,4 @@ class AnalyticsAggregationRepository:
                 },
             )
             await self.db.execute(stmt)
-        await self.db.commit()
+        await self.db.flush()

--- a/backend/app/repositories/api_keys.py
+++ b/backend/app/repositories/api_keys.py
@@ -80,7 +80,7 @@ class ApiKeysRepository(DbRepository[ApiKeyModel]):
         for role_id in api_key_create.role_ids:
             self.db.add(ApiKeyRoleModel(api_key_id=new_key.id, role_id=role_id))
 
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(new_key)
         return await self.get_by_id(new_key.id)
 
@@ -123,7 +123,7 @@ class ApiKeysRepository(DbRepository[ApiKeyModel]):
 
     async def delete(self, api_key: ApiKeyModel):
         await self.db.delete(api_key)
-        await self.db.commit()
+        await self.db.flush()
         return {"message": f"API key {api_key.id} deleted."}
 
 
@@ -160,7 +160,7 @@ class ApiKeysRepository(DbRepository[ApiKeyModel]):
         api_key.updated_by = user_id
 
         self.db.add(api_key)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(api_key)
         return api_key
 
@@ -211,7 +211,7 @@ class ApiKeysRepository(DbRepository[ApiKeyModel]):
         api_key.updated_by = user_id
 
         self.db.add(api_key)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(api_key)
         return await self.get_by_id(api_key_id)
 
@@ -222,4 +222,4 @@ class ApiKeysRepository(DbRepository[ApiKeyModel]):
                 .values(is_deleted=True)
                 .execution_options(synchronize_session="fetch")  # keep session in sync
                 )
-        await self.db.commit()
+        await self.db.flush()

--- a/backend/app/repositories/app_settings.py
+++ b/backend/app/repositories/app_settings.py
@@ -26,7 +26,7 @@ class AppSettingsRepository(DbRepository[AppSettingsModel]):
             is_active=dto.is_active,
         )
         self.db.add(obj)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(obj)
         return obj
 
@@ -57,7 +57,7 @@ class AppSettingsRepository(DbRepository[AppSettingsModel]):
             return None
         for field, val in dto.model_dump(exclude_unset=True).items():
             setattr(obj, field, val)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(obj)
         return obj
 
@@ -66,7 +66,7 @@ class AppSettingsRepository(DbRepository[AppSettingsModel]):
         if not obj:
             return False
         await self.db.delete(obj)
-        await self.db.commit()
+        await self.db.flush()
         return True
 
     async def get_all(self) -> List[AppSettingsModel]:

--- a/backend/app/repositories/audio_providers.py
+++ b/backend/app/repositories/audio_providers.py
@@ -16,7 +16,7 @@ class AudioProviderRepository(DbRepository[AudioProvidersModel]):
     async def create(self, data) -> AudioProvidersModel:
         obj = AudioProvidersModel(**data.model_dump())
         self.db.add(obj)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(obj)
         return obj
 
@@ -25,14 +25,14 @@ class AudioProviderRepository(DbRepository[AudioProvidersModel]):
 
     async def update(self, obj: AudioProvidersModel) -> AudioProvidersModel:
         self.db.add(obj)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(obj)
         return obj
 
     async def delete(self, obj: AudioProvidersModel):
         obj.is_deleted = 1
         self.db.add(obj)
-        await self.db.commit()
+        await self.db.flush()
 
     async def get_all(self):
         result = await self.db.execute(

--- a/backend/app/repositories/audit_logs.py
+++ b/backend/app/repositories/audit_logs.py
@@ -104,5 +104,5 @@ class AuditLogRepository(DbRepository[AuditLogModel]):
 
         stmt = delete(AuditLogModel).where(AuditLogModel.record_id.in_(record_ids))
         result = await self.db.execute(stmt)
-        await self.db.commit()
+        await self.db.flush()
         return int(result.rowcount or 0)

--- a/backend/app/repositories/bedrock_fine_tuning.py
+++ b/backend/app/repositories/bedrock_fine_tuning.py
@@ -55,7 +55,7 @@ class BedrockFineTuningRepository(DbRepository[BedrockFineTuningJobModel]):
             last_synced_at=utc_now(),
         )
         self.db.add(job_record)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(job_record)
         logger.info(f"Created Bedrock fine-tuning job record for {job_arn}")
         return job_record
@@ -105,7 +105,7 @@ class BedrockFineTuningRepository(DbRepository[BedrockFineTuningJobModel]):
         if error_message:
             job.error_message = error_message
 
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(job)
         logger.info(f"Updated Bedrock job {id} status to {status}")
         return job
@@ -127,7 +127,7 @@ class BedrockFineTuningRepository(DbRepository[BedrockFineTuningJobModel]):
         if failure_message:
             job.error_message = failure_message
 
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(job)
         logger.info(f"Updated Bedrock job {id} deployment to {deployment_status}")
         return job
@@ -145,7 +145,7 @@ class BedrockFineTuningRepository(DbRepository[BedrockFineTuningJobModel]):
         job.deployment_status = BedrockDeploymentStatus.NOT_DEPLOYED
         job.deployment_arn = None
 
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(job)
         logger.info(f"Cleared Bedrock job {id} deployment")
         return job
@@ -185,4 +185,4 @@ class BedrockFineTuningRepository(DbRepository[BedrockFineTuningJobModel]):
             .values(is_deleted=True)
             .execution_options(synchronize_session="fetch")
         )
-        await self.db.commit()
+        await self.db.flush()

--- a/backend/app/repositories/conversation_analysis.py
+++ b/backend/app/repositories/conversation_analysis.py
@@ -46,7 +46,7 @@ class ConversationAnalysisRepository(DbRepository[ConversationAnalysisModel]):
                     )
             self.db.add(analysis)
 
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(analysis)
         return analysis
 

--- a/backend/app/repositories/conversation_read_receipt.py
+++ b/backend/app/repositories/conversation_read_receipt.py
@@ -68,4 +68,4 @@ class ConversationReadReceiptRepository(DbRepository[ConversationReadReceiptMode
             )
         )
         await self.db.execute(stmt)
-        await self.db.commit()
+        await self.db.flush()

--- a/backend/app/repositories/conversations.py
+++ b/backend/app/repositories/conversations.py
@@ -80,7 +80,7 @@ class ConversationRepository(DbRepository[ConversationModel]):
             data["group_id"] = await self.resolve_group_id_for_operator(conversation_data.operator_id)
         new_conversation = ConversationModel(**data)
         self.db.add(new_conversation)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(new_conversation)
         return new_conversation
 
@@ -223,7 +223,7 @@ class ConversationRepository(DbRepository[ConversationModel]):
         Updates an existing conversation in DB
         """
         self.db.add(conversation)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(conversation)
         return conversation
 
@@ -250,7 +250,7 @@ class ConversationRepository(DbRepository[ConversationModel]):
             .values(custom_attributes=custom_attributes)
         )
         await self.db.execute(stmt)
-        await self.db.commit()
+        await self.db.flush()
 
     def _apply_base_filters(self, query, conversation_filter: ConversationFilter):
         """Apply all shared WHERE clauses so fetch and count stay in sync."""
@@ -570,7 +570,7 @@ class ConversationRepository(DbRepository[ConversationModel]):
 
     async def delete_conversation(self, conversation: ConversationModel):
         await self.db.delete(conversation)
-        await self.db.commit()
+        await self.db.flush()
 
     async def get_topics_count(self) -> List[Tuple[str, int]]:
         """
@@ -609,7 +609,7 @@ class ConversationRepository(DbRepository[ConversationModel]):
         if not conv:
             return None
         conv.zendesk_ticket_id = zendesk_ticket_id
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(conv)
         return conv
 

--- a/backend/app/repositories/customers.py
+++ b/backend/app/repositories/customers.py
@@ -35,7 +35,7 @@ class CustomersRepository(DbRepository[CustomerModel]):
             source_ref=customer_create.source_ref,
         )
         self.db.add(new_customer)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(new_customer)
         return new_customer
 
@@ -72,7 +72,7 @@ class CustomersRepository(DbRepository[CustomerModel]):
             customer.source_ref = data.source_ref
 
         self.db.add(customer)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(customer)
         return customer
 
@@ -83,4 +83,4 @@ class CustomersRepository(DbRepository[CustomerModel]):
             .values(is_deleted=True)
             .execution_options(synchronize_session="fetch")
         )
-        await self.db.commit()
+        await self.db.flush()

--- a/backend/app/repositories/datasources.py
+++ b/backend/app/repositories/datasources.py
@@ -27,7 +27,7 @@ class DataSourcesRepository(DbRepository[DataSourceModel]):
             is_active=datasource_data.is_active,
         )
         self.db.add(new_datasource)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(new_datasource)
         return new_datasource
 
@@ -59,7 +59,7 @@ class DataSourcesRepository(DbRepository[DataSourceModel]):
             setattr(datasource, key, value)
         
         datasource.updated_by = context.get("user_id")
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(datasource)
         return datasource
 
@@ -67,7 +67,7 @@ class DataSourcesRepository(DbRepository[DataSourceModel]):
         """Delete a datasource."""
         datasource = await self.get_by_id(datasource_id)
         await self.db.delete(datasource)
-        await self.db.commit()
+        await self.db.flush()
 
     async def get_active(self) -> List[DataSourceModel]:
         """Fetch all active datasources."""

--- a/backend/app/repositories/db_repository.py
+++ b/backend/app/repositories/db_repository.py
@@ -158,7 +158,7 @@ class DbRepository(Generic[OrmModelT]):
     # ---------- WRITE ----------
     async def create(self, obj: OrmModelT) -> OrmModelT:
         self.db.add(obj)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(obj)
         return obj
 
@@ -166,24 +166,28 @@ class DbRepository(Generic[OrmModelT]):
     async def update(self, obj: OrmModelT) -> OrmModelT:
         """
         Accepts a *managed* ORM object whose attributes have already been
-        mutated by the caller.  Flush/commit & refresh are done here.
+        mutated by the caller. Flush & refresh are done here; the commit is
+        owned by the request/task transaction boundary.
         """
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(obj)
         return obj
 
 
     async def delete(self, obj: OrmModelT) -> None:
         await self.db.delete(obj)
-        await self.db.commit()
+        await self.db.flush()
 
     async def soft_delete(self, obj: OrmModelT, commit: bool = True) -> None:
-        """Skip the commit to batch this delete with later writes."""
+        """
+        Mark the row deleted. The ``commit`` flag is retained for backward
+        compatibility but no longer commits — the transaction boundary owns that.
+        The Core UPDATE below is emitted to the current transaction immediately.
+        """
         await self.db.execute(
                 update(obj.__class__)
                 .where(obj.__class__.id == obj.id)
                 .values(is_deleted=1)
                 .execution_options(synchronize_session="fetch")
                 )
-        if commit:
-            await self.db.commit()
+        await self.db.flush()

--- a/backend/app/repositories/fallback_chains.py
+++ b/backend/app/repositories/fallback_chains.py
@@ -16,7 +16,7 @@ class FallbackChainRepository(DbRepository[FallbackChainModel]):
     async def create(self, data):
         obj = FallbackChainModel(**data)
         self.db.add(obj)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(obj)
         return obj
 
@@ -25,7 +25,7 @@ class FallbackChainRepository(DbRepository[FallbackChainModel]):
 
     async def update(self, obj: FallbackChainModel):
         self.db.add(obj)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(obj)
         return obj
 

--- a/backend/app/repositories/feature_flag.py
+++ b/backend/app/repositories/feature_flag.py
@@ -15,7 +15,7 @@ class FeatureFlagRepository(DbRepository[FeatureFlagModel]):
     async def create(self, dto: FeatureFlagCreate) -> FeatureFlagModel:
         obj = FeatureFlagModel(**dto.model_dump())
         self.db.add(obj)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(obj)
         return obj
 
@@ -34,7 +34,7 @@ class FeatureFlagRepository(DbRepository[FeatureFlagModel]):
             return None
         for field, val in dto.model_dump(exclude_unset=True).items():
             setattr(obj, field, val)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(obj)
         return obj
 
@@ -43,5 +43,5 @@ class FeatureFlagRepository(DbRepository[FeatureFlagModel]):
         if not obj:
             return False
         await self.db.delete(obj)
-        await self.db.commit()
+        await self.db.flush()
         return True

--- a/backend/app/repositories/file_manager.py
+++ b/backend/app/repositories/file_manager.py
@@ -43,7 +43,7 @@ class FileManagerRepository(DbRepository[FileModel]):
 
         # avoid null values when creating the file
         self.db.add(new_file)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(new_file)
         return new_file
 
@@ -118,7 +118,7 @@ class FileManagerRepository(DbRepository[FileModel]):
             setattr(file, key, value)
         
         file.updated_by = context.get("user_id")
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(file)
         
         # Invalidate cache (safe for Redis Cluster: Lua scripts without keys not supported)
@@ -137,7 +137,7 @@ class FileManagerRepository(DbRepository[FileModel]):
         file = await self.get_file_by_id(file_id)
         file.is_deleted = 1
         file.updated_by = context.get("user_id")
-        await self.db.commit()
+        await self.db.flush()
         
         # Invalidate cache (safe for Redis Cluster: Lua scripts without keys not supported)
         cache_key = f"file_manager:file:{file_id}"

--- a/backend/app/repositories/fine_tuning_event.py
+++ b/backend/app/repositories/fine_tuning_event.py
@@ -102,7 +102,7 @@ class FineTuningEventRepository(DbRepository[FineTuningEventModel]):
             List of created events
         """
         self.db.add_all(events)
-        await self.db.commit()
+        await self.db.flush()
 
         for event in events:
             await self.db.refresh(event)

--- a/backend/app/repositories/llm_analysts.py
+++ b/backend/app/repositories/llm_analysts.py
@@ -16,7 +16,7 @@ class LlmAnalystRepository(DbRepository[LlmAnalystModel]):
     async def create(self, data: LlmAnalystCreate) -> LlmAnalystModel:
         obj = LlmAnalystModel(**data.model_dump())
         self.db.add(obj)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(obj)
         return obj
 
@@ -36,7 +36,7 @@ class LlmAnalystRepository(DbRepository[LlmAnalystModel]):
     async def update(self, obj: LlmAnalystModel):
         obj.updated_by = context["user_id"]
         self.db.add(obj)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(obj)
         return obj
 

--- a/backend/app/repositories/llm_cost_rates.py
+++ b/backend/app/repositories/llm_cost_rates.py
@@ -20,10 +20,12 @@ class LlmCostRateRepository(DbRepository[LlmCostRateModel]):
         super().__init__(LlmCostRateModel, db)
 
     async def create(self, obj: LlmCostRateModel) -> LlmCostRateModel:
+        # SAVEPOINT so a duplicate only rolls back this insert, not the whole
+        # request/task transaction (repos no longer own the commit boundary).
         try:
-            return await super().create(obj)
+            async with self.db.begin_nested():
+                return await super().create(obj)
         except IntegrityError as e:
-            await self.db.rollback()
             logger.warning("Duplicate active LLM cost rate rejected by the database: %s", e)
             raise AppException(error_key=ErrorKey.LLM_COST_RATE_ALREADY_EXISTS, status_code=409) from e
 
@@ -71,5 +73,5 @@ class LlmCostRateRepository(DbRepository[LlmCostRateModel]):
         if not row:
             return False
         row.is_deleted = 1
-        await self.db.commit()
+        await self.db.flush()
         return True

--- a/backend/app/repositories/llm_providers.py
+++ b/backend/app/repositories/llm_providers.py
@@ -13,7 +13,7 @@ class LlmProviderRepository(DbRepository[LlmProvidersModel]):
     async def create(self, data):
         obj = LlmProvidersModel(**data.model_dump())
         self.db.add(obj)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(obj)
         return obj
 
@@ -22,7 +22,7 @@ class LlmProviderRepository(DbRepository[LlmProvidersModel]):
 
     async def update(self, obj: LlmProvidersModel):
         self.db.add(obj)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(obj)
         return obj
 

--- a/backend/app/repositories/llm_usage_backfill.py
+++ b/backend/app/repositories/llm_usage_backfill.py
@@ -108,7 +108,7 @@ class LlmUsageBackfillRepository(DbRepository[LlmUsageEventModel]):
         else:
             stmt = stmt.on_conflict_do_nothing(constraint="uq_llm_usage_events_execution_call")
         result = await self.db.execute(stmt)
-        await self.db.commit()
+        await self.db.flush()
         return result.rowcount or 0
 
     async def legacy_event_aggregates(self) -> tuple[int, int, int, int, Decimal]:

--- a/backend/app/repositories/llm_usage_control.py
+++ b/backend/app/repositories/llm_usage_control.py
@@ -33,5 +33,5 @@ class LlmUsageControlRepository(DbRepository[LlmUsageControlModel]):
                 capture_started_at=func.coalesce(LlmUsageControlModel.capture_started_at, func.now()),
             )
         )
-        await self.db.commit()
+        await self.db.flush()
         return await self.get_singleton()

--- a/backend/app/repositories/mcp_server.py
+++ b/backend/app/repositories/mcp_server.py
@@ -53,7 +53,7 @@ class MCPServerRepository(DbRepository[MCPServerModel]):
                 )
                 self.db.add(workflow)
 
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(mcp_server)
         return await self.get_by_id(mcp_server.id)
 
@@ -199,7 +199,7 @@ class MCPServerRepository(DbRepository[MCPServerModel]):
                         )
                     )
 
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(mcp_server)
         return await self.get_by_id(mcp_server_id, user_id)
 
@@ -209,6 +209,6 @@ class MCPServerRepository(DbRepository[MCPServerModel]):
         if not mcp_server:
             return False
         mcp_server.is_deleted = 1
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(mcp_server)
         return True

--- a/backend/app/repositories/ml_model_pipeline.py
+++ b/backend/app/repositories/ml_model_pipeline.py
@@ -45,12 +45,12 @@ class MLModelPipelineConfigRepository(DbRepository[MLModelPipelineConfig]):
                 is_default=config_data.is_default,
                 cron_schedule=config_data.cron_schedule,
             )
-            self.db.add(new_config)
-            await self.db.commit()
+            async with self.db.begin_nested():
+                self.db.add(new_config)
+                await self.db.flush()
             await self.db.refresh(new_config)
             return new_config
         except IntegrityError as e:
-            await self.db.rollback()
             logger.error(f"IntegrityError while creating pipeline config: {str(e)}")
             raise AppException(
                 error_key=ErrorKey.INTERNAL_ERROR
@@ -118,11 +118,11 @@ class MLModelPipelineConfigRepository(DbRepository[MLModelPipelineConfig]):
                 # Context not available (e.g., in background tasks)
                 pass
 
-            await self.db.commit()
+            async with self.db.begin_nested():
+                await self.db.flush()
             await self.db.refresh(config)
             return config
         except IntegrityError as e:
-            await self.db.rollback()
             logger.error(f"IntegrityError while updating pipeline config: {str(e)}")
             raise AppException(
                 error_key=ErrorKey.INTERNAL_ERROR
@@ -132,7 +132,7 @@ class MLModelPipelineConfigRepository(DbRepository[MLModelPipelineConfig]):
         """Soft delete a pipeline configuration."""
         config = await self.get_by_id(config_id)
         config.is_deleted = 1
-        await self.db.commit()
+        await self.db.flush()
         return config
 
     async def unset_default_for_model(self, model_id: UUID, exclude_config_id: Optional[UUID] = None):
@@ -152,7 +152,7 @@ class MLModelPipelineConfigRepository(DbRepository[MLModelPipelineConfig]):
         configs = result.scalars().all()
         for config in configs:
             config.is_default = False
-        await self.db.commit()
+        await self.db.flush()
 
 
 @inject
@@ -171,12 +171,12 @@ class MLModelPipelineRunRepository(DbRepository[MLModelPipelineRun]):
                 workflow_id=run_data.workflow_id,
                 status=PipelineRunStatus.PENDING,
             )
-            self.db.add(new_run)
-            await self.db.commit()
+            async with self.db.begin_nested():
+                self.db.add(new_run)
+                await self.db.flush()
             await self.db.refresh(new_run)
             return new_run
         except IntegrityError as e:
-            await self.db.rollback()
             logger.error(f"IntegrityError while creating pipeline run: {str(e)}")
             raise AppException(
                 error_key=ErrorKey.INTERNAL_ERROR
@@ -265,7 +265,7 @@ class MLModelPipelineRunRepository(DbRepository[MLModelPipelineRun]):
             # Context not available (e.g., in background tasks)
             pass
 
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(run)
         return run
 
@@ -287,12 +287,12 @@ class MLModelPipelineArtifactRepository(DbRepository[MLModelPipelineArtifact]):
                 artifact_name=artifact_data.artifact_name,
                 file_size=artifact_data.file_size,
             )
-            self.db.add(new_artifact)
-            await self.db.commit()
+            async with self.db.begin_nested():
+                self.db.add(new_artifact)
+                await self.db.flush()
             await self.db.refresh(new_artifact)
             return new_artifact
         except IntegrityError as e:
-            await self.db.rollback()
             logger.error(f"IntegrityError while creating pipeline artifact: {str(e)}")
             raise AppException(
                 error_key=ErrorKey.INTERNAL_ERROR

--- a/backend/app/repositories/ml_models.py
+++ b/backend/app/repositories/ml_models.py
@@ -35,12 +35,12 @@ class MLModelsRepository(DbRepository[MLModel]):
                 target_variable=ml_model_data.target_variable,
                 inference_params=ml_model_data.inference_params,
             )
-            self.db.add(new_ml_model)
-            await self.db.commit()
+            async with self.db.begin_nested():
+                self.db.add(new_ml_model)
+                await self.db.flush()
             await self.db.refresh(new_ml_model)
             return new_ml_model
         except IntegrityError as e:
-            await self.db.rollback()
             logger.error(f"IntegrityError while creating ML model: {str(e)}")
             raise AppException(
                 error_key=ErrorKey.ML_MODEL_NAME_EXISTS
@@ -95,11 +95,11 @@ class MLModelsRepository(DbRepository[MLModel]):
                 # Context not available, skip updating updated_by
                 pass
 
-            await self.db.commit()
+            async with self.db.begin_nested():
+                await self.db.flush()
             await self.db.refresh(ml_model)
             return ml_model
         except IntegrityError as e:
-            await self.db.rollback()
             logger.error(f"IntegrityError while updating ML model: {str(e)}")
             raise AppException(
                 error_key=ErrorKey.ML_MODEL_NAME_EXISTS
@@ -109,7 +109,7 @@ class MLModelsRepository(DbRepository[MLModel]):
         """Soft delete an ML model."""
         ml_model = await self.get_by_id(ml_model_id)
         ml_model.is_deleted = 1
-        await self.db.commit()
+        await self.db.flush()
         return ml_model
 
 

--- a/backend/app/repositories/notification.py
+++ b/backend/app/repositories/notification.py
@@ -49,7 +49,7 @@ class NotificationRepository:
                 )
                 self.db.add(row)
                 by_key[key] = row
-            await self.db.commit()
+            await self.db.flush()
             for row in by_key.values():
                 await self.db.refresh(row)
 
@@ -82,7 +82,7 @@ class NotificationRepository:
         )
         current[type_key] = bool(is_enabled)
         user.notification_settings = current
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(user)
         return {str(k): bool(v) for k, v in current.items()}
 
@@ -90,7 +90,7 @@ class NotificationRepository:
         self, notification_type: NotificationTypeModel, is_enabled: bool
     ) -> NotificationTypeModel:
         notification_type.is_enabled = is_enabled
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(notification_type)
         return notification_type
 
@@ -247,7 +247,7 @@ class NotificationRepository:
                 )
             )
 
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(nt)
         users_map, groups_map = await self._recipients_by_type_id([nt.id])
         return nt, users_map.get(nt.id, set()), groups_map.get(nt.id, set())

--- a/backend/app/repositories/openai_fine_tuning.py
+++ b/backend/app/repositories/openai_fine_tuning.py
@@ -41,7 +41,7 @@ class FineTuningRepository(DbRepository[FineTuningJobModel]):
                 bytes=bytes,
                 )
         self.db.add(file_record)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(file_record)
         logger.info(f"Created file record for OpenAI file {openai_file_id}")
         return file_record
@@ -94,7 +94,7 @@ class FineTuningRepository(DbRepository[FineTuningJobModel]):
                 last_synced_at=utc_now()
                 )
         self.db.add(job_record)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(job_record)
         logger.info(f"Created job record for OpenAI job {openai_job_id}")
         return job_record
@@ -153,7 +153,7 @@ class FineTuningRepository(DbRepository[FineTuningJobModel]):
         if error_code:
             job.error_code = error_code
 
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(job)
         logger.info(f"Updated job {id} status to {status}")
         return job
@@ -228,4 +228,4 @@ class FineTuningRepository(DbRepository[FineTuningJobModel]):
                 .values(is_deleted=True)
                 .execution_options(synchronize_session="fetch")  # keep session in sync
                 )
-        await self.db.commit()
+        await self.db.flush()

--- a/backend/app/repositories/operator_statistics.py
+++ b/backend/app/repositories/operator_statistics.py
@@ -24,7 +24,7 @@ class OperatorStatisticsRepository(DbRepository[OperatorStatisticsModel]):
     async def create(self, operator_id: UUID):
         new_stats = OperatorStatisticsModel(id=operator_id)
         self.db.add(new_stats)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(new_stats)
         return new_stats
 
@@ -42,4 +42,4 @@ class OperatorStatisticsRepository(DbRepository[OperatorStatisticsModel]):
                 .where(OperatorStatisticsModel.id == statistics_id)
                 .values(**kwargs)
                 )
-        await self.db.commit()
+        await self.db.flush()

--- a/backend/app/repositories/operators.py
+++ b/backend/app/repositories/operators.py
@@ -25,12 +25,12 @@ class OperatorRepository(DbRepository[OperatorModel]):
 
     async def create(self, operator: OperatorModel) -> OperatorModel:
         self.db.add(operator)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(operator, ["operator_statistics", "user"])
         return operator
         # async with self.session_factory() as session:
         #     session.add(operator)
-        #     await session.commit()
+        #     await session.flush()
         #     await session.refresh(operator, ["operator_statistics", "user"])
         #     return operator
 

--- a/backend/app/repositories/recordings.py
+++ b/backend/app/repositories/recordings.py
@@ -123,7 +123,7 @@ class RecordingsRepository(DbRepository[RecordingModel]):
                 )
 
         self.db.add(new_recording)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(new_recording)  #  Reload object with DB-assigned values
 
         return new_recording
@@ -263,7 +263,7 @@ class RecordingsRepository(DbRepository[RecordingModel]):
 
     async def delete_recording(self, recording: RecordingModel) -> None:
         await self.db.delete(recording)
-        await self.db.commit()
+        await self.db.flush()
 
     async def recording_exists(self , original_filename: str ,data_source_id: UUID):
         stmt = select(RecordingModel).where(

--- a/backend/app/repositories/role_permissions.py
+++ b/backend/app/repositories/role_permissions.py
@@ -30,8 +30,6 @@ class RolePermissionsRepository(DbRepository[RolePermissionModel]):
         )
         self.db.add(rp)
         await self.db.flush()
-
-        await self.db.commit()
         await self.db.refresh(rp)
         return rp
 
@@ -52,7 +50,7 @@ class RolePermissionsRepository(DbRepository[RolePermissionModel]):
             rp.permission_id = data.permission_id
 
         self.db.add(rp)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(rp)
         return rp
 

--- a/backend/app/repositories/support_ticket.py
+++ b/backend/app/repositories/support_ticket.py
@@ -141,7 +141,7 @@ class SupportTicketRepository(DbRepository[SupportTicketModel]):
         return result.scalars().first()
 
     async def save(self, ticket: SupportTicketModel) -> SupportTicketModel:
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(ticket)
         return ticket
 
@@ -160,7 +160,7 @@ class SupportTicketRepository(DbRepository[SupportTicketModel]):
             actor_user_id=actor_user_id,
         )
         self.db.add(event)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(event)
         return event
 
@@ -173,7 +173,7 @@ class SupportTicketRepository(DbRepository[SupportTicketModel]):
             body=body,
         )
         self.db.add(comment)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(comment)
         return comment
 
@@ -206,7 +206,7 @@ class SupportTicketRepository(DbRepository[SupportTicketModel]):
             row.payload = payload
             row.status = "pending"
             row.last_error = None
-            await self.db.commit()
+            await self.db.flush()
             await self.db.refresh(row)
             return row
 
@@ -217,7 +217,7 @@ class SupportTicketRepository(DbRepository[SupportTicketModel]):
             status="pending",
         )
         self.db.add(outbox)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(outbox)
         return outbox
 
@@ -255,6 +255,6 @@ class SupportTicketRepository(DbRepository[SupportTicketModel]):
         if not ticket:
             return None
         ticket.vote_count = (ticket.vote_count or 1) + 1
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(ticket)
         return ticket

--- a/backend/app/repositories/template.py
+++ b/backend/app/repositories/template.py
@@ -63,7 +63,7 @@ class TemplateRepository(DbRepository[TemplateModel]):
             .where(TemplateModel.id == template_id)
             .values(install_count=TemplateModel.install_count + 1)
         )
-        await self.db.commit()
+        await self.db.flush()
 
     async def find_published(
         self, source_template_id: UUID, statuses: Iterable[TemplateStatus]

--- a/backend/app/repositories/test_suite.py
+++ b/backend/app/repositories/test_suite.py
@@ -44,7 +44,7 @@ class TestCaseRepository(DbRepository[TestCaseModel]):
         await self.db.execute(
             delete(TestCaseModel).where(TestCaseModel.suite_id == str(suite_id))
         )
-        await self.db.commit()
+        await self.db.flush()
 
     async def soft_delete_all_for_suite(
         self, suite_id: UUID, commit: bool = True
@@ -57,7 +57,7 @@ class TestCaseRepository(DbRepository[TestCaseModel]):
             .execution_options(synchronize_session="fetch")
         )
         if commit:
-            await self.db.commit()
+            await self.db.flush()
 
     async def soft_delete_for_conversation(
         self, suite_id: UUID, conversation_id: UUID, commit: bool = True
@@ -74,12 +74,12 @@ class TestCaseRepository(DbRepository[TestCaseModel]):
             .execution_options(synchronize_session="fetch")
         )
         if commit:
-            await self.db.commit()
+            await self.db.flush()
 
     async def create_many(self, cases: List[TestCaseModel]) -> List[TestCaseModel]:
         """Insert cases in a single transaction so a partial import cannot persist."""
         self.db.add_all(cases)
-        await self.db.commit()
+        await self.db.flush()
         for case in cases:
             await self.db.refresh(case)
         return cases
@@ -111,7 +111,7 @@ class TestRunRepository(DbRepository[TestRunModel]):
             .values(is_deleted=1)
             .execution_options(synchronize_session="fetch")
         )
-        await self.db.commit()
+        await self.db.flush()
 
     async def mark_stuck_as_failed(
         self,
@@ -142,7 +142,7 @@ class TestRunRepository(DbRepository[TestRunModel]):
             .execution_options(synchronize_session=False)
         )
         result = await self.db.execute(stmt)
-        await self.db.commit()
+        await self.db.flush()
         return result.rowcount or 0
 
 
@@ -176,7 +176,7 @@ class TestToolRuleResultRepository(DbRepository[TestToolRuleResultModel]):
         if not results:
             return []
         self.db.add_all(results)
-        await self.db.commit()
+        await self.db.flush()
         return results
 
     async def get_all_for_run(self, run_id: UUID) -> List[TestToolRuleResultModel]:

--- a/backend/app/repositories/transcript_message.py
+++ b/backend/app/repositories/transcript_message.py
@@ -32,7 +32,7 @@ class TranscriptMessageRepository(DbRepository[TranscriptMessageModel]):
     async def save_messages(self, messages: List[TranscriptMessageModel]) -> List[TranscriptMessageModel]:
         """Save multiple transcript messages"""
         self.db.add_all(messages)
-        await self.db.commit()
+        await self.db.flush()
         for msg in messages:
             await self.db.refresh(msg)
         return messages
@@ -109,7 +109,7 @@ class TranscriptMessageRepository(DbRepository[TranscriptMessageModel]):
             if transcript_feedback.feedback_message is not None:
                 existing_feedback.feedback_message = transcript_feedback.feedback_message
             existing_feedback.feedback_timestamp = datetime.now(timezone.utc)
-            await self.db.commit()
+            await self.db.flush()
             await self.db.refresh(existing_feedback)
             return existing_feedback, previous_feedback
         else:
@@ -125,7 +125,7 @@ class TranscriptMessageRepository(DbRepository[TranscriptMessageModel]):
                     feedback_message=transcript_feedback.feedback_message
                     )
             self.db.add(new_feedback)
-            await self.db.commit()
+            await self.db.flush()
             await self.db.refresh(new_feedback)
             return new_feedback, None
 
@@ -149,7 +149,7 @@ class TranscriptMessageRepository(DbRepository[TranscriptMessageModel]):
         messages = await self.get_messages_by_conversation_id(conversation_id)
         for message in messages:
             await self.db.delete(message)
-        await self.db.commit()
+        await self.db.flush()
 
 
     async def get_messages_by_type(
@@ -332,6 +332,6 @@ class TranscriptMessageRepository(DbRepository[TranscriptMessageModel]):
                     )
             self.db.add(issue)
 
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(issue)
         return issue

--- a/backend/app/repositories/translations.py
+++ b/backend/app/repositories/translations.py
@@ -46,7 +46,7 @@ class LanguagesRepository(DbRepository[LanguageModel]):
     async def create(self, code: str, name: str) -> LanguageModel:
         obj = LanguageModel(code=code, name=name)
         self.db.add(obj)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(obj)
         return obj
 
@@ -55,7 +55,7 @@ class LanguagesRepository(DbRepository[LanguageModel]):
             model.name = dto.name
         if dto.is_active is not None:
             model.is_active = dto.is_active
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(model)
         return model
 
@@ -66,13 +66,13 @@ class LanguagesRepository(DbRepository[LanguageModel]):
                 TranslationValueModel.language_id == model.id
             )
         )
-        await self.db.commit()
+        await self.db.flush()
 
     async def restore(self, model: LanguageModel, name: str) -> LanguageModel:
         model.is_deleted = 0
         model.is_active = True
         model.name = name
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(model)
         return model
 
@@ -130,7 +130,7 @@ class TranslationsRepository(DbRepository[TranslationKeyModel]):
                     TranslationValueModel(language_id=lang_id, value=value)
                 )
         self.db.add(obj)
-        await self.db.commit()
+        await self.db.flush()
         # Re-fetch with eager loading to populate language relationships
         return await self.get_by_key(dto.key)  # type: ignore[return-value]
 
@@ -165,7 +165,7 @@ class TranslationsRepository(DbRepository[TranslationKeyModel]):
                     # Empty string means remove this translation
                     await self.db.delete(existing_val)
 
-        await self.db.commit()
+        await self.db.flush()
         return await self.get_by_key(key)
 
     async def delete_by_key(self, key: str) -> bool:
@@ -173,5 +173,5 @@ class TranslationsRepository(DbRepository[TranslationKeyModel]):
         if not obj:
             return False
         await self.db.delete(obj)
-        await self.db.commit()
+        await self.db.flush()
         return True

--- a/backend/app/repositories/user_groups.py
+++ b/backend/app/repositories/user_groups.py
@@ -44,7 +44,7 @@ class UserGroupRepository(DbRepository[UserGroupModel]):
         """Assign the user as a supervisor of the group and persist it."""
         link = UserSupervisedGroupModel(group_id=group_id, user_id=user_id)
         self.db.add(link)
-        await self.db.commit()
+        await self.db.flush()
         return link
 
     async def remove_supervisor(self, group_id: UUID, user_id: UUID) -> None:
@@ -55,7 +55,7 @@ class UserGroupRepository(DbRepository[UserGroupModel]):
                 UserSupervisedGroupModel.user_id == user_id,
             )
         )
-        await self.db.commit()
+        await self.db.flush()
 
     async def get_supervisor_user_ids(self, group_id: UUID) -> List[UUID]:
         """Return the user IDs of all supervisors of the group."""

--- a/backend/app/repositories/user_types.py
+++ b/backend/app/repositories/user_types.py
@@ -18,7 +18,7 @@ class UserTypesRepository(DbRepository[UserTypeModel]):
                 name=user_type.name,
                 )
         self.db.add(new_user_type)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(new_user_type)
         return new_user_type
 
@@ -29,7 +29,7 @@ class UserTypesRepository(DbRepository[UserTypeModel]):
 
     async def update(self, user_type: UserTypeModel):
         self.db.add(user_type)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(user_type)
         return user_type
 

--- a/backend/app/repositories/users.py
+++ b/backend/app/repositories/users.py
@@ -64,7 +64,7 @@ class UserRepository(DbRepository[UserModel]):
             user_role = UserRoleModel(user_id=new_user.id, role_id=role_id)
             self.db.add(user_role)
 
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(new_user)
         return new_user
 
@@ -151,7 +151,7 @@ class UserRepository(DbRepository[UserModel]):
             .values(entra_oid=entra_oid)
         )
         result = await self.db.execute(stmt)
-        await self.db.commit()
+        await self.db.flush()
         if result.rowcount:
             await self._clear_user_full_cache(user_id)
 
@@ -188,10 +188,12 @@ class UserRepository(DbRepository[UserModel]):
         for role_id in role_ids:
             self.db.add(UserRoleModel(user_id=new_user.id, role_id=role_id))
         try:
-            await self.db.commit()
+            # SAVEPOINT so a role-assignment conflict rolls back only these inserts,
+            # not the whole request transaction (the boundary owns the commit).
+            async with self.db.begin_nested():
+                await self.db.flush()
             await self.db.refresh(new_user)
         except IntegrityError as err:
-            await self.db.rollback()
             logger.warning("create_from_microsoft_sso integrity error: %s", err)
             raise AppException(error_key=ErrorKey.SSO_MICROSOFT_OAUTH_ERROR, status_code=409) from None
         return new_user
@@ -262,7 +264,7 @@ class UserRepository(DbRepository[UserModel]):
                     raise AppException(error_key=ErrorKey.ROLE_NOT_FOUND)
                 self.db.add(UserRoleModel(user_id=user.id, role_id=role_id))
 
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(user)
 
         await self._clear_user_full_cache(user_id)
@@ -284,7 +286,7 @@ class UserRepository(DbRepository[UserModel]):
             .values(is_deleted=1)
         )
         result = await self.db.execute(stmt)
-        await self.db.commit()
+        await self.db.flush()
         if result.rowcount:
             await self._clear_user_full_cache(user_id)
             return True
@@ -297,7 +299,7 @@ class UserRepository(DbRepository[UserModel]):
             .values(is_deleted=0)
         )
         result = await self.db.execute(stmt)
-        await self.db.commit()
+        await self.db.flush()
         if result.rowcount:
             await self._clear_user_full_cache(user_id)
             return True
@@ -311,4 +313,4 @@ class UserRepository(DbRepository[UserModel]):
             .values(hashed_password=new_hashed, force_upd_pass_date=next_update_date)
         )
         await self.db.execute(stmt)
-        await self.db.commit()
+        await self.db.flush()

--- a/backend/app/repositories/webhook_repository.py
+++ b/backend/app/repositories/webhook_repository.py
@@ -40,7 +40,7 @@ class WebhookRepository(DbRepository[WebhookModel]):
             webhook.id = webhook_id
 
         self.db.add(webhook)
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(webhook)
         return webhook
 
@@ -88,7 +88,7 @@ class WebhookRepository(DbRepository[WebhookModel]):
             clean_value = str(value) if isinstance(value, (HttpUrl, UUID)) else value
             setattr(webhook, key, clean_value)
 
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(webhook)
         return webhook
 
@@ -99,6 +99,6 @@ class WebhookRepository(DbRepository[WebhookModel]):
             return False
         webhook.is_deleted = 1
         # await self.db.delete(webhook) # Only Soft Delete
-        await self.db.commit()
+        await self.db.flush()
         await self.db.refresh(webhook)
         return True

--- a/backend/app/repositories/workflow.py
+++ b/backend/app/repositories/workflow.py
@@ -60,7 +60,7 @@ class WorkflowRepository(DbRepository[WorkflowModel]):
             .execution_options(synchronize_session="fetch")
         )
         if commit:
-            await self.db.commit()
+            await self.db.flush()
 
     async def get_summaries_by_agent(self, agent_id: UUID) -> List:
         stmt = (

--- a/backend/app/repositories/workflow_schedule_run.py
+++ b/backend/app/repositories/workflow_schedule_run.py
@@ -171,5 +171,5 @@ class WorkflowScheduleRunRepository(DbRepository[WorkflowScheduleRunModel]):
             .execution_options(synchronize_session=False)
         )
         result = await self.db.execute(stmt)
-        await self.db.commit()
+        await self.db.flush()
         return result.rowcount or 0

--- a/backend/app/services/template.py
+++ b/backend/app/services/template.py
@@ -63,7 +63,14 @@ class TemplateService:
         """
         factory = multi_tenant_manager.get_tenant_session_factory("master")
         async with factory() as session:
-            yield TemplateRepository(session)
+            # This is an out-of-band master session, not the request-scoped one, so
+            # it owns its own commit/rollback (repositories only flush now).
+            try:
+                yield TemplateRepository(session)
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
 
     @staticmethod
     def _to_item(

--- a/backend/app/tasks/base.py
+++ b/backend/app/tasks/base.py
@@ -115,10 +115,23 @@ def create_task_wrapper(task_func: Callable[..., Awaitable[Any]]) -> Callable:
         
         request_scope_factory = injector.get(RequestScopeFactory)
         
+        from app.core.utils.db_connection_utils import (
+            commit_scope_session,
+            rollback_scope_session,
+        )
+
         async with request_scope_factory.create_scope():
             try:
                 # Call the actual task function with the provided kwargs
-                return await task_func(**kwargs)
+                result = await task_func(**kwargs)
+            except Exception:
+                # Repos only flush; roll back this task's pending writes on error.
+                await rollback_scope_session(context="celery_task")
+                raise
+            else:
+                # Commit the task's unit of work (no-op if nothing was written).
+                await commit_scope_session(context="celery_task")
+                return result
             finally:
                 # Ensure any sessions created via DI are closed
                 try:

--- a/backend/app/tasks/ml_model_pipeline_tasks.py
+++ b/backend/app/tasks/ml_model_pipeline_tasks.py
@@ -118,6 +118,9 @@ async def execute_pipeline_run_async(run_id: UUID):
 
                 # Update status to running
                 await run_repository.update_status(run_id, PipelineRunStatus.RUNNING)
+                # Commit the RUNNING marker so it is visible during the long run
+                # below (repos only flush now; this session owns its commit).
+                await session.commit()
 
                 # Get workflow
                 workflow = await workflow_repository.get_by_id(run.workflow_id)
@@ -181,6 +184,8 @@ async def execute_pipeline_run_async(run_id: UUID):
                     execution_output=execution_output,
                     execution_id=UUID(state.execution_id) if state.execution_id else None,
                 )
+                # Persist artifacts + completed status for this run.
+                await session.commit()
 
                 logger.info(f"Pipeline run {run_id} completed successfully")
 
@@ -192,9 +197,12 @@ async def execute_pipeline_run_async(run_id: UUID):
                 # Update run status to failed
                 # Skip if run doesn't exist in this tenant's database
                 try:
+                    # Clear any failed-transaction state before writing FAILED.
+                    await session.rollback()
                     await run_repository.update_status(
                         run_id, PipelineRunStatus.FAILED, error_message=str(e)
                     )
+                    await session.commit()
                     socket_connection_manager = injector.get(SocketConnectionManager)
                     emit_notification(
                         socket_connection_manager=socket_connection_manager,
@@ -362,6 +370,9 @@ async def check_and_execute_scheduled_pipelines_async():
                             )
 
                             run = await run_repository.create(run_data)
+                            # Commit the run before dispatch so the executing worker
+                            # (a separate session) can find it (repos only flush now).
+                            await session.commit()
 
                             # Queue async execution (import here to avoid circular imports)
                             from app.tasks.ml_model_pipeline_tasks import (

--- a/backend/app/tasks/test_suite_tasks.py
+++ b/backend/app/tasks/test_suite_tasks.py
@@ -162,6 +162,8 @@ async def reconcile_stuck_test_runs_async() -> None:
                 running_before=running_before,
                 error_message=_STUCK_TEST_RUN_ERROR,
             )
+            # Repos only flush now; this out-of-band session owns its commit.
+            await session.commit()
             if failed:
                 logger.warning(
                     "Reconciled %s stuck evaluation run(s) as failed for tenant %s",
@@ -169,6 +171,7 @@ async def reconcile_stuck_test_runs_async() -> None:
                     tenant_id,
                 )
         except Exception as exc:
+            await session.rollback()
             logger.error("Error reconciling stuck evaluation runs: %s", exc, exc_info=True)
         finally:
             await session.close()

--- a/backend/app/tasks/workflow_schedule_tasks.py
+++ b/backend/app/tasks/workflow_schedule_tasks.py
@@ -100,6 +100,9 @@ async def execute_workflow_run_async(run_id: UUID):
                 await run_repository.update_status(
                     run_id, WorkflowScheduleRunStatus.RUNNING
                 )
+                # Commit the RUNNING marker so reconcilers/other workers see it
+                # during the long execution below (repos only flush now).
+                await session.commit()
 
                 schedule = await schedule_repository.get_by_id(run.schedule_id)
 
@@ -121,6 +124,7 @@ async def execute_workflow_run_async(run_id: UUID):
                         await schedule_repository.set_fixed_thread_id(
                             schedule.id, thread_id
                         )
+                        await session.commit()
                 else:
                     thread_id = str(uuid.uuid4())
 
@@ -161,6 +165,7 @@ async def execute_workflow_run_async(run_id: UUID):
                     workflow_id=workflow.id,
                     thread_id=thread_id,
                 )
+                await session.commit()
                 logger.info(f"Workflow schedule run {run_id} completed successfully")
 
             except Exception as e:
@@ -169,11 +174,15 @@ async def execute_workflow_run_async(run_id: UUID):
                     exc_info=True,
                 )
                 try:
+                    # Clear any failed-transaction state from the execution error
+                    # before writing the FAILED status (repos only flush now).
+                    await session.rollback()
                     await run_repository.update_status(
                         run_id,
                         WorkflowScheduleRunStatus.FAILED,
                         error_message=str(e),
                     )
+                    await session.commit()
                     socket_connection_manager = injector.get(SocketConnectionManager)
                     emit_notification(
                         socket_connection_manager=socket_connection_manager,
@@ -281,6 +290,9 @@ async def check_and_execute_scheduled_workflows_async():
                         schedule_id=schedule.id,
                         agent_id=schedule.agent_id,
                     )
+                    # Commit the run before dispatch so the executing worker (a
+                    # separate session) can find it (repos only flush now).
+                    await session.commit()
 
                     # Dispatch first so a metadata-write hiccup can never block
                     # the actual execution.
@@ -295,7 +307,9 @@ async def check_and_execute_scheduled_workflows_async():
                         await schedule_repository.set_last_run_at(
                             schedule.id, current_time
                         )
+                        await session.commit()
                     except Exception as e:
+                        await session.rollback()
                         logger.exception(
                             f"Failed to set last_run_at for schedule {schedule.id}: {str(e)}"
                         )
@@ -377,12 +391,15 @@ async def reconcile_stuck_workflow_runs_async():
                 running_before=running_before,
                 error_message=_STUCK_RUN_ERROR,
             )
+            # Repos only flush now; this out-of-band session owns its commit.
+            await session.commit()
             if failed:
                 logger.warning(
                     f"Reconciled {failed} stuck workflow schedule run(s) as FAILED "
                     f"for tenant {tenant_id}"
                 )
         except Exception as e:
+            await session.rollback()
             logger.error(
                 f"Error reconciling stuck workflow runs: {str(e)}", exc_info=True
             )

--- a/backend/tests/unit/test_agent_response_log.py
+++ b/backend/tests/unit/test_agent_response_log.py
@@ -86,13 +86,15 @@ async def _log(session, execution_id="exec-1"):
 
 class TestLogResponse:
     @pytest.mark.asyncio
-    async def test_writes_inside_a_savepoint_and_commits(self):
+    async def test_writes_inside_a_savepoint_and_defers_commit_to_boundary(self):
         session = FakeSession()
         entry = await _log(session)
 
         assert session.savepoints_opened == 1
         assert session.savepoints_released == 1
-        assert session.committed == 1
+        # Repositories flush inside the savepoint; the request/task transaction
+        # boundary owns the commit, so the repo itself never commits.
+        assert session.committed == 0
         assert entry.workflow_execution_id == "exec-1"
         assert entry.total_tokens == 15
 

--- a/backend/tests/unit/test_analytics_aggregation_usage.py
+++ b/backend/tests/unit/test_analytics_aggregation_usage.py
@@ -22,6 +22,9 @@ class CapturingSession:
     async def commit(self):
         pass
 
+    async def flush(self):
+        pass
+
 
 def _rendered_upsert() -> str:
     session = CapturingSession()

--- a/backend/tests/unit/test_evaluation_run_reliability.py
+++ b/backend/tests/unit/test_evaluation_run_reliability.py
@@ -499,12 +499,13 @@ class TestPausedConversationExecution:
 
 class TestWatchdogRepo:
     @pytest.mark.asyncio
-    async def test_mark_stuck_as_failed_commits_and_returns_rowcount(self):
+    async def test_mark_stuck_as_failed_flushes_and_returns_rowcount(self):
         from app.repositories.test_suite import TestRunRepository
 
         db = MagicMock()
         db.execute = AsyncMock(return_value=SimpleNamespace(rowcount=3))
-        db.commit = AsyncMock()
+        # Repos flush; the reconcile task/boundary owns the commit.
+        db.flush = AsyncMock()
         repo = TestRunRepository(db)
 
         now = datetime.now(timezone.utc)
@@ -514,7 +515,7 @@ class TestWatchdogRepo:
 
         assert failed == 3
         db.execute.assert_awaited_once()
-        db.commit.assert_awaited_once()
+        db.flush.assert_awaited_once()
 
 
 class TestWatchdogTask:

--- a/backend/tests/unit/test_read_receipts.py
+++ b/backend/tests/unit/test_read_receipts.py
@@ -76,6 +76,9 @@ class _SpySession:
     async def commit(self):
         pass
 
+    async def flush(self):
+        pass
+
 
 def _compile(statement) -> str:
     return str(statement.compile(dialect=postgresql.dialect()))
@@ -108,9 +111,10 @@ async def test_advance_read_marker_upsert_refuses_to_regress():
 
 
 @pytest.mark.asyncio
-async def test_advance_read_marker_commits_once():
+async def test_advance_read_marker_flushes_once():
+    # Repositories flush; the request/task transaction boundary owns the commit.
     session = _SpySession()
-    session.commit = AsyncMock()
+    session.flush = AsyncMock()
     repo = ConversationReadReceiptRepository(session)
 
     await repo.advance_read_marker(
@@ -120,7 +124,7 @@ async def test_advance_read_marker_commits_once():
         last_read_sequence=0,
     )
 
-    session.commit.assert_awaited_once()
+    session.flush.assert_awaited_once()
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Description

## Description

Introduces a service-level transaction boundary. Repositories now `flush()` instead of `commit()`, so a request/task is atomic (all-or-nothing) with a single commit-on-success / rollback-on-error boundary — instead of each repository committing piecemeal (which left partial writes behind when a later step failed).

Work item: https://dev.azure.com/Ritech/GenAssist/_workitems/edit/66662

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

- [x] **`TransactionManager`** (`app/db/transaction_manager.py`): request-scoped, injectable; `commit()`/`rollback()` + a `transaction()` context manager that opens a SAVEPOINT when nested.
- [x] **HTTP boundary** (`TransactionMiddleware`): commits on `<400` responses, rolls back on `>=400` and on unhandled exceptions; registered innermost so tenant context is still active at commit time.
- [x] **Background boundary**: `create_task_wrapper`, `create_tenant_request_scope`, the workflow engine/orchestrator scopes, and DB seeding now commit on success / roll back on error.
- [x] **Out-of-band task sessions** (reconcilers, schedulers, pipeline/workflow executors): commit exactly where repos used to — preserving `RUNNING`-marker cross-session visibility and commit-before-Celery-dispatch.
- [x] **Repositories** (~40 files): `commit()` → `flush()`; `IntegrityError` handlers use `begin_nested()` SAVEPOINTs instead of a full `rollback()` that would discard the whole request's pending work.
- [x] Intentional service-level commits kept where a write must persist before an external call / on a self-managed out-of-band session.
- [x] Updated unit tests to assert flush / boundary-commit semantics.

## Testing

- [x] Unit tests (updated: `test_read_receipts`, `test_agent_response_log`, `test_evaluation_run_reliability`, `test_analytics_aggregation_usage`)
- [ ] Integration tests
- [x] Manual testing — end-to-end via the UI against a patched dev stack:
  - Create feature flag → `POST 201` + boundary `COMMIT` (persisted)
  - Duplicate key → `POST 400`, insert flushed then boundary `ROLLBACK` (no partial write)
  - Delete → `DELETE 204` + `COMMIT`
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes <!-- run full suite in CI/Docker -->
- [ ] Any dependent changes have been merged and published
- [x] Multi-tenant considerations addressed — boundary resolves the tenant-scoped session; out-of-band/background sessions commit per-tenant

## Related Issues

<!-- [AB#66662](https://dev.azure.com/Ritech/0e111cb8-31e4-4487-b2c2-03586ee0fcee/_workitems/edit/66662) — link the Azure work item, or a mirrored GH issue if one exists -->

## Screenshots (if applicable)

_Backend logs from manual testing:_
`POST /api/feature-flags → COMMIT → 201` · `POST (dup) → ROLLBACK → 400` · `DELETE → COMMIT → 204`
## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
