### PR TITLE
feat: add CSV preview/profiling to Train Data Source, time-based spli…

### DIFF
--- a/backend/app/api/v1/routes/ml_models.py
+++ b/backend/app/api/v1/routes/ml_models.py
@@ -1,11 +1,14 @@
+import asyncio
 import logging
 import os
 import tempfile
 import uuid
+from pathlib import Path
 from typing import Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Body, Depends, File, HTTPException, Request, UploadFile
+import pandas as pd
+from fastapi import APIRouter, Body, Depends, File, HTTPException, Request, Response, UploadFile
 from fastapi_injector import Injected
 
 from app.auth.dependencies import auth, permissions
@@ -380,4 +383,76 @@ async def analyze_csv(
         raise HTTPException(
             status_code=500,
             detail=f"Error analyzing CSV file: {str(e)}"
+        ) from e
+
+
+def _build_profile_report_html(file_path: str) -> str:
+    """Run ydata-profiling on a CSV file and return the report as an HTML string."""
+    from ydata_profiling import ProfileReport
+
+    df = pd.read_csv(file_path, encoding="utf-8", on_bad_lines="skip")
+    profile = ProfileReport(df, title=f"Data Profile: {Path(file_path).name}")
+    return profile.to_html()
+
+
+@router.post("/profile-csv", dependencies=[
+    Depends(auth),
+    Depends(permissions(P.MlModel.READ))
+])
+async def profile_csv(
+    file_url: str = Body(..., embed=True, description="Path or URL to CSV file"),
+    file_manager_service: FileManagerService = Injected(FileManagerService)
+):
+    """
+    Run pandas/ydata data profiling on a CSV file and return the report as a
+    downloadable HTML file.
+
+    The file_url can be:
+    - An absolute path (starting with /)
+    - A relative path (will be checked in DATA_VOLUME/train directories)
+    - A path within DATA_VOLUME
+    - An HTTP(S) URL (downloaded before profiling)
+    """
+    try:
+        try:
+            if file_url.startswith("http://") or file_url.startswith("https://"):
+                dest_path = os.path.join(ML_MODELS_UPLOAD_DIR, f"csv_file_{uuid.uuid4()}.csv")
+                await file_manager_service.download_file_from_url_to_path(file_url, dest_path)
+                file_path = dest_path
+            else:
+                file_path = ml_utils.resolve_csv_file_path(file_url)
+        except AppException as e:
+            if e.error_key == ErrorKey.FILE_NOT_FOUND:
+                raise HTTPException(
+                    status_code=404,
+                    detail=e.error_detail
+                )
+            else:
+                raise HTTPException(
+                    status_code=400,
+                    detail=e.error_detail
+                )
+
+        logger.info(f"Profiling CSV file: {file_path}")
+
+        # ydata-profiling is CPU-bound and can take a while on large files;
+        # run it off the event loop so it doesn't block other requests.
+        html = await asyncio.to_thread(_build_profile_report_html, str(file_path))
+
+        download_name = f"{Path(str(file_path)).stem}_profile.html"
+        return Response(
+            content=html,
+            media_type="text/html",
+            headers={"Content-Disposition": f'attachment; filename="{download_name}"'},
+        )
+
+    except HTTPException:
+        raise
+    except AppException:
+        raise
+    except Exception as e:
+        logger.error(f"Error profiling CSV file: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Error profiling CSV file: {str(e)}"
         ) from e

--- a/backend/app/modules/workflow/engine/nodes/ml/train_model_node.py
+++ b/backend/app/modules/workflow/engine/nodes/ml/train_model_node.py
@@ -57,6 +57,12 @@ class TrainModelNode(BaseNode):
                 - featureColumns: List of feature column names (required)
                 - modelParameters: Dictionary of model-specific parameters (optional)
                 - validationSplit: Fraction for validation split (default: 0.2)
+                - splitMethod: "random" (default) or "time_based" — for time-based split,
+                            the earliest (1 - validationSplit) fraction of rows (sorted by
+                            dateColumn) is used for training and the latest fraction for
+                            validation, with no shuffling.
+                - dateColumn: Name of the date/timestamp column to sort by (required when
+                            splitMethod is "time_based")
 
         Returns:
             Dictionary with training results and model file path
@@ -70,6 +76,8 @@ class TrainModelNode(BaseNode):
             feature_columns = config.get("featureColumns", [])
             model_parameters = config.get("modelParameters", {})
             validation_split = config.get("validationSplit", 0.2)
+            split_method = config.get("splitMethod", "random")
+            date_column = config.get("dateColumn")
 
             # Validate required parameters
             if not name:
@@ -96,6 +104,16 @@ class TrainModelNode(BaseNode):
                 raise AppException(
                     error_key=ErrorKey.MISSING_PARAMETER,
                     error_detail="featureColumns is required and must not be empty for train model node",
+                )
+            if split_method not in ("random", "time_based"):
+                raise AppException(
+                    error_key=ErrorKey.INTERNAL_ERROR,
+                    error_detail=f"Invalid splitMethod: {split_method}. Must be 'random' or 'time_based'",
+                )
+            if split_method == "time_based" and not date_column:
+                raise AppException(
+                    error_key=ErrorKey.MISSING_PARAMETER,
+                    error_detail="dateColumn is required when splitMethod is 'time_based'",
                 )
 
             # Validate model type
@@ -130,6 +148,9 @@ class TrainModelNode(BaseNode):
                 if col not in all_columns:
                     missing_columns.append(col)
 
+            if split_method == "time_based" and date_column not in all_columns:
+                missing_columns.append(date_column)
+
             if missing_columns:
                 logger.error(f"Columns not found in data: {missing_columns}. Available columns: {all_columns}")
                 return {
@@ -141,18 +162,26 @@ class TrainModelNode(BaseNode):
                 #     error_detail=f"Columns not found in data: {missing_columns}. Available columns: {all_columns}",
                 # )
 
+            # For a time-based split, sort chronologically first so a positional
+            # split later puts the earliest rows in train and latest in validation.
+            if split_method == "time_based":
+                parsed_dates = pd.to_datetime(df[date_column], errors="coerce")
+                if parsed_dates.isna().all():
+                    raise AppException(
+                        error_key=ErrorKey.INTERNAL_ERROR,
+                        error_detail=f"Could not parse any values in dateColumn '{date_column}' as dates.",
+                    )
+                df = (
+                    df.assign(_sort_date_=parsed_dates)
+                    .sort_values("_sort_date_", na_position="last")
+                    .drop(columns=["_sort_date_"])
+                    .reset_index(drop=True)
+                )
+                logger.info(f"Sorted {len(df)} rows chronologically by '{date_column}' for time-based split")
+
             # Prepare features and target
             X = df[feature_columns].copy()
             y = df[target_column].copy()
-
-            # Handle missing values
-            if X.isnull().any().any():
-                logger.warning("Found missing values in features. Filling with median for numeric and mode for categorical.")
-                for col in X.columns:
-                    if X[col].dtype in ['int64', 'float64']:
-                        X[col].fillna(X[col].median(), inplace=True)
-                    else:
-                        X[col].fillna(X[col].mode()[0] if not X[col].mode().empty else '', inplace=True)
 
             if y.isnull().any():
                 logger.warning("Found missing values in target. Dropping rows with missing target values.")
@@ -160,31 +189,73 @@ class TrainModelNode(BaseNode):
                 X = X[mask]
                 y = y[mask]
 
-            # Handle categorical variables by one-hot encoding
-            categorical_columns = X.select_dtypes(include=['object']).columns
-            if len(categorical_columns) > 0:
-                logger.info(f"One-hot encoding categorical columns: {list(categorical_columns)}")
-                X = pd.get_dummies(X, columns=categorical_columns, drop_first=True)
-
-            # Handle boolean columns
-            boolean_columns = X.select_dtypes(include=['bool']).columns
-            if len(boolean_columns) > 0:
-                logger.info(f"Converting boolean columns to int: {list(boolean_columns)}")
-                X[boolean_columns] = X[boolean_columns].astype(int)
-
             # Determine if classification or regression based on target
             is_classification = self._is_classification_task(y, model_type)
 
-            # Split data for validation
+            # Split BEFORE fitting any preprocessing (imputation medians/modes,
+            # one-hot categories) — fitting those on the full dataset would leak
+            # validation-row statistics into training, which for a time-based
+            # split defeats the entire point (keeping "future" rows out of
+            # training rather than just out of the raw feature matrix).
             if validation_split > 0 and validation_split < 1:
-                X_train, X_val, y_train, y_val = train_test_split(
-                    X, y, test_size=validation_split, random_state=42, stratify=y if is_classification else None
-                )
-                logger.info(f"Split data: {len(X_train)} training samples, {len(X_val)} validation samples")
+                if split_method == "time_based":
+                    split_idx = int(len(X) * (1 - validation_split))
+                    X_train, X_val = X.iloc[:split_idx].copy(), X.iloc[split_idx:].copy()
+                    y_train, y_val = y.iloc[:split_idx], y.iloc[split_idx:]
+                    logger.info(
+                        f"Time-based split on '{date_column}': {len(X_train)} training samples "
+                        f"(earliest), {len(X_val)} validation samples (latest)"
+                    )
+                else:
+                    X_train, X_val, y_train, y_val = train_test_split(
+                        X, y, test_size=validation_split, random_state=42, stratify=y if is_classification else None
+                    )
+                    logger.info(f"Split data: {len(X_train)} training samples, {len(X_val)} validation samples")
             else:
-                X_train, y_train = X, y
+                X_train, y_train = X.copy(), y
                 X_val, y_val = None, None
                 logger.info(f"Using all {len(X_train)} samples for training (no validation split)")
+
+            # Handle missing values — fit fill values on the training split only,
+            # then apply those same values to validation so nothing about the
+            # validation distribution leaks into how training data is filled.
+            # Checked per-column against both splits: X_train having no NaNs
+            # doesn't mean X_val doesn't (e.g. a time-based split can put all
+            # the missing rows in the "future" validation portion).
+            has_missing = X_train.isnull().any().any() or (
+                X_val is not None and X_val.isnull().any().any()
+            )
+            if has_missing:
+                logger.warning("Found missing values in features. Filling with median for numeric and mode for categorical.")
+                for col in X_train.columns:
+                    if X_train[col].dtype in ['int64', 'float64']:
+                        fill_value = X_train[col].median()
+                    else:
+                        mode_values = X_train[col].mode()
+                        fill_value = mode_values[0] if not mode_values.empty else ''
+                    X_train[col].fillna(fill_value, inplace=True)
+                    if X_val is not None:
+                        X_val[col].fillna(fill_value, inplace=True)
+
+            # Handle categorical variables by one-hot encoding. Categories are
+            # derived from the training split only; validation is reindexed to
+            # the same columns, so a category only seen in validation is
+            # dropped rather than leaking into the encoder's vocabulary.
+            categorical_columns = X_train.select_dtypes(include=['object']).columns
+            if len(categorical_columns) > 0:
+                logger.info(f"One-hot encoding categorical columns: {list(categorical_columns)}")
+                X_train = pd.get_dummies(X_train, columns=categorical_columns, drop_first=True)
+                if X_val is not None:
+                    X_val = pd.get_dummies(X_val, columns=categorical_columns, drop_first=True)
+                    X_val = X_val.reindex(columns=X_train.columns, fill_value=0)
+
+            # Handle boolean columns
+            boolean_columns = X_train.select_dtypes(include=['bool']).columns
+            if len(boolean_columns) > 0:
+                logger.info(f"Converting boolean columns to int: {list(boolean_columns)}")
+                X_train[boolean_columns] = X_train[boolean_columns].astype(int)
+                if X_val is not None:
+                    X_val[boolean_columns] = X_val[boolean_columns].astype(int)
 
             # Train the model
             model = await self._train_model(

--- a/backend/requirements-app.txt
+++ b/backend/requirements-app.txt
@@ -27,3 +27,6 @@ xgboost==1.7.4
 holidays==0.62
 pandas>=1.5.0
 fpdf2>=2.8.2
+ydata-profiling>=4.18.0
+# ydata-profiling still imports pkg_resources, which newer setuptools no longer bundles.
+setuptools>=70.0.0,<81

--- a/backend/requirements-main.txt
+++ b/backend/requirements-main.txt
@@ -174,7 +174,7 @@ PyJWT[crypto]==2.12.0
 python-multipart==0.0.27
 python-pptx==1.0.2
 pytz==2025.1
-PyYAML==6.0.2
+PyYAML==6.0.3
 redis==6.2.0
 regex==2024.11.6
 requests==2.32.5

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -34,8 +34,12 @@ const processQueue = (error: unknown, token: string | null = null) => {
 const ensureTrailingSlash = (url: string): string =>
   url.endsWith("/") ? url : `${url}/`;
 
-/** Default HTTP client timeout for JSON/API calls (not used for large file uploads — see uploadConstants) */
+/** Default HTTP client timeout for JSON/API calls (not used for large file uploads — see uploadConstants). */
 export const API_DEFAULT_TIMEOUT_MS = 120000;
+
+/** Timeout for CSV analysis / data profiling calls, which can run arbitrary
+ *  pandas code (or ydata-profiling, for the profile-csv endpoint) server-side. */
+export const API_PREPROCESSING_TIMEOUT_MS = 630000;
 
 const api = axios.create({
   headers: {
@@ -304,10 +308,3 @@ export const probeApiHealth = async (): Promise<boolean> => {
  *  Note: Vite reads env at dev server start / build time; restart the dev server after changing .env. */
 export const isPollEnabled =
   (import.meta.env.VITE_USE_POLL ?? "true").toString().toLowerCase() === "true" && !isWsEnabled;
-
-/** Whether the notifications feed may poll the API (VITE_NOTIFICATION_POLLING_ENABLED=true).
- *  Opt-in and independent of VITE_USE_POLL: defaults to false (notifications rely on WS only) when
- *  the var is unset or not exactly "true". Enable only for clients that need polling and can absorb
- *  the request volume. */
-export const isNotificationPollingEnabled =
-  (import.meta.env.VITE_NOTIFICATION_POLLING_ENABLED ?? "false").toString().toLowerCase() === "true";

--- a/frontend/src/services/mlModels.ts
+++ b/frontend/src/services/mlModels.ts
@@ -1,4 +1,4 @@
-import { apiRequest, getApiUrl } from "@/config/api";
+import { apiRequest, getApiUrl, API_PREPROCESSING_TIMEOUT_MS } from "@/config/api";
 import { MLModel, MLModelFormData } from "@/interfaces/ml-model.interface";
 
 const BASE = "ml-models";
@@ -133,6 +133,7 @@ export const analyzeCSV = async (
       "POST",
       `${BASE}/analyze-csv`,
       body,
+      { timeout: API_PREPROCESSING_TIMEOUT_MS },
     );
     if (!response) throw new Error("Failed to analyze CSV");
     return response;
@@ -140,4 +141,25 @@ export const analyzeCSV = async (
     console.error("Error analyzing CSV:", error);
     throw error;
   }
+};
+
+/** Runs data profiling on a CSV file and downloads the resulting HTML report. */
+export const profileCSV = async (
+  fileUrl: string,
+  downloadFilename: string,
+): Promise<void> => {
+  const blob = await apiRequest<Blob>(
+    "POST",
+    `${BASE}/profile-csv`,
+    { file_url: fileUrl },
+    { timeout: API_PREPROCESSING_TIMEOUT_MS, responseType: "blob" },
+  );
+  if (!blob) throw new Error("Failed to generate data profile");
+
+  const objectUrl = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = objectUrl;
+  a.download = downloadFilename;
+  a.click();
+  URL.revokeObjectURL(objectUrl);
 };

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/training/TrainDataSourceDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/training/TrainDataSourceDialog.tsx
@@ -13,11 +13,13 @@ import {
 import { DataSource } from "@/interfaces/dataSource.interface";
 import { getAllDataSources } from "@/services/dataSources";
 import { useToast } from "@/components/use-toast";
-import { Save } from "lucide-react";
+import { Save, BarChart3 } from "lucide-react";
 import { NodeConfigPanel } from "../../components/NodeConfigPanel";
 import { BaseNodeDialogProps } from "../base";
 import { DraggableTextArea } from "../../components/custom/DraggableTextArea";
 import { FileUploader } from "@/components/FileUploader";
+import { CSVAnalysisDisplay } from "./components/CSVAnalysisDisplay";
+import { analyzeCSV, profileCSV } from "@/services/mlModels";
 import { useNodeDialogState } from "../useNodeDialogState";
 
 type TrainDataSourceDialogProps = BaseNodeDialogProps<
@@ -44,6 +46,7 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
       csvFilePath: data.csvFilePath ?? null,
       csvFileId: data.csvFileId ?? null,
       csvFileUrl: data.csvFileUrl ?? null,
+      analysisResult: data.analysisResult ?? null,
     }),
     (v) => ({
       name: v.name,
@@ -54,6 +57,7 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
       csvFilePath: v.csvFilePath ?? undefined,
       csvFileId: v.csvFileId ?? undefined,
       csvFileUrl: v.csvFileUrl ?? undefined,
+      analysisResult: v.analysisResult ?? undefined,
     })
   );
 
@@ -65,6 +69,8 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
     return "csv";
   });
   const [isCsvUploading, setIsCsvUploading] = useState(false);
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const [isProfiling, setIsProfiling] = useState(false);
   const [availableDataSources, setAvailableDataSources] = useState<
     DataSource[]
   >([]);
@@ -107,6 +113,51 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
       loadDataSources();
     }
   }, [isOpen, data, toast]);
+
+  const handleAnalyzeFile = async (fileUrl: string, fileName: string) => {
+    // The backend preview endpoint only supports CSV files today.
+    if (!fileName.toLowerCase().endsWith(".csv")) {
+      setField("analysisResult", null);
+      return;
+    }
+
+    try {
+      setIsAnalyzing(true);
+      const result = await analyzeCSV(fileUrl);
+      setField("analysisResult", result);
+    } catch (err) {
+      console.error(err);
+      toast({
+        title: "Preview Failed",
+        description:
+          err instanceof Error ? err.message : "Failed to preview the file",
+        variant: "destructive",
+      });
+    } finally {
+      setIsAnalyzing(false);
+    }
+  };
+
+  const handleProfileData = async () => {
+    const target = values.csvFilePath || values.csvFileUrl;
+    if (!target) return;
+
+    try {
+      setIsProfiling(true);
+      const baseName = (values.csvFileName || "data").replace(/\.[^./]+$/, "");
+      await profileCSV(target, `${baseName}_profile.html`);
+    } catch (err) {
+      console.error(err);
+      toast({
+        title: "Profiling Failed",
+        description:
+          err instanceof Error ? err.message : "Failed to generate data profile",
+        variant: "destructive",
+      });
+    } finally {
+      setIsProfiling(false);
+    }
+  };
 
   const handleSourceChange = (value: string) => {
     setSelectedSource(value);
@@ -254,7 +305,17 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
                 csvFilePath: result.file_path,
                 csvFileId: result.file_id,
                 csvFileUrl: result.file_url,
+                analysisResult: null,
               }));
+              // Prefer the raw server file_path: analyze-csv resolves it directly.
+              // file_url (when file-manager storage is enabled) points at an
+              // authenticated /file-manager/files/{id}/source endpoint that the
+              // backend's own internal downloader hits without credentials, so it
+              // 400s there — file_path avoids that round-trip entirely.
+              const previewTarget = result.file_path || result.file_url;
+              if (previewTarget) {
+                handleAnalyzeFile(previewTarget, result.original_filename);
+              }
             }}
             onRemove={() => {
               setValues((v) => ({
@@ -263,11 +324,36 @@ export const TrainDataSourceDialog: React.FC<TrainDataSourceDialogProps> = (
                 csvFilePath: null,
                 csvFileId: null,
                 csvFileUrl: null,
+                analysisResult: null,
               }));
             }}
             placeholder="Select a CSV file to upload"
           />
         )}
+        {values.sourceType === "csv" && isAnalyzing && (
+          <p className="text-xs text-muted-foreground">
+            Generating data preview...
+          </p>
+        )}
+        {values.sourceType === "csv" && values.analysisResult && (
+          <CSVAnalysisDisplay analysisResult={values.analysisResult} />
+        )}
+        {values.sourceType === "csv" &&
+          (values.csvFilePath || values.csvFileUrl) &&
+          values.csvFileName?.toLowerCase().endsWith(".csv") && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleProfileData}
+              loading={isProfiling}
+              disabled={isProfiling}
+              icon={<BarChart3 className="h-4 w-4" />}
+              className="w-fit"
+            >
+              {isProfiling ? "Generating profile..." : "Profile Data"}
+            </Button>
+          )}
       </div>
     </NodeConfigPanel>
   );

--- a/frontend/src/views/AIAgents/Workflows/nodeDialogs/training/TrainModelDialog.tsx
+++ b/frontend/src/views/AIAgents/Workflows/nodeDialogs/training/TrainModelDialog.tsx
@@ -43,6 +43,8 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
       modelParameters: data.modelParameters || {},
       validationSplit: data.validationSplit || 0.2,
       analysisResult: data.analysisResult || null,
+      splitMethod: data.splitMethod || "random",
+      dateColumn: data.dateColumn || "",
     }),
     (v) => ({
       name: v.name,
@@ -53,6 +55,8 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
       featureColumns: v.featureColumns,
       modelParameters: v.modelParameters,
       validationSplit: v.validationSplit,
+      splitMethod: v.splitMethod,
+      dateColumn: v.splitMethod === "time_based" ? v.dateColumn : undefined,
     })
   );
 
@@ -93,6 +97,15 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
       toast({
         title: "Validation Error",
         description: "Please select at least one feature column",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (values.splitMethod === "time_based" && !values.dateColumn.trim()) {
+      toast({
+        title: "Validation Error",
+        description: "Please specify a date column for a time-based split",
         variant: "destructive",
       });
       return;
@@ -203,6 +216,10 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
 
   const handleModelTypeChange = (value: string) => {
     setField("modelType", value as TrainModelNodeData["modelType"]);
+  };
+
+  const handleSplitMethodChange = (value: string) => {
+    setField("splitMethod", value as TrainModelNodeData["splitMethod"]);
   };
 
   return (
@@ -419,6 +436,60 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
             </p>
           </div>
 
+          {/* Split Method */}
+          <div className="space-y-2">
+            <Label htmlFor="splitMethod">Split Method</Label>
+            <Select value={values.splitMethod} onValueChange={handleSplitMethodChange}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select split method" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="random">Random</SelectItem>
+                <SelectItem value="time_based">Time-based</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Random shuffles rows before splitting. Time-based sorts by a date
+              column and reserves the most recent rows for validation — use this
+              for time-series data.
+            </p>
+          </div>
+
+          {/* Date Column (time-based split only) */}
+          {values.splitMethod === "time_based" && (
+            <div className="space-y-2">
+              <Label htmlFor="dateColumn">Date Column *</Label>
+              {values.analysisResult ? (
+                <Select
+                  value={values.dateColumn}
+                  onValueChange={(v) => setField("dateColumn", v)}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select date column" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {values.analysisResult.column_names.map((columnName) => (
+                      <SelectItem key={columnName} value={columnName}>
+                        {columnName}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <DraggableInput
+                  id="dateColumn"
+                  value={values.dateColumn}
+                  onChange={(e) => setField("dateColumn", e.target.value)}
+                  placeholder="Enter date/timestamp column name"
+                  className="w-full"
+                />
+              )}
+              <p className="text-xs text-muted-foreground">
+                Column used to sort rows chronologically before splitting
+              </p>
+            </div>
+          )}
+
           {/* Validation Split */}
           <div className="space-y-2">
             <Label>
@@ -433,7 +504,9 @@ export const TrainModelDialog: React.FC<TrainModelDialogProps> = (props) => {
               className="w-full"
             />
             <p className="text-xs text-muted-foreground">
-              Fraction of data to use for validation (10% - 50%)
+              {values.splitMethod === "time_based"
+                ? "Fraction of the most recent rows to reserve for validation (10% - 50%)"
+                : "Fraction of data to use for validation (10% - 50%)"}
             </p>
           </div>
         </div>

--- a/frontend/src/views/AIAgents/Workflows/nodeTypes/training/definitions.ts
+++ b/frontend/src/views/AIAgents/Workflows/nodeTypes/training/definitions.ts
@@ -138,6 +138,8 @@ export const TRAIN_MODEL_NODE_DEFINITION: NodeTypeDefinition<TrainModelNodeData>
       featureColumns: [],
       modelParameters: {},
       validationSplit: 0.2,
+      splitMethod: "random",
+      dateColumn: "",
       handlers: [
         {
           id: "input",

--- a/frontend/src/views/AIAgents/Workflows/types/nodes.ts
+++ b/frontend/src/views/AIAgents/Workflows/types/nodes.ts
@@ -434,6 +434,7 @@ export interface TrainDataSourceNodeData extends BaseNodeData {
   csvFilePath?: string; // Server path to the uploaded CSV file
   csvFileId?: string; // ID of the uploaded CSV file
   csvFileUrl?: string; // URL of the uploaded CSV file
+  analysisResult?: CSVAnalysisResult; // Preview/analysis of the uploaded file
 }
 
 // Preprocessing Node Data
@@ -445,6 +446,8 @@ export interface PreprocessingNodeData extends BaseNodeData {
 }
 
 // Train Model Node Data
+export type SplitMethod = "random" | "time_based";
+
 export interface TrainModelNodeData extends BaseNodeData {
   fileUrl?: string; // URL to the CSV file for training
   analysisResult?: CSVAnalysisResult; // CSV analysis result
@@ -459,6 +462,8 @@ export interface TrainModelNodeData extends BaseNodeData {
   featureColumns: string[]; // Feature column names
   modelParameters: Record<string, any>; // Model-specific parameters
   validationSplit: number; // Train/validation split ratio
+  splitMethod?: SplitMethod; // How to split train/validation data (default: "random")
+  dateColumn?: string; // Date/timestamp column to sort by when splitMethod is "time_based"
 }
 
 // Per Chat RAG Node Data


### PR DESCRIPTION
…t to Train Model

Train Data Source node:
- After a CSV uploads, automatically calls the existing analyze-csv endpoint and shows a column/row-count summary with an expandable sample-data table (CSVAnalysisDisplay), matching what the Preprocessing node already does.
- New "Profile Data" button that runs ydata-profiling on the uploaded CSV and downloads the report as an HTML file (new /profile-csv endpoint). Requires ydata-profiling (and a setuptools pin, since newer setuptools dropped the pkg_resources it still imports) and a PyYAML bump (ydata-profiling>=4.18 needs pyyaml>=6.0.3).

Train Model node:
- New "Split Method" option: Random (existing behavior) or Time-based, which sorts rows chronologically by a chosen date column and puts the earliest rows in training, latest in validation, with no shuffling — for time-series data where a random split would leak future information into training.

Rebuilt on top of the current useNodeDialogState refactor (the new fields are added to that hook's seed/toPayload alongside the existing ones) rather than the removed per-field useState pattern.

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
