### PR TITLE
enhancement: ignore node names

### DIFF
--- a/frontend/src/interfaces/workflow-diff.interface.ts
+++ b/frontend/src/interfaces/workflow-diff.interface.ts
@@ -15,6 +15,8 @@ export type NodeDiffStatus = 'added' | 'removed' | 'modified' | 'unchanged';
 export interface DiffOptions {
   /** Drop record-reference ids (provider, KB, connector, data source) from both sides. */
   ignoreIdReferences?: boolean;
+  /** Drop each node's display name. */
+  ignoreNodeNames?: boolean;
 }
 
 /** A single configuration field that differs between base and target for a modified node. */

--- a/frontend/src/views/AIAgents/Workflows/components/diff/DiffGraphView.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/diff/DiffGraphView.tsx
@@ -193,7 +193,7 @@ const DiffGraphView: React.FC<DiffGraphViewProps> = ({ diff }) => {
                 {selectedStyle.label}
               </span>
             </div>
-            <ScrollArea className="flex-1 p-3">
+            <ScrollArea className="flex-1 p-3" viewportProps={{ className: '[&>div]:!block' }}>
               {selectedNode.fieldChanges.length > 0 ? (
                 <div className="space-y-2">
                   {selectedNode.fieldChanges.map((change) => (

--- a/frontend/src/views/AIAgents/Workflows/components/diff/DiffListView.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/diff/DiffListView.tsx
@@ -90,7 +90,10 @@ const DiffListView: React.FC<DiffListViewProps> = ({ diff }) => {
               />
               <div className="flex min-w-0 flex-col leading-tight">
                 <span
-                  className={cn('text-lg font-semibold tabular-nums', active ? 'text-foreground' : 'text-muted-foreground')}
+                  className={cn(
+                    'text-lg font-semibold tabular-nums',
+                    active ? 'text-foreground' : 'text-muted-foreground'
+                  )}
                 >
                   {value}
                 </span>
@@ -114,7 +117,7 @@ const DiffListView: React.FC<DiffListViewProps> = ({ diff }) => {
           </p>
         </div>
       ) : (
-        <ScrollArea className="mt-4 flex-1 pr-3">
+        <ScrollArea className="mt-4 flex-1 pr-3" viewportProps={{ className: '[&>div]:!block' }}>
           <Accordion type="multiple" defaultValue={defaultOpen} className="w-full space-y-3">
             {modified.length > 0 && (
               <AccordionItem value="modified" className="border-none">
@@ -192,7 +195,9 @@ const DiffListView: React.FC<DiffListViewProps> = ({ diff }) => {
               <AccordionItem value="connections" className="border-none">
                 <AccordionTrigger className="py-1 hover:no-underline">
                   <span className="flex items-center gap-2">
-                    <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Connections</span>
+                    <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Connections
+                    </span>
                     <span className="flex items-center gap-1.5 text-[11px] font-medium tabular-nums">
                       <span className="text-emerald-600 dark:text-emerald-400">+{addedEdges.length}</span>
                       <span className="text-slate-300">/</span>

--- a/frontend/src/views/AIAgents/Workflows/components/diff/FieldChangeRow.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/diff/FieldChangeRow.tsx
@@ -181,7 +181,7 @@ const ValueLine: React.FC<{ side: 'before' | 'after'; value: unknown; glyph?: bo
       )}
       <span className="sr-only">{removed ? 'Before:' : 'After:'}</span>
       {isObj(value) ? (
-        <pre className="min-w-0 flex-1 overflow-x-auto whitespace-pre font-mono text-[11px] leading-5 text-muted-foreground">
+        <pre className="min-w-0 flex-1 whitespace-pre-wrap break-words font-mono text-[11px] leading-5 text-muted-foreground">
           {JSON.stringify(value, null, 2)}
         </pre>
       ) : (

--- a/frontend/src/views/AIAgents/Workflows/components/diff/VersionDiffDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/diff/VersionDiffDialog.tsx
@@ -35,6 +35,7 @@ const VersionDiffDialog: React.FC<VersionDiffDialogProps> = ({ open, onClose, ba
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [ignoreIdReferences, setIgnoreIdReferences] = useState(false);
+  const [ignoreNodeNames, setIgnoreNodeNames] = useState(false);
 
   const loadVersions = useCallback(async () => {
     setLoading(true);
@@ -61,13 +62,14 @@ const VersionDiffDialog: React.FC<VersionDiffDialogProps> = ({ open, onClose, ba
       setResolvedTarget(undefined);
       setError(null);
       setIgnoreIdReferences(false);
+      setIgnoreNodeNames(false);
     }
   }, [open, loadVersions]);
 
   const diff = useMemo(() => {
     if (!resolvedBase || !resolvedTarget) return null;
-    return computeWorkflowDiff(resolvedBase, resolvedTarget, { ignoreIdReferences });
-  }, [resolvedBase, resolvedTarget, ignoreIdReferences]);
+    return computeWorkflowDiff(resolvedBase, resolvedTarget, { ignoreIdReferences, ignoreNodeNames });
+  }, [resolvedBase, resolvedTarget, ignoreIdReferences, ignoreNodeNames]);
 
   const versionChip = (workflow: Workflow, side: 'base' | 'target') => {
     const isTarget = side === 'target';
@@ -100,6 +102,15 @@ const VersionDiffDialog: React.FC<VersionDiffDialogProps> = ({ open, onClose, ba
       </span>
     );
   };
+
+  const optionToggle = (id: string, label: string, checked: boolean, onCheckedChange: (next: boolean) => void) => (
+    <div className="flex items-center gap-2">
+      <Switch id={id} checked={checked} onCheckedChange={onCheckedChange} />
+      <label htmlFor={id} className="cursor-pointer select-none text-sm font-medium text-muted-foreground">
+        {label}
+      </label>
+    </div>
+  );
 
   return (
     <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
@@ -152,18 +163,14 @@ const VersionDiffDialog: React.FC<VersionDiffDialogProps> = ({ open, onClose, ba
                 </TabsTrigger>
               </TabsList>
 
-              <div className="flex items-center gap-2">
-                <Switch
-                  id="ignore-id-references"
-                  checked={ignoreIdReferences}
-                  onCheckedChange={setIgnoreIdReferences}
-                />
-                <label
-                  htmlFor="ignore-id-references"
-                  className="cursor-pointer select-none text-sm font-medium text-muted-foreground"
-                >
-                  Ignore ID references
-                </label>
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+                {optionToggle(
+                  'ignore-id-references',
+                  'Ignore ID references',
+                  ignoreIdReferences,
+                  setIgnoreIdReferences
+                )}
+                {optionToggle('ignore-node-names', 'Ignore node names', ignoreNodeNames, setIgnoreNodeNames)}
               </div>
             </div>
             <TabsContent value="list" className="min-h-0 flex-1 pt-3 data-[state=inactive]:hidden">

--- a/frontend/src/views/AIAgents/Workflows/utils/versionDiff.ts
+++ b/frontend/src/views/AIAgents/Workflows/utils/versionDiff.ts
@@ -150,7 +150,8 @@ export const getNodeLabel = (node: Node): string => {
 /**
  * Field-level comparison of two same-id nodes' normalized `data`. Compares every field present in
  * either node via `isEqual`. If the node's `type` itself changed, that is surfaced as a synthetic
- * `type` field change so the user sees the node was re-typed.
+ * `type` field change so the user sees the node was re-typed. `options.ignoreNodeNames` skips the
+ * node's own `data.name`.
  */
 export const diffNodeData = (baseNode: Node, targetNode: Node, options: DiffOptions = {}): FieldChange[] => {
   const changes: FieldChange[] = [];
@@ -168,6 +169,7 @@ export const diffNodeData = (baseNode: Node, targetNode: Node, options: DiffOpti
   const keys = Array.from(new Set([...Object.keys(baseData), ...Object.keys(targetData)]));
 
   for (const key of keys) {
+    if (options.ignoreNodeNames && key === 'name') continue;
     if (!isEqual(baseData[key], targetData[key])) {
       changes.push({ key, before: baseData[key], after: targetData[key] });
     }


### PR DESCRIPTION
## Description

When comparing two workflow versions, the user has the option to ignore changes in the node names.
Extra: long values shown on the compare versions dialog wrap.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [X] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
