### PR TITLE
feat: optional prompt caching for LLM, agent and sub-agent nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 .DS_Store
 frontend/.claude/skills/ui-skills/SKILL.md
+docs/research/
 
 # Claude local config & templates
 .claude/

--- a/backend/app/core/config/llm_prompt_cache_capabilities.py
+++ b/backend/app/core/config/llm_prompt_cache_capabilities.py
@@ -1,0 +1,54 @@
+"""Prompt-caching capability facts"""
+
+from typing import Optional
+
+# Bedrock rejects a cachePoint on a model that doesn't support it, failing every call.
+# Nova support is family-wide; Claude support is version-specific, Claude 3 (v1) and the
+# original Claude 3.5 Sonnet release never got caching, only 3.5 Sonnet v2 and later did.
+# Verified against AWS's supported-models table (docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html).
+BEDROCK_CACHEABLE_ANTHROPIC_MARKERS = (
+    "claude-3-5-sonnet-20241022",  # the v2 release; the 20240620 v1 release is not cache-capable
+    "claude-3-5-haiku",
+    "claude-3-7-sonnet",
+    "claude-opus-4",
+    "claude-sonnet-4",
+    "claude-haiku-4",
+    # Claude 5: only Sonnet and Fable are served on the Converse path
+    "claude-sonnet-5",
+    "claude-fable-5",
+)
+
+CLAUDE_FAMILY = "claude"
+NOVA_FAMILY = "nova"
+
+# These cache long prompts server-side with no marker, so a node's caching toggle is
+# moot rather than a mistake on them
+AUTOMATIC_CACHING_PROVIDERS = frozenset({"openai", "azure_openai", "google_genai", "google_vertexai"})
+
+_RATED_ARN_RESOURCES = ("foundation-model/", "inference-profile/")
+
+
+def prompt_caching_mode(provider: Optional[str], model_key: Optional[str]) -> str:
+    """Caching mode for this provider/model pair: "explicit" (the call is wraped
+    with its own cache marker), "automatic" (provider caches server-side, no marker),
+    or "none". Exposed so the builder doesn't reimplement this classification"""
+    family = (provider or "").strip().lower()
+    if family == "anthropic":
+        return "explicit"
+    if family == "bedrock":
+        return "explicit" if bedrock_cache_family(model_key) else "none"
+    if family in AUTOMATIC_CACHING_PROVIDERS:
+        return "automatic"
+    return "none"
+
+
+def bedrock_cache_family(model_key: Optional[str]) -> Optional[str]:
+    """The cache-capable Bedrock family a model id names, or None"""
+    name = (model_key or "").lower()
+    if name.startswith("arn:") and not name.split(":", 5)[-1].startswith(_RATED_ARN_RESOURCES):
+        return None
+    if NOVA_FAMILY in name:
+        return NOVA_FAMILY
+    if any(marker in name for marker in BEDROCK_CACHEABLE_ANTHROPIC_MARKERS):
+        return CLAUDE_FAMILY
+    return None

--- a/backend/app/core/config/llm_prompt_cache_capabilities.py
+++ b/backend/app/core/config/llm_prompt_cache_capabilities.py
@@ -3,9 +3,9 @@
 from typing import Optional
 
 # Bedrock rejects a cachePoint on a model that doesn't support it, failing every call.
-# Nova support is family-wide; Claude support is version-specific, Claude 3 (v1) and the
-# original Claude 3.5 Sonnet release never got caching, only 3.5 Sonnet v2 and later did.
-# Verified against AWS's supported-models table (docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html).
+# Support is version-specific: Claude 3 (v1) and the original Claude 3.5 Sonnet release
+# never got caching, only 3.5 Sonnet v2 and later did.
+# Verified against AWS's supported-models table (docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html)
 BEDROCK_CACHEABLE_ANTHROPIC_MARKERS = (
     "claude-3-5-sonnet-20241022",  # the v2 release; the 20240620 v1 release is not cache-capable
     "claude-3-5-haiku",
@@ -13,9 +13,17 @@ BEDROCK_CACHEABLE_ANTHROPIC_MARKERS = (
     "claude-opus-4",
     "claude-sonnet-4",
     "claude-haiku-4",
-    # Claude 5: only Sonnet and Fable are served on the Converse path
+    "claude-opus-5",
     "claude-sonnet-5",
     "claude-fable-5",
+)
+
+BEDROCK_CACHEABLE_NOVA_MARKERS = (
+    "amazon.nova-micro",
+    "amazon.nova-lite",
+    "amazon.nova-pro",
+    "amazon.nova-premier",
+    "amazon.nova-2-lite",
 )
 
 CLAUDE_FAMILY = "claude"
@@ -47,7 +55,7 @@ def bedrock_cache_family(model_key: Optional[str]) -> Optional[str]:
     name = (model_key or "").lower()
     if name.startswith("arn:") and not name.split(":", 5)[-1].startswith(_RATED_ARN_RESOURCES):
         return None
-    if NOVA_FAMILY in name:
+    if any(marker in name for marker in BEDROCK_CACHEABLE_NOVA_MARKERS):
         return NOVA_FAMILY
     if any(marker in name for marker in BEDROCK_CACHEABLE_ANTHROPIC_MARKERS):
         return CLAUDE_FAMILY

--- a/backend/app/core/utils/llm_usage_utils.py
+++ b/backend/app/core/utils/llm_usage_utils.py
@@ -36,6 +36,20 @@ def _first_present(data: Any, *keys: str) -> Optional[int]:
     return None
 
 
+def extract_cache_tokens(token_details: Any) -> tuple[int, int]:
+    """Cache read and cache creation counts from a stored ``token_details``
+
+    Returns:
+        ``(cache_read, cache_creation)``
+    """
+    if not isinstance(token_details, dict):
+        return 0, 0
+    details = token_details.get("input_token_details")
+    if not isinstance(details, dict) or not details:
+        details = token_details
+    return _coerce_count(details.get("cache_read")) or 0, _coerce_count(details.get("cache_creation")) or 0
+
+
 def _provider_total(metadata: Dict[str, Any]) -> Optional[int]:
     """Provider-reported total"""
     for source in (

--- a/backend/app/db/seed/knowledge/node_specs.md
+++ b/backend/app/db/seed/knowledge/node_specs.md
@@ -260,7 +260,7 @@ Sub-agent delegation — single edge from child to parent:
 | Field | Type | Default | Condition |
 |---|---|---|---|
 | name | text | — | Always |
-| promptCaching | boolean | false | Cache the stable system-prompt prefix and the tool-loop conversation (Anthropic / cache-capable Bedrock models only) |
+| promptCaching | boolean | false | Cache the stable system-prompt prefix (Anthropic / cache-capable Bedrock models only) |
 | memoryTrimmingMode | select | "message_count" | When memory=true. Options: message_count, token_budget, message_compacting, rag_retrieval |
 | maxMessages | number | 10 | When memoryTrimmingMode=message_count |
 | tokenBudget | number | 10000 | When memoryTrimmingMode=token_budget |
@@ -308,7 +308,7 @@ Sub-agent delegation — single edge from child to parent:
 | timeoutSeconds | number | 120 | Max seconds the parent waits for one delegated turn (5–300) |
 | memory | boolean | true | Enable the child's own conversation memory |
 | piiMasking | boolean | false | Mask PII before sending text to the LLM |
-| promptCaching | boolean | false | Cache the stable system-prompt prefix and the tool-loop conversation (Anthropic / cache-capable Bedrock models only) |
+| promptCaching | boolean | false | Cache the stable system-prompt prefix (Anthropic / cache-capable Bedrock models only) |
 | memoryTrimmingMode | select | "message_count" | When memory=true. Options: message_count, token_budget, message_compacting, rag_retrieval |
 | maxMessages | number | 20 | When memoryTrimmingMode=message_count |
 | tokenBudget | number | 10000 | When memoryTrimmingMode=token_budget |

--- a/backend/app/db/seed/knowledge/node_specs.md
+++ b/backend/app/db/seed/knowledge/node_specs.md
@@ -260,6 +260,7 @@ Sub-agent delegation — single edge from child to parent:
 | Field | Type | Default | Condition |
 |---|---|---|---|
 | name | text | — | Always |
+| promptCaching | boolean | false | Cache the stable system-prompt prefix and the tool-loop conversation (Anthropic / cache-capable Bedrock models only) |
 | memoryTrimmingMode | select | "message_count" | When memory=true. Options: message_count, token_budget, message_compacting, rag_retrieval |
 | maxMessages | number | 10 | When memoryTrimmingMode=message_count |
 | tokenBudget | number | 10000 | When memoryTrimmingMode=token_budget |
@@ -307,6 +308,7 @@ Sub-agent delegation — single edge from child to parent:
 | timeoutSeconds | number | 120 | Max seconds the parent waits for one delegated turn (5–300) |
 | memory | boolean | true | Enable the child's own conversation memory |
 | piiMasking | boolean | false | Mask PII before sending text to the LLM |
+| promptCaching | boolean | false | Cache the stable system-prompt prefix and the tool-loop conversation (Anthropic / cache-capable Bedrock models only) |
 | memoryTrimmingMode | select | "message_count" | When memory=true. Options: message_count, token_budget, message_compacting, rag_retrieval |
 | maxMessages | number | 20 | When memoryTrimmingMode=message_count |
 | tokenBudget | number | 10000 | When memoryTrimmingMode=token_budget |
@@ -341,7 +343,12 @@ Memory sub-settings match agentNode. **Attachment:** single edge `subAgentNode.o
 | type | select | "Base" | Model type: "Base" or "Chain-of-Thought" |
 | memory | boolean | false | Enable memory |
 
-**Optional config:** Same memory sub-settings as agentNode (conditional on memoryTrimmingMode).
+**Optional config:**
+| Field | Type | Default | Condition |
+|---|---|---|---|
+| promptCaching | boolean | false | Cache the stable system-prompt prefix (Anthropic / cache-capable Bedrock models only) |
+
+Same memory sub-settings as agentNode (conditional on memoryTrimmingMode).
 
 ---
 

--- a/backend/app/modules/workflow/agents/agent_prompts.py
+++ b/backend/app/modules/workflow/agents/agent_prompts.py
@@ -156,22 +156,18 @@ Always respond with a JSON object in this format:
     return base_prompt + no_tools_guidance
 
 
-def create_tool_agent_no_tools_query_prompt(enhanced_prompt: str, context: str, query: str) -> str:
-    """Create query prompt for ToolAgent when no tools are available"""
-    return f"""{enhanced_prompt}
-
-{context}
+def create_tool_agent_no_tools_query_portion(context: str, query: str) -> str:
+    """The part of the no-tools query prompt that follows the system prompt"""
+    return f"""{context}
 
 User Query: {query}
 
 Since no tools are available, provide a direct response based on your knowledge using the JSON format specified above."""
 
 
-def create_tool_agent_tools_query_prompt(enhanced_prompt: str, context: str, query: str) -> str:
-    """Create query prompt for ToolAgent when tools are available"""
-    return f"""{enhanced_prompt}
-
-{context}
+def create_tool_agent_tools_query_portion(context: str, query: str) -> str:
+    """The part of the tools query prompt that follows the system prompt"""
+    return f"""{context}
 
 User Query: {query}
 
@@ -180,6 +176,16 @@ Analyze the query and decide if you need to use any tools. Respond using the JSO
 - If you can answer directly, use the "direct_response" action format
 - Make sure to include all required parameters and follow the parameter types specified
 - Always include your reasoning for the decision"""
+
+
+def create_tool_agent_no_tools_query_prompt(enhanced_prompt: str, context: str, query: str) -> str:
+    """Create query prompt for ToolAgent when no tools are available"""
+    return enhanced_prompt + "\n\n" + create_tool_agent_no_tools_query_portion(context, query)
+
+
+def create_tool_agent_tools_query_prompt(enhanced_prompt: str, context: str, query: str) -> str:
+    """Create query prompt for ToolAgent when tools are available"""
+    return enhanced_prompt + "\n\n" + create_tool_agent_tools_query_portion(context, query)
 
 
 def create_tool_agent_iteration_continuation_prompt(last_tool_name: str, last_tool_result: str) -> str:

--- a/backend/app/modules/workflow/agents/agent_prompts.py
+++ b/backend/app/modules/workflow/agents/agent_prompts.py
@@ -96,12 +96,7 @@ Respond with a human readable explanation of your thought process and the final 
 
 # ==================== TOOL AGENT PROMPTS ====================
 
-def create_tool_agent_tools_available_prompt(base_prompt: str, tool_descriptions: List[str]) -> str:
-    """Create ToolAgent system prompt when tools are available"""
-    tool_guidance = f"""
-
-AVAILABLE TOOLS:
-{chr(10).join(tool_descriptions)}
+_TOOL_AGENT_GUIDANCE = """
 
 TOOL USAGE GUIDELINES:
 - Always consider which tools are available before responding
@@ -115,24 +110,37 @@ TOOL USAGE GUIDELINES:
 
 TOOL CALL FORMAT:
 When you need to use a tool, respond with a JSON object in this exact format:
-{{
+{
     "action": "tool_call",
     "tool_name": "tool_name_here",
-    "parameters": {{
+    "parameters": {
         "param1": "value1",
         "param2": "value2"
-    }},
+    },
     "reasoning": "Brief explanation of why you chose this tool and these parameters"
-}}
+}
 
 If you don't need to use any tools, respond with:
-{{
+{
     "action": "direct_response",
     "response": "Your direct answer here",
     "reasoning": "Brief explanation of why no tools were needed"
-}}
+}
 """
-    return base_prompt + tool_guidance
+
+
+def create_tool_agent_tools_available_prompt(base_prompt: str, tool_descriptions: List[str]) -> str:
+    """Create ToolAgent system prompt when tools are available"""
+    head, rest = create_tool_agent_tools_available_parts(base_prompt, tool_descriptions, [])
+    return head + rest
+
+
+def create_tool_agent_tools_available_parts(
+    base_prompt: str, stable_descriptions: List[str], trailing_descriptions: List[str]
+) -> tuple[str, str]:
+    head = base_prompt + f"\n\nAVAILABLE TOOLS:\n{chr(10).join(stable_descriptions)}"
+    separator = "\n" if stable_descriptions and trailing_descriptions else ""
+    return head, separator + chr(10).join(trailing_descriptions) + _TOOL_AGENT_GUIDANCE
 
 
 def create_tool_agent_no_tools_prompt(base_prompt: str) -> str:

--- a/backend/app/modules/workflow/agents/agent_runtime.py
+++ b/backend/app/modules/workflow/agents/agent_runtime.py
@@ -2,12 +2,15 @@
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+from langchain_core.messages import SystemMessage
 
 from app.modules.workflow.agents.react_agent import ReActAgent
 from app.modules.workflow.agents.react_agent_lc import ReActAgentLC
 from app.modules.workflow.agents.simple_tool_agent import SimpleToolAgent
 from app.modules.workflow.agents.tool_agent import ToolAgent
+from app.modules.workflow.llm.prompt_caching_chat_model import build_cacheable_system_message
 from app.modules.workflow.llm.provider import LLMProvider
 
 if TYPE_CHECKING:
@@ -29,6 +32,21 @@ class AgentRunResult:
     llm_model: Any
 
 
+def _react_system_prompt(
+    system_prompt: str, stable_volatile_parts: Optional[tuple[str, str]], llm_model: Any
+) -> tuple[Union[str, SystemMessage], tuple[bool, Optional[str]]]:
+    """A cacheable prefix plus its volatile tail, or the full string when ineligible,
+    together with the (applied, reason) decision that produced it"""
+    from app.modules.workflow.engine import prompt_cache_diagnostics as diagnostics
+
+    applied, reason = diagnostics.cache_split_decision(stable_volatile_parts, llm_model)
+    if not applied:
+        return system_prompt, (False, reason)
+
+    stable, volatile = stable_volatile_parts
+    return build_cacheable_system_message(stable, volatile), (True, None)
+
+
 async def run_agent_once(
     *,
     state: "WorkflowState",
@@ -42,6 +60,8 @@ async def run_agent_once(
     max_iterations: int,
     chat_history: Optional[List[Any]] = None,
     llm_model: Any = None,
+    stable_volatile_parts: Optional[tuple[str, str]] = None,
+    prompt_caching_enabled: bool = False,
 ) -> AgentRunResult:
     """Pick the LLM if needed, create the agent for ``agent_type``, run it once,
     add its token usage to ``state``, and return a normalized result"""
@@ -49,8 +69,13 @@ async def run_agent_once(
         from app.dependencies.injector import injector
 
         llm_provider = injector.get(LLMProvider)
-        llm_model = await llm_provider.get_model_for_node(provider_id, fallback_chain_id)
+        llm_model = await llm_provider.get_model_for_node(provider_id, fallback_chain_id, prompt_caching_enabled)
         logger.info("Agent type selected: %s, LLM model: %s", agent_type, llm_model)
+
+    # The decision always reads back the branch's own split outcome, so the diagnostic
+    # can never claim caching that did not happen.
+    decision: tuple[bool, Optional[str]] = (False, None)
+    mode_never_splits = False
 
     if agent_type == "ReActAgent":
         agent = ReActAgent(
@@ -59,10 +84,12 @@ async def run_agent_once(
             tools=tools,
             max_iterations=max_iterations,
         )
+        mode_never_splits = True
     elif agent_type == "ReActAgentLC":
+        react_prompt, decision = _react_system_prompt(system_prompt, stable_volatile_parts, llm_model)
         agent = ReActAgentLC(
             llm_model=llm_model,
-            system_prompt=system_prompt,
+            system_prompt=react_prompt,
             tools=tools,
             max_iterations=max_iterations,
         )
@@ -72,20 +99,40 @@ async def run_agent_once(
             system_prompt=system_prompt,
             tools=tools,
         )
+        mode_never_splits = True
     else:
         agent = ToolAgent(
             llm_model=llm_model,
             system_prompt=system_prompt,
             tools=tools,
             max_iterations=max_iterations,
+            stable_volatile_parts=stable_volatile_parts,
         )
+        # The agent's own stored decision, so a change to its split rule carries over here.
+        decision = agent.cache_split_decision
+
+    applied, split_reason = decision
+    # A withheld verdict is config-truth and lands before the call; "applied" waits
+    # until the invocation returns, so a raising agent leaves no misleading marker
+    if prompt_caching_enabled and not applied:
+        from app.modules.workflow.engine import prompt_cache_diagnostics as diagnostics
+
+        reason = diagnostics.REASON_UNSUPPORTED_MODE if mode_never_splits else split_reason
+        diagnostics.record(state, node_id, applied=False, reason=reason)
 
     result = await agent.invoke(user_prompt, chat_history=chat_history or [])
     logger.debug("Agent result: %s", result)
 
     from app.modules.workflow.engine.llm_usage_tracking import merge_llm_usage_from_result
 
-    await merge_llm_usage_from_result(state, result, node_id, provider_id)
+    await merge_llm_usage_from_result(state, result, node_id, provider_id, prompt_caching_enabled)
+
+    if prompt_caching_enabled and applied:
+        from app.modules.workflow.engine import prompt_cache_diagnostics as diagnostics
+
+        diagnostics.record(state, node_id, applied=True)
+        usage_entries = result.get("llm_usage") if isinstance(result, dict) else None
+        diagnostics.record_observed_cache_tokens(state, node_id, usage_entries)
 
     steps_key = "reasoning_steps" if agent_type in ["ReActAgent", "ReActAgentLC"] else "steps"
 

--- a/backend/app/modules/workflow/agents/agent_runtime.py
+++ b/backend/app/modules/workflow/agents/agent_runtime.py
@@ -61,6 +61,7 @@ async def run_agent_once(
     chat_history: Optional[List[Any]] = None,
     llm_model: Any = None,
     stable_volatile_parts: Optional[tuple[str, str]] = None,
+    stable_tool_names: Optional[frozenset[str]] = None,
     prompt_caching_enabled: bool = False,
 ) -> AgentRunResult:
     """Pick the LLM if needed, create the agent for ``agent_type``, run it once,
@@ -107,13 +108,14 @@ async def run_agent_once(
             tools=tools,
             max_iterations=max_iterations,
             stable_volatile_parts=stable_volatile_parts,
+            stable_tool_names=stable_tool_names,
         )
         # The agent's own stored decision, so a change to its split rule carries over here.
         decision = agent.cache_split_decision
 
     applied, split_reason = decision
     # A withheld verdict is config-truth and lands before the call; "applied" waits
-    # until the invocation returns, so a raising agent leaves no misleading marker
+    # until the invocation returns, so a failed run leaves no misleading marker
     if prompt_caching_enabled and not applied:
         from app.modules.workflow.engine import prompt_cache_diagnostics as diagnostics
 
@@ -127,12 +129,10 @@ async def run_agent_once(
 
     await merge_llm_usage_from_result(state, result, node_id, provider_id, prompt_caching_enabled)
 
-    if prompt_caching_enabled and applied:
+    if prompt_caching_enabled and applied and not (result.get("status") == "error" and not result.get("llm_usage")):
         from app.modules.workflow.engine import prompt_cache_diagnostics as diagnostics
 
         diagnostics.record(state, node_id, applied=True)
-        usage_entries = result.get("llm_usage") if isinstance(result, dict) else None
-        diagnostics.record_observed_cache_tokens(state, node_id, usage_entries)
 
     steps_key = "reasoning_steps" if agent_type in ["ReActAgent", "ReActAgentLC"] else "steps"
 

--- a/backend/app/modules/workflow/agents/react_agent_lc.py
+++ b/backend/app/modules/workflow/agents/react_agent_lc.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Union
 import logging
 import uuid
 from langchain_core.language_models import BaseChatModel
@@ -35,10 +35,12 @@ class RetryOnToolErrorMiddleware(AgentMiddleware):
 class ReActAgentLC(BaseToolAgent):
     """ReAct Agent implementation using LangGraph's prebuilt React agent"""
 
+    system_prompt: Union[str, SystemMessage]
+
     def __init__(
         self,
         llm_model: BaseChatModel,
-        system_prompt: str,
+        system_prompt: Union[str, SystemMessage],
         tools: List[BaseTool],
         verbose: bool = False,
         max_iterations: int = 5,
@@ -47,7 +49,9 @@ class ReActAgentLC(BaseToolAgent):
 
         Args:
             llm_model: The language model to use for reasoning and decision making
-            system_prompt: System prompt that defines the agent's behavior and role
+            system_prompt: System prompt that defines the agent's behavior and role.
+                A SystemMessage is passed to create_agent unchanged, so its content
+                blocks survive into the request
             tools: List of tools the agent can use to take actions
             verbose: Whether to enable verbose logging of reasoning cycles
             max_iterations: Maximum number of reasoning/action cycles
@@ -221,7 +225,6 @@ class ReActAgentLC(BaseToolAgent):
 
         try:
             # Prepare the input for LangGraph
-            # Add system prompt as the first message if it exists
             messages: List[BaseMessage] = []
 
             # Add chat history if available
@@ -517,11 +520,9 @@ class ReActAgentLC(BaseToolAgent):
         thread_id = kwargs.get("thread_id", str(uuid.uuid4()))
 
         try:
-            # Prepare the input for LangGraph
-            # Add system prompt as the first message if it exists
+            # Prepare the input for LangGraph.
+            # No system message here: create_agent already injects self.system_prompt
             messages: List[BaseMessage] = []
-            if self.system_prompt:
-                messages.append(SystemMessage(content=self.system_prompt))
 
             # Add chat history if available
             if chat_history:

--- a/backend/app/modules/workflow/agents/sub_agents/models.py
+++ b/backend/app/modules/workflow/agents/sub_agents/models.py
@@ -13,6 +13,9 @@ FRAME_VERSION = 1
 FRAME_TTL_HOURS = 24
 
 SUB_AGENT_RESUME_KEY = "__sub_agent_resume"
+# Rides inside the frame's free-form request_context, so ParentResume keeps its schema
+# and an older pod can still resume a frame written by a newer one
+SUB_AGENT_DIAGNOSTICS_KEY = "__prompt_caching_diagnostics"
 
 MAX_TASK_CHARS = 4000
 MAX_USER_PROMPT_CHARS = 4000

--- a/backend/app/modules/workflow/agents/sub_agents/orchestrator.py
+++ b/backend/app/modules/workflow/agents/sub_agents/orchestrator.py
@@ -118,6 +118,19 @@ def _force_child_pii(nodes: list, child_node_id: str) -> list:
     return out
 
 
+def propagate_prompt_cache_diagnostics(child_state: "WorkflowState", parent_state: "WorkflowState") -> None:
+    """Carry a child's prompt-caching diagnostics up to the parent, out of band"""
+    try:
+        merged = getattr(child_state, "prompt_caching_diagnostics", None)
+        if not isinstance(merged, dict) or not merged:
+            return
+        collected = getattr(parent_state, "prompt_caching_diagnostics", None)
+        if isinstance(collected, dict):
+            collected.update(merged)
+    except Exception:
+        logger.warning("Failed propagating sub-agent prompt-caching diagnostics", exc_info=True)
+
+
 async def run_child_turn(
     *,
     workflow: Dict[str, Any],

--- a/backend/app/modules/workflow/agents/sub_agents/turn_router.py
+++ b/backend/app/modules/workflow/agents/sub_agents/turn_router.py
@@ -119,6 +119,7 @@ class SubAgentTurnRouter:
             registry_managed=True,
             usage_context=usage_context,
         )
+        orchestrator.propagate_prompt_cache_diagnostics(child_state, state)
         return self.finalize(state.format_state_as_response())
 
     def _child_timeout(self, child_node_id: str) -> float:

--- a/backend/app/modules/workflow/agents/tool_agent.py
+++ b/backend/app/modules/workflow/agents/tool_agent.py
@@ -2,6 +2,7 @@ from typing import List, Dict, Any, Optional
 import logging
 import json
 from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import SystemMessage
 
 from app.modules.workflow.agents.base_tool import BaseTool
 from app.modules.workflow.agents.base_tool_agent import BaseToolAgent
@@ -21,11 +22,14 @@ from app.modules.workflow.agents.agent_prompts import (
     create_tool_agent_tools_available_prompt,
     create_tool_agent_no_tools_prompt,
     create_tool_agent_no_tools_query_prompt,
+    create_tool_agent_no_tools_query_portion,
     create_tool_agent_tools_query_prompt,
+    create_tool_agent_tools_query_portion,
     create_tool_agent_iteration_continuation_prompt,
     create_tool_selection_prompt,
     create_conversation_context as build_conversation_context
 )
+from app.modules.workflow.llm.prompt_caching_chat_model import build_cacheable_system_message
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +43,8 @@ class ToolAgent(BaseToolAgent):
         system_prompt: str,
         tools: List[BaseTool],
         verbose: bool = False,
-        max_iterations: int = 6
+        max_iterations: int = 6,
+        stable_volatile_parts: Optional[tuple[str, str]] = None
     ):
         """Initialize a Tool agent
 
@@ -49,19 +54,48 @@ class ToolAgent(BaseToolAgent):
             tools: List of tools the agent can use to accomplish tasks
             verbose: Whether to enable verbose logging of tool execution
             max_iterations: Maximum number of tool execution iterations
+            stable_volatile_parts: ``system_prompt`` split into its stable half and the
+                trailing part that changes every request. Set only when the stable half
+                is worth caching
         """
         super().__init__(llm_model, system_prompt, tools,
                          verbose=verbose, max_iterations=max_iterations)
 
+        from app.modules.workflow.engine.prompt_cache_diagnostics import cache_split_decision
+
+        self.stable_volatile_parts = stable_volatile_parts
+        # Splitting moves the guidance out of the fused user turn, so it is only worth
+        # doing when the provider can cache it and the caller marked the prompt eligible.
+        # The enhanced prefix always carries the wrapped tool guidance, so even a blank
+        # base prompt stays cacheable.
+        self.cache_split_decision = cache_split_decision(stable_volatile_parts, llm_model, stable_never_blank=True)
+        self._cache_split = self.cache_split_decision[0]
+
     # ==================== PROMPT GENERATION ====================
 
-    def _create_enhanced_system_prompt(self) -> str:
+    def _create_enhanced_system_prompt(self, base_prompt: Optional[str] = None) -> str:
         """Create an enhanced system prompt using centralized prompt templates"""
+        base_prompt = self.system_prompt if base_prompt is None else base_prompt
         if self.tools:
             tool_descriptions = create_tool_descriptions(self.tools)
-            return create_tool_agent_tools_available_prompt(self.system_prompt, tool_descriptions)
+            return create_tool_agent_tools_available_prompt(base_prompt, tool_descriptions)
         else:
-            return create_tool_agent_no_tools_prompt(self.system_prompt)
+            return create_tool_agent_no_tools_prompt(base_prompt)
+
+    def _cacheable_system_message(self) -> SystemMessage:
+        """The split mode's system turn. Built per invoke, not at init: tools stay
+        mutable afterwards. The volatile tail sits after the guidance, in front, the
+        guidance would fall outside the cacheable prefix."""
+        stable, volatile = self.stable_volatile_parts
+        return build_cacheable_system_message(self._create_enhanced_system_prompt(stable), volatile)
+
+    def _build_messages(self, query_prompt: str, system_message: Optional[SystemMessage] = None) -> List[Any]:
+        """One fused user turn, or a cacheable system turn plus the query portion"""
+        if not self._cache_split:
+            return [{"role": "user", "content": query_prompt}]
+        if system_message is None:
+            system_message = self._cacheable_system_message()
+        return [system_message, {"role": "user", "content": query_prompt}]
 
     # ==================== RESPONSE PARSING ====================
 
@@ -158,14 +192,15 @@ class ToolAgent(BaseToolAgent):
 
     async def _handle_no_tools_workflow(self, query: str, chat_history: List[Dict[str, str]]) -> Dict[str, Any]:
         """Handle workflow when no tools are available"""
-        enhanced_prompt = self._create_enhanced_system_prompt()
         context = build_conversation_context(chat_history)
-        prompt = create_tool_agent_no_tools_query_prompt(
-            enhanced_prompt, context, query)
+        if self._cache_split:
+            prompt = create_tool_agent_no_tools_query_portion(context, query)
+        else:
+            prompt = create_tool_agent_no_tools_query_prompt(
+                self._create_enhanced_system_prompt(), context, query)
 
         try:
-            response = await self.llm_model.ainvoke(
-                [{"role": "user", "content": prompt}])
+            response = await self.llm_model.ainvoke(self._build_messages(prompt))
             response_content = self._extract_response_content(response)
             logger.debug(f"Response: {response}")
             direct_response = extract_direct_response(response_content)
@@ -195,19 +230,24 @@ class ToolAgent(BaseToolAgent):
 
     async def _handle_tools_workflow(self, query: str, chat_history: List[Dict[str, str]]) -> Dict[str, Any]:
         """Handle workflow when tools are available"""
-        enhanced_prompt = self._create_enhanced_system_prompt()
         context = build_conversation_context(chat_history)
-        prompt = create_tool_agent_tools_query_prompt(
-            enhanced_prompt, context, query)
+        if self._cache_split:
+            prompt = create_tool_agent_tools_query_portion(context, query)
+        else:
+            prompt = create_tool_agent_tools_query_prompt(
+                self._create_enhanced_system_prompt(), context, query)
 
         workflow_steps: List[Dict[str, Any]] = []
         tools_used: List[Dict[str, Any]] = []
         llm_usage_entries: List[Dict[str, Any]] = []
+        # Byte-identical across iterations (only the user turn grows), so its built once
+        # per invoke. Kept invocation-local: tools added later still reach the next invoke
+        system_message = self._cacheable_system_message() if self._cache_split else None
 
         for iteration in range(self.max_iterations):
             try:
                 result = await self._execute_workflow_iteration(
-                    prompt, iteration, workflow_steps, tools_used, llm_usage_entries
+                    prompt, iteration, workflow_steps, tools_used, llm_usage_entries, system_message
                 )
 
                 if result is not None:
@@ -253,9 +293,10 @@ class ToolAgent(BaseToolAgent):
         workflow_steps: List[Dict],
         tools_used: List[Dict],
         llm_usage_entries: List[Dict],
+        system_message: Optional[SystemMessage] = None,
     ) -> Optional[Dict[str, Any]]:
         """Execute a single workflow iteration"""
-        response = await self.llm_model.ainvoke([{"role": "user", "content": prompt}])
+        response = await self.llm_model.ainvoke(self._build_messages(prompt, system_message))
         response_content = self._extract_response_content(response)
 
         usage = extract_usage_from_aimessage(response)

--- a/backend/app/modules/workflow/agents/tool_agent.py
+++ b/backend/app/modules/workflow/agents/tool_agent.py
@@ -19,6 +19,7 @@ from app.modules.workflow.agents.agent_utils import (
     extract_direct_response
 )
 from app.modules.workflow.agents.agent_prompts import (
+    create_tool_agent_tools_available_parts,
     create_tool_agent_tools_available_prompt,
     create_tool_agent_no_tools_prompt,
     create_tool_agent_no_tools_query_prompt,
@@ -44,7 +45,8 @@ class ToolAgent(BaseToolAgent):
         tools: List[BaseTool],
         verbose: bool = False,
         max_iterations: int = 6,
-        stable_volatile_parts: Optional[tuple[str, str]] = None
+        stable_volatile_parts: Optional[tuple[str, str]] = None,
+        stable_tool_names: Optional[frozenset[str]] = None,
     ):
         """Initialize a Tool agent
 
@@ -64,10 +66,11 @@ class ToolAgent(BaseToolAgent):
         from app.modules.workflow.engine.prompt_cache_diagnostics import cache_split_decision
 
         self.stable_volatile_parts = stable_volatile_parts
+        self.stable_tool_names = stable_tool_names
         # Splitting moves the guidance out of the fused user turn, so it is only worth
         # doing when the provider can cache it and the caller marked the prompt eligible.
-        # The enhanced prefix always carries the wrapped tool guidance, so even a blank
-        # base prompt stays cacheable.
+        # The enhanced prefix carries at least the tools header, so even a blank base
+        # prompt stays cacheable.
         self.cache_split_decision = cache_split_decision(stable_volatile_parts, llm_model, stable_never_blank=True)
         self._cache_split = self.cache_split_decision[0]
 
@@ -87,7 +90,18 @@ class ToolAgent(BaseToolAgent):
         mutable afterwards. The volatile tail sits after the guidance, in front, the
         guidance would fall outside the cacheable prefix."""
         stable, volatile = self.stable_volatile_parts
-        return build_cacheable_system_message(self._create_enhanced_system_prompt(stable), volatile)
+        if self.stable_tool_names is None or not self.tools:
+            return build_cacheable_system_message(self._create_enhanced_system_prompt(stable), volatile)
+
+        split_at = next(
+            (i for i, tool in enumerate(self.tools) if tool.name not in self.stable_tool_names),
+            len(self.tools),
+        )
+        descriptions = create_tool_descriptions(self.tools)
+        head, rest = create_tool_agent_tools_available_parts(
+            stable, descriptions[:split_at], descriptions[split_at:]
+        )
+        return build_cacheable_system_message(head, rest + volatile)
 
     def _build_messages(self, query_prompt: str, system_message: Optional[SystemMessage] = None) -> List[Any]:
         """One fused user turn, or a cacheable system turn plus the query portion"""

--- a/backend/app/modules/workflow/engine/llm_usage_tracking.py
+++ b/backend/app/modules/workflow/engine/llm_usage_tracking.py
@@ -18,10 +18,14 @@ from app.services.llm_providers import LlmProviderService
 logger = logging.getLogger(__name__)
 
 
+# One provider id resolved to (provider, model)
+ProviderAttribution = tuple[str, str]
+
+
 async def resolve_provider_model(
     provider_id: Any,
-    cache: Optional[Dict[str, tuple[str, str]]] = None,
-) -> tuple[str, str]:
+    cache: Optional[Dict[str, ProviderAttribution]] = None,
+) -> ProviderAttribution:
     """Resolve provider/model names for pricing, memoized per id when ``cache`` is given"""
     key = str(provider_id) if provider_id else ""
     if cache is not None and key in cache:
@@ -47,6 +51,7 @@ async def merge_llm_usage_from_result(
     result: Dict[str, Any],
     node_id: str,
     provider_id: str,
+    prompt_caching_enabled: bool = False,
 ) -> None:
     """
     Merge llm_usage from agent result into workflow state.
@@ -59,13 +64,14 @@ async def merge_llm_usage_from_result(
         result: Agent result dict that may contain "llm_usage" list
         node_id: Node ID for tracking
         provider_id: LLM provider ID to resolve provider/model names
+        prompt_caching_enabled: Whether the node asked for prompt caching on this call
     """
     try:
         llm_usage_list = result.get("llm_usage", []) if isinstance(result, dict) else []
         if not llm_usage_list:
             return
 
-        resolved: Dict[str, tuple[str, str]] = {}
+        resolved: Dict[str, ProviderAttribution] = {}
 
         for u in llm_usage_list:
             if not isinstance(u, dict):
@@ -82,6 +88,7 @@ async def merge_llm_usage_from_result(
                 purpose=u.get("purpose"),
                 token_details=u.get("token_details"),
                 llm_provider_id=pid,
+                prompt_caching_enabled=prompt_caching_enabled,
             )
     except Exception:
         logger.warning("Failed merging LLM usage for node %s", node_id, exc_info=True)
@@ -93,6 +100,7 @@ async def record_node_llm_usage(
     node_id: str,
     provider_id: str,
     purpose: Optional[str] = None,
+    prompt_caching_enabled: bool = False,
 ) -> None:
     """Record token usage from one LangChain message onto ``state``"""
     if response is None:
@@ -106,7 +114,7 @@ async def record_node_llm_usage(
 
     entry = usage_or_placeholder(usage)
     entry["purpose"] = purpose
-    await merge_llm_usage_from_result(state, {"llm_usage": [entry]}, node_id, provider_id)
+    await merge_llm_usage_from_result(state, {"llm_usage": [entry]}, node_id, provider_id, prompt_caching_enabled)
 
 
 async def record_compaction_usage(

--- a/backend/app/modules/workflow/engine/nodes/agent_node.py
+++ b/backend/app/modules/workflow/engine/nodes/agent_node.py
@@ -6,13 +6,14 @@ import asyncio
 import datetime
 import logging
 import uuid
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from app.core.utils.token_utils import calculate_history_tokens
 from app.modules.workflow.agents.agent_runtime import run_agent_once
 from app.modules.workflow.engine import BaseNode
 from app.modules.workflow.engine.node_result import node_failure
 from app.modules.workflow.engine.pii_anonymizer_mixin import PIIAnonymizerMixin
+from app.modules.workflow.engine.utils import has_volatile_template_vars
 from app.modules.workflow.llm.provider import LLMProvider
 from app.services.llm_providers import LlmProviderService
 
@@ -321,6 +322,7 @@ class AgentNode(PIIAnonymizerMixin, BaseNode):
             child_output = child_state.get_node_output(child_id)
             if child_output is not None:
                 state.node_outputs[child_id] = child_output
+            orchestrator.propagate_prompt_cache_diagnostics(child_state, state)
 
             completion = orchestrator.child_completion(child_state)
             message = orchestrator.child_message(child_state)
@@ -339,6 +341,15 @@ class AgentNode(PIIAnonymizerMixin, BaseNode):
 
         return _delegate
 
+    def _timestamped_system_prompt(self, system_prompt: str) -> tuple[str, Optional[tuple[str, str]]]:
+        """Full prompt with the timestamp appended, plus its (stable, volatile) parts.
+        None when the raw template is volatile, so the prompt must not be cached"""
+        suffix = f" Current time: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+        full = system_prompt + suffix
+        if has_volatile_template_vars(self.node_data.get("systemPrompt")):
+            return full, None
+        return full, (system_prompt, suffix)
+
     @staticmethod
     def _drop_child_tools(all_tools, delegation_map, child_ids):
         """Remove delegation tools for children already delegated this turn"""
@@ -349,6 +360,8 @@ class AgentNode(PIIAnonymizerMixin, BaseNode):
     async def _run_agent_with_delegations(
         self, *, config, provider_id, fallback_chain_id, agent_type,
         system_prompt, prompt, all_tools, delegation_map, max_iterations, chat_history,
+        stable_volatile_parts: Optional[tuple[str, str]] = None,
+        prompt_caching_enabled: bool = False,
     ) -> Dict[str, Any]:
         """Invoke the agent, resolving delegation tool calls, until it answers or pauses"""
         from app.modules.workflow.agents.sub_agents import orchestrator
@@ -380,6 +393,8 @@ class AgentNode(PIIAnonymizerMixin, BaseNode):
                 system_prompt=system_prompt, user_prompt=current_prompt,
                 tools=active_tools, max_iterations=max_iterations,
                 chat_history=chat_history, llm_model=llm_model,
+                stable_volatile_parts=stable_volatile_parts,
+                prompt_caching_enabled=prompt_caching_enabled,
             )
             llm_model = run.llm_model
             steps.extend(run.steps)
@@ -429,6 +444,7 @@ class AgentNode(PIIAnonymizerMixin, BaseNode):
         from app.modules.workflow.agents.sub_agents.models import (
             MAX_TASK_CHARS,
             MAX_USER_PROMPT_CHARS,
+            SUB_AGENT_DIAGNOSTICS_KEY,
             ParentResume,
             SubAgentFrame,
             SubAgentStack,
@@ -445,10 +461,15 @@ class AgentNode(PIIAnonymizerMixin, BaseNode):
             return self._shape_delegated_message(messages.DELEGATION_DEPTH_REACHED, steps, tools_used)
 
         workflow = state.workflow
+        request_context = state.capture_resume_context()
+        # Added only when there is something to carry, so an unused-caching frame stays
+        # byte-identical to one written before this key existed
+        if state.prompt_caching_diagnostics:
+            request_context[SUB_AGENT_DIAGNOSTICS_KEY] = dict(state.prompt_caching_diagnostics)
         resume = ParentResume(
             node_outputs=_frame_snapshot(state.node_outputs),
             node_execution_status=_frame_snapshot(_without_tool_references(state.node_execution_status)),
-            request_context=_frame_snapshot(state.capture_resume_context()),
+            request_context=_frame_snapshot(request_context),
             user_prompt=current_prompt[:MAX_USER_PROMPT_CHARS],
             completed_count=completed_count,
             accumulated_steps=_frame_snapshot(steps),
@@ -477,6 +498,12 @@ class AgentNode(PIIAnonymizerMixin, BaseNode):
         state.node_execution_status.update(resume.get("node_execution_status") or {})
         request_context = resume.get("request_context")
         if request_context:
+            from app.modules.workflow.agents.sub_agents.models import SUB_AGENT_DIAGNOSTICS_KEY
+
+            request_context = dict(request_context)
+            carried = request_context.pop(SUB_AGENT_DIAGNOSTICS_KEY, None)
+            if isinstance(carried, dict):
+                state.prompt_caching_diagnostics.update(carried)
             state.restore_resume_context(request_context, drop_keys={"message"})
         steps = list(resume.get("accumulated_steps") or [])
         tools_used = list(resume.get("accumulated_tools_used") or [])
@@ -572,6 +599,7 @@ class AgentNode(PIIAnonymizerMixin, BaseNode):
         agent_type: str = config.get("type", "ToolSelector")
         max_iterations = config.get("maxIterations", 7)
         memory_enabled = config.get("memory", False)
+        prompt_caching_enabled = config.get("promptCaching") is True
 
         # Get input data from state (this would typically come from connected nodes)
         # For now, we'll use default values
@@ -595,8 +623,9 @@ class AgentNode(PIIAnonymizerMixin, BaseNode):
         if config.get("piiMasking") and all_tools:
             self._wrap_tools_for_pii_unmask(all_tools)
 
-        # Add current time to system prompt
-        system_prompt += f" Current time: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+        # Add current time to system prompt. Forwarded parts mean "the stable half may be
+        # cached", so a prompt built from per-request template variables withholds them.
+        system_prompt, stable_volatile_parts = self._timestamped_system_prompt(system_prompt)
 
         # Set input for tracking
         self.set_node_input({
@@ -630,6 +659,8 @@ class AgentNode(PIIAnonymizerMixin, BaseNode):
                     delegation_map=delegation_map,
                     max_iterations=max_iterations,
                     chat_history=chat_history,
+                    stable_volatile_parts=stable_volatile_parts,
+                    prompt_caching_enabled=prompt_caching_enabled,
                 )
 
             run = await run_agent_once(
@@ -643,6 +674,8 @@ class AgentNode(PIIAnonymizerMixin, BaseNode):
                 tools=tools,
                 max_iterations=max_iterations,
                 chat_history=chat_history,
+                stable_volatile_parts=stable_volatile_parts,
+                prompt_caching_enabled=prompt_caching_enabled,
             )
 
             # The agent caught an error internally and returned a standardized error response

--- a/backend/app/modules/workflow/engine/nodes/agent_node.py
+++ b/backend/app/modules/workflow/engine/nodes/agent_node.py
@@ -375,6 +375,11 @@ class AgentNode(PIIAnonymizerMixin, BaseNode):
         completed_count = 0
         current_prompt = prompt
 
+        stable_tool_names = None
+        if delegation_map:
+            first_delegation = next((i for i, t in enumerate(all_tools) if t.name in delegation_map), len(all_tools))
+            stable_tool_names = frozenset(t.name for t in all_tools[:first_delegation])
+
         resume = (state.initial_values or {}).get(SUB_AGENT_RESUME_KEY)
         if resume:
             completed_count, steps, tools_used, current_prompt = self._apply_sub_agent_resume(resume, pii)
@@ -394,6 +399,7 @@ class AgentNode(PIIAnonymizerMixin, BaseNode):
                 tools=active_tools, max_iterations=max_iterations,
                 chat_history=chat_history, llm_model=llm_model,
                 stable_volatile_parts=stable_volatile_parts,
+                stable_tool_names=stable_tool_names,
                 prompt_caching_enabled=prompt_caching_enabled,
             )
             llm_model = run.llm_model

--- a/backend/app/modules/workflow/engine/nodes/llm_model_node.py
+++ b/backend/app/modules/workflow/engine/nodes/llm_model_node.py
@@ -4,7 +4,7 @@ LLM model node implementation using the BaseNode class.
 
 import base64
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from langchain_core.messages import HumanMessage, SystemMessage
 
@@ -15,6 +15,7 @@ from app.modules.workflow.agents.cot_agent import ChainOfThoughtAgent
 from app.modules.workflow.engine import BaseNode
 from app.modules.workflow.engine.node_result import node_failure
 from app.modules.workflow.engine.pii_anonymizer_mixin import PIIAnonymizerMixin
+from app.modules.workflow.engine.utils import has_volatile_template_vars
 from app.modules.workflow.llm.provider import LLMProvider
 from app.services.llm_providers import LlmProviderService
 
@@ -128,6 +129,13 @@ class LLMModelNode(PIIAnonymizerMixin, BaseNode):
             max_messages = config.get("maxMessages", 10)
             return await memory.get_chat_history(as_string=True, max_messages=max_messages)
 
+    def _system_prompt_is_cacheable(self, llm: Any, system_prompt: Any) -> tuple[bool, Optional[str]]:
+        """Whether the system prompt is stable enough across requests to cache"""
+        from app.modules.workflow.engine import prompt_cache_diagnostics as diagnostics
+
+        parts = None if has_volatile_template_vars(self.node_data.get("systemPrompt")) else (system_prompt, "")
+        return diagnostics.cache_split_decision(parts, llm)
+
     async def _perform_compaction(self, memory, config: Dict[str, Any], provider_id: str) -> None:
         """
         Perform message compaction using configured settings.
@@ -193,6 +201,7 @@ class LLMModelNode(PIIAnonymizerMixin, BaseNode):
         prompt = config.get("userPrompt", "Hello, how can you help me?")
         _type = config.get("type", "base")
         memory_enabled = config.get("memory", False)
+        prompt_caching_enabled = config.get("promptCaching") is True
 
         logger.debug(f"Input data: system_prompt={system_prompt}, prompt={prompt}")
 
@@ -204,11 +213,18 @@ class LLMModelNode(PIIAnonymizerMixin, BaseNode):
             from app.dependencies.injector import injector
 
             llm_provider = injector.get(LLMProvider)
-            llm = await llm_provider.get_model_for_node(provider_id, fallback_chain_id)
+            llm = await llm_provider.get_model_for_node(provider_id, fallback_chain_id, prompt_caching_enabled)
 
             memory = self.get_memory() if memory_enabled else None
 
             if _type == "Chain-of-Thought":
+                if prompt_caching_enabled:
+                    from app.modules.workflow.engine import prompt_cache_diagnostics as diagnostics
+
+                    diagnostics.record(
+                        self.get_state(), self.node_id,
+                        applied=False, reason=diagnostics.REASON_UNSUPPORTED_MODE,
+                    )
                 agent = ChainOfThoughtAgent(
                     llm_model=llm,
                     system_prompt=system_prompt,
@@ -221,16 +237,30 @@ class LLMModelNode(PIIAnonymizerMixin, BaseNode):
 
                 from app.modules.workflow.engine.llm_usage_tracking import merge_llm_usage_from_result
 
-                await merge_llm_usage_from_result(self.get_state(), result, self.node_id, provider_id)
+                await merge_llm_usage_from_result(
+                    self.get_state(), result, self.node_id, provider_id, prompt_caching_enabled
+                )
                 if isinstance(result, dict) and "llm_usage" in result:
                     result = {k: v for k, v in result.items() if k != "llm_usage"}
                 return result
 
+            cacheable_prefix, cache_reason = self._system_prompt_is_cacheable(llm, system_prompt)
+
+            chat_history = ""
             if memory:
                 chat_history = await self._get_chat_history_for_context(
                     memory, config, provider_id, system_prompt, prompt
                 )
-                system_prompt = system_prompt + "\n\n" + chat_history
+
+            if cacheable_prefix:
+                from app.modules.workflow.llm.prompt_caching_chat_model import build_cacheable_system_message
+
+                stable_text = (system_prompt + "\n\n") if memory else system_prompt
+                system_message = build_cacheable_system_message(stable_text, chat_history)
+            elif memory:
+                system_message = SystemMessage(content=system_prompt + "\n\n" + chat_history)
+            else:
+                system_message = SystemMessage(content=system_prompt)
 
             # default message content
             message_content = [{"type": "text", "text": prompt}]
@@ -242,12 +272,25 @@ class LLMModelNode(PIIAnonymizerMixin, BaseNode):
                 attachments_message_content = self._build_attachments_message_content(attachments)
                 message_content.extend(attachments_message_content)
 
+            if prompt_caching_enabled and not cacheable_prefix:
+                from app.modules.workflow.engine import prompt_cache_diagnostics as diagnostics
+
+                diagnostics.record(self.get_state(), self.node_id, applied=False, reason=cache_reason)
+
             # Process the input through the model
-            response = await llm.ainvoke([SystemMessage(content=system_prompt), HumanMessage(content=message_content)])
+            response = await llm.ainvoke([system_message, HumanMessage(content=message_content)])
 
             from app.modules.workflow.engine.llm_usage_tracking import record_node_llm_usage
 
-            await record_node_llm_usage(self.get_state(), response, self.node_id, provider_id)
+            await record_node_llm_usage(
+                self.get_state(), response, self.node_id, provider_id, prompt_caching_enabled=prompt_caching_enabled
+            )
+
+            if prompt_caching_enabled and cacheable_prefix:
+                from app.modules.workflow.engine import prompt_cache_diagnostics as diagnostics
+
+                diagnostics.record(self.get_state(), self.node_id, applied=True)
+                diagnostics.record_observed_cache_tokens(self.get_state(), self.node_id, [response])
 
             return response.content
 

--- a/backend/app/modules/workflow/engine/nodes/llm_model_node.py
+++ b/backend/app/modules/workflow/engine/nodes/llm_model_node.py
@@ -290,7 +290,6 @@ class LLMModelNode(PIIAnonymizerMixin, BaseNode):
                 from app.modules.workflow.engine import prompt_cache_diagnostics as diagnostics
 
                 diagnostics.record(self.get_state(), self.node_id, applied=True)
-                diagnostics.record_observed_cache_tokens(self.get_state(), self.node_id, [response])
 
             return response.content
 

--- a/backend/app/modules/workflow/engine/nodes/sub_agent_node.py
+++ b/backend/app/modules/workflow/engine/nodes/sub_agent_node.py
@@ -1,6 +1,5 @@
 """Sub-agent node: a specialist agent a parent delegates to"""
 
-import datetime
 import logging
 from typing import Any, Dict, Optional
 
@@ -29,6 +28,7 @@ class SubAgentNode(AgentNode):
         max_iterations = config.get("maxIterations", 7)
         memory_enabled = config.get("memory", False)
         mode = config.get("mode", "single_turn")
+        prompt_caching_enabled = config.get("promptCaching") is True
 
         system_prompt = config.get("systemPrompt") or "You are a helpful assistant."
         system_prompt += self._completion_instructions(mode)
@@ -48,7 +48,8 @@ class SubAgentNode(AgentNode):
         if config.get("piiMasking") and all_tools:
             self._wrap_tools_for_pii_unmask(all_tools)
 
-        system_prompt += f" Current time: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+        system_prompt, stable_volatile_parts = self._timestamped_system_prompt(system_prompt)
+
         self.set_node_input({"system_prompt": system_prompt, "prompt": prompt, "tools_reference": all_tools})
 
         try:
@@ -70,6 +71,8 @@ class SubAgentNode(AgentNode):
                     delegation_map=delegation_map,
                     max_iterations=max_iterations,
                     chat_history=chat_history,
+                    stable_volatile_parts=stable_volatile_parts,
+                    prompt_caching_enabled=prompt_caching_enabled,
                 )
 
             run = await run_agent_once(
@@ -83,6 +86,8 @@ class SubAgentNode(AgentNode):
                 tools=all_tools,
                 max_iterations=max_iterations,
                 chat_history=chat_history,
+                stable_volatile_parts=stable_volatile_parts,
+                prompt_caching_enabled=prompt_caching_enabled,
             )
             return self._shape_delegated_output(run, run.steps, run.tools_used)
         except Exception as e:

--- a/backend/app/modules/workflow/engine/nodes/workflow_executor_node.py
+++ b/backend/app/modules/workflow/engine/nodes/workflow_executor_node.py
@@ -90,6 +90,16 @@ class WorkflowExecutorNode(BaseNode):
             # Nested runs use a separate state; carry their tool events up for evaluation.
             self.get_state().absorb_tool_events(state)
 
+            child_diagnostics = getattr(state, "prompt_caching_diagnostics", None)
+            if child_diagnostics:
+                from app.modules.workflow.engine import prompt_cache_diagnostics as diagnostics
+
+                diagnostics.record(
+                    self.get_state(),
+                    self.node_id,
+                    applied=any(isinstance(e, dict) and e.get("applied") for e in child_diagnostics.values()),
+                )
+
             # Format and return the response
             result = state.format_state_as_response()
 

--- a/backend/app/modules/workflow/engine/prompt_cache_diagnostics.py
+++ b/backend/app/modules/workflow/engine/prompt_cache_diagnostics.py
@@ -53,23 +53,22 @@ def record(state: Any, node_id: str, *, applied: bool, reason: Optional[str] = N
     """Write the node's decision into the state's diagnostics map. Best effort: a
     diagnostic must never raise into the business path.
 
+    ``applied`` means a cache marker was serialized into the provider request.
+
     A delegation loop re-records the same node once per turn, so the entry covers
     the whole node execution: one applied turn marks the node applied, and observed
     token counts from earlier turns carry over"""
     try:
+        if not applied and reason:
+            logger.debug("Prompt caching withheld for node %s: %s", node_id, reason)
         diagnostics_map = _diagnostics_map(state)
         if diagnostics_map is None:
             return
-        entry = {
-            "requested": True,
-            "applied": applied,
-            "reason": None if applied else reason,
-        }
+        entry = {"requested": True, "applied": applied}
         previous = diagnostics_map.get(node_id)
         if isinstance(previous, dict):
             if previous.get("applied"):
                 entry["applied"] = True
-                entry["reason"] = None
             for key in ("cache_read_tokens", "cache_creation_tokens"):
                 if key in previous:
                     entry[key] = previous[key]

--- a/backend/app/modules/workflow/engine/prompt_cache_diagnostics.py
+++ b/backend/app/modules/workflow/engine/prompt_cache_diagnostics.py
@@ -56,8 +56,7 @@ def record(state: Any, node_id: str, *, applied: bool, reason: Optional[str] = N
     ``applied`` means a cache marker was serialized into the provider request.
 
     A delegation loop re-records the same node once per turn, so the entry covers
-    the whole node execution: one applied turn marks the node applied, and observed
-    token counts from earlier turns carry over"""
+    the whole node execution: one applied turn marks the node applied"""
     try:
         if not applied and reason:
             logger.debug("Prompt caching withheld for node %s: %s", node_id, reason)
@@ -66,47 +65,34 @@ def record(state: Any, node_id: str, *, applied: bool, reason: Optional[str] = N
             return
         entry = {"requested": True, "applied": applied}
         previous = diagnostics_map.get(node_id)
-        if isinstance(previous, dict):
-            if previous.get("applied"):
-                entry["applied"] = True
-            for key in ("cache_read_tokens", "cache_creation_tokens"):
-                if key in previous:
-                    entry[key] = previous[key]
+        if isinstance(previous, dict) and previous.get("applied"):
+            entry["applied"] = True
         diagnostics_map[node_id] = entry
     except Exception:
         logger.warning("Failed writing the prompt-caching diagnostic for node %s", node_id, exc_info=True)
 
 
-def record_observed_cache_tokens(state: Any, node_id: str, usage_entries: Any) -> None:
-    """Stamp the provider-reported cache activity onto an applied diagnostic, so
-    "marker applied" can be told apart from "provider actually cached" (short prompts
-    below the provider's minimum are silently processed uncached)"""
-    try:
-        diagnostics_map = _diagnostics_map(state)
-        if diagnostics_map is None:
-            return
-        entry = diagnostics_map.get(node_id)
+def with_observed_cache_tokens(diagnostics_map: dict, llm_usage: Any) -> dict:
+
+    from app.core.utils.llm_usage_utils import extract_cache_tokens, is_usage_metadata_missing
+
+    serialized: dict = {}
+    for node_id, entry in diagnostics_map.items():
         if not isinstance(entry, dict) or not entry.get("applied"):
-            return
-
-        from app.core.utils.llm_usage_utils import extract_cache_tokens, extract_usage_from_aimessage
-
+            serialized[node_id] = entry
+            continue
         cache_read = cache_creation = 0
         reported = False
-        for usage in usage_entries or []:
-            if usage is not None and not isinstance(usage, dict):
-                usage = extract_usage_from_aimessage(usage)
-            if not isinstance(usage, dict):
+        for usage in llm_usage or []:
+            if not isinstance(usage, dict) or usage.get("node_id") != node_id:
+                continue
+            if not usage.get("prompt_caching_enabled") or is_usage_metadata_missing(usage.get("token_details")):
                 continue
             reported = True
             read, creation = extract_cache_tokens(usage.get("token_details"))
             cache_read += read
             cache_creation += creation
-        # A run with no usage at all stays unstamped: absent fields mean "not reported",
-        # zeros mean "reported, and nothing was cached". Added, not assigned, so
-        # delegation turns accumulate into one node total
         if reported:
-            entry["cache_read_tokens"] = entry.get("cache_read_tokens", 0) + cache_read
-            entry["cache_creation_tokens"] = entry.get("cache_creation_tokens", 0) + cache_creation
-    except Exception:
-        logger.warning("Failed recording observed cache tokens for node %s", node_id, exc_info=True)
+            entry = {**entry, "cache_read_tokens": cache_read, "cache_creation_tokens": cache_creation}
+        serialized[node_id] = entry
+    return serialized

--- a/backend/app/modules/workflow/engine/prompt_cache_diagnostics.py
+++ b/backend/app/modules/workflow/engine/prompt_cache_diagnostics.py
@@ -1,0 +1,113 @@
+"""Per-node prompt-caching diagnostics: what a node asked for, and what it actually got"""
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+REASON_UNSUPPORTED_MODE = "unsupported_mode"
+REASON_VOLATILE_PROMPT = "volatile_prompt"
+REASON_MIXED_FALLBACK_CHAIN = "mixed_fallback_chain"
+REASON_UNSUPPORTED_CACHE_MARKERS = "unsupported_cache_markers"
+REASON_EMPTY_PROMPT = "empty_prompt"
+
+
+def unwrapped_model_reason(llm: Any) -> Optional[str]:
+    """Why this model cannot cache: a chain only partly wrappable, or a provider/model that
+    does not accept explicit cache markers. None when the model can cache after all"""
+    from app.modules.workflow.llm.fallback_chat_model import FallbackChatModel
+    from app.modules.workflow.llm.prompt_caching_chat_model import model_has_prompt_caching
+
+    if model_has_prompt_caching(llm):
+        return None
+    if isinstance(llm, FallbackChatModel) and any(model_has_prompt_caching(child) for child in llm.models or []):
+        return REASON_MIXED_FALLBACK_CHAIN
+    return REASON_UNSUPPORTED_CACHE_MARKERS
+
+
+def cache_split_decision(
+    stable_volatile_parts: Optional[tuple], llm: Any, *, stable_never_blank: bool = False
+) -> tuple[bool, Optional[str]]:
+    """The shared caching gate every node type calls: returns (applied, reason),checked in order"""
+    if not stable_volatile_parts:
+        return False, REASON_VOLATILE_PROMPT
+
+    unsupported = unwrapped_model_reason(llm)
+    if unsupported:
+        return False, unsupported
+
+    if stable_never_blank:
+        return True, None
+    stable = stable_volatile_parts[0]
+    if not isinstance(stable, str) or not stable.strip():
+        return False, REASON_EMPTY_PROMPT
+    return True, None
+
+
+def _diagnostics_map(state: Any) -> Optional[dict]:
+    diagnostics_map = getattr(state, "prompt_caching_diagnostics", None)
+    return diagnostics_map if isinstance(diagnostics_map, dict) else None
+
+
+def record(state: Any, node_id: str, *, applied: bool, reason: Optional[str] = None) -> None:
+    """Write the node's decision into the state's diagnostics map. Best effort: a
+    diagnostic must never raise into the business path.
+
+    A delegation loop re-records the same node once per turn, so the entry covers
+    the whole node execution: one applied turn marks the node applied, and observed
+    token counts from earlier turns carry over"""
+    try:
+        diagnostics_map = _diagnostics_map(state)
+        if diagnostics_map is None:
+            return
+        entry = {
+            "requested": True,
+            "applied": applied,
+            "reason": None if applied else reason,
+        }
+        previous = diagnostics_map.get(node_id)
+        if isinstance(previous, dict):
+            if previous.get("applied"):
+                entry["applied"] = True
+                entry["reason"] = None
+            for key in ("cache_read_tokens", "cache_creation_tokens"):
+                if key in previous:
+                    entry[key] = previous[key]
+        diagnostics_map[node_id] = entry
+    except Exception:
+        logger.warning("Failed writing the prompt-caching diagnostic for node %s", node_id, exc_info=True)
+
+
+def record_observed_cache_tokens(state: Any, node_id: str, usage_entries: Any) -> None:
+    """Stamp the provider-reported cache activity onto an applied diagnostic, so
+    "marker applied" can be told apart from "provider actually cached" (short prompts
+    below the provider's minimum are silently processed uncached)"""
+    try:
+        diagnostics_map = _diagnostics_map(state)
+        if diagnostics_map is None:
+            return
+        entry = diagnostics_map.get(node_id)
+        if not isinstance(entry, dict) or not entry.get("applied"):
+            return
+
+        from app.core.utils.llm_usage_utils import extract_cache_tokens, extract_usage_from_aimessage
+
+        cache_read = cache_creation = 0
+        reported = False
+        for usage in usage_entries or []:
+            if usage is not None and not isinstance(usage, dict):
+                usage = extract_usage_from_aimessage(usage)
+            if not isinstance(usage, dict):
+                continue
+            reported = True
+            read, creation = extract_cache_tokens(usage.get("token_details"))
+            cache_read += read
+            cache_creation += creation
+        # A run with no usage at all stays unstamped: absent fields mean "not reported",
+        # zeros mean "reported, and nothing was cached". Added, not assigned, so
+        # delegation turns accumulate into one node total
+        if reported:
+            entry["cache_read_tokens"] = entry.get("cache_read_tokens", 0) + cache_read
+            entry["cache_creation_tokens"] = entry.get("cache_creation_tokens", 0) + cache_creation
+    except Exception:
+        logger.warning("Failed recording observed cache tokens for node %s", node_id, exc_info=True)

--- a/backend/app/modules/workflow/engine/utils.py
+++ b/backend/app/modules/workflow/engine/utils.py
@@ -50,6 +50,13 @@ def find_all_vars(obj_str: str) -> list:
     return re.findall(r"{{[^\s{}]+}}", obj_str)
 
 
+def has_volatile_template_vars(template: Any) -> bool:
+    """Whether a raw template contains any substitutable {{var}}"""
+    if not isinstance(template, str) or not template:
+        return False
+    return bool(find_all_vars(template))
+
+
 def find_code_param_vars(code_string: str) -> list:
     """
     Find all variable names referenced via params.get("varName") or param.get("varName")

--- a/backend/app/modules/workflow/engine/workflow_state.py
+++ b/backend/app/modules/workflow/engine/workflow_state.py
@@ -739,7 +739,11 @@ class WorkflowState:
         }
         # Conditional: a run with no opted-in sub-agent stays byte-identical to before
         if self.prompt_caching_diagnostics:
-            full["promptCachingDiagnostics"] = self.prompt_caching_diagnostics
+            from app.modules.workflow.engine.prompt_cache_diagnostics import with_observed_cache_tokens
+
+            full["promptCachingDiagnostics"] = with_observed_cache_tokens(
+                self.prompt_caching_diagnostics, self.llm_usage
+            )
         return full
 
     def _collect_failed_nodes(self) -> list[dict]:

--- a/backend/app/modules/workflow/engine/workflow_state.py
+++ b/backend/app/modules/workflow/engine/workflow_state.py
@@ -10,6 +10,7 @@ import uuid
 from datetime import datetime
 from typing import Any, Dict, Optional, Union
 
+from app.core.utils.llm_usage_utils import extract_cache_tokens
 from app.modules.workflow.agents.memory import (
     BaseConversationMemory,
     ConversationMemory,
@@ -122,6 +123,10 @@ class WorkflowState:
         self.node_execution_status: dict[str, Any] = {}
         self.execution_path: list[str] = []
         self.execution_history: list[str] = []
+        # The single store for prompt-caching diagnostics: this run's own nodes plus any
+        # propagated in from sub-agent child runs. Kept out of node_execution_status so
+        # no metric, analytics or failure consumer ever sees them
+        self.prompt_caching_diagnostics: dict[str, Any] = {}
 
         # Performance metrics
         self.time_taken = 0
@@ -292,6 +297,7 @@ class WorkflowState:
         token_details: Optional[dict] = None,
         llm_provider_id: Optional[str] = None,
         total_tokens: Optional[int] = None,
+        prompt_caching_enabled: bool = False,
     ) -> None:
         """Append LLM token usage for this workflow execution"""
         self.llm_usage.append({
@@ -304,6 +310,7 @@ class WorkflowState:
             "purpose": purpose,
             "token_details": token_details,
             "llm_provider_id": llm_provider_id,
+            "prompt_caching_enabled": prompt_caching_enabled,
         })
 
     def add_tool_event(
@@ -350,22 +357,37 @@ class WorkflowState:
             for u in self.llm_usage
         )
         total_cost_usd = 0.0
+        total_cache_read = 0
+        total_cache_creation = 0
         from app.services.llm_cost_calculator import LlmCostCalculator
         self.llm_cost_calculator = LlmCostCalculator()
         for u in self.llm_usage:
+            cache_read, cache_creation = extract_cache_tokens(u.get("token_details"))
+            total_cache_read += cache_read
+            total_cache_creation += cache_creation
             total_cost_usd += self.llm_cost_calculator.calculate_cost(
                 u.get("provider", ""),
                 u.get("model", ""),
                 u.get("input_tokens", 0),
                 u.get("output_tokens", 0),
             )
-        return {
+        totals = {
             "input_tokens": total_input,
             "output_tokens": total_output,
             "total_tokens": total_tokens,
+            "cache_read_tokens": total_cache_read,
+            "cache_creation_tokens": total_cache_creation,
             "cost_usd": round(total_cost_usd, 6),
             "calls": len(self.llm_usage),
         }
+        if not (total_cache_read or total_cache_creation or self._prompt_caching_requested()):
+            del totals["cache_read_tokens"]
+            del totals["cache_creation_tokens"]
+        return totals
+
+    def _prompt_caching_requested(self) -> bool:
+        """Whether any call this run came from a node with the caching toggle on"""
+        return any(u.get("prompt_caching_enabled") for u in self.llm_usage)
 
     def reset_execution_state(self) -> None:
         """Reset execution state to initial values"""
@@ -378,6 +400,7 @@ class WorkflowState:
         self.node_execution_status.clear()
         self.execution_path.clear()
         self.execution_history.clear()
+        self.prompt_caching_diagnostics.clear()
         self.errors.clear()
         self.llm_usage.clear()
         self.tool_events.clear()
@@ -671,6 +694,10 @@ class WorkflowState:
             **self.node_execution_status,
             **state.node_execution_status,
         }
+        self.prompt_caching_diagnostics = {
+            **self.prompt_caching_diagnostics,
+            **state.prompt_caching_diagnostics,
+        }
         self.execution_path = [*self.execution_path, *state.execution_path]
         self.execution_history = [*self.execution_history, *state.execution_history]
         # Usage is not merged here: nested engines append into the parent usage_sink,
@@ -694,7 +721,7 @@ class WorkflowState:
 
     def get_full_state(self) -> Dict[str, Any]:
         """Get the complete state including all execution details"""
-        return {
+        full = {
             "status": self.status,
             "input": self.initial_values,
             "output": self.output,
@@ -710,6 +737,10 @@ class WorkflowState:
             "performanceMetrics": self.performance_metrics,
             "execution_end_time": self.execution_end_time,
         }
+        # Conditional: a run with no opted-in sub-agent stays byte-identical to before
+        if self.prompt_caching_diagnostics:
+            full["promptCachingDiagnostics"] = self.prompt_caching_diagnostics
+        return full
 
     def _collect_failed_nodes(self) -> list[dict]:
         """Collect the nodes that failed in this run, latest run per node only.

--- a/backend/app/modules/workflow/llm/fallback_chat_model.py
+++ b/backend/app/modules/workflow/llm/fallback_chat_model.py
@@ -39,7 +39,21 @@ logger = logging.getLogger(__name__)
 
 # Re-exported for callers that import it from here (defined in fallback_exceptions
 # so lightweight modules like llm_usage_utils can use it without importing langchain).
-__all__ = ["FallbackChatModel", "FALLBACK_PROVIDER_ID_KEY"]
+__all__ = ["FallbackChatModel", "FALLBACK_PROVIDER_ID_KEY", "child_callback_config"]
+
+
+def child_callback_config(run_manager: Optional[Any]) -> Optional[dict]:
+    """Config that nests a delegated call under the caller's run"""
+    if run_manager is None:
+        return None
+    from langchain_core.callbacks import AsyncCallbackManager, CallbackManager
+
+    manager_cls = AsyncCallbackManager if isinstance(run_manager, AsyncCallbackManagerForLLMRun) else CallbackManager
+    manager = manager_cls(handlers=[], parent_run_id=run_manager.run_id)
+    manager.set_handlers(run_manager.inheritable_handlers)
+    manager.add_tags(list(run_manager.inheritable_tags or []))
+    manager.add_metadata(dict(run_manager.inheritable_metadata or {}))
+    return {"callbacks": manager}
 
 
 class FallbackChatModel(BaseChatModel):
@@ -116,7 +130,7 @@ class FallbackChatModel(BaseChatModel):
         )
 
     async def _ainvoke_one(
-        self, model: Any, messages: List[BaseMessage], invoke_kwargs: dict, timeout: float
+        self, model: Any, messages: List[BaseMessage], config: Optional[dict], invoke_kwargs: dict, timeout: float
     ) -> AIMessage:
         """Invoke a single child, enforcing this provider's timeout if set.
 
@@ -125,10 +139,10 @@ class FallbackChatModel(BaseChatModel):
         """
         if timeout and timeout > 0:
             return await asyncio.wait_for(
-                model.ainvoke(messages, **invoke_kwargs),
+                model.ainvoke(messages, config=config, **invoke_kwargs),
                 timeout=timeout,
             )
-        return await model.ainvoke(messages, **invoke_kwargs)
+        return await model.ainvoke(messages, config=config, **invoke_kwargs)
 
     # ----- async (primary path) --------------------------------------------
 
@@ -142,13 +156,14 @@ class FallbackChatModel(BaseChatModel):
         invoke_kwargs = dict(kwargs)
         if stop is not None:
             invoke_kwargs["stop"] = stop
+        config = child_callback_config(run_manager)
 
         last_exc: Optional[BaseException] = None
         for idx, model in enumerate(self.models):
             timeout = self._timeout_at(idx)
             for attempt in range(self.retry_count + 1):
                 try:
-                    ai = await self._ainvoke_one(model, messages, invoke_kwargs, timeout)
+                    ai = await self._ainvoke_one(model, messages, config, invoke_kwargs, timeout)
                 except BaseException as exc:  # noqa: BLE001 - re-raised below when not retryable
                     if not is_retryable(exc):
                         raise
@@ -186,6 +201,7 @@ class FallbackChatModel(BaseChatModel):
         invoke_kwargs = dict(kwargs)
         if stop is not None:
             invoke_kwargs["stop"] = stop
+        config = child_callback_config(run_manager)
 
         last_exc: Optional[BaseException] = None
         for idx, model in enumerate(self.models):
@@ -194,7 +210,7 @@ class FallbackChatModel(BaseChatModel):
             for attempt in range(self.retry_count + 1):
                 emitted = False
                 try:
-                    aiter = model.astream(messages, **invoke_kwargs).__aiter__()
+                    aiter = model.astream(messages, config=config, **invoke_kwargs).__aiter__()
                     while True:
                         # Bound time-to-first-token by the request timeout. Subsequent
                         # chunks are not individually timed (mid-stream stalls are rare
@@ -242,12 +258,13 @@ class FallbackChatModel(BaseChatModel):
         invoke_kwargs = dict(kwargs)
         if stop is not None:
             invoke_kwargs["stop"] = stop
+        config = child_callback_config(run_manager)
 
         last_exc: Optional[BaseException] = None
         for idx, model in enumerate(self.models):
             for attempt in range(self.retry_count + 1):
                 try:
-                    ai = model.invoke(messages, **invoke_kwargs)
+                    ai = model.invoke(messages, config=config, **invoke_kwargs)
                 except BaseException as exc:  # noqa: BLE001
                     if not is_retryable(exc):
                         raise
@@ -274,13 +291,14 @@ class FallbackChatModel(BaseChatModel):
         invoke_kwargs = dict(kwargs)
         if stop is not None:
             invoke_kwargs["stop"] = stop
+        config = child_callback_config(run_manager)
 
         last_exc: Optional[BaseException] = None
         for idx, model in enumerate(self.models):
             for attempt in range(self.retry_count + 1):
                 emitted = False
                 try:
-                    for chunk in model.stream(messages, **invoke_kwargs):
+                    for chunk in model.stream(messages, config=config, **invoke_kwargs):
                         if not emitted:
                             self._stamp(chunk, idx)
                             emitted = True

--- a/backend/app/modules/workflow/llm/prompt_caching_chat_model.py
+++ b/backend/app/modules/workflow/llm/prompt_caching_chat_model.py
@@ -12,6 +12,9 @@ tool message."""
 
 from __future__ import annotations
 
+import hashlib
+import json
+import logging
 from typing import Any, AsyncIterator, Iterator, List, Literal, Optional, Sequence
 
 from langchain_core.callbacks import (
@@ -19,10 +22,12 @@ from langchain_core.callbacks import (
     CallbackManagerForLLMRun,
 )
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages import BaseMessage, SystemMessage
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 
 from app.modules.workflow.llm.fallback_chat_model import FallbackChatModel, child_callback_config
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "PROMPT_CACHE_OPT_IN_KEY",
@@ -39,6 +44,10 @@ _MARKER_KEYS: dict[str, str] = {"anthropic": "cache_control", "bedrock_converse"
 PROMPT_CACHE_OPT_IN_KEY = "genassist_prompt_cache"
 
 
+def _sha12(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()[:12]
+
+
 def build_cacheable_system_message(stable: str, volatile: Optional[str] = None) -> SystemMessage:
     """The only sanctioned constructor for a cache-eligible system message"""
     content: List[Any] = [{"type": "text", "text": stable}]
@@ -52,103 +61,97 @@ class PromptCachingChatModel(BaseChatModel):
 
     inner: Any
     cache_style: CacheStyle
-    # Set by bind_tools: a tool loop re-sends a growing prefix, so the conversation
-    # tail earns its own breakpoint. Stays off for single-shot callers, whose tail
-    # changes every request and would pay the cache write without a read-back.
-    cache_conversation: bool = False
 
     @property
     def _llm_type(self) -> str:
         return "prompt_caching_chat_model"
 
     def bind_tools(self, tools: Sequence[Any], **kwargs: Any) -> "PromptCachingChatModel":
-        """Re-wrap the bound child so the type stays stable"""
-        return PromptCachingChatModel(
-            inner=self.inner.bind_tools(tools, **kwargs),
-            cache_style=self.cache_style,
-            cache_conversation=True,
-        )
+        """Re-wrap the bound child so a tool loop keeps caching its system prefix"""
+        return PromptCachingChatModel(inner=self.inner.bind_tools(tools, **kwargs), cache_style=self.cache_style)
 
-    def _mark_messages(self, messages: List[BaseMessage]) -> tuple[List[BaseMessage], bool]:
-        """`messages` with the first SystemMessage marked, plus whether caching is active"""
+    def _mark_messages(self, messages: List[BaseMessage]) -> List[BaseMessage]:
+        """`messages` with the first SystemMessage marked, or unchanged if none is eligible"""
         for idx, message in enumerate(messages):
             if not isinstance(message, SystemMessage):
                 continue
-            marked, active = self._mark_system(message)
+            marked = self._mark_system(message)
             if marked is message:
-                return messages, active
+                return messages
             new_messages = list(messages)
             new_messages[idx] = marked
-            return new_messages, active
-        return messages, False
+            return new_messages
+        return messages
 
-    def _mark_system(self, message: SystemMessage) -> tuple[SystemMessage, bool]:
+    def _mark_system(self, message: SystemMessage) -> SystemMessage:
         """Mark the first content block, or return `message` untouched if ineligible"""
         if not message.additional_kwargs.get(PROMPT_CACHE_OPT_IN_KEY):
-            return message, False
+            return message
 
         content = message.content
         if not isinstance(content, list) or not content:
-            return message, False
+            return message
 
         # Scans every block, not just the first: a marker the caller placed further down
         # is left as the only breakpoint rather than silently getting a second one.
         marker_key = _MARKER_KEYS[self.cache_style]
         if any(isinstance(block, dict) and marker_key in block for block in content):
-            return message, True
+            return message
 
         first = content[0]
         if not isinstance(first, dict) or first.get("type") != "text":
-            return message, False
+            return message
         text = first.get("text")
         if not isinstance(text, str) or not text.strip():
-            return message, False
+            return message
 
         if self.cache_style == "anthropic":
             new_content: List[Any] = [{**first, "cache_control": {"type": "ephemeral"}}, *content[1:]]
         else:
             new_content = [first, {"cachePoint": {"type": "default"}}, *content[1:]]
-        return message.model_copy(update={"content": new_content}), True
-
-    def _mark_conversation_tail(self, messages: List[BaseMessage]) -> List[BaseMessage]:
-        """Append a Bedrock cachePoint to the last human or tool message.
-
-        Anthropic never comes through here — its tail breakpoint travels as a request
-        kwarg so the provider package can pick the last eligible block itself."""
-        last = messages[-1] if messages else None
-        if not isinstance(last, (HumanMessage, ToolMessage)):
-            return messages
-
-        content = last.content
-        if isinstance(content, str):
-            if not content.strip():
-                return messages
-            new_content: List[Any] = [{"type": "text", "text": content}, {"cachePoint": {"type": "default"}}]
-        elif isinstance(content, list) and content:
-            if any(isinstance(block, dict) and "cachePoint" in block for block in content):
-                return messages
-            new_content = [*content, {"cachePoint": {"type": "default"}}]
-        else:
-            return messages
-
-        new_messages = list(messages)
-        new_messages[-1] = last.model_copy(update={"content": new_content})
-        return new_messages
+        return message.model_copy(update={"content": new_content})
 
     def _prepare(
         self, messages: List[BaseMessage], stop: Optional[List[str]], kwargs: dict
     ) -> tuple[List[BaseMessage], dict]:
         """Marked messages plus the kwargs the delegated call should carry"""
-        marked, active = self._mark_messages(messages)
         invoke_kwargs = dict(kwargs)
         if stop is not None:
             invoke_kwargs["stop"] = stop
-        if active and self.cache_conversation:
-            if self.cache_style == "anthropic":
-                invoke_kwargs.setdefault("cache_control", {"type": "ephemeral"})
-            else:
-                marked = self._mark_conversation_tail(marked)
-        return marked, invoke_kwargs
+        return self._mark_messages(messages), invoke_kwargs
+
+    def _log_cache_call(self, marked: List[BaseMessage], ai: Any) -> None:
+        """Logs for diagnosing unstable cache reads: the hashes tie a call to the
+        prefix and tool set it should hit, without logging prompt content"""
+        if not logger.isEnabledFor(logging.DEBUG):
+            return
+        try:
+            system = next((m for m in marked if isinstance(m, SystemMessage)), None)
+            stable = ""
+            if system is not None:
+                if isinstance(system.content, list) and system.content and isinstance(system.content[0], dict):
+                    stable = str(system.content[0].get("text", ""))
+                elif isinstance(system.content, str):
+                    stable = system.content
+            bound_kwargs = getattr(self.inner, "kwargs", None)
+            tools = bound_kwargs.get("tools") if isinstance(bound_kwargs, dict) else None
+            base = getattr(self.inner, "bound", self.inner)
+            metadata = getattr(ai, "response_metadata", None) or {}
+            usage = getattr(ai, "usage_metadata", None) or {}
+            details = usage.get("input_token_details") or {}
+            logger.debug(
+                "prompt-cache call style=%s model=%s request_id=%s prefix_sha=%s tools_sha=%s "
+                "cache_read=%s cache_creation=%s",
+                self.cache_style,
+                getattr(base, "model_id", None) or getattr(base, "model", None),
+                metadata.get("id") or (metadata.get("ResponseMetadata") or {}).get("RequestId"),
+                _sha12(stable) if stable else None,
+                _sha12(json.dumps(tools, sort_keys=True, default=str)) if tools else None,
+                details.get("cache_read"),
+                details.get("cache_creation"),
+            )
+        except Exception:
+            logger.debug("prompt-cache call breadcrumb failed", exc_info=True)
 
     async def _agenerate(
         self,
@@ -159,6 +162,7 @@ class PromptCachingChatModel(BaseChatModel):
     ) -> ChatResult:
         marked, invoke_kwargs = self._prepare(messages, stop, kwargs)
         ai = await self.inner.ainvoke(marked, config=child_callback_config(run_manager), **invoke_kwargs)
+        self._log_cache_call(marked, ai)
         return ChatResult(generations=[ChatGeneration(message=ai)])
 
     async def _astream(
@@ -182,6 +186,7 @@ class PromptCachingChatModel(BaseChatModel):
     ) -> ChatResult:
         marked, invoke_kwargs = self._prepare(messages, stop, kwargs)
         ai = self.inner.invoke(marked, config=child_callback_config(run_manager), **invoke_kwargs)
+        self._log_cache_call(marked, ai)
         return ChatResult(generations=[ChatGeneration(message=ai)])
 
     def _stream(

--- a/backend/app/modules/workflow/llm/prompt_caching_chat_model.py
+++ b/backend/app/modules/workflow/llm/prompt_caching_chat_model.py
@@ -1,0 +1,205 @@
+"""Marks a stable system prefix so the provider can cache it.
+
+The marker is provider-specific: Anthropic sets `cache_control: {"type": "ephemeral"}`
+on the system block itself, Bedrock Converse adds a `{"cachePoint": {"type": "default"}}`
+block after it.
+
+A tool-bound wrapper additionally marks the end of the conversation on every call, so
+each turn of a tool loop re-reads the previous turn's prefix. Anthropic takes this as
+a `cache_control` request kwarg — the provider package places it on the last eligible
+block itself — while Bedrock takes a cachePoint block appended to the last human or
+tool message."""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Iterator, List, Literal, Optional, Sequence
+
+from langchain_core.callbacks import (
+    AsyncCallbackManagerForLLMRun,
+    CallbackManagerForLLMRun,
+)
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+
+from app.modules.workflow.llm.fallback_chat_model import FallbackChatModel, child_callback_config
+
+__all__ = [
+    "PROMPT_CACHE_OPT_IN_KEY",
+    "PromptCachingChatModel",
+    "build_cacheable_system_message",
+    "model_has_prompt_caching",
+]
+
+CacheStyle = Literal["anthropic", "bedrock_converse"]
+
+_MARKER_KEYS: dict[str, str] = {"anthropic": "cache_control", "bedrock_converse": "cachePoint"}
+
+# Optional marker the builder stamps and the wrapper requires
+PROMPT_CACHE_OPT_IN_KEY = "genassist_prompt_cache"
+
+
+def build_cacheable_system_message(stable: str, volatile: Optional[str] = None) -> SystemMessage:
+    """The only sanctioned constructor for a cache-eligible system message"""
+    content: List[Any] = [{"type": "text", "text": stable}]
+    if volatile:
+        content.append({"type": "text", "text": volatile})
+    return SystemMessage(content=content, additional_kwargs={PROMPT_CACHE_OPT_IN_KEY: True})
+
+
+class PromptCachingChatModel(BaseChatModel):
+    """Adds a provider cache marker to an opted-in system prefix, then delegates"""
+
+    inner: Any
+    cache_style: CacheStyle
+    # Set by bind_tools: a tool loop re-sends a growing prefix, so the conversation
+    # tail earns its own breakpoint. Stays off for single-shot callers, whose tail
+    # changes every request and would pay the cache write without a read-back.
+    cache_conversation: bool = False
+
+    @property
+    def _llm_type(self) -> str:
+        return "prompt_caching_chat_model"
+
+    def bind_tools(self, tools: Sequence[Any], **kwargs: Any) -> "PromptCachingChatModel":
+        """Re-wrap the bound child so the type stays stable"""
+        return PromptCachingChatModel(
+            inner=self.inner.bind_tools(tools, **kwargs),
+            cache_style=self.cache_style,
+            cache_conversation=True,
+        )
+
+    def _mark_messages(self, messages: List[BaseMessage]) -> tuple[List[BaseMessage], bool]:
+        """`messages` with the first SystemMessage marked, plus whether caching is active"""
+        for idx, message in enumerate(messages):
+            if not isinstance(message, SystemMessage):
+                continue
+            marked, active = self._mark_system(message)
+            if marked is message:
+                return messages, active
+            new_messages = list(messages)
+            new_messages[idx] = marked
+            return new_messages, active
+        return messages, False
+
+    def _mark_system(self, message: SystemMessage) -> tuple[SystemMessage, bool]:
+        """Mark the first content block, or return `message` untouched if ineligible"""
+        if not message.additional_kwargs.get(PROMPT_CACHE_OPT_IN_KEY):
+            return message, False
+
+        content = message.content
+        if not isinstance(content, list) or not content:
+            return message, False
+
+        # Scans every block, not just the first: a marker the caller placed further down
+        # is left as the only breakpoint rather than silently getting a second one.
+        marker_key = _MARKER_KEYS[self.cache_style]
+        if any(isinstance(block, dict) and marker_key in block for block in content):
+            return message, True
+
+        first = content[0]
+        if not isinstance(first, dict) or first.get("type") != "text":
+            return message, False
+        text = first.get("text")
+        if not isinstance(text, str) or not text.strip():
+            return message, False
+
+        if self.cache_style == "anthropic":
+            new_content: List[Any] = [{**first, "cache_control": {"type": "ephemeral"}}, *content[1:]]
+        else:
+            new_content = [first, {"cachePoint": {"type": "default"}}, *content[1:]]
+        return message.model_copy(update={"content": new_content}), True
+
+    def _mark_conversation_tail(self, messages: List[BaseMessage]) -> List[BaseMessage]:
+        """Append a Bedrock cachePoint to the last human or tool message.
+
+        Anthropic never comes through here — its tail breakpoint travels as a request
+        kwarg so the provider package can pick the last eligible block itself."""
+        last = messages[-1] if messages else None
+        if not isinstance(last, (HumanMessage, ToolMessage)):
+            return messages
+
+        content = last.content
+        if isinstance(content, str):
+            if not content.strip():
+                return messages
+            new_content: List[Any] = [{"type": "text", "text": content}, {"cachePoint": {"type": "default"}}]
+        elif isinstance(content, list) and content:
+            if any(isinstance(block, dict) and "cachePoint" in block for block in content):
+                return messages
+            new_content = [*content, {"cachePoint": {"type": "default"}}]
+        else:
+            return messages
+
+        new_messages = list(messages)
+        new_messages[-1] = last.model_copy(update={"content": new_content})
+        return new_messages
+
+    def _prepare(
+        self, messages: List[BaseMessage], stop: Optional[List[str]], kwargs: dict
+    ) -> tuple[List[BaseMessage], dict]:
+        """Marked messages plus the kwargs the delegated call should carry"""
+        marked, active = self._mark_messages(messages)
+        invoke_kwargs = dict(kwargs)
+        if stop is not None:
+            invoke_kwargs["stop"] = stop
+        if active and self.cache_conversation:
+            if self.cache_style == "anthropic":
+                invoke_kwargs.setdefault("cache_control", {"type": "ephemeral"})
+            else:
+                marked = self._mark_conversation_tail(marked)
+        return marked, invoke_kwargs
+
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        marked, invoke_kwargs = self._prepare(messages, stop, kwargs)
+        ai = await self.inner.ainvoke(marked, config=child_callback_config(run_manager), **invoke_kwargs)
+        return ChatResult(generations=[ChatGeneration(message=ai)])
+
+    async def _astream(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[ChatGenerationChunk]:
+        marked, invoke_kwargs = self._prepare(messages, stop, kwargs)
+        config = child_callback_config(run_manager)
+        async for chunk in self.inner.astream(marked, config=config, **invoke_kwargs):
+            yield ChatGenerationChunk(message=chunk)
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        marked, invoke_kwargs = self._prepare(messages, stop, kwargs)
+        ai = self.inner.invoke(marked, config=child_callback_config(run_manager), **invoke_kwargs)
+        return ChatResult(generations=[ChatGeneration(message=ai)])
+
+    def _stream(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> Iterator[ChatGenerationChunk]:
+        marked, invoke_kwargs = self._prepare(messages, stop, kwargs)
+        config = child_callback_config(run_manager)
+        for chunk in self.inner.stream(marked, config=config, **invoke_kwargs):
+            yield ChatGenerationChunk(message=chunk)
+
+
+def model_has_prompt_caching(model: Any) -> bool:
+    if isinstance(model, PromptCachingChatModel):
+        return True
+    if isinstance(model, FallbackChatModel):
+        return bool(model.models) and all(isinstance(child, PromptCachingChatModel) for child in model.models)
+    return False

--- a/backend/app/modules/workflow/llm/provider.py
+++ b/backend/app/modules/workflow/llm/provider.py
@@ -10,6 +10,7 @@ import httpx
 from injector import inject
 if TYPE_CHECKING:  # type hints only — langchain_core.language_models pulls torch/transformers
     from langchain_core.language_models import BaseChatModel
+from app.core.config.llm_prompt_cache_capabilities import bedrock_cache_family
 from app.core.utils.encryption_utils import decrypt_key
 from app.core.utils.enums.open_ai_fine_tuning_enum import JobStatus
 from app.core.utils.enums.bedrock_fine_tuning_enum import (
@@ -23,11 +24,19 @@ from app.services.bedrock_fine_tuning import BedrockFineTuningService
 
 logger = logging.getLogger(__name__)
 
+def _bedrock_supports_prompt_caching(model_name: Optional[str]) -> bool:
+    """True if this Bedrock model accepts prompt caching"""
+    if bedrock_cache_family(model_name) is not None:
+        return True
+    logger.debug("Prompt caching skipped: %r is not a cache-capable Bedrock model", model_name)
+    return False
+
 
 async def build_chat_model(
     provider_name: Optional[str],
     connection_data: Dict[str, Any],
     model_name: Optional[str],
+    prompt_caching_enabled: bool = False,
 ) -> BaseChatModel:
     cd = dict(connection_data)
     original_provider = (provider_name or "").lower()
@@ -38,6 +47,8 @@ async def build_chat_model(
     # `provider`. Pull the user-selected family out of connection_data here so it never
     # collides with init_chat_model's own `model_provider` routing kwarg in the spread below.
     bedrock_model_provider = cd.pop("model_provider", None)
+
+    cd.pop("prompt_caching_enabled", None)
 
     if provider == "vllm":
         provider = "openai"
@@ -111,7 +122,19 @@ async def build_chat_model(
     # torch/transformers, which must not be loaded into a Celery prefork master process.
     from langchain.chat_models import init_chat_model
 
-    return init_chat_model(**model_kwargs)
+    llm = init_chat_model(**model_kwargs)
+
+    # Wrap outside init_chat_model so the Opik callbacks stay attached to the inner
+    # model and every invocation is still traced.
+    if prompt_caching_enabled and (
+        provider == "anthropic"
+        or (provider == "bedrock_converse" and _bedrock_supports_prompt_caching(model_name))
+    ):
+        from app.modules.workflow.llm.prompt_caching_chat_model import PromptCachingChatModel
+
+        return PromptCachingChatModel(inner=llm, cache_style=provider)
+
+    return llm
 
 
 @inject
@@ -224,7 +247,11 @@ class LLMProvider:
         return schemas
 
 
-    async def get_model(self, model_id: str | None = None) -> BaseChatModel:
+    async def get_model(
+        self,
+        model_id: str | None = None,
+        prompt_caching_enabled: bool = False,
+    ) -> BaseChatModel:
         from app.dependencies.injector import injector
         llm_provider_service = injector.get(LlmProviderService)
 
@@ -235,9 +262,9 @@ class LLMProvider:
         else:
             llm_provider = await llm_provider_service.get_by_id(model_id)
 
-        return await self._build_from_provider(llm_provider)
+        return await self._build_from_provider(llm_provider, prompt_caching_enabled)
 
-    async def _build_one(self, model_id: str) -> BaseChatModel:
+    async def _build_one(self, model_id: str, prompt_caching_enabled: bool = False) -> BaseChatModel:
         """Build a single chat model from a stored provider id.
 
         Shared by get_model and get_model_with_fallback so residency checks,
@@ -247,9 +274,9 @@ class LLMProvider:
         llm_provider_service = injector.get(LlmProviderService)
 
         llm_provider = await llm_provider_service.get_by_id(model_id)
-        return await self._build_from_provider(llm_provider)
+        return await self._build_from_provider(llm_provider, prompt_caching_enabled)
 
-    async def _build_from_provider(self, llm_provider) -> BaseChatModel:
+    async def _build_from_provider(self, llm_provider, prompt_caching_enabled: bool = False) -> BaseChatModel:
         from app.dependencies.injector import injector
         from app.core.data_residency import assert_provider_residency, bedrock_regions_from_connection_data
         from app.services.app_settings import AppSettingsService
@@ -279,6 +306,7 @@ class LLMProvider:
                 provider_name=llm_provider.llm_model_provider,
                 connection_data=validated_data,
                 model_name=llm_provider.llm_model,
+                prompt_caching_enabled=prompt_caching_enabled,
             )
             logger.info(f"Created LLM with init_chat_model for llm provider with ID: {llm_provider.id}")
         except Exception as e:
@@ -291,6 +319,7 @@ class LLMProvider:
         self,
         provider_id: str | None,
         fallback_chain_id: str | None = None,
+        prompt_caching_enabled: bool = False,
     ) -> BaseChatModel:
         """Resolve the model a node should use, honoring an optional fallback chain.
 
@@ -300,7 +329,7 @@ class LLMProvider:
         is applied per provider.
         """
         if not fallback_chain_id:
-            return await self.get_model(provider_id)
+            return await self.get_model(provider_id, prompt_caching_enabled)
 
         from app.dependencies.injector import injector
         from app.services.fallback_chains import FallbackChainService
@@ -314,12 +343,13 @@ class LLMProvider:
             effective_ids = chain_ids
 
         retry_policy = chain.retry_policy.model_dump() if chain.retry_policy else None
-        return await self.get_model_with_fallback(effective_ids, retry_policy)
+        return await self.get_model_with_fallback(effective_ids, retry_policy, prompt_caching_enabled)
 
     async def get_model_with_fallback(
         self,
         provider_ids: list[str],
         retry_policy: Optional[Dict[str, Any]] = None,
+        prompt_caching_enabled: bool = False,
     ) -> BaseChatModel:
         """Build a chat model that fails over across an ordered list of providers.
 
@@ -359,7 +389,7 @@ class LLMProvider:
         # Fast path: single provider, no retries, no timeout → no wrapper, zero
         # behavior change for plain single-provider nodes.
         if len(ids) == 1 and not has_retry and not has_timeout:
-            return await self._build_one(ids[0])
+            return await self._build_one(ids[0], prompt_caching_enabled)
 
         from app.modules.workflow.llm.fallback_chat_model import FallbackChatModel
 
@@ -370,7 +400,7 @@ class LLMProvider:
                 # Children stay as raw chat models (NOT wrapped with .with_retry, which
                 # returns a RunnableRetry lacking bind_tools and would break the agent
                 # path). Per-provider retry is handled inside FallbackChatModel instead.
-                model = await self._build_one(pid)
+                model = await self._build_one(pid, prompt_caching_enabled)
             except Exception as e:
                 # A provider that can't even be instantiated (e.g. deleted) is skipped
                 # so the rest of the chain can still serve the request.

--- a/backend/app/schemas/dynamic_form_schemas/nodes/agent_schema.py
+++ b/backend/app/schemas/dynamic_form_schemas/nodes/agent_schema.py
@@ -68,5 +68,16 @@ AGENT_NODE_DIALOG_SCHEMA: List[FieldSchema] = [
             "sending text to the LLM. Original values are restored in the response."
         ),
     ),
+    FieldSchema(
+        name="promptCaching",
+        type="boolean",
+        label="Enable Prompt Caching",
+        required=False,
+        default=False,
+        description=(
+            "Caches the stable start of the system prompt for 5 minutes so repeat calls "
+            "read it at a reduced rate. Anthropic and Bedrock cache-capable models only."
+        ),
+    ),
     *memory_trimming_fields(max_messages_default=10),
 ]

--- a/backend/app/schemas/dynamic_form_schemas/nodes/llm_model_schema.py
+++ b/backend/app/schemas/dynamic_form_schemas/nodes/llm_model_schema.py
@@ -58,6 +58,17 @@ LLM_MODEL_NODE_DIALOG_SCHEMA: List[FieldSchema] = [
         ),
     ),
     FieldSchema(
+        name="promptCaching",
+        type="boolean",
+        label="Enable Prompt Caching",
+        required=False,
+        default=False,
+        description=(
+            "Caches the stable start of the system prompt for 5 minutes so repeat calls "
+            "read it at a reduced rate. Anthropic and Bedrock cache-capable models only."
+        ),
+    ),
+    FieldSchema(
         name="memoryTrimmingMode",
         type="select",
         label="Memory Trimming Mode",

--- a/backend/app/schemas/dynamic_form_schemas/nodes/sub_agent_schema.py
+++ b/backend/app/schemas/dynamic_form_schemas/nodes/sub_agent_schema.py
@@ -105,5 +105,16 @@ SUB_AGENT_NODE_DIALOG_SCHEMA: List[FieldSchema] = [
             "inherits masking and unmasks with its own map so its tools still get real values."
         ),
     ),
+    FieldSchema(
+        name="promptCaching",
+        type="boolean",
+        label="Enable Prompt Caching",
+        required=False,
+        default=False,
+        description=(
+            "Caches the stable start of the system prompt for 5 minutes so repeat calls "
+            "read it at a reduced rate. Anthropic and Bedrock cache-capable models only."
+        ),
+    ),
     *memory_trimming_fields(max_messages_default=20),
 ]

--- a/backend/app/schemas/llm.py
+++ b/backend/app/schemas/llm.py
@@ -2,8 +2,9 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
+from app.core.config import llm_prompt_cache_capabilities
 from app.schemas.common import ConnectionStatus
 
 
@@ -42,6 +43,12 @@ class LlmProviderCreate(LlmProviderBase):
 
 class LlmProviderRead(LlmProviderBase):
     id: UUID
+
+    @computed_field
+    @property
+    def prompt_caching_mode(self) -> str:
+        """Backend-derived caching capability ("explicit" | "automatic" | "none")"""
+        return llm_prompt_cache_capabilities.prompt_caching_mode(self.llm_model_provider, self.llm_model)
 
 
 class LlmProviderUpdate(LlmProviderBase):

--- a/backend/app/services/llm_providers.py
+++ b/backend/app/services/llm_providers.py
@@ -59,6 +59,8 @@ class LlmProviderService:
         if api_key:
             connection_data["masked_api_key"] = get_masked_api_key(api_key)
 
+        connection_data.pop("prompt_caching_enabled", None)
+
         connection_data = await self.encrypt_connection_data_fields(connection_data)
         data.connection_data = connection_data
 
@@ -109,6 +111,14 @@ class LlmProviderService:
 
         existing_conn_data = obj.connection_data or {}
         update_conn_data = update_data.get("connection_data", {})
+
+        # Prompt caching is a node setting now. Stripping the legacy provider key before the
+        # changed-comparison keeps a resubmitted stale value from resetting connection_status.
+        had_legacy_caching_key = "prompt_caching_enabled" in update_conn_data
+        update_conn_data.pop("prompt_caching_enabled", None)
+        if had_legacy_caching_key and not update_conn_data:
+            # Assigning the now-empty dict would erase the stored credentials.
+            update_data.pop("connection_data", None)
 
         if obj.llm_model_provider == "vllm_fine_tuned" and ":::" in update_conn_data.get("model", ""):
             _, update_data["llm_model"] = self._extract_vllm_fine_tuned(

--- a/backend/tests/unit/test_analytics_realtime_parse.py
+++ b/backend/tests/unit/test_analytics_realtime_parse.py
@@ -101,3 +101,31 @@ def test_bad_response_time_is_ignored():
     }
     data = parse_agent_response_for_stats(payload)
     assert data["response_ms"] is None
+
+
+_DIAGNOSTICS = {"child": {"requested": True, "applied": False, "reason": "unsupported_mode"}}
+
+
+def _payload(**state_extra):
+    return {
+        "agent_id": _AGENT_ID,
+        "status": "success",
+        "row_agent_response": {
+            "state": {
+                "nodeExecutionStatus": {
+                    "n1": {"type": "llm", "status": "success", "time_taken": "50"},
+                    "n2": {"type": "tool", "status": "failed", "execution_time_ms": 20},
+                },
+                **state_extra,
+            }
+        },
+    }
+
+
+def test_propagated_prompt_caching_diagnostics_do_not_change_node_stats():
+    plain = parse_agent_response_for_stats(_payload())
+    annotated = parse_agent_response_for_stats(_payload(promptCachingDiagnostics=_DIAGNOSTICS))
+
+    assert annotated["total_nodes_executed"] == plain["total_nodes_executed"] == 2
+    assert annotated["nodes"] == plain["nodes"]
+    assert annotated["is_success"] == plain["is_success"]

--- a/backend/tests/unit/test_analytics_realtime_parse.py
+++ b/backend/tests/unit/test_analytics_realtime_parse.py
@@ -103,7 +103,7 @@ def test_bad_response_time_is_ignored():
     assert data["response_ms"] is None
 
 
-_DIAGNOSTICS = {"child": {"requested": True, "applied": False, "reason": "unsupported_mode"}}
+_DIAGNOSTICS = {"child": {"requested": True, "applied": False}}
 
 
 def _payload(**state_extra):

--- a/backend/tests/unit/test_evaluators.py
+++ b/backend/tests/unit/test_evaluators.py
@@ -2558,3 +2558,17 @@ class TestGuardrailNliNode:
         assert out["answer"] == "A"
         assert out.get("blocked") is None
         assert out["_guardrail_nli"]["verdict"] == "entails"
+
+
+class TestPromptCachingDiagnosticsAreInvisibleToGrading:
+    def test_the_collection_does_not_change_the_grading_context(self):
+        trace = _sample_trace()
+        annotated = {
+            **trace,
+            "state": {
+                **trace["state"],
+                "promptCachingDiagnostics": {"child": {"requested": True, "applied": False, "reason": None}},
+            },
+        }
+
+        assert _build_grading_context(annotated) == _build_grading_context(trace)

--- a/backend/tests/unit/test_evaluators.py
+++ b/backend/tests/unit/test_evaluators.py
@@ -2567,7 +2567,7 @@ class TestPromptCachingDiagnosticsAreInvisibleToGrading:
             **trace,
             "state": {
                 **trace["state"],
-                "promptCachingDiagnostics": {"child": {"requested": True, "applied": False, "reason": None}},
+                "promptCachingDiagnostics": {"child": {"requested": True, "applied": False}},
             },
         }
 

--- a/backend/tests/unit/test_llm_model_node_prompt_caching.py
+++ b/backend/tests/unit/test_llm_model_node_prompt_caching.py
@@ -1,0 +1,489 @@
+"""Unit tests for the LLM node's prompt-caching opt-in"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+
+from app.modules.workflow.engine.nodes.llm_model_node import LLMModelNode
+from app.modules.workflow.llm.fallback_chat_model import FallbackChatModel
+from app.modules.workflow.llm.prompt_caching_chat_model import (
+    PROMPT_CACHE_OPT_IN_KEY,
+    PromptCachingChatModel,
+)
+from app.modules.workflow.llm.provider import LLMProvider
+
+_BASE = "You are a helpful assistant with a long stable prefix."
+_HISTORY = "User: hi\nAssistant: hello"
+_STYLES = ["anthropic", "bedrock_converse"]
+
+
+class _CapturingModel(BaseChatModel):
+
+    seen: list = []
+
+    @property
+    def _llm_type(self) -> str:
+        return "capturing"
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        self.seen.append(list(messages))
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content="ok"))])
+
+    async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        return self._generate(messages, stop, run_manager, **kwargs)
+
+
+class _RaisingModel(_CapturingModel):
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        raise RuntimeError("provider unavailable")
+
+
+class _FakeMemory:
+    def __init__(self, history: str):
+        self._history = history
+
+    async def get_chat_history(self, as_string: bool = False, max_messages: int = 10) -> str:
+        return self._history
+
+
+class _FakeState:
+    def __init__(self, memory=None):
+        self._memory = memory
+        self.llm_usage: list = []
+        self.prompt_caching_diagnostics: dict = {}
+
+    def get_memory(self):
+        return self._memory
+
+    def get_value(self, key, default=None):
+        return default
+
+    def add_llm_usage(self, **kwargs):
+        self.llm_usage.append(kwargs)
+
+
+def _patch_injector(llm):
+    provider = MagicMock()
+    provider.get_model_for_node = AsyncMock(return_value=llm)
+    service = MagicMock()
+    service.get_by_id = AsyncMock(
+        return_value=SimpleNamespace(llm_model_provider="anthropic", llm_model="claude-sonnet-4-5")
+    )
+    inj = MagicMock()
+    inj.get = MagicMock(side_effect=lambda cls: provider if cls is LLMProvider else service)
+    return patch("app.dependencies.injector.injector", inj), provider
+
+
+def _caching_llm(style: str = "anthropic"):
+    inner = _CapturingModel()
+    return PromptCachingChatModel(inner=inner, cache_style=style), inner
+
+
+def _plain_llm():
+    inner = _CapturingModel()
+    return inner, inner
+
+
+async def _run(llm, *, raw=_BASE, resolved=None, history=None, node_data=None):
+    memory = _FakeMemory(history) if history is not None else None
+    data = node_data if node_data is not None else {"systemPrompt": raw}
+    node = LLMModelNode("llm-1", {"type": "llmModelNode", "data": data}, _FakeState(memory=memory))
+
+    config = {
+        "providerId": "p1",
+        "systemPrompt": _BASE if resolved is None else resolved,
+        "userPrompt": "hello",
+        "memory": memory is not None,
+    }
+    ctx, _ = _patch_injector(llm)
+    with ctx:
+        return await node.process(config)
+
+
+def _sent(inner: _CapturingModel) -> list:
+    return inner.seen[-1]
+
+
+def _system_content(inner: _CapturingModel):
+    return _sent(inner)[0].content
+
+
+def _rendered(content) -> str:
+    # Assumes the provider joins system blocks with no separator; only an E2E call proves it.
+    if isinstance(content, str):
+        return content
+    return "".join(block.get("text", "") for block in content)
+
+
+def _text_blocks(content) -> list:
+    return [block for block in content if "text" in block]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("style", _STYLES)
+class TestRenderingIsByteIdentical:
+
+    async def test_memory_on_with_history(self, style):
+        cached, cached_inner = _caching_llm(style)
+        plain, plain_inner = _plain_llm()
+
+        await _run(cached, history=_HISTORY)
+        await _run(plain, history=_HISTORY)
+
+        assert _rendered(_system_content(cached_inner)) == _BASE + "\n\n" + _HISTORY
+        assert _rendered(_system_content(cached_inner)) == _system_content(plain_inner)
+
+    async def test_memory_on_with_empty_first_turn_history(self, style):
+        cached, cached_inner = _caching_llm(style)
+        plain, plain_inner = _plain_llm()
+
+        await _run(cached, history="")
+        await _run(plain, history="")
+
+        assert _rendered(_system_content(cached_inner)) == _BASE + "\n\n"
+        assert _rendered(_system_content(cached_inner)) == _system_content(plain_inner)
+
+    async def test_memory_off(self, style):
+        cached, cached_inner = _caching_llm(style)
+        plain, plain_inner = _plain_llm()
+
+        await _run(cached)
+        await _run(plain)
+
+        assert _rendered(_system_content(cached_inner)) == _BASE
+        assert _rendered(_system_content(cached_inner)) == _system_content(plain_inner)
+
+
+@pytest.mark.asyncio
+class TestBlockShapes:
+    async def test_anthropic_marks_only_the_stable_block(self):
+        llm, inner = _caching_llm("anthropic")
+
+        await _run(llm, history=_HISTORY)
+
+        assert _system_content(inner) == [
+            {"type": "text", "text": _BASE + "\n\n", "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": _HISTORY},
+        ]
+
+    async def test_bedrock_cache_point_sits_between_prefix_and_history(self):
+        llm, inner = _caching_llm("bedrock_converse")
+
+        await _run(llm, history=_HISTORY)
+
+        assert _system_content(inner) == [
+            {"type": "text", "text": _BASE + "\n\n"},
+            {"cachePoint": {"type": "default"}},
+            {"type": "text", "text": _HISTORY},
+        ]
+
+    async def test_memory_off_sends_a_single_block(self):
+        llm, inner = _caching_llm("anthropic")
+
+        await _run(llm)
+
+        assert _system_content(inner) == [{"type": "text", "text": _BASE, "cache_control": {"type": "ephemeral"}}]
+
+    @pytest.mark.parametrize("style", _STYLES)
+    async def test_empty_history_emits_no_blank_block(self, style):
+        llm, inner = _caching_llm(style)
+
+        await _run(llm, history="")
+
+        blocks = _text_blocks(_system_content(inner))
+        assert len(blocks) == 1
+        assert blocks[0]["text"].strip()
+
+    async def test_the_system_turn_carries_the_opt_in_tag(self):
+        llm, inner = _caching_llm("anthropic")
+
+        await _run(llm, history=_HISTORY)
+
+        assert _sent(inner)[0].additional_kwargs == {PROMPT_CACHE_OPT_IN_KEY: True}
+
+    async def test_the_uncached_system_turn_carries_no_tag(self):
+        llm, inner = _plain_llm()
+
+        await _run(llm, history=_HISTORY)
+
+        assert _sent(inner)[0].additional_kwargs == {}
+
+    async def test_user_turn_is_untouched_by_the_split(self):
+        llm, inner = _caching_llm("anthropic")
+
+        await _run(llm, history=_HISTORY)
+
+        assert _sent(inner)[1].content == [{"type": "text", "text": "hello"}]
+
+    async def test_node_still_returns_the_model_content(self):
+        llm, _ = _caching_llm("anthropic")
+
+        assert await _run(llm, history=_HISTORY) == "ok"
+
+
+@pytest.mark.asyncio
+class TestStringPathIsPreserved:
+    async def test_model_without_caching_keeps_the_single_string(self):
+        llm, inner = _plain_llm()
+
+        await _run(llm, history=_HISTORY)
+
+        assert _system_content(inner) == _BASE + "\n\n" + _HISTORY
+
+    @pytest.mark.parametrize("prompt", ["", "   \n "], ids=["empty", "whitespace"])
+    async def test_blank_prompt_keeps_the_single_string(self, prompt):
+        llm, inner = _caching_llm("anthropic")
+
+        await _run(llm, raw=prompt, resolved=prompt, history=_HISTORY)
+
+        assert _system_content(inner) == prompt + "\n\n" + _HISTORY
+
+    async def test_blank_prompt_without_memory_keeps_the_single_string(self):
+        llm, inner = _caching_llm("anthropic")
+
+        await _run(llm, raw="", resolved="")
+
+        assert _system_content(inner) == ""
+
+    @pytest.mark.parametrize(
+        "var",
+        [
+            "{{source}}",
+            "{{source.text}}",
+            "{{sourceLanguage}}",
+            "{{direct_input}}",
+            "{{direct_input.query}}",
+            "{{node_outputs.node-1.result}}",
+            "{{timestamp}}",
+            "{{execution_id}}",
+            "{{session.message}}",
+            "{{session}}",
+            "{{session.language}}",
+            "{{thread_id}}",
+            "{{customer_name}}",
+            "{{message}}",
+            "{{output}}",
+            "{{current_step}}",
+        ],
+    )
+    async def test_volatile_template_var_keeps_the_single_string(self, var):
+        llm, inner = _caching_llm("anthropic")
+
+        await _run(llm, raw=f"Summarize this: {var}", resolved="Summarize this: a bug report", history=_HISTORY)
+
+        assert _system_content(inner) == "Summarize this: a bug report" + "\n\n" + _HISTORY
+
+    async def test_raw_prompt_absent_from_node_data_still_opts_in(self):
+        llm, inner = _caching_llm("anthropic")
+
+        await _run(llm, node_data={}, history=_HISTORY)
+
+        assert _system_content(inner)[0]["cache_control"] == {"type": "ephemeral"}
+
+
+@pytest.mark.asyncio
+class TestFallbackChain:
+    async def test_chain_with_every_child_cached_opts_in_chain_wide(self):
+        primary, primary_inner = _caching_llm("anthropic")
+        chain = FallbackChatModel(models=[primary, _caching_llm("anthropic")[0]])
+
+        await _run(chain, history=_HISTORY)
+
+        assert _system_content(primary_inner) == [
+            {"type": "text", "text": _BASE + "\n\n", "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": _HISTORY},
+        ]
+
+    async def test_mixed_chain_keeps_the_single_string(self):
+        primary = _CapturingModel()
+        chain = FallbackChatModel(models=[primary, _caching_llm("anthropic")[0]])
+
+        await _run(chain, history=_HISTORY)
+
+        assert _system_content(primary) == _BASE + "\n\n" + _HISTORY
+
+    async def test_chain_without_a_cached_child_keeps_the_single_string(self):
+        primary = _CapturingModel()
+        chain = FallbackChatModel(models=[primary, _CapturingModel()])
+
+        await _run(chain, history=_HISTORY)
+
+        assert _system_content(primary) == _BASE + "\n\n" + _HISTORY
+
+
+async def _forward(llm, **config_overrides):
+    state = _FakeState()
+    node = LLMModelNode("llm-1", {"type": "llmModelNode", "data": {"systemPrompt": _BASE}}, state)
+    config = {"providerId": "p1", "systemPrompt": _BASE, "userPrompt": "hello", **config_overrides}
+
+    ctx, provider = _patch_injector(llm)
+    with ctx:
+        await node.process(config)
+    return provider, state
+
+
+@pytest.mark.asyncio
+class TestNodeOptInForwarding:
+
+    async def test_the_toggle_reaches_the_model_build(self):
+        provider, _ = await _forward(_caching_llm()[0], promptCaching=True)
+
+        assert provider.get_model_for_node.await_args.args == ("p1", None, True)
+
+    @pytest.mark.parametrize("raw", [None, False, "true", "True", 1, "1"], ids=repr)
+    async def test_only_a_real_true_requests_caching(self, raw):
+        config = {} if raw is None else {"promptCaching": raw}
+        provider, _ = await _forward(_plain_llm()[0], **config)
+
+        assert provider.get_model_for_node.await_args.args == ("p1", None, False)
+
+    async def test_the_chain_id_still_travels_with_the_toggle(self):
+        provider, _ = await _forward(_plain_llm()[0], fallbackChainId="chain-1", promptCaching=True)
+
+        assert provider.get_model_for_node.await_args.args == ("p1", "chain-1", True)
+
+    async def test_usage_entries_carry_the_request(self):
+        _, state = await _forward(_caching_llm()[0], promptCaching=True)
+
+        assert state.llm_usage[0]["prompt_caching_enabled"] is True
+
+    async def test_usage_entries_stay_unmarked_when_the_toggle_is_off(self):
+        _, state = await _forward(_plain_llm()[0])
+
+        assert state.llm_usage[0]["prompt_caching_enabled"] is False
+
+    async def test_chain_of_thought_forwards_the_request_too(self):
+        with patch("app.modules.workflow.engine.nodes.llm_model_node.ChainOfThoughtAgent") as agent_cls:
+            agent_cls.return_value.invoke = AsyncMock(return_value={"response": "ok"})
+            provider, _ = await _forward(_plain_llm()[0], type="Chain-of-Thought", promptCaching=True)
+
+        assert provider.get_model_for_node.await_args.args == ("p1", None, True)
+
+
+async def _diagnose(llm, *, raw=_BASE, resolved=None, history=None, node_data=None, **config_overrides):
+    memory = _FakeMemory(history) if history is not None else None
+    data = node_data if node_data is not None else {"systemPrompt": raw}
+    state = _FakeState(memory=memory)
+    node = LLMModelNode("llm-1", {"type": "llmModelNode", "data": data}, state)
+    config = {
+        "providerId": "p1",
+        "systemPrompt": _BASE if resolved is None else resolved,
+        "userPrompt": "hello",
+        "memory": memory is not None,
+        **config_overrides,
+    }
+
+    ctx, _ = _patch_injector(llm)
+    with ctx:
+        await node.process(config)
+    return state.prompt_caching_diagnostics.get("llm-1")
+
+
+@pytest.mark.asyncio
+class TestNodeDiagnostic:
+
+    async def test_a_split_prompt_reports_applied(self):
+        diagnostic = await _diagnose(_caching_llm()[0], history=_HISTORY, promptCaching=True)
+
+        assert diagnostic == {"requested": True, "applied": True, "reason": None}
+
+    async def test_a_volatile_prompt_names_the_gate(self):
+        diagnostic = await _diagnose(
+            _caching_llm()[0], raw="Summarize: {{message}}", resolved="Summarize: a bug", promptCaching=True
+        )
+
+        assert diagnostic == {"requested": True, "applied": False, "reason": "volatile_prompt"}
+
+    async def test_an_unwrapped_model_names_the_provider(self):
+        diagnostic = await _diagnose(_plain_llm()[0], promptCaching=True)
+
+        assert diagnostic == {"requested": True, "applied": False, "reason": "unsupported_cache_markers"}
+
+    async def test_a_mixed_chain_is_distinguished_from_a_plain_model(self):
+        chain = FallbackChatModel(models=[_CapturingModel(), _caching_llm()[0]])
+        diagnostic = await _diagnose(chain, promptCaching=True)
+
+        assert diagnostic["reason"] == "mixed_fallback_chain"
+
+    async def test_a_chain_with_no_cacheable_child_reads_as_unsupported(self):
+        chain = FallbackChatModel(models=[_CapturingModel(), _CapturingModel()])
+        diagnostic = await _diagnose(chain, promptCaching=True)
+
+        assert diagnostic["reason"] == "unsupported_cache_markers"
+
+    async def test_a_blank_prompt_names_the_first_gate(self):
+        diagnostic = await _diagnose(_caching_llm()[0], raw="", resolved="   ", promptCaching=True)
+
+        assert diagnostic == {"requested": True, "applied": False, "reason": "empty_prompt"}
+
+    async def test_chain_of_thought_reports_the_mode(self):
+        with patch("app.modules.workflow.engine.nodes.llm_model_node.ChainOfThoughtAgent") as agent_cls:
+            agent_cls.return_value.invoke = AsyncMock(return_value={"response": "ok"})
+            diagnostic = await _diagnose(_caching_llm()[0], type="Chain-of-Thought", promptCaching=True)
+
+        assert diagnostic == {"requested": True, "applied": False, "reason": "unsupported_mode"}
+
+    @pytest.mark.parametrize("raw", [None, False, "true", 1], ids=repr)
+    async def test_an_unrequested_node_writes_no_annotation(self, raw):
+        config = {} if raw is None else {"promptCaching": raw}
+        diagnostic = await _diagnose(_caching_llm()[0], history=_HISTORY, **config)
+
+        assert diagnostic is None
+
+    async def test_a_failed_memory_lookup_leaves_no_applied_marker(self):
+        class _RaisingMemory:
+            async def get_chat_history(self, as_string: bool = False, max_messages: int = 10) -> str:
+                raise RuntimeError("memory backend down")
+
+        state = _FakeState(memory=_RaisingMemory())
+        node = LLMModelNode("llm-1", {"type": "llmModelNode", "data": {"systemPrompt": _BASE}}, state)
+        config = {"providerId": "p1", "systemPrompt": _BASE, "userPrompt": "hi", "memory": True, "promptCaching": True}
+
+        ctx, _ = _patch_injector(_caching_llm()[0])
+        with ctx:
+            await node.process(config)
+
+        assert state.prompt_caching_diagnostics == {}
+
+    async def test_an_unreadable_attachment_leaves_no_applied_marker(self):
+        class _StateWithAttachments(_FakeState):
+            def get_value(self, key, default=None):
+                if key == "attachments":
+                    return [{"type": "image/png", "file_mime_type": "image/png", "file_local_path": "/nonexistent.png"}]
+                return default
+
+        state = _StateWithAttachments()
+        node = LLMModelNode("llm-1", {"type": "llmModelNode", "data": {"systemPrompt": _BASE}}, state)
+        config = {"providerId": "p1", "systemPrompt": _BASE, "userPrompt": "hi", "promptCaching": True}
+
+        ctx, _ = _patch_injector(_caching_llm()[0])
+        with ctx:
+            await node.process(config)
+
+        assert state.prompt_caching_diagnostics == {}
+
+    async def test_a_raising_model_call_leaves_no_applied_marker(self):
+        llm = PromptCachingChatModel(inner=_RaisingModel(), cache_style="anthropic")
+        diagnostic = await _diagnose(llm, promptCaching=True)
+
+        assert diagnostic is None
+
+    async def test_a_withheld_verdict_survives_a_raising_model_call(self):
+        diagnostic = await _diagnose(_RaisingModel(), promptCaching=True)
+
+        assert diagnostic == {"requested": True, "applied": False, "reason": "unsupported_cache_markers"}
+
+    async def test_a_state_without_the_store_never_breaks_the_node(self):
+        state = _FakeState()
+        del state.prompt_caching_diagnostics  # a state built before the diagnostic existed
+        node = LLMModelNode("llm-1", {"type": "llmModelNode", "data": {"systemPrompt": _BASE}}, state)
+        config = {"providerId": "p1", "systemPrompt": _BASE, "userPrompt": "hi", "promptCaching": True}
+
+        ctx, _ = _patch_injector(_caching_llm()[0])
+        with ctx:
+            assert await node.process(config) == "ok"

--- a/backend/tests/unit/test_llm_model_node_prompt_caching.py
+++ b/backend/tests/unit/test_llm_model_node_prompt_caching.py
@@ -390,43 +390,43 @@ class TestNodeDiagnostic:
     async def test_a_split_prompt_reports_applied(self):
         diagnostic = await _diagnose(_caching_llm()[0], history=_HISTORY, promptCaching=True)
 
-        assert diagnostic == {"requested": True, "applied": True, "reason": None}
+        assert diagnostic == {"requested": True, "applied": True}
 
-    async def test_a_volatile_prompt_names_the_gate(self):
+    async def test_a_volatile_prompt_is_withheld(self):
         diagnostic = await _diagnose(
             _caching_llm()[0], raw="Summarize: {{message}}", resolved="Summarize: a bug", promptCaching=True
         )
 
-        assert diagnostic == {"requested": True, "applied": False, "reason": "volatile_prompt"}
+        assert diagnostic == {"requested": True, "applied": False}
 
-    async def test_an_unwrapped_model_names_the_provider(self):
+    async def test_an_unwrapped_model_is_withheld(self):
         diagnostic = await _diagnose(_plain_llm()[0], promptCaching=True)
 
-        assert diagnostic == {"requested": True, "applied": False, "reason": "unsupported_cache_markers"}
+        assert diagnostic == {"requested": True, "applied": False}
 
-    async def test_a_mixed_chain_is_distinguished_from_a_plain_model(self):
+    async def test_a_mixed_chain_is_withheld(self):
         chain = FallbackChatModel(models=[_CapturingModel(), _caching_llm()[0]])
         diagnostic = await _diagnose(chain, promptCaching=True)
 
-        assert diagnostic["reason"] == "mixed_fallback_chain"
+        assert diagnostic == {"requested": True, "applied": False}
 
-    async def test_a_chain_with_no_cacheable_child_reads_as_unsupported(self):
+    async def test_a_chain_with_no_cacheable_child_is_withheld(self):
         chain = FallbackChatModel(models=[_CapturingModel(), _CapturingModel()])
         diagnostic = await _diagnose(chain, promptCaching=True)
 
-        assert diagnostic["reason"] == "unsupported_cache_markers"
+        assert diagnostic == {"requested": True, "applied": False}
 
-    async def test_a_blank_prompt_names_the_first_gate(self):
+    async def test_a_blank_prompt_is_withheld(self):
         diagnostic = await _diagnose(_caching_llm()[0], raw="", resolved="   ", promptCaching=True)
 
-        assert diagnostic == {"requested": True, "applied": False, "reason": "empty_prompt"}
+        assert diagnostic == {"requested": True, "applied": False}
 
-    async def test_chain_of_thought_reports_the_mode(self):
+    async def test_chain_of_thought_is_withheld(self):
         with patch("app.modules.workflow.engine.nodes.llm_model_node.ChainOfThoughtAgent") as agent_cls:
             agent_cls.return_value.invoke = AsyncMock(return_value={"response": "ok"})
             diagnostic = await _diagnose(_caching_llm()[0], type="Chain-of-Thought", promptCaching=True)
 
-        assert diagnostic == {"requested": True, "applied": False, "reason": "unsupported_mode"}
+        assert diagnostic == {"requested": True, "applied": False}
 
     @pytest.mark.parametrize("raw", [None, False, "true", 1], ids=repr)
     async def test_an_unrequested_node_writes_no_annotation(self, raw):
@@ -476,7 +476,7 @@ class TestNodeDiagnostic:
     async def test_a_withheld_verdict_survives_a_raising_model_call(self):
         diagnostic = await _diagnose(_RaisingModel(), promptCaching=True)
 
-        assert diagnostic == {"requested": True, "applied": False, "reason": "unsupported_cache_markers"}
+        assert diagnostic == {"requested": True, "applied": False}
 
     async def test_a_state_without_the_store_never_breaks_the_node(self):
         state = _FakeState()

--- a/backend/tests/unit/test_llm_providers_prompt_caching.py
+++ b/backend/tests/unit/test_llm_providers_prompt_caching.py
@@ -1,0 +1,203 @@
+"""LlmProviderService prompt-caching seams: the connection probe through a wrapped
+model, and the sanitation of the legacy provider-level prompt-caching key"""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import botocore.exceptions as botocore_exceptions
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+
+from app.modules.workflow.llm.prompt_caching_chat_model import PromptCachingChatModel
+from app.repositories.llm_providers import LlmProviderRepository
+from app.schemas.dynamic_form_schemas import LLM_FORM_SCHEMAS_DICT
+from app.schemas.llm import LlmProviderCreate, LlmProviderUpdate
+from app.services.app_settings import AppSettingsService
+from app.services.llm_providers import LlmProviderService
+
+_BUILD = "app.modules.workflow.llm.provider.build_chat_model"
+_RESIDENCY = "app.services.llm_providers.assert_provider_residency"
+_ENCRYPT = "app.services.llm_providers.encrypt_key"
+_LEGACY_KEY = "prompt_caching_enabled"
+
+
+@pytest.fixture
+def service():
+    return LlmProviderService(
+        repository=AsyncMock(spec=LlmProviderRepository),
+        app_settings_service=AsyncMock(spec=AppSettingsService),
+    )
+
+
+class _CapturingModel(BaseChatModel):
+    seen: list = []
+    error: Any = None
+
+    @property
+    def _llm_type(self) -> str:
+        return "capturing"
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        raise NotImplementedError
+
+    async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        self.seen.append(list(messages))
+        if self.error is not None:
+            raise self.error
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content="pong"))])
+
+
+async def _test_connection(service, built_model, **connection_data):
+    with patch(_BUILD, new=AsyncMock(return_value=built_model)):
+        return await service.test_connection("bedrock", {"model": "a-model", **connection_data})
+
+
+@pytest.mark.asyncio
+class TestProbeShape:
+    @pytest.mark.parametrize("cache_style", ["bedrock_converse", "anthropic", None], ids=repr)
+    async def test_the_probe_is_a_plain_ping(self, service, cache_style):
+        model = _CapturingModel()
+        built = model if cache_style is None else PromptCachingChatModel(inner=model, cache_style=cache_style)
+        result = await _test_connection(service, built)
+
+        assert result == {"success": True, "message": "Connection successful."}
+        assert [type(m) for m in model.seen[-1]] == [HumanMessage]
+        assert model.seen[-1][0].content == "ping"
+
+
+@pytest.mark.asyncio
+class TestFailures:
+    async def test_a_provider_error_reports_failure(self, service):
+        inner = _CapturingModel(
+            error=botocore_exceptions.ClientError(
+                {
+                    "Error": {"Code": "ValidationException", "Message": "model is not supported"},
+                    "ResponseMetadata": {"HTTPStatusCode": 400},
+                },
+                "Converse",
+            )
+        )
+        result = await _test_connection(service, PromptCachingChatModel(inner=inner, cache_style="bedrock_converse"))
+
+        assert result["success"] is False
+        assert "model is not supported" in result["message"]
+
+    async def test_build_failure_reports_failure(self, service):
+        with patch(_BUILD, new=AsyncMock(side_effect=ValueError("bad region"))):
+            result = await service.test_connection("bedrock", {"model": "a-model"})
+
+        assert result == {"success": False, "message": "bad region"}
+
+
+def _stored(**connection_data):
+    return SimpleNamespace(
+        llm_model_provider="anthropic",
+        llm_model="claude-3-opus",
+        connection_data={"api_key": "stored-cipher", **connection_data},
+        connection_status={"status": "Untested", "last_tested_at": None, "message": None},
+    )
+
+
+async def _create(service, connection_data: dict) -> dict:
+    with patch(_RESIDENCY, new=AsyncMock()), patch(_ENCRYPT, side_effect=lambda v: f"enc:{v}"):
+        await service.create(
+            LlmProviderCreate(
+                name="anthropic-1",
+                llm_model_provider="anthropic",
+                llm_model="claude-3-opus",
+                connection_data=connection_data,
+            )
+        )
+    return service.repository.create.await_args.args[0].connection_data
+
+
+async def _update(service, stored, **payload):
+    service.repository.get_by_id.return_value = stored
+    with patch(_RESIDENCY, new=AsyncMock()), patch(_ENCRYPT, side_effect=lambda v: f"enc:{v}"):
+        await service.update(uuid4(), LlmProviderUpdate(**payload))
+    return stored
+
+
+@pytest.mark.asyncio
+class TestCreateStripsTheLegacyKey:
+    @pytest.mark.parametrize("value", [True, False, "true", 1], ids=repr)
+    async def test_the_key_never_reaches_storage(self, service, value):
+        stored = await _create(service, {"api_key": "plain", _LEGACY_KEY: value})
+
+        assert _LEGACY_KEY not in stored
+
+    async def test_the_rest_of_the_payload_survives(self, service):
+        stored = await _create(service, {"api_key": "plain", "temperature": 0.5, _LEGACY_KEY: True})
+
+        assert stored["temperature"] == 0.5
+        assert stored["api_key"] == "enc:plain"
+
+
+@pytest.mark.asyncio
+class TestUpdateStripsTheLegacyKey:
+    async def test_a_resubmitted_key_is_dropped(self, service):
+        stored = await _update(
+            service, _stored(), connection_data={"api_key": "stored-cipher", "temperature": 0.5, _LEGACY_KEY: True}
+        )
+
+        assert _LEGACY_KEY not in stored.connection_data
+        assert stored.connection_data["temperature"] == 0.5
+
+    async def test_a_stored_key_is_cleared_on_the_next_save(self, service):
+        stored = await _update(
+            service, _stored(prompt_caching_enabled=True), connection_data={"api_key": "stored-cipher"}
+        )
+
+        assert _LEGACY_KEY not in stored.connection_data
+
+    async def test_the_key_is_never_invented_for_a_clean_provider(self, service):
+        stored = await _update(service, _stored(), connection_data={"temperature": 0.5})
+
+        assert _LEGACY_KEY not in stored.connection_data
+
+    async def test_stripping_does_not_look_like_a_connection_data_change(self, service):
+        stored = _stored()
+        tested = {"status": "Success", "last_tested_at": "2026-08-23T00:00:00", "message": "ok"}
+        stored.connection_status = tested
+
+        await _update(service, stored, connection_data={"api_key": "stored-cipher", _LEGACY_KEY: True})
+
+        assert stored.connection_status == tested
+
+
+@pytest.mark.asyncio
+class TestStaleKeyOnlyPayload:
+
+    async def test_stored_credentials_survive(self, service):
+        stored = await _update(service, _stored(), connection_data={_LEGACY_KEY: True})
+
+        assert stored.connection_data == {"api_key": "stored-cipher"}
+
+    async def test_stored_connection_status_survives(self, service):
+        stored = _stored()
+        tested = {"status": "Success", "last_tested_at": "2026-08-23T00:00:00", "message": "ok"}
+        stored.connection_status = tested
+
+        await _update(service, stored, connection_data={_LEGACY_KEY: True})
+
+        assert stored.connection_status == tested
+
+    async def test_a_genuinely_empty_payload_keeps_its_existing_semantics(self, service):
+        stored = await _update(service, _stored(), connection_data={})
+
+        assert stored.connection_data == {}
+
+
+class TestTheFormFieldStaysGone:
+    def test_no_provider_schema_offers_the_toggle(self):
+        offering = [
+            key
+            for key, schema in LLM_FORM_SCHEMAS_DICT.items()
+            if any(f.get("name") == _LEGACY_KEY for f in schema.get("fields") or [])
+        ]
+
+        assert offering == []

--- a/backend/tests/unit/test_llm_usage_tracking.py
+++ b/backend/tests/unit/test_llm_usage_tracking.py
@@ -40,8 +40,11 @@ def _patch_provider_service(providers=None, error=None):
     return patch("app.dependencies.injector.injector", inj), service
 
 
-def _provider(provider="OpenAI", model="gpt-4o"):
-    return SimpleNamespace(llm_model_provider=provider, llm_model=model)
+def _provider(provider="OpenAI", model="gpt-4o", prompt_caching_enabled=None):
+    connection_data = {"api_key": "k"}
+    if prompt_caching_enabled is not None:
+        connection_data["prompt_caching_enabled"] = prompt_caching_enabled
+    return SimpleNamespace(llm_model_provider=provider, llm_model=model, connection_data=connection_data)
 
 
 class TestResolveProviderModel:
@@ -74,6 +77,33 @@ class TestResolveProviderModel:
             await resolve_provider_model("p2", cache)
         assert service.get_by_id.await_count == 2
 
+    @pytest.mark.asyncio
+    async def test_resolution_is_names_only(self):
+        ctx, _ = _patch_provider_service({"p1": _provider("Anthropic", "claude-3-opus", prompt_caching_enabled=True)})
+        with ctx:
+            assert await resolve_provider_model("p1") == ("anthropic", "claude-3-opus")
+
+
+class TestTheLegacyStoredKeyIsNeverRead:
+
+    @pytest.mark.asyncio
+    async def test_a_stored_opt_in_does_not_mark_usage(self):
+        state = FakeState()
+        ctx, _ = _patch_provider_service({"p1": _provider("Anthropic", "claude-3-opus", prompt_caching_enabled=True)})
+        with ctx:
+            await merge_llm_usage_from_result(state, {"llm_usage": [{"input_tokens": 1}]}, "node-1", "p1")
+
+        assert state.llm_usage[0]["prompt_caching_enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_the_stored_connection_data_is_never_rewritten(self):
+        provider = _provider("Anthropic", "claude-3-opus", prompt_caching_enabled=True)
+        ctx, _ = _patch_provider_service({"p1": provider})
+        with ctx:
+            await resolve_provider_model("p1")
+
+        assert provider.connection_data["prompt_caching_enabled"] is True
+
 
 class TestMergeLlmUsageFromResult:
     @pytest.mark.asyncio
@@ -89,6 +119,7 @@ class TestMergeLlmUsageFromResult:
         assert entry["total_tokens"] == 20
         assert entry["purpose"] == "chat" and entry["node_id"] == "node-1"
         assert entry["llm_provider_id"] == "p1"
+        assert entry["prompt_caching_enabled"] is False
 
     @pytest.mark.asyncio
     async def test_per_item_provider_id_overrides_the_node_primary(self):
@@ -131,6 +162,37 @@ class TestMergeLlmUsageFromResult:
         with ctx:
             await merge_llm_usage_from_result(state, {"llm_usage": ["junk"]}, "node-1", "p1")
         assert state.llm_usage == []
+
+
+class TestNodeRequestedCaching:
+
+    @pytest.mark.asyncio
+    async def test_the_request_marks_every_entry(self):
+        state = FakeState()
+        ctx, _ = _patch_provider_service({"p1": _provider(), "p2": _provider("Anthropic", "claude-3-opus")})
+        result = {"llm_usage": [{"input_tokens": 1}, {"input_tokens": 2, "provider_id": "p2"}]}
+        with ctx:
+            await merge_llm_usage_from_result(state, result, "node-1", "p1", True)
+
+        assert [e["prompt_caching_enabled"] for e in state.llm_usage] == [True, True]
+
+    @pytest.mark.asyncio
+    async def test_without_the_request_a_plain_provider_stays_unmarked(self):
+        state = FakeState()
+        ctx, _ = _patch_provider_service({"p1": _provider()})
+        with ctx:
+            await merge_llm_usage_from_result(state, {"llm_usage": [{"input_tokens": 1}]}, "node-1", "p1")
+
+        assert state.llm_usage[0]["prompt_caching_enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_record_node_llm_usage_forwards_the_request(self):
+        state = FakeState()
+        ctx, _ = _patch_provider_service({"p1": _provider()})
+        with ctx:
+            await record_node_llm_usage(state, _message({"input_tokens": 5}), "node-1", "p1", None, True)
+
+        assert state.llm_usage[0]["prompt_caching_enabled"] is True
 
 
 class TestRecordNodeLlmUsage:

--- a/backend/tests/unit/test_llm_usage_utils.py
+++ b/backend/tests/unit/test_llm_usage_utils.py
@@ -2,6 +2,7 @@
 
 from app.core.utils.llm_usage_utils import (
     USAGE_METADATA_MISSING,
+    extract_cache_tokens,
     extract_usage_from_aimessage,
     extract_usage_from_response_metadata,
     is_usage_metadata_missing,
@@ -268,3 +269,71 @@ class TestUsagePlaceholder:
         assert is_usage_metadata_missing(None) is False
         assert is_usage_metadata_missing("junk") is False
         assert is_usage_metadata_missing({"cache_read": 1}) is False
+
+
+class TestExtractCacheTokens:
+    def test_standard_nested_details(self):
+        details = {"input_token_details": {"cache_read": 3697, "cache_creation": 60}}
+        assert extract_cache_tokens(details) == (3697, 60)
+
+    def test_flat_details_shape(self):
+        assert extract_cache_tokens({"cache_read": 12, "cache_creation": 34}) == (12, 34)
+
+    def test_nested_wins_over_flat_when_both_present(self):
+        details = {"cache_read": 1, "input_token_details": {"cache_read": 500, "cache_creation": 7}}
+        assert extract_cache_tokens(details) == (500, 7)
+
+    def test_empty_nested_details_fall_back_to_the_blob(self):
+        assert extract_cache_tokens({"input_token_details": {}, "cache_read": 9}) == (9, 0)
+
+    def test_non_dict_nested_details_fall_back_to_the_blob(self):
+        assert extract_cache_tokens({"input_token_details": "junk", "cache_creation": 4}) == (0, 4)
+
+    def test_missing_buckets_are_zero(self):
+        assert extract_cache_tokens({"input_token_details": {"audio": 10}}) == (0, 0)
+        assert extract_cache_tokens({}) == (0, 0)
+
+    def test_partial_buckets_keep_the_reported_one(self):
+        assert extract_cache_tokens({"input_token_details": {"cache_read": 500}}) == (500, 0)
+        assert extract_cache_tokens({"input_token_details": {"cache_creation": 500}}) == (0, 500)
+
+    def test_explicit_zeros_are_zero(self):
+        assert extract_cache_tokens({"input_token_details": {"cache_read": 0, "cache_creation": 0}}) == (0, 0)
+
+    def test_none_and_non_dicts(self):
+        assert extract_cache_tokens(None) == (0, 0)
+        assert extract_cache_tokens("junk") == (0, 0)
+        assert extract_cache_tokens(42) == (0, 0)
+        assert extract_cache_tokens([{"cache_read": 5}]) == (0, 0)
+
+    def test_usage_metadata_missing_sentinel(self):
+        assert extract_cache_tokens({USAGE_METADATA_MISSING: True}) == (0, 0)
+
+    def test_junk_values_count_as_zero(self):
+        details = {"input_token_details": {"cache_read": "500", "cache_creation": None}}
+        assert extract_cache_tokens(details) == (0, 0)
+
+    def test_booleans_are_not_token_counts(self):
+        assert extract_cache_tokens({"input_token_details": {"cache_read": True}}) == (0, 0)
+
+    def test_non_finite_values_count_as_zero(self):
+        details = {"input_token_details": {"cache_read": float("inf"), "cache_creation": float("nan")}}
+        assert extract_cache_tokens(details) == (0, 0)
+
+    def test_negative_counts_clamp_to_zero(self):
+        details = {"input_token_details": {"cache_read": -5, "cache_creation": -1}}
+        assert extract_cache_tokens(details) == (0, 0)
+
+    def test_anthropic_ephemeral_keys_are_ignored(self):
+        details = {
+            "input_token_details": {
+                "cache_read": 100,
+                "cache_creation": 200,
+                "ephemeral_5m_input_tokens": 200,
+                "ephemeral_1h_input_tokens": None,
+            }
+        }
+        assert extract_cache_tokens(details) == (100, 200)
+
+    def test_floats_truncate_to_int(self):
+        assert extract_cache_tokens({"input_token_details": {"cache_read": 12.9}}) == (12, 0)

--- a/backend/tests/unit/test_node_dialog_schema_prompt_caching.py
+++ b/backend/tests/unit/test_node_dialog_schema_prompt_caching.py
@@ -1,0 +1,30 @@
+"""The promptCaching dialog field is declared on exactly the cache-aware node types"""
+
+import pytest
+
+from app.schemas.dynamic_form_schemas.nodes import NODE_DIALOG_SCHEMAS
+
+_CACHE_AWARE = ("agentNode", "subAgentNode", "llmModelNode")
+
+
+def _field(node_type: str):
+    return next((f for f in NODE_DIALOG_SCHEMAS[node_type] if f.name == "promptCaching"), None)
+
+
+@pytest.mark.parametrize("node_type", _CACHE_AWARE)
+def test_cache_aware_nodes_declare_an_optional_boolean_defaulting_off(node_type):
+    field = _field(node_type)
+    assert field is not None
+    assert field.type == "boolean"
+    assert field.required is False
+    assert field.default is False
+
+
+@pytest.mark.parametrize("node_type", _CACHE_AWARE)
+def test_the_label_matches_the_dialog_switch(node_type):
+    assert _field(node_type).label == "Enable Prompt Caching"
+
+
+def test_no_other_node_type_offers_the_toggle():
+    others = set(NODE_DIALOG_SCHEMAS) - set(_CACHE_AWARE)
+    assert [t for t in others if _field(t) is not None] == []

--- a/backend/tests/unit/test_prompt_caching_chat_model.py
+++ b/backend/tests/unit/test_prompt_caching_chat_model.py
@@ -1,0 +1,991 @@
+"""Model-layer prompt caching: PromptCachingChatModel marking semantics, what the real
+provider formatters serialize, and the build_chat_model opt-in that applies the wrapper"""
+
+import copy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from langchain_anthropic.chat_models import _format_messages
+from langchain_aws.chat_models.bedrock_converse import _messages_to_bedrock
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+    message_to_dict,
+    messages_from_dict,
+)
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+
+from app.modules.workflow.llm.fallback_chat_model import FallbackChatModel
+from app.modules.workflow.llm.prompt_caching_chat_model import (
+    PROMPT_CACHE_OPT_IN_KEY,
+    PromptCachingChatModel,
+    build_cacheable_system_message,
+    model_has_prompt_caching,
+)
+from app.modules.workflow.llm.provider import LLMProvider, build_chat_model
+
+_STYLES = ["anthropic", "bedrock_converse"]
+
+
+class _CapturingModel(BaseChatModel):
+    seen: list = []
+    seen_kwargs: list = []
+    text: str = "ok-response"
+    tools_bound: list = []
+    fail: bool = False
+
+    @property
+    def _llm_type(self) -> str:
+        return "capturing"
+
+    def _record(self, messages, stop, kwargs) -> None:
+        self.seen.append(list(messages))
+        self.seen_kwargs.append({"stop": stop, **kwargs})
+        if self.fail:
+            raise httpx.ConnectError("no route")
+
+    @property
+    def last(self) -> list:
+        return self.seen[-1]
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        self._record(messages, stop, kwargs)
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content=self.text))])
+
+    async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        self._record(messages, stop, kwargs)
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content=self.text))])
+
+    def _stream(self, messages, stop=None, run_manager=None, **kwargs):
+        self._record(messages, stop, kwargs)
+        yield ChatGenerationChunk(message=AIMessageChunk(content=self.text))
+
+    async def _astream(self, messages, stop=None, run_manager=None, **kwargs):
+        self._record(messages, stop, kwargs)
+        yield ChatGenerationChunk(message=AIMessageChunk(content=self.text))
+
+    def bind_tools(self, tools, **kwargs):
+        return _CapturingModel(text=self.text, tools_bound=list(tools))
+
+
+def _wrap(style: str) -> tuple[PromptCachingChatModel, _CapturingModel]:
+    inner = _CapturingModel()
+    return PromptCachingChatModel(inner=inner, cache_style=style), inner
+
+
+def _system_blocks(sent: list) -> list:
+    return [m for m in sent if isinstance(m, SystemMessage)][0].content
+
+
+def _tagged(content) -> SystemMessage:
+    return SystemMessage(content=content, additional_kwargs={PROMPT_CACHE_OPT_IN_KEY: True})
+
+
+@pytest.mark.asyncio
+class TestInversionRule:
+    async def test_anthropic_marks_first_block(self):
+        wrapper, inner = _wrap("anthropic")
+        await wrapper.ainvoke([build_cacheable_system_message("stable"), HumanMessage(content="hi")])
+        assert _system_blocks(inner.last) == [
+            {"type": "text", "text": "stable", "cache_control": {"type": "ephemeral"}}
+        ]
+
+    async def test_bedrock_inserts_cache_point_after_first_block(self):
+        wrapper, inner = _wrap("bedrock_converse")
+        await wrapper.ainvoke([build_cacheable_system_message("stable"), HumanMessage(content="hi")])
+        assert _system_blocks(inner.last) == [
+            {"type": "text", "text": "stable"},
+            {"cachePoint": {"type": "default"}},
+        ]
+
+    @pytest.mark.parametrize("style", _STYLES)
+    async def test_plain_string_system_is_never_marked(self, style):
+        wrapper, inner = _wrap(style)
+        original = _tagged("a plain string prompt")
+        await wrapper.ainvoke([original, HumanMessage(content="hi")])
+        sent_system = [m for m in inner.last if isinstance(m, SystemMessage)][0]
+        assert sent_system.content == "a plain string prompt"
+        assert isinstance(sent_system.content, str)
+
+    @pytest.mark.parametrize("style", _STYLES)
+    async def test_no_system_message_passes_through(self, style):
+        wrapper, inner = _wrap(style)
+        messages = [HumanMessage(content="hi")]
+        await wrapper.ainvoke(messages)
+        assert [m.content for m in inner.last] == ["hi"]
+
+
+class TestCacheableSystemMessageBuilder:
+    def test_two_blocks_when_a_volatile_part_is_given(self):
+        assert build_cacheable_system_message("stable", "volatile").content == [
+            {"type": "text", "text": "stable"},
+            {"type": "text", "text": "volatile"},
+        ]
+
+    @pytest.mark.parametrize("volatile", [None, ""], ids=["omitted", "empty"])
+    def test_a_missing_volatile_part_emits_one_block(self, volatile):
+        assert build_cacheable_system_message("stable", volatile).content == [{"type": "text", "text": "stable"}]
+
+    def test_the_tag_is_stamped(self):
+        assert build_cacheable_system_message("stable").additional_kwargs == {PROMPT_CACHE_OPT_IN_KEY: True}
+
+    def test_the_class_stays_a_plain_system_message(self):
+        assert type(build_cacheable_system_message("stable")) is SystemMessage
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("style", _STYLES)
+class TestOptInTag:
+
+    async def test_untagged_blocks_pass_through_unmarked(self, style):
+        wrapper, inner = _wrap(style)
+        content = [{"type": "text", "text": "stable"}, {"type": "text", "text": "volatile"}]
+
+        await wrapper.ainvoke([SystemMessage(content=list(content)), HumanMessage(content="hi")])
+
+        assert _system_blocks(inner.last) == content
+
+    @pytest.mark.parametrize("tag", [False, None, 0, ""], ids=["false", "none", "zero", "empty"])
+    async def test_a_falsy_tag_never_authorizes_marking(self, style, tag):
+        wrapper, inner = _wrap(style)
+        message = SystemMessage(
+            content=[{"type": "text", "text": "stable"}], additional_kwargs={PROMPT_CACHE_OPT_IN_KEY: tag}
+        )
+
+        await wrapper.ainvoke([message, HumanMessage(content="hi")])
+
+        assert _system_blocks(inner.last) == [{"type": "text", "text": "stable"}]
+
+    async def test_a_tagged_message_that_round_tripped_through_a_dict_still_marks(self, style):
+        wrapper, inner = _wrap(style)
+        restored = messages_from_dict([message_to_dict(build_cacheable_system_message("stable"))])[0]
+
+        await wrapper.ainvoke([restored, HumanMessage(content="hi")])
+
+        assert len(_system_blocks(inner.last)) == (1 if style == "anthropic" else 2)
+
+
+@pytest.mark.asyncio
+class TestBlockSelection:
+    @pytest.mark.parametrize(
+        "style,expected",
+        [
+            (
+                "anthropic",
+                [
+                    {"type": "text", "text": "stable base", "cache_control": {"type": "ephemeral"}},
+                    {"type": "text", "text": "volatile suffix"},
+                ],
+            ),
+            (
+                "bedrock_converse",
+                [
+                    {"type": "text", "text": "stable base"},
+                    {"cachePoint": {"type": "default"}},
+                    {"type": "text", "text": "volatile suffix"},
+                ],
+            ),
+        ],
+    )
+    async def test_only_first_block_is_selected(self, style, expected):
+        wrapper, inner = _wrap(style)
+        await wrapper.ainvoke(
+            [
+                build_cacheable_system_message("stable base", "volatile suffix"),
+                HumanMessage(content="hi"),
+            ]
+        )
+        assert _system_blocks(inner.last) == expected
+
+    @pytest.mark.parametrize("style", _STYLES)
+    @pytest.mark.parametrize(
+        "first_block",
+        [
+            {"type": "text", "text": ""},
+            {"type": "text", "text": "   "},
+            {"type": "text"},
+            {"type": "image", "source": {"data": "x"}},
+            "a bare string block",
+        ],
+        ids=["empty", "whitespace", "no-text-key", "non-text-type", "not-a-dict"],
+    )
+    async def test_blank_or_non_text_first_block_is_untouched(self, style, first_block):
+        wrapper, inner = _wrap(style)
+        content = [first_block, {"type": "text", "text": "later"}]
+        await wrapper.ainvoke([_tagged(list(content)), HumanMessage(content="hi")])
+        assert _system_blocks(inner.last) == content
+
+    @pytest.mark.parametrize("style", _STYLES)
+    async def test_empty_block_list_is_untouched(self, style):
+        wrapper, inner = _wrap(style)
+        await wrapper.ainvoke([_tagged([]), HumanMessage(content="hi")])
+        assert _system_blocks(inner.last) == []
+
+    @pytest.mark.parametrize(
+        "style,already_marked",
+        [
+            ("anthropic", [{"type": "text", "text": "a", "cache_control": {"type": "ephemeral"}}]),
+            ("bedrock_converse", [{"type": "text", "text": "a"}, {"cachePoint": {"type": "default"}}]),
+        ],
+    )
+    async def test_idempotent_when_already_marked(self, style, already_marked):
+        wrapper, inner = _wrap(style)
+        await wrapper.ainvoke([_tagged(list(already_marked)), HumanMessage(content="hi")])
+        assert _system_blocks(inner.last) == already_marked
+
+    @pytest.mark.parametrize("style", _STYLES)
+    async def test_marker_placed_elsewhere_is_left_alone(self, style):
+        wrapper, inner = _wrap(style)
+        if style == "anthropic":
+            content = [
+                {"type": "text", "text": "a"},
+                {"type": "text", "text": "b", "cache_control": {"type": "ephemeral"}},
+            ]
+        else:
+            content = [
+                {"type": "text", "text": "a"},
+                {"type": "text", "text": "b"},
+                {"cachePoint": {"type": "default"}},
+            ]
+        await wrapper.ainvoke([_tagged(list(content)), HumanMessage(content="hi")])
+        assert _system_blocks(inner.last) == content
+
+    @pytest.mark.parametrize("style", _STYLES)
+    async def test_only_the_first_system_message_is_considered(self, style):
+        wrapper, inner = _wrap(style)
+        await wrapper.ainvoke(
+            [
+                build_cacheable_system_message("first"),
+                HumanMessage(content="hi"),
+                build_cacheable_system_message("second"),
+            ]
+        )
+        systems = [m for m in inner.last if isinstance(m, SystemMessage)]
+        assert systems[1].content == [{"type": "text", "text": "second"}]
+        assert len(systems[0].content) == (1 if style == "anthropic" else 2)
+
+    @pytest.mark.parametrize("style", _STYLES)
+    async def test_first_system_ineligible_does_not_fall_through_to_a_later_one(self, style):
+        wrapper, inner = _wrap(style)
+        await wrapper.ainvoke(
+            [
+                _tagged("plain"),
+                HumanMessage(content="hi"),
+                build_cacheable_system_message("second"),
+            ]
+        )
+        systems = [m for m in inner.last if isinstance(m, SystemMessage)]
+        assert systems[0].content == "plain"
+        assert systems[1].content == [{"type": "text", "text": "second"}]
+
+
+@pytest.mark.asyncio
+class TestCopyOnWrite:
+    @pytest.mark.parametrize("style", _STYLES)
+    async def test_caller_objects_are_never_mutated(self, style):
+        wrapper, inner = _wrap(style)
+        system = build_cacheable_system_message("stable", "suffix")
+        messages = [system, HumanMessage(content="hi")]
+        original_content = system.content
+        original_first = original_content[0]
+        before = copy.deepcopy(messages)
+
+        await wrapper.ainvoke(messages)
+
+        assert [m.content for m in messages] == [m.content for m in before]
+        assert system.content is original_content
+        assert original_content[0] is original_first
+        assert original_first == {"type": "text", "text": "stable"}
+        assert inner.last is not messages
+        assert inner.last[0] is not system
+
+    @pytest.mark.parametrize("style", _STYLES)
+    async def test_repeated_invocations_do_not_accumulate_markers(self, style):
+        wrapper, inner = _wrap(style)
+        messages = [build_cacheable_system_message("stable"), HumanMessage(content="hi")]
+        await wrapper.ainvoke(messages)
+        await wrapper.ainvoke(messages)
+        assert _system_blocks(inner.seen[0]) == _system_blocks(inner.seen[1])
+
+
+class TestMethodContracts:
+    @pytest.mark.asyncio
+    async def test_agenerate_returns_chat_result(self):
+        wrapper, _ = _wrap("anthropic")
+        result = await wrapper._agenerate([HumanMessage(content="hi")])
+        assert isinstance(result, ChatResult)
+        assert result.generations[0].message.content == "ok-response"
+
+    def test_generate_returns_chat_result(self):
+        wrapper, _ = _wrap("anthropic")
+        result = wrapper._generate([HumanMessage(content="hi")])
+        assert isinstance(result, ChatResult)
+        assert result.generations[0].message.content == "ok-response"
+
+    @pytest.mark.asyncio
+    async def test_astream_marks_and_yields_chunks(self):
+        wrapper, inner = _wrap("anthropic")
+        out = "".join(
+            [
+                chunk.content
+                async for chunk in wrapper.astream(
+                    [build_cacheable_system_message("stable"), HumanMessage(content="hi")]
+                )
+            ]
+        )
+        assert out == "ok-response"
+        assert _system_blocks(inner.last)[0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_stream_marks_and_yields_chunks(self):
+        wrapper, inner = _wrap("bedrock_converse")
+        out = "".join(
+            chunk.content
+            for chunk in wrapper.stream([build_cacheable_system_message("stable"), HumanMessage(content="hi")])
+        )
+        assert out == "ok-response"
+        assert _system_blocks(inner.last)[1] == {"cachePoint": {"type": "default"}}
+
+    @pytest.mark.asyncio
+    async def test_stop_and_kwargs_are_forwarded(self):
+        wrapper, inner = _wrap("anthropic")
+        await wrapper.ainvoke([HumanMessage(content="hi")], stop=["</end>"], temperature=0.3)
+        assert inner.seen_kwargs[-1]["stop"] == ["</end>"]
+        assert inner.seen_kwargs[-1]["temperature"] == 0.3
+
+    @pytest.mark.asyncio
+    async def test_stop_absent_when_not_supplied(self):
+        wrapper, inner = _wrap("anthropic")
+        await wrapper.ainvoke([HumanMessage(content="hi")])
+        assert inner.seen_kwargs[-1]["stop"] is None
+
+    @pytest.mark.asyncio
+    async def test_astream_forwards_stop_and_kwargs(self):
+        wrapper, inner = _wrap("anthropic")
+        async for _ in wrapper.astream([HumanMessage(content="hi")], stop=["</end>"], temperature=0.3):
+            pass
+        assert inner.seen_kwargs[-1]["stop"] == ["</end>"]
+        assert inner.seen_kwargs[-1]["temperature"] == 0.3
+
+    def test_stream_forwards_stop_and_kwargs(self):
+        wrapper, inner = _wrap("anthropic")
+        list(wrapper.stream([HumanMessage(content="hi")], stop=["</end>"], temperature=0.3))
+        assert inner.seen_kwargs[-1]["stop"] == ["</end>"]
+        assert inner.seen_kwargs[-1]["temperature"] == 0.3
+
+    def test_llm_type(self):
+        wrapper, _ = _wrap("anthropic")
+        assert wrapper._llm_type == "prompt_caching_chat_model"
+
+
+@pytest.mark.asyncio
+class TestBindTools:
+    async def test_bind_tools_rewraps_and_keeps_marking(self):
+        wrapper, _ = _wrap("bedrock_converse")
+        bound = wrapper.bind_tools([{"name": "search"}])
+        assert isinstance(bound, PromptCachingChatModel)
+        assert bound.cache_style == "bedrock_converse"
+        assert bound.inner.tools_bound == [{"name": "search"}]
+
+        await bound.ainvoke([build_cacheable_system_message("stable"), HumanMessage(content="hi")])
+        assert _system_blocks(bound.inner.last)[1] == {"cachePoint": {"type": "default"}}
+
+
+@pytest.mark.asyncio
+class TestRunnableBinding:
+    async def test_bind_keeps_marking_and_forwards_its_kwargs(self):
+        """`.bind()` wraps outside — the shape router_node and nlp_node already use."""
+        wrapper, inner = _wrap("bedrock_converse")
+        bound = wrapper.bind(temperature=0)
+
+        await bound.ainvoke([build_cacheable_system_message("stable"), HumanMessage(content="hi")])
+
+        assert _system_blocks(inner.last)[1] == {"cachePoint": {"type": "default"}}
+        assert inner.seen_kwargs[-1]["temperature"] == 0
+
+
+def _loop_turn(tail) -> list:
+    return [
+        build_cacheable_system_message("stable"),
+        HumanMessage(content="hi"),
+        AIMessage(content="calling", tool_calls=[{"name": "t", "args": {}, "id": "tc1"}]),
+        tail,
+    ]
+
+
+@pytest.mark.asyncio
+class TestConversationBreakpoint:
+    """bind_tools opts the wrapper into tail caching, so each tool-loop turn re-reads
+    the previous turn's prefix. Unbound (single-shot) callers never pay the write."""
+
+    @staticmethod
+    def _bound(style):
+        wrapper, _ = _wrap(style)
+        bound = wrapper.bind_tools([{"name": "search"}])
+        return bound, bound.inner
+
+    async def test_bind_tools_turns_it_on(self):
+        bound, _ = self._bound("anthropic")
+        assert bound.cache_conversation is True
+
+    @pytest.mark.parametrize("style", _STYLES)
+    async def test_an_unbound_wrapper_leaves_the_tail_alone(self, style):
+        wrapper, inner = _wrap(style)
+        await wrapper.ainvoke([build_cacheable_system_message("stable"), HumanMessage(content="hi")])
+        assert inner.last[-1].content == "hi"
+        assert "cache_control" not in inner.seen_kwargs[-1]
+
+    async def test_bound_anthropic_forwards_the_kwarg_and_keeps_the_tail_untouched(self):
+        bound, inner = self._bound("anthropic")
+        await bound.ainvoke([build_cacheable_system_message("stable"), HumanMessage(content="hi")])
+        assert inner.seen_kwargs[-1]["cache_control"] == {"type": "ephemeral"}
+        assert inner.last[-1].content == "hi"
+
+    @pytest.mark.parametrize("style", _STYLES)
+    async def test_a_system_that_never_opted_in_keeps_the_tail_uncached(self, style):
+        bound, inner = self._bound(style)
+        await bound.ainvoke([SystemMessage(content="plain"), HumanMessage(content="hi")])
+        assert "cache_control" not in inner.seen_kwargs[-1]
+        assert inner.last[-1].content == "hi"
+
+    async def test_a_caller_supplied_cache_control_wins(self):
+        bound, inner = self._bound("anthropic")
+        await bound.ainvoke(
+            [build_cacheable_system_message("stable"), HumanMessage(content="hi")],
+            cache_control={"type": "ephemeral", "ttl": "1h"},
+        )
+        assert inner.seen_kwargs[-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+    async def test_bound_bedrock_appends_a_cache_point_to_a_string_human_tail(self):
+        bound, inner = self._bound("bedrock_converse")
+        await bound.ainvoke([build_cacheable_system_message("stable"), HumanMessage(content="hi")])
+        assert inner.last[-1].content == [{"type": "text", "text": "hi"}, {"cachePoint": {"type": "default"}}]
+
+    async def test_bound_bedrock_marks_a_tool_result_tail(self):
+        bound, inner = self._bound("bedrock_converse")
+        await bound.ainvoke(_loop_turn(ToolMessage(content="result", tool_call_id="tc1")))
+        assert inner.last[-1].content == [{"type": "text", "text": "result"}, {"cachePoint": {"type": "default"}}]
+
+    async def test_bound_bedrock_tail_marking_is_idempotent(self):
+        bound, inner = self._bound("bedrock_converse")
+        content = [{"type": "text", "text": "hi"}, {"cachePoint": {"type": "default"}}]
+        await bound.ainvoke([build_cacheable_system_message("stable"), HumanMessage(content=list(content))])
+        assert inner.last[-1].content == content
+
+    async def test_an_ai_tail_is_left_alone(self):
+        bound, inner = self._bound("bedrock_converse")
+        await bound.ainvoke([build_cacheable_system_message("stable"), AIMessage(content="draft")])
+        assert inner.last[-1].content == "draft"
+
+    async def test_bound_bedrock_never_mutates_the_caller_tail(self):
+        bound, inner = self._bound("bedrock_converse")
+        tail = HumanMessage(content=[{"type": "text", "text": "hi"}])
+        content = tail.content
+        await bound.ainvoke([build_cacheable_system_message("stable"), tail])
+        assert tail.content is content
+        assert content == [{"type": "text", "text": "hi"}]
+        assert inner.last[-1] is not tail
+
+    @pytest.mark.parametrize("content", ["", "   ", []], ids=["empty", "whitespace", "no-blocks"])
+    async def test_blank_tails_are_skipped(self, content):
+        bound, inner = self._bound("bedrock_converse")
+        await bound.ainvoke([build_cacheable_system_message("stable"), HumanMessage(content=content)])
+        assert inner.last[-1].content == content
+
+    async def test_astream_carries_the_breakpoint(self):
+        bound, inner = self._bound("anthropic")
+        async for _ in bound.astream([build_cacheable_system_message("stable"), HumanMessage(content="hi")]):
+            pass
+        assert inner.seen_kwargs[-1]["cache_control"] == {"type": "ephemeral"}
+
+
+class TestConversationBreakpointSerialization:
+    """The tail breakpoint must land on a top-level block of the provider payload —
+    a marker nested inside tool_result content would be rejected by the API"""
+
+    def test_anthropic_places_the_kwarg_on_the_top_level_tool_result_block(self):
+        from langchain_anthropic import ChatAnthropic
+
+        payload = ChatAnthropic(model="claude-sonnet-4-5", api_key="test")._get_request_payload(
+            [
+                SystemMessage(content="sys"),
+                HumanMessage(content="hi"),
+                AIMessage(content="calling", tool_calls=[{"name": "t", "args": {}, "id": "tc1"}]),
+                ToolMessage(content="result", tool_call_id="tc1"),
+            ],
+            cache_control={"type": "ephemeral"},
+        )
+
+        last_block = payload["messages"][-1]["content"][-1]
+        assert last_block["type"] == "tool_result"
+        assert last_block["cache_control"] == {"type": "ephemeral"}
+
+    @pytest.mark.asyncio
+    async def test_bedrock_renders_the_tail_point_as_a_sibling_of_the_tool_result(self):
+        wrapper, inner = _wrap("bedrock_converse")
+        bound = wrapper.bind_tools([{"name": "search"}])
+        await bound.ainvoke(_loop_turn(ToolMessage(content="result", tool_call_id="tc1")))
+
+        messages, _ = _messages_to_bedrock(bound.inner.last)
+
+        tail_content = messages[-1]["content"]
+        assert tail_content[-1] == {"cachePoint": {"type": "default"}}
+        assert "cachePoint" not in str(tail_content[0]["toolResult"])
+
+
+class TestLangChainIntrospection:
+    def test_provider_strategy_probe_reads_no_model_name(self):
+        """LangChain reads `.model` as a model-name string; a child model there crashes it.
+
+        Pinned against langchain's private helper on purpose — an upgrade that moves it
+        should re-open the question rather than pass silently.
+        """
+        from langchain.agents.factory import _supports_provider_strategy
+
+        plain = _CapturingModel()
+        wrapper = PromptCachingChatModel(inner=plain, cache_style="anthropic")
+
+        assert _supports_provider_strategy(wrapper) is False
+        assert _supports_provider_strategy(plain) is False
+        assert _supports_provider_strategy(FallbackChatModel(models=[plain, wrapper])) is False
+
+
+class TestModelHasPromptCaching:
+    def test_truth_table(self):
+        plain = _CapturingModel()
+        wrapper = PromptCachingChatModel(inner=_CapturingModel(), cache_style="anthropic")
+
+        assert model_has_prompt_caching(wrapper) is True
+        assert model_has_prompt_caching(plain) is False
+        assert model_has_prompt_caching(None) is False
+        assert model_has_prompt_caching(FallbackChatModel(models=[wrapper])) is True
+        assert model_has_prompt_caching(FallbackChatModel(models=[wrapper, wrapper])) is True
+        assert model_has_prompt_caching(FallbackChatModel(models=[plain, wrapper])) is False
+        assert model_has_prompt_caching(FallbackChatModel(models=[wrapper, plain])) is False
+        assert model_has_prompt_caching(FallbackChatModel(models=[plain, plain])) is False
+        assert model_has_prompt_caching(FallbackChatModel(models=[])) is False
+
+    def test_survives_chain_wide_bind_tools(self):
+        chain = FallbackChatModel(
+            models=[
+                PromptCachingChatModel(inner=_CapturingModel(), cache_style="anthropic"),
+                PromptCachingChatModel(inner=_CapturingModel(), cache_style="anthropic"),
+            ],
+            provider_ids=["p1", "p2"],
+        )
+        assert model_has_prompt_caching(chain.bind_tools([{"name": "search"}])) is True
+
+
+class TestMixedFallbackChain:
+
+    @pytest.mark.parametrize("position", [0, 1], ids=["primary", "fallback"])
+    def test_a_single_unwrapped_child_disables_the_chain(self, position):
+        models = [PromptCachingChatModel(inner=_CapturingModel(), cache_style="anthropic") for _ in range(2)]
+        models[position] = _CapturingModel()
+
+        assert model_has_prompt_caching(FallbackChatModel(models=models, provider_ids=["p1", "p2"])) is False
+
+
+@pytest.mark.asyncio
+class TestHomogeneousFallbackChain:
+    async def test_failover_to_a_wrapped_child_still_marks(self):
+        primary_inner = _CapturingModel(fail=True)
+        fallback_inner = _CapturingModel(text="from-fallback-child")
+        chain = FallbackChatModel(
+            models=[
+                PromptCachingChatModel(inner=primary_inner, cache_style="anthropic"),
+                PromptCachingChatModel(inner=fallback_inner, cache_style="anthropic"),
+            ],
+            provider_ids=["p1", "p2"],
+        )
+        system = build_cacheable_system_message("stable")
+        messages = [system, HumanMessage(content="hi")]
+        original_content = system.content
+
+        assert model_has_prompt_caching(chain) is True
+        resp = await chain.ainvoke(messages)
+        assert resp.content == "from-fallback-child"
+        for inner in (primary_inner, fallback_inner):
+            assert _system_blocks(inner.last) == [
+                {"type": "text", "text": "stable", "cache_control": {"type": "ephemeral"}}
+            ]
+        assert messages[0] is system
+        assert system.content is original_content
+        assert original_content == [{"type": "text", "text": "stable"}]
+
+
+_STABLE = "You are a helpful assistant with a long stable prefix."
+_VOLATILE = "Current time: 2026-08-17T10:00:00Z"
+
+
+async def _sent(style: str, system_content) -> list:
+    wrapper, inner = _wrap(style)
+    await wrapper.ainvoke([_tagged(system_content), HumanMessage(content="hello")])
+    return inner.last
+
+
+def _contains_key(obj, key: str) -> bool:
+    if isinstance(obj, dict):
+        return key in obj or any(_contains_key(v, key) for v in obj.values())
+    if isinstance(obj, list):
+        return any(_contains_key(v, key) for v in obj)
+    return False
+
+
+@pytest.mark.asyncio
+class TestAnthropicSerialization:
+    async def test_cache_control_reaches_the_system_payload(self):
+        system, messages = _format_messages(await _sent("anthropic", [{"type": "text", "text": _STABLE}]))
+        assert system == [{"type": "text", "text": _STABLE, "cache_control": {"type": "ephemeral"}}]
+        assert messages[0]["role"] == "user"
+
+    async def test_only_the_stable_block_carries_the_marker(self):
+        system, _ = _format_messages(
+            await _sent(
+                "anthropic",
+                [{"type": "text", "text": _STABLE}, {"type": "text", "text": _VOLATILE}],
+            )
+        )
+        assert system == [
+            {"type": "text", "text": _STABLE, "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": _VOLATILE},
+        ]
+
+    async def test_plain_string_system_serializes_without_any_marker(self):
+        system, messages = _format_messages(await _sent("anthropic", _STABLE))
+        assert system == _STABLE
+        assert not _contains_key(system, "cache_control")
+        assert not _contains_key(messages, "cache_control")
+
+
+@pytest.mark.asyncio
+class TestBedrockConverseSerialization:
+    async def test_cache_point_reaches_the_system_payload(self):
+        messages, system = _messages_to_bedrock(await _sent("bedrock_converse", [{"type": "text", "text": _STABLE}]))
+        assert system == [{"text": _STABLE}, {"cachePoint": {"type": "default"}}]
+        assert messages[0]["role"] == "user"
+
+    async def test_cache_point_sits_between_stable_and_volatile_blocks(self):
+        _, system = _messages_to_bedrock(
+            await _sent(
+                "bedrock_converse",
+                [{"type": "text", "text": _STABLE}, {"type": "text", "text": _VOLATILE}],
+            )
+        )
+        assert system == [
+            {"text": _STABLE},
+            {"cachePoint": {"type": "default"}},
+            {"text": _VOLATILE},
+        ]
+
+    async def test_plain_string_system_serializes_without_any_marker(self):
+        messages, system = _messages_to_bedrock(await _sent("bedrock_converse", _STABLE))
+        assert system == [{"text": _STABLE}]
+        assert not _contains_key(system, "cachePoint")
+        assert not _contains_key(messages, "cachePoint")
+
+
+_AGENT_SUFFIX = " Current time: 2026-08-17 12:00:00"
+_HISTORY = "User: hi\nAssistant: hello"
+
+_LEGACY_RENDERINGS = [
+    pytest.param(_STABLE + _AGENT_SUFFIX, id="agent_split"),
+    pytest.param(_STABLE + "\n\n" + _HISTORY, id="llm_node_split"),
+]
+
+
+class TestOptInTagStaysInProcess:
+
+    def test_it_survives_a_dict_round_trip(self):
+        message = build_cacheable_system_message(_STABLE, _VOLATILE)
+
+        restored = messages_from_dict([message_to_dict(message)])[0]
+
+        assert type(restored) is SystemMessage
+        assert restored.additional_kwargs[PROMPT_CACHE_OPT_IN_KEY] is True
+        assert restored.content == message.content
+
+    def test_anthropic_never_sees_it(self):
+        system, messages = _format_messages(
+            [build_cacheable_system_message(_STABLE, _VOLATILE), HumanMessage(content="hello")]
+        )
+
+        assert not _contains_key(system, PROMPT_CACHE_OPT_IN_KEY)
+        assert not _contains_key(messages, PROMPT_CACHE_OPT_IN_KEY)
+
+    def test_bedrock_never_sees_it(self):
+        messages, system = _messages_to_bedrock(
+            [build_cacheable_system_message(_STABLE, _VOLATILE), HumanMessage(content="hello")]
+        )
+
+        assert not _contains_key(system, PROMPT_CACHE_OPT_IN_KEY)
+        assert not _contains_key(messages, PROMPT_CACHE_OPT_IN_KEY)
+
+    def test_openai_never_sees_it(self):
+        from langchain_openai.chat_models.base import _convert_message_to_dict
+
+        assert not _contains_key(
+            _convert_message_to_dict(build_cacheable_system_message(_STABLE, _VOLATILE)), PROMPT_CACHE_OPT_IN_KEY
+        )
+
+
+@pytest.mark.parametrize("rendered", _LEGACY_RENDERINGS)
+class TestMixedChainKeepsTheLegacyString:
+
+    def test_openai_receives_the_flattened_string(self, rendered):
+        from langchain_openai.chat_models.base import _convert_message_to_dict
+
+        assert _convert_message_to_dict(SystemMessage(content=rendered)) == {"role": "system", "content": rendered}
+
+    def test_google_receives_one_part(self, rendered):
+        from langchain_google_genai.chat_models import _parse_chat_history
+
+        system, _ = _parse_chat_history(
+            [SystemMessage(content=rendered), HumanMessage(content="hi")], convert_system_message_to_human=False
+        )
+        assert [part.text for part in system.parts] == [rendered]
+
+    def test_ollama_receives_the_flattened_string(self, rendered):
+        from langchain_ollama import ChatOllama
+
+        content = ChatOllama(model="llama3")._convert_messages_to_ollama_messages(
+            [SystemMessage(content=rendered), HumanMessage(content="hi")]
+        )[0]["content"]
+
+        assert content == rendered
+
+
+_INIT = "langchain.chat_models.init_chat_model"
+_OPIK = "app.modules.workflow.llm.opik_tracing.get_opik_callbacks"
+
+
+async def _build(provider, connection_data, model_name="a-model", requested=True):
+    """One build with the node opt-in on, unless a case is about the default-off path"""
+    with patch(_INIT) as init:
+        init.return_value = MagicMock(name="inner-model")
+        llm = await build_chat_model(provider, connection_data, model_name, requested)
+    return llm, init
+
+
+@pytest.mark.asyncio
+class TestWrappedProviders:
+    async def test_anthropic_flag_wraps_with_anthropic_style(self):
+        llm, init = await _build("anthropic", {"api_key": "k"})
+        assert isinstance(llm, PromptCachingChatModel)
+        assert llm.cache_style == "anthropic"
+        assert llm.inner is init.return_value
+        assert "prompt_caching_enabled" not in init.call_args.kwargs
+
+    async def test_bedrock_flag_wraps_with_bedrock_converse_style(self):
+        llm, init = await _build(
+            "bedrock",
+            {"region_name": "eu-central-1"},
+            "eu.anthropic.claude-sonnet-4-5-v1:0",
+        )
+        assert isinstance(llm, PromptCachingChatModel)
+        assert llm.cache_style == "bedrock_converse"
+        assert init.call_args.kwargs["model_provider"] == "bedrock_converse"
+        assert "prompt_caching_enabled" not in init.call_args.kwargs
+
+
+@pytest.mark.asyncio
+class TestBedrockFamilyGuard:
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "eu.amazon.nova-2-lite-v1:0",
+            "eu.anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "us.anthropic.claude-sonnet-4-5-v1:0",
+            "global.anthropic.claude-sonnet-5",
+            "us.anthropic.claude-fable-5",
+        ],
+    )
+    async def test_cacheable_families_wrap(self, model_name):
+        llm, _ = await _build("bedrock", {}, model_name)
+        assert isinstance(llm, PromptCachingChatModel)
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "meta.llama3-3-70b-instruct-v1:0",
+            "mistral.mistral-large-2407-v1:0",
+            "amazon.titan-text-premier-v1:0",
+            "deepseek.r1-v1:0",
+        ],
+    )
+    async def test_families_without_cache_support_run_uncached(self, model_name):
+        llm, init = await _build("bedrock", {}, model_name)
+        assert llm is init.return_value, "wrapping these fails every call with a ValidationException"
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "anthropic.claude-3-haiku-20240307-v1:0",
+            "anthropic.claude-3-sonnet-20240229-v1:0",
+            "anthropic.claude-3-opus-20240229-v1:0",
+            "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+        ],
+    )
+    async def test_non_cacheable_claude_versions_run_uncached(self, model_name):
+        llm, init = await _build("bedrock", {}, model_name)
+        assert llm is init.return_value, "wrapping these fails every call with a ValidationException"
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "arn:aws:bedrock:eu-central-1::foundation-model/amazon.nova-2-lite-v1:0",
+            "arn:aws:bedrock:us-east-1::inference-profile/us.anthropic.claude-sonnet-4-5-v1:0",
+            "arn:aws:bedrock:us-east-1::inference-profile/global.anthropic.claude-fable-5",
+        ],
+    )
+    async def test_arn_wraps_on_a_model_it_names_itself(self, model_name):
+        llm, _ = await _build("bedrock", {"model_provider": "amazon"}, model_name)
+        assert isinstance(llm, PromptCachingChatModel)
+
+    @pytest.mark.parametrize("model_provider", ["anthropic", "amazon"])
+    async def test_opaque_arns_stay_uncached(self, model_provider):
+        llm, init = await _build(
+            "bedrock",
+            {"model_provider": model_provider},
+            "arn:aws:bedrock:eu-central-1:123456789012:provisioned-model/abc123",
+        )
+        assert llm is init.return_value
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "arn:aws:bedrock:us-east-1:123456789012:custom-model/my-nova-finetune",
+            "arn:aws:bedrock:us-east-1:123456789012:provisioned-model/nova-throughput",
+            "arn:aws:bedrock:us-east-1:123456789012:custom-model/claude-sonnet-5-finetune",
+            "arn:aws:bedrock:eu-central-1:123456789012:provisioned-model/claude-fable-5-throughput",
+        ],
+    )
+    async def test_a_deployment_arn_never_inherits_its_base_family(self, model_name):
+        llm, init = await _build("bedrock", {"model_provider": "amazon"}, model_name)
+        assert llm is init.return_value
+
+    async def test_missing_model_name_stays_uncached(self):
+        llm, init = await _build("bedrock", {}, None)
+        assert llm is init.return_value
+
+    async def test_anthropic_direct_is_unaffected_by_the_model_name(self):
+        llm, _ = await _build("anthropic", {"api_key": "k"}, "some-model")
+        assert isinstance(llm, PromptCachingChatModel)
+
+
+@pytest.mark.asyncio
+class TestUnwrappedCases:
+    async def test_the_default_is_off(self):
+        llm, init = await _build("anthropic", {"api_key": "k"}, requested=False)
+        assert llm is init.return_value
+
+    async def test_an_unset_parameter_is_off(self):
+        with patch(_INIT) as init:
+            init.return_value = MagicMock(name="inner-model")
+            llm = await build_chat_model("anthropic", {"api_key": "k"}, "a-model")
+        assert llm is init.return_value
+
+    async def test_an_opted_in_openai_provider_stays_plain(self):
+        llm, init = await _build("openai", {"api_key": "k"})
+        assert llm is init.return_value
+        assert "prompt_caching_enabled" not in init.call_args.kwargs
+
+    @pytest.mark.parametrize("raw", [True, "true", "false", 1, 0, None, ""], ids=repr)
+    async def test_a_stale_stored_key_never_decides_anything(self, raw):
+        llm, init = await _build("anthropic", {"api_key": "k", "prompt_caching_enabled": raw}, requested=False)
+        assert llm is init.return_value
+        assert "prompt_caching_enabled" not in init.call_args.kwargs
+
+    async def test_a_stale_stored_key_is_popped_from_an_opted_in_build_too(self):
+        llm, init = await _build("anthropic", {"api_key": "k", "prompt_caching_enabled": True})
+        assert isinstance(llm, PromptCachingChatModel)
+        assert "prompt_caching_enabled" not in init.call_args.kwargs
+
+    async def test_the_stored_connection_data_is_never_rewritten(self):
+        connection_data = {"api_key": "k", "prompt_caching_enabled": True}
+        await _build("anthropic", connection_data)
+        assert connection_data == {"api_key": "k", "prompt_caching_enabled": True}
+
+
+@pytest.mark.asyncio
+class TestOpikCallbacks:
+    async def test_callbacks_stay_on_the_inner_model(self):
+        callback = MagicMock(name="opik-tracer")
+        with patch(_OPIK, return_value=[callback]):
+            llm, init = await _build("anthropic", {"api_key": "k"})
+        assert init.call_args.kwargs["callbacks"] == [callback]
+        assert llm.callbacks is None
+
+
+def _patch_provider_lookups(chain=None):
+    from app.services.fallback_chains import FallbackChainService
+
+    provider_service = MagicMock()
+    provider_service.get_by_id = AsyncMock(return_value=SimpleNamespace(id="p1"))
+    chain_service = MagicMock()
+    chain_service.get_by_id = AsyncMock(return_value=chain)
+
+    inj = MagicMock()
+    inj.get = MagicMock(
+        side_effect=lambda cls: chain_service if cls is FallbackChainService else provider_service
+    )
+    return patch("app.dependencies.injector.injector", inj)
+
+
+def _fallback_chain(provider_ids):
+    return SimpleNamespace(provider_ids=provider_ids, retry_policy=None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("requested", [True, False], ids=["opted-in", "default-off"])
+class TestOptInThreading:
+
+    @staticmethod
+    def _spy():
+        build = AsyncMock(return_value=MagicMock(name="built-model"))
+        return build, patch.object(LLMProvider, "_build_from_provider", build)
+
+    @staticmethod
+    def _flags(build):
+        return [
+            call.kwargs.get("prompt_caching_enabled", call.args[1] if len(call.args) > 1 else False)
+            for call in build.await_args_list
+        ]
+
+    async def _run(self, requested, coro_factory, chain=None):
+        build, spy = self._spy()
+        with _patch_provider_lookups(chain), spy:
+            await coro_factory(LLMProvider())
+        return self._flags(build)
+
+    async def test_get_model(self, requested):
+        flags = await self._run(requested, lambda p: p.get_model("p1", requested))
+        assert flags == [requested]
+
+    async def test_get_model_for_node_without_a_chain(self, requested):
+        flags = await self._run(requested, lambda p: p.get_model_for_node("p1", None, requested))
+        assert flags == [requested]
+
+    async def test_single_provider_fast_path(self, requested):
+        flags = await self._run(requested, lambda p: p.get_model_with_fallback(["p1"], None, requested))
+        assert flags == [requested]
+
+    async def test_every_child_of_a_multi_provider_chain(self, requested):
+        flags = await self._run(
+            requested, lambda p: p.get_model_with_fallback(["p1", "p2", "p3"], {"retry_count": 1}, requested)
+        )
+        assert flags == [requested] * 3
+
+    async def test_get_model_for_node_with_a_chain_id(self, requested):
+        flags = await self._run(
+            requested,
+            lambda p: p.get_model_for_node("p1", "chain-1", requested),
+            chain=_fallback_chain(["p2"]),
+        )
+        assert flags == [requested] * 2

--- a/backend/tests/unit/test_prompt_caching_chat_model.py
+++ b/backend/tests/unit/test_prompt_caching_chat_model.py
@@ -418,124 +418,19 @@ def _loop_turn(tail) -> list:
     ]
 
 
-@pytest.mark.asyncio
-class TestConversationBreakpoint:
-    """bind_tools opts the wrapper into tail caching, so each tool-loop turn re-reads
-    the previous turn's prefix. Unbound (single-shot) callers never pay the write."""
-
-    @staticmethod
-    def _bound(style):
-        wrapper, _ = _wrap(style)
-        bound = wrapper.bind_tools([{"name": "search"}])
-        return bound, bound.inner
-
-    async def test_bind_tools_turns_it_on(self):
-        bound, _ = self._bound("anthropic")
-        assert bound.cache_conversation is True
-
-    @pytest.mark.parametrize("style", _STYLES)
-    async def test_an_unbound_wrapper_leaves_the_tail_alone(self, style):
-        wrapper, inner = _wrap(style)
-        await wrapper.ainvoke([build_cacheable_system_message("stable"), HumanMessage(content="hi")])
-        assert inner.last[-1].content == "hi"
-        assert "cache_control" not in inner.seen_kwargs[-1]
-
-    async def test_bound_anthropic_forwards_the_kwarg_and_keeps_the_tail_untouched(self):
-        bound, inner = self._bound("anthropic")
-        await bound.ainvoke([build_cacheable_system_message("stable"), HumanMessage(content="hi")])
-        assert inner.seen_kwargs[-1]["cache_control"] == {"type": "ephemeral"}
-        assert inner.last[-1].content == "hi"
-
-    @pytest.mark.parametrize("style", _STYLES)
-    async def test_a_system_that_never_opted_in_keeps_the_tail_uncached(self, style):
-        bound, inner = self._bound(style)
-        await bound.ainvoke([SystemMessage(content="plain"), HumanMessage(content="hi")])
-        assert "cache_control" not in inner.seen_kwargs[-1]
-        assert inner.last[-1].content == "hi"
-
-    async def test_a_caller_supplied_cache_control_wins(self):
-        bound, inner = self._bound("anthropic")
-        await bound.ainvoke(
-            [build_cacheable_system_message("stable"), HumanMessage(content="hi")],
-            cache_control={"type": "ephemeral", "ttl": "1h"},
-        )
-        assert inner.seen_kwargs[-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
-
-    async def test_bound_bedrock_appends_a_cache_point_to_a_string_human_tail(self):
-        bound, inner = self._bound("bedrock_converse")
-        await bound.ainvoke([build_cacheable_system_message("stable"), HumanMessage(content="hi")])
-        assert inner.last[-1].content == [{"type": "text", "text": "hi"}, {"cachePoint": {"type": "default"}}]
-
-    async def test_bound_bedrock_marks_a_tool_result_tail(self):
-        bound, inner = self._bound("bedrock_converse")
-        await bound.ainvoke(_loop_turn(ToolMessage(content="result", tool_call_id="tc1")))
-        assert inner.last[-1].content == [{"type": "text", "text": "result"}, {"cachePoint": {"type": "default"}}]
-
-    async def test_bound_bedrock_tail_marking_is_idempotent(self):
-        bound, inner = self._bound("bedrock_converse")
-        content = [{"type": "text", "text": "hi"}, {"cachePoint": {"type": "default"}}]
-        await bound.ainvoke([build_cacheable_system_message("stable"), HumanMessage(content=list(content))])
-        assert inner.last[-1].content == content
-
-    async def test_an_ai_tail_is_left_alone(self):
-        bound, inner = self._bound("bedrock_converse")
-        await bound.ainvoke([build_cacheable_system_message("stable"), AIMessage(content="draft")])
-        assert inner.last[-1].content == "draft"
-
-    async def test_bound_bedrock_never_mutates_the_caller_tail(self):
-        bound, inner = self._bound("bedrock_converse")
-        tail = HumanMessage(content=[{"type": "text", "text": "hi"}])
-        content = tail.content
-        await bound.ainvoke([build_cacheable_system_message("stable"), tail])
-        assert tail.content is content
-        assert content == [{"type": "text", "text": "hi"}]
-        assert inner.last[-1] is not tail
-
-    @pytest.mark.parametrize("content", ["", "   ", []], ids=["empty", "whitespace", "no-blocks"])
-    async def test_blank_tails_are_skipped(self, content):
-        bound, inner = self._bound("bedrock_converse")
-        await bound.ainvoke([build_cacheable_system_message("stable"), HumanMessage(content=content)])
-        assert inner.last[-1].content == content
-
-    async def test_astream_carries_the_breakpoint(self):
-        bound, inner = self._bound("anthropic")
-        async for _ in bound.astream([build_cacheable_system_message("stable"), HumanMessage(content="hi")]):
-            pass
-        assert inner.seen_kwargs[-1]["cache_control"] == {"type": "ephemeral"}
-
-
-class TestConversationBreakpointSerialization:
-    """The tail breakpoint must land on a top-level block of the provider payload —
-    a marker nested inside tool_result content would be rejected by the API"""
-
-    def test_anthropic_places_the_kwarg_on_the_top_level_tool_result_block(self):
-        from langchain_anthropic import ChatAnthropic
-
-        payload = ChatAnthropic(model="claude-sonnet-4-5", api_key="test")._get_request_payload(
-            [
-                SystemMessage(content="sys"),
-                HumanMessage(content="hi"),
-                AIMessage(content="calling", tool_calls=[{"name": "t", "args": {}, "id": "tc1"}]),
-                ToolMessage(content="result", tool_call_id="tc1"),
-            ],
-            cache_control={"type": "ephemeral"},
-        )
-
-        last_block = payload["messages"][-1]["content"][-1]
-        assert last_block["type"] == "tool_result"
-        assert last_block["cache_control"] == {"type": "ephemeral"}
+class TestSystemPrefixOnly:
 
     @pytest.mark.asyncio
-    async def test_bedrock_renders_the_tail_point_as_a_sibling_of_the_tool_result(self):
-        wrapper, inner = _wrap("bedrock_converse")
-        bound = wrapper.bind_tools([{"name": "search"}])
+    async def test_a_tool_loop_turn_carries_no_cache_point_in_messages(self):
+        llm, _ = await _build("bedrock", {}, "eu.amazon.nova-2-lite-v1:0")
+        bound = llm.bind_tools([{"name": "search"}])
+        bound.inner = _CapturingModel()
+
         await bound.ainvoke(_loop_turn(ToolMessage(content="result", tool_call_id="tc1")))
 
-        messages, _ = _messages_to_bedrock(bound.inner.last)
-
-        tail_content = messages[-1]["content"]
-        assert tail_content[-1] == {"cachePoint": {"type": "default"}}
-        assert "cachePoint" not in str(tail_content[0]["toolResult"])
+        messages, system = _messages_to_bedrock(bound.inner.last)
+        assert "cachePoint" not in str(messages), "a cachePoint in messages fails the call"
+        assert {"cachePoint": {"type": "default"}} in system, "the system prefix still caches"
 
 
 class TestLangChainIntrospection:
@@ -800,9 +695,12 @@ class TestBedrockFamilyGuard:
         "model_name",
         [
             "eu.amazon.nova-2-lite-v1:0",
+            "us.amazon.nova-pro-v1:0",
+            "us.amazon.nova-premier-v1:0",
             "eu.anthropic.claude-3-5-sonnet-20241022-v2:0",
             "us.anthropic.claude-sonnet-4-5-v1:0",
             "global.anthropic.claude-sonnet-5",
+            "global.anthropic.claude-opus-5",
             "us.anthropic.claude-fable-5",
         ],
     )
@@ -822,6 +720,11 @@ class TestBedrockFamilyGuard:
     async def test_families_without_cache_support_run_uncached(self, model_name):
         llm, init = await _build("bedrock", {}, model_name)
         assert llm is init.return_value, "wrapping these fails every call with a ValidationException"
+
+    @pytest.mark.parametrize("model_name", ["amazon.nova-sonic-v1:0", "amazon.nova-2-sonic-v1:0"])
+    async def test_speech_novas_run_uncached(self, model_name):
+        llm, init = await _build("bedrock", {}, model_name)
+        assert llm is init.return_value
 
     @pytest.mark.parametrize(
         "model_name",

--- a/backend/tests/unit/test_react_agent_lc_usage.py
+++ b/backend/tests/unit/test_react_agent_lc_usage.py
@@ -3,19 +3,26 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
 
 from app.modules.workflow.agents.react_agent_lc import ReActAgentLC
+from app.modules.workflow.llm.prompt_caching_chat_model import (
+    PromptCachingChatModel,
+    build_cacheable_system_message,
+)
+
+_CREATE_AGENT = "app.modules.workflow.agents.react_agent_lc.create_agent"
+_STABLE = "You are a helpful agent with a long stable prefix."
+_SUFFIX = " Current time: 2026-08-17 12:00:00"
 
 
-def _build_agent(fake_result):
-    with patch(
-        "app.modules.workflow.agents.react_agent_lc.create_agent",
-        return_value=MagicMock(),
-    ):
+def _build_agent(fake_result, system_prompt="you are a helpful agent"):
+    with patch(_CREATE_AGENT, return_value=MagicMock()):
         agent = ReActAgentLC(
             llm_model=MagicMock(),
-            system_prompt="you are a helpful agent",
+            system_prompt=system_prompt,
             tools=[],
         )
     agent.agent_executor.ainvoke = AsyncMock(return_value=fake_result)
@@ -56,3 +63,103 @@ async def test_no_llm_usage_key_when_no_usage_reported():
 
     assert result["status"] == "success"
     assert "llm_usage" not in result
+
+
+@pytest.mark.parametrize(
+    "system_prompt",
+    ["you are a helpful agent", SystemMessage(content=[{"type": "text", "text": "stable prefix"}])],
+    ids=["str", "system_message"],
+)
+def test_create_agent_receives_the_system_prompt_unchanged(system_prompt):
+    with patch(_CREATE_AGENT, return_value=MagicMock()) as create_agent:
+        ReActAgentLC(llm_model=MagicMock(), system_prompt=system_prompt, tools=[])
+
+    assert create_agent.call_args.kwargs["system_prompt"] is system_prompt
+
+
+@pytest.mark.asyncio
+async def test_stream_input_carries_no_system_message():
+    agent = _build_agent({"messages": [AIMessage(content="done")]})
+    seen = {}
+
+    async def _astream(input_data, config=None, **kwargs):
+        seen["messages"] = input_data["messages"]
+        for chunk in ():
+            yield chunk
+
+    agent.agent_executor.astream = _astream
+
+    async for _ in agent.stream("hi", chat_history=[{"role": "user", "content": "earlier"}]):
+        pass
+
+    assert not any(isinstance(message, SystemMessage) for message in seen["messages"])
+    assert seen["messages"][-1] == HumanMessage(content="hi")
+
+
+class _CapturingModel(BaseChatModel):
+    seen: list = []
+
+    @property
+    def _llm_type(self) -> str:
+        return "capturing"
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        self.seen.append(list(messages))
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content="the answer"))])
+
+    async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        return self._generate(messages, stop, run_manager, **kwargs)
+
+
+def _two_block_system_message() -> SystemMessage:
+    return build_cacheable_system_message(_STABLE, _SUFFIX)
+
+
+@pytest.mark.asyncio
+class TestBlockSystemPromptReachesTheModel:
+    @staticmethod
+    def _agent(system_prompt):
+        inner = _CapturingModel()
+        llm = PromptCachingChatModel(inner=inner, cache_style="anthropic")
+        return ReActAgentLC(llm_model=llm, system_prompt=system_prompt, tools=[]), inner
+
+    async def test_marker_lands_on_the_stable_block_only(self):
+        system_message = _two_block_system_message()
+        agent, inner = self._agent(system_message)
+
+        await agent.invoke("hi")
+
+        assert inner.seen[-1][0].content == [
+            {"type": "text", "text": _STABLE, "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": _SUFFIX},
+        ]
+
+    async def test_rendered_text_matches_the_plain_string_form(self):
+        system_message = _two_block_system_message()
+        agent, inner = self._agent(system_message)
+
+        await agent.invoke("hi")
+
+        blocks = inner.seen[-1][0].content
+        assert "".join(block["text"] for block in blocks) == _STABLE + _SUFFIX
+
+    async def test_repeated_turns_never_stack_markers(self):
+        system_message = _two_block_system_message()
+        agent, inner = self._agent(system_message)
+
+        await agent.invoke("hi")
+        await agent.invoke("hi again")
+
+        for sent in inner.seen:
+            assert sum("cache_control" in block for block in sent[0].content) == 1
+        assert system_message.content == [
+            {"type": "text", "text": _STABLE},
+            {"type": "text", "text": _SUFFIX},
+        ]
+
+    async def test_string_system_prompt_is_never_marked(self):
+        agent, inner = self._agent(_STABLE + _SUFFIX)
+
+        await agent.invoke("hi")
+
+        assert inner.seen[-1][0].content == _STABLE + _SUFFIX

--- a/backend/tests/unit/test_tool_agent_prompt_caching.py
+++ b/backend/tests/unit/test_tool_agent_prompt_caching.py
@@ -73,7 +73,7 @@ def _weather_tool(result="Sunny, 21C"):
 _PARTS = (_BASE, _SUFFIX)
 
 
-def _agent(*, tools=None, replies=None, caching=True, parts=_PARTS, system_prompt=None):
+def _agent(*, tools=None, replies=None, caching=True, parts=_PARTS, system_prompt=None, stable_tool_names=None):
     inner = _CapturingModel(replies=replies or [_DIRECT_JSON])
     llm = PromptCachingChatModel(inner=inner, cache_style="anthropic") if caching else inner
     agent = ToolAgent(
@@ -81,6 +81,7 @@ def _agent(*, tools=None, replies=None, caching=True, parts=_PARTS, system_promp
         system_prompt=_BASE + _SUFFIX if system_prompt is None else system_prompt,
         tools=tools if tools is not None else [],
         stable_volatile_parts=parts,
+        stable_tool_names=stable_tool_names,
     )
     return agent, inner
 
@@ -274,6 +275,103 @@ class TestSplitMode:
 
         assert split_text != fused_text
         assert split_text.replace(_SUFFIX, "", 1) == fused_text.replace(_SUFFIX, "", 1)
+
+
+def _delegation_tool(name="delegate_to_helper"):
+    return BaseTool(
+        node_id="child-1",
+        name=name,
+        description=f"Delegate a task to the '{name}' sub-agent (single_turn mode).",
+        parameters={"task": {"type": "string", "description": "The task.", "required": True}},
+        function=AsyncMock(return_value="{}"),
+        return_direct=True,
+    )
+
+
+def _return_direct_tool(name="lookup_order"):
+    tool = _weather_tool("record 42")
+    tool.name = name
+    tool.description = "Look up an order and return it verbatim."
+    tool.return_direct = True
+    return tool
+
+
+async def _cached_head(tools, stable_tool_names, parts=_PARTS, system_prompt=None):
+    agent, inner = _agent(
+        tools=tools, stable_tool_names=stable_tool_names, parts=parts, system_prompt=system_prompt
+    )
+    await agent.invoke(_QUERY)
+    system_content, _ = _split_turns(inner)
+    return system_content
+
+
+_STABLE_NAMES = frozenset({"weather"})
+
+
+@pytest.mark.asyncio
+class TestDelegationToolsSitPastTheMarker:
+
+    async def test_the_cached_block_excludes_non_stable_descriptions(self):
+        weather, delegate = _weather_tool(), _delegation_tool()
+        system_content = await _cached_head([weather, delegate], _STABLE_NAMES)
+
+        assert weather.description in system_content[0]["text"]
+        assert delegate.description not in system_content[0]["text"]
+        assert delegate.description in system_content[-1]["text"]
+
+    async def test_the_relocation_loses_nothing(self):
+        weather, delegate = _weather_tool(), _delegation_tool()
+        system_content = await _cached_head([weather, delegate], _STABLE_NAMES)
+
+        joined = "".join(block["text"] for block in system_content)
+        expected = create_tool_agent_tools_available_prompt(
+            _BASE, create_tool_descriptions([weather, delegate])
+        )
+        assert joined == expected + _SUFFIX
+
+    async def test_the_cached_block_is_identical_across_every_drop(self):
+        weather = _weather_tool()
+        turns = [
+            [weather, _delegation_tool("delegate_to_a"), _delegation_tool("delegate_to_b")],
+            [weather, _delegation_tool("delegate_to_b")],
+            [weather],
+        ]
+
+        heads = [(await _cached_head(tools, _STABLE_NAMES))[0] for tools in turns]
+
+        assert heads[0] == heads[1] == heads[2]
+
+    async def test_a_non_stable_tool_surviving_the_drops_stays_past_the_marker(self):
+        weather, finish = _weather_tool(), _delegation_tool("finish_task")
+        with_delegate = await _cached_head([weather, _delegation_tool(), finish], _STABLE_NAMES)
+        final_turn = await _cached_head([weather, finish], _STABLE_NAMES)
+
+        assert with_delegate[0] == final_turn[0]
+        assert finish.description in final_turn[-1]["text"]
+
+    async def test_a_return_direct_tool_outside_a_delegation_run_stays_cached(self):
+        lookup, weather = _return_direct_tool(), _weather_tool()
+        system_content = await _cached_head([lookup, weather], None)
+
+        assert system_content[0]["text"] == create_tool_agent_tools_available_prompt(
+            _BASE, create_tool_descriptions([lookup, weather])
+        )
+        assert system_content[0]["cache_control"] == {"type": "ephemeral"}
+
+    async def test_an_all_delegation_toolset_caches_exactly_the_header(self):
+        heads = [
+            (
+                await _cached_head(
+                    tools, frozenset(), parts=("", _SUFFIX), system_prompt=_SUFFIX
+                )
+            )[0]
+            for tools in ([_delegation_tool("delegate_to_a"), _delegation_tool("delegate_to_b")],
+                          [_delegation_tool("delegate_to_b")])
+        ]
+
+        assert heads[0] == heads[1]
+        assert heads[0]["text"] == "\n\nAVAILABLE TOOLS:\n"
+        assert heads[0]["cache_control"] == {"type": "ephemeral"}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_tool_agent_prompt_caching.py
+++ b/backend/tests/unit/test_tool_agent_prompt_caching.py
@@ -1,0 +1,401 @@
+"""ToolAgent's gated system/user split, and the fused payload it must preserve when off"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+
+from app.modules.workflow.agents.agent_prompts import (
+    create_conversation_context,
+    create_tool_agent_no_tools_prompt,
+    create_tool_agent_no_tools_query_portion,
+    create_tool_agent_no_tools_query_prompt,
+    create_tool_agent_tools_available_prompt,
+    create_tool_agent_tools_query_portion,
+    create_tool_agent_tools_query_prompt,
+)
+from app.modules.workflow.agents.agent_utils import create_tool_descriptions
+from app.modules.workflow.agents.base_tool import BaseTool
+from app.modules.workflow.agents.tool_agent import ToolAgent
+from app.modules.workflow.llm.fallback_chat_model import FallbackChatModel
+from app.modules.workflow.llm.prompt_caching_chat_model import (
+    PROMPT_CACHE_OPT_IN_KEY,
+    PromptCachingChatModel,
+)
+
+_BASE = "You are a helpful assistant with a long stable prefix."
+_SUFFIX = " Current time: 2026-08-17 12:00:00"
+_QUERY = "what is the weather?"
+_HISTORY = [{"role": "user", "content": "earlier"}, {"role": "assistant", "content": "noted"}]
+
+_DIRECT_JSON = json.dumps({"action": "direct_response", "response": "It is sunny.", "reasoning": "known"})
+_TOOL_CALL_JSON = json.dumps(
+    {
+        "action": "tool_call",
+        "tool_name": "weather",
+        "parameters": {"city": "Berlin"},
+        "reasoning": "the user asked for weather",
+    }
+)
+
+
+class _CapturingModel(BaseChatModel):
+
+    seen: list = []
+    replies: list = []
+
+    @property
+    def _llm_type(self) -> str:
+        return "capturing"
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        self.seen.append(list(messages))
+        text = self.replies[len(self.seen) - 1] if len(self.seen) <= len(self.replies) else self.replies[-1]
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content=text))])
+
+    async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        return self._generate(messages, stop, run_manager, **kwargs)
+
+
+def _weather_tool(result="Sunny, 21C"):
+    return BaseTool(
+        node_id="n1",
+        name="weather",
+        description="Look up the weather for a city.",
+        parameters={"city": {"type": "string", "description": "City name", "required": True}},
+        function=AsyncMock(return_value=result),
+    )
+
+
+_PARTS = (_BASE, _SUFFIX)
+
+
+def _agent(*, tools=None, replies=None, caching=True, parts=_PARTS, system_prompt=None):
+    inner = _CapturingModel(replies=replies or [_DIRECT_JSON])
+    llm = PromptCachingChatModel(inner=inner, cache_style="anthropic") if caching else inner
+    agent = ToolAgent(
+        llm_model=llm,
+        system_prompt=_BASE + _SUFFIX if system_prompt is None else system_prompt,
+        tools=tools if tools is not None else [],
+        stable_volatile_parts=parts,
+    )
+    return agent, inner
+
+
+def _fused_text(inner) -> str:
+    sent = inner.seen[-1]
+    assert len(sent) == 1
+    return sent[0].content
+
+
+def _split_turns(inner):
+    sent = inner.seen[-1]
+    assert isinstance(sent[0], SystemMessage)
+    assert isinstance(sent[1], HumanMessage)
+    return sent[0].content, sent[1].content
+
+
+class TestGate:
+    @pytest.mark.parametrize(
+        "kwargs,expected",
+        [
+            ({}, True),
+            ({"caching": False}, False),
+            ({"parts": None}, False),
+        ],
+        ids=["caching_and_parts", "no_caching", "no_parts"],
+    )
+    def test_split_only_when_the_prompt_is_marked_cacheable(self, kwargs, expected):
+        agent, _ = _agent(**kwargs)
+
+        assert agent._cache_split is expected
+
+    def test_a_mixed_fallback_chain_stays_fused(self):
+        chain = FallbackChatModel(
+            models=[
+                _CapturingModel(replies=[_DIRECT_JSON]),
+                PromptCachingChatModel(inner=_CapturingModel(replies=[_DIRECT_JSON]), cache_style="anthropic"),
+            ]
+        )
+        agent = ToolAgent(llm_model=chain, system_prompt=_BASE + _SUFFIX, tools=[], stable_volatile_parts=_PARTS)
+
+        assert agent._cache_split is False
+        assert agent.cache_split_decision == (False, "mixed_fallback_chain")
+
+    @pytest.mark.parametrize(
+        "kwargs,expected",
+        [
+            ({}, (True, None)),
+            ({"caching": False}, (False, "unsupported_cache_markers")),
+            ({"parts": None}, (False, "volatile_prompt")),
+        ],
+        ids=["caching_and_parts", "no_caching", "no_parts"],
+    )
+    def test_the_stored_decision_names_the_gate(self, kwargs, expected):
+        agent, _ = _agent(**kwargs)
+
+        assert agent.cache_split_decision == expected
+
+    def test_a_blank_base_is_still_eligible_through_the_enhanced_prefix(self):
+        agent, _ = _agent(tools=[_weather_tool()], system_prompt=_SUFFIX, parts=("", _SUFFIX))
+
+        assert agent.cache_split_decision == (True, None)
+
+    def test_construction_never_builds_the_enhanced_prompt(self, monkeypatch):
+        def _boom(self, base_prompt=None):
+            raise AssertionError("the enhanced prompt must stay invocation-local")
+
+        monkeypatch.setattr(ToolAgent, "_create_enhanced_system_prompt", _boom)
+
+        for kwargs in ({}, {"caching": False}, {"parts": None}):
+            agent, _ = _agent(tools=[_weather_tool()], **kwargs)
+            assert isinstance(agent.cache_split_decision, tuple)
+
+
+@pytest.mark.asyncio
+class TestFusedModeIsUnchanged:
+    async def test_no_tools_sends_the_original_single_user_turn(self):
+        agent, inner = _agent(caching=False)
+
+        await agent.invoke(_QUERY, chat_history=_HISTORY)
+
+        expected = create_tool_agent_no_tools_query_prompt(
+            create_tool_agent_no_tools_prompt(_BASE + _SUFFIX),
+            create_conversation_context(_HISTORY),
+            _QUERY,
+        )
+        assert _fused_text(inner) == expected
+
+    async def test_tools_send_the_original_single_user_turn(self):
+        tool = _weather_tool()
+        agent, inner = _agent(tools=[tool], caching=False)
+
+        await agent.invoke(_QUERY, chat_history=_HISTORY)
+
+        expected = create_tool_agent_tools_query_prompt(
+            create_tool_agent_tools_available_prompt(_BASE + _SUFFIX, create_tool_descriptions([tool])),
+            create_conversation_context(_HISTORY),
+            _QUERY,
+        )
+        assert _fused_text(inner) == expected
+
+    async def test_caching_model_without_parts_stays_fused_and_unmarked(self):
+        agent, inner = _agent(tools=[_weather_tool()], parts=None)
+
+        await agent.invoke(_QUERY)
+
+        assert isinstance(_fused_text(inner), str)
+
+
+@pytest.mark.asyncio
+class TestSplitMode:
+    async def test_no_tools_moves_the_guidance_into_the_system_turn(self):
+        agent, inner = _agent()
+
+        await agent.invoke(_QUERY, chat_history=_HISTORY)
+
+        system_content, user_content = _split_turns(inner)
+        assert system_content == [
+            {
+                "type": "text",
+                "text": create_tool_agent_no_tools_prompt(_BASE),
+                "cache_control": {"type": "ephemeral"},
+            },
+            {"type": "text", "text": _SUFFIX},
+        ]
+        assert user_content.startswith(create_conversation_context(_HISTORY))
+        assert f"User Query: {_QUERY}" in user_content
+
+    async def test_tools_keep_the_descriptions_in_the_cached_block(self):
+        tool = _weather_tool()
+        agent, inner = _agent(tools=[tool])
+
+        await agent.invoke(_QUERY, chat_history=_HISTORY)
+
+        system_content, user_content = _split_turns(inner)
+        assert system_content[0]["text"] == create_tool_agent_tools_available_prompt(
+            _BASE, create_tool_descriptions([tool])
+        )
+        assert "TOOL CALL FORMAT" in system_content[0]["text"]
+        assert tool.description in system_content[0]["text"]
+        assert "TOOL CALL FORMAT" not in user_content
+
+    async def test_volatile_tail_is_the_last_block(self):
+        agent, inner = _agent(tools=[_weather_tool()])
+
+        await agent.invoke(_QUERY)
+
+        system_content, _ = _split_turns(inner)
+        assert system_content[-1] == {"type": "text", "text": _SUFFIX}
+        assert "Current time" not in system_content[0]["text"]
+
+    async def test_the_system_turn_carries_the_opt_in_tag(self):
+        agent, inner = _agent(tools=[_weather_tool()])
+
+        await agent.invoke(_QUERY)
+
+        assert inner.seen[-1][0].additional_kwargs == {PROMPT_CACHE_OPT_IN_KEY: True}
+
+    async def test_tools_added_after_construction_reach_the_cached_block(self):
+        agent, inner = _agent(tools=[_weather_tool()])
+        late = _weather_tool()
+        late.name = "currency"
+        late.description = "Convert between currencies."
+        agent.add_tool(late)
+
+        await agent.invoke(_QUERY)
+
+        system_content, _ = _split_turns(inner)
+        assert late.description in system_content[0]["text"]
+
+    async def test_blank_base_still_yields_a_non_blank_cached_block(self):
+        agent, inner = _agent(tools=[_weather_tool()], system_prompt=_SUFFIX, parts=("", _SUFFIX))
+
+        await agent.invoke(_QUERY)
+
+        system_content, _ = _split_turns(inner)
+        assert system_content[0]["text"].strip()
+        assert system_content[0]["cache_control"] == {"type": "ephemeral"}
+
+    async def test_split_relocates_the_volatile_tail_and_loses_nothing(self):
+        tool = _weather_tool()
+        split_agent, split_inner = _agent(tools=[tool])
+        fused_agent, fused_inner = _agent(tools=[tool], caching=False)
+
+        await split_agent.invoke(_QUERY, chat_history=_HISTORY)
+        await fused_agent.invoke(_QUERY, chat_history=_HISTORY)
+
+        system_content, user_content = _split_turns(split_inner)
+        split_text = "".join(block["text"] for block in system_content) + "\n\n" + user_content
+        fused_text = _fused_text(fused_inner)
+
+        assert split_text != fused_text
+        assert split_text.replace(_SUFFIX, "", 1) == fused_text.replace(_SUFFIX, "", 1)
+
+
+@pytest.mark.asyncio
+class TestSplitModeStillDrivesTheWorkflow:
+    async def test_json_tool_call_parses_from_a_split_mode_response(self):
+        tool = _weather_tool()
+        agent, _ = _agent(tools=[tool], replies=[_TOOL_CALL_JSON, _DIRECT_JSON])
+
+        result = await agent.invoke(_QUERY)
+
+        assert result["status"] == "success"
+        assert result["tools_used"][0]["tool_name"] == "weather"
+        assert result["tools_used"][0]["args"] == {"city": "Berlin"}
+        tool.function.assert_awaited_once_with({"parameters": {"city": "Berlin"}})
+
+    async def test_direct_response_parses_from_a_split_mode_response(self):
+        agent, _ = _agent(tools=[_weather_tool()], replies=[_DIRECT_JSON])
+
+        result = await agent.invoke(_QUERY)
+
+        assert result["status"] == "success"
+        assert result["response"] == "It is sunny."
+
+    async def test_continuation_appends_to_the_user_turn_only(self):
+        agent, inner = _agent(tools=[_weather_tool()], replies=[_TOOL_CALL_JSON, _DIRECT_JSON])
+
+        await agent.invoke(_QUERY)
+
+        first_system, first_user = inner.seen[0][0].content, inner.seen[0][1].content
+        second_system, second_user = inner.seen[1][0].content, inner.seen[1][1].content
+        assert second_system == first_system
+        assert second_user.startswith(first_user)
+        assert "Tool Result from weather" in second_user
+
+    async def test_repeated_iterations_never_stack_markers(self):
+        agent, inner = _agent(tools=[_weather_tool()], replies=[_TOOL_CALL_JSON, _DIRECT_JSON])
+
+        await agent.invoke(_QUERY)
+
+        assert len(inner.seen) == 2
+        for sent in inner.seen:
+            assert sum("cache_control" in block for block in sent[0].content) == 1
+
+    async def test_the_system_turn_is_built_once_per_invoke(self):
+        agent, inner = _agent(tools=[_weather_tool()], replies=[_TOOL_CALL_JSON, _DIRECT_JSON])
+        agent._cacheable_system_message = MagicMock(side_effect=agent._cacheable_system_message)
+
+        await agent.invoke(_QUERY)
+
+        assert len(inner.seen) == 2
+        agent._cacheable_system_message.assert_called_once()
+
+    async def test_no_tools_workflow_returns_the_direct_response(self):
+        agent, _ = _agent(replies=[_DIRECT_JSON])
+
+        result = await agent.invoke(_QUERY)
+
+        assert result["response"] == "It is sunny."
+        assert result["no_tools_available"] is True
+
+
+@pytest.mark.asyncio
+class TestUntouchedPaths:
+    async def test_select_tool_still_sends_one_user_turn(self):
+        agent, inner = _agent(tools=[_weather_tool()], replies=["use weather"])
+
+        await agent.select_tool(_QUERY)
+
+        sent = inner.seen[-1]
+        assert len(sent) == 1
+        assert isinstance(sent[0], HumanMessage)
+
+    async def test_llm_failure_still_returns_an_error_response(self):
+        agent, _ = _agent(tools=[_weather_tool()])
+        agent.llm_model = MagicMock(ainvoke=AsyncMock(side_effect=RuntimeError("provider down")))
+
+        result = await agent.invoke(_QUERY)
+
+        assert result["status"] == "error"
+        assert "provider down" in result["error"]
+
+
+_NO_TOOLS_PORTION = """CTX
+
+User Query: Q
+
+Since no tools are available, provide a direct response based on your knowledge using the JSON format specified above."""
+
+_TOOLS_PORTION = """CTX
+
+User Query: Q
+
+Analyze the query and decide if you need to use any tools. Respond using the JSON format specified above.
+- If you need a tool, use the "tool_call" action format
+- If you can answer directly, use the "direct_response" action format
+- Make sure to include all required parameters and follow the parameter types specified
+- Always include your reasoning for the decision"""
+
+_PORTION_CASES = [
+    pytest.param(
+        create_tool_agent_no_tools_query_prompt,
+        create_tool_agent_no_tools_query_portion,
+        _NO_TOOLS_PORTION,
+        id="no_tools",
+    ),
+    pytest.param(
+        create_tool_agent_tools_query_prompt,
+        create_tool_agent_tools_query_portion,
+        _TOOLS_PORTION,
+        id="tools",
+    ),
+]
+
+
+@pytest.mark.parametrize("fused,portion,expected", _PORTION_CASES)
+class TestQueryPortions:
+    def test_portion_renders_verbatim(self, fused, portion, expected):
+        assert portion("CTX", "Q") == expected
+
+    def test_fused_prompt_is_the_system_prompt_plus_the_portion(self, fused, portion, expected):
+        assert fused("SYS", "CTX", "Q") == "SYS\n\n" + expected
+
+    @pytest.mark.parametrize("system_prompt", ["", "SYS", "multi\nline", "{braces}", "trailing\n\n"], ids=repr)
+    def test_portion_carries_no_part_of_the_system_prompt(self, fused, portion, expected, system_prompt):
+        assert fused(system_prompt, "CTX", "Q") == system_prompt + "\n\n" + portion("CTX", "Q")

--- a/backend/tests/unit/test_workflow_engine_utils.py
+++ b/backend/tests/unit/test_workflow_engine_utils.py
@@ -1,4 +1,10 @@
-from app.modules.workflow.engine.utils import get_nested_value, replace_config_vars
+import pytest
+
+from app.modules.workflow.engine.utils import (
+    get_nested_value,
+    has_volatile_template_vars,
+    replace_config_vars,
+)
 from app.modules.workflow.engine.workflow_state import WorkflowState
 
 
@@ -33,3 +39,66 @@ class TestReplaceConfigVars:
         assert replacements["source.prediction[0].label"] == "Not Available"
         assert '"prediction": 3891' in resolved["pythonScript"]
         assert '"label": "Not Available"' in resolved["pythonScript"]
+
+
+class TestHasVolatileTemplateVars:
+    @pytest.mark.parametrize(
+        "template",
+        [
+            "{{source}}",
+            "Summarize {{source.text}}",
+            "{{sourceLanguage}}",
+            "{{direct_input}}",
+            "{{direct_input.query}}",
+            "{{node_outputs.node-1.result}}",
+            "{{node_inputs.node-1}}",
+            "{{node_execution_status.node-1.output}}",
+            "Now: {{timestamp}}",
+            "{{execution_id}}",
+            "{{execution_path}}",
+            "{{execution_path[0]}}",
+            "{{execution_history}}",
+            "{{execution_start_time}}",
+            "{{execution_end_time}}",
+            "{{session.message}}",
+            "{{session}}",
+            "{{initial_values}}",
+            "{{message}}",
+            "{{output}}",
+            "{{current_step}}",
+            "{{total_steps}}",
+            "{{status}}",
+            "{{is_executing}}",
+            "{{time_taken}}",
+            "{{performance_metrics.slowestNode}}",
+            "{{errors}}",
+            "{{llm_usage}}",
+            "{{tool_events}}",
+            "{{memory}}",
+            "Reply in {{session.language}}.",
+            "Greet {{session.customer_name}}.",
+            "Greet {{customer_name}}.",
+            "{{thread_id}}",
+            "{{workflow_id}}",
+        ],
+        ids=repr,
+    )
+    def test_any_template_var_is_treated_as_volatile(self, template):
+        assert has_volatile_template_vars(template) is True
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            "You are a helpful assistant.",
+            "{{ source }}",
+            "",
+            None,
+            {"systemPrompt": "{{source}}"},
+        ],
+        ids=repr,
+    )
+    def test_var_free_or_unresolvable_templates_are_not_volatile(self, template):
+        assert has_volatile_template_vars(template) is False
+
+    def test_unrecognized_var_is_over_blocked_by_design(self):
+        assert has_volatile_template_vars("{{some_future_state_field}}") is True

--- a/backend/tests/unit/test_workflow_state_usage.py
+++ b/backend/tests/unit/test_workflow_state_usage.py
@@ -234,41 +234,90 @@ class TestDelegationTurnsMergeIntoOneEntry:
 
         assert state.prompt_caching_diagnostics == {"agent": _APPLIED}
 
-    def test_observed_counts_survive_the_next_turns_re_record(self):
+    def test_a_re_record_keeps_the_entry_flag_only(self):
         state = _state()
         diagnostics.record(state, "agent", applied=True)
-        diagnostics.record_observed_cache_tokens(state, "agent", [{"token_details": {"cache_read": 900}}])
         diagnostics.record(state, "agent", applied=True)
 
-        assert state.prompt_caching_diagnostics["agent"] == {
-            **_APPLIED,
-            "cache_read_tokens": 900,
-            "cache_creation_tokens": 0,
-        }
+        assert state.prompt_caching_diagnostics == {"agent": _APPLIED}
 
-    def test_observed_counts_accumulate_across_turns(self):
+
+class TestSerializedCacheTokensComeFromUsage:
+
+    @staticmethod
+    def _serialized(state) -> dict:
+        return state.get_full_state()["promptCachingDiagnostics"]["agent"]
+
+    def test_an_applied_run_serializes_what_the_provider_reported(self):
         state = _state()
         diagnostics.record(state, "agent", applied=True)
-        diagnostics.record_observed_cache_tokens(
-            state, "agent", [{"token_details": {"cache_read": 900, "cache_creation": 100}}]
+        state.add_llm_usage(
+            5, 2, node_id="agent", prompt_caching_enabled=True,
+            token_details={"cache_read": 900, "cache_creation": 100},
         )
-        diagnostics.record(state, "agent", applied=True)
-        diagnostics.record_observed_cache_tokens(state, "agent", [{"token_details": {"cache_read": 50}}])
+        state.add_llm_usage(
+            5, 2, node_id="agent", prompt_caching_enabled=True, token_details={"cache_read": 50}
+        )
 
-        assert state.prompt_caching_diagnostics["agent"] == {
+        assert self._serialized(state) == {
             **_APPLIED,
             "cache_read_tokens": 950,
             "cache_creation_tokens": 100,
         }
 
-    def test_a_turn_with_no_usage_keeps_earlier_counts(self):
+    def test_zero_activity_is_stamped_as_zero_not_left_absent(self):
         state = _state()
         diagnostics.record(state, "agent", applied=True)
-        diagnostics.record_observed_cache_tokens(state, "agent", [{"token_details": {"cache_read": 900}}])
-        diagnostics.record(state, "agent", applied=True)
-        diagnostics.record_observed_cache_tokens(state, "agent", [])
+        state.add_llm_usage(5, 2, node_id="agent", prompt_caching_enabled=True)
 
-        assert state.prompt_caching_diagnostics["agent"]["cache_read_tokens"] == 900
+        serialized = self._serialized(state)
+        assert serialized["cache_read_tokens"] == 0
+        assert serialized["cache_creation_tokens"] == 0
+
+    def test_a_run_with_no_usage_stays_unstamped(self):
+        state = _state()
+        diagnostics.record(state, "agent", applied=True)
+
+        assert self._serialized(state) == _APPLIED
+
+    def test_a_placeholder_with_no_provider_report_never_stamps_zeros(self):
+        state = _state()
+        diagnostics.record(state, "agent", applied=True)
+        state.add_llm_usage(
+            0, 0, node_id="agent", prompt_caching_enabled=True,
+            token_details={"usage_metadata_missing": True},
+        )
+
+        assert self._serialized(state) == _APPLIED
+
+    def test_a_withheld_entry_never_gains_token_fields(self):
+        state = _state()
+        diagnostics.record(state, "agent", applied=False, reason="volatile_prompt")
+        state.add_llm_usage(
+            5, 2, node_id="agent", prompt_caching_enabled=True, token_details={"cache_read": 900}
+        )
+
+        assert self._serialized(state) == _WITHHELD
+
+    def test_unflagged_and_other_node_usage_is_ignored(self):
+        state = _state()
+        diagnostics.record(state, "agent", applied=True)
+        state.add_llm_usage(5, 2, node_id="agent", token_details={"cache_read": 900})
+        state.add_llm_usage(
+            5, 2, node_id="other", prompt_caching_enabled=True, token_details={"cache_read": 50}
+        )
+
+        assert self._serialized(state) == _APPLIED
+
+    def test_the_stored_collection_stays_flag_only(self):
+        state = _state()
+        diagnostics.record(state, "agent", applied=True)
+        state.add_llm_usage(
+            5, 2, node_id="agent", prompt_caching_enabled=True, token_details={"cache_read": 900}
+        )
+        state.get_full_state()
+
+        assert state.prompt_caching_diagnostics == {"agent": _APPLIED}
 
 
 class TestCollectionLifecycle:

--- a/backend/tests/unit/test_workflow_state_usage.py
+++ b/backend/tests/unit/test_workflow_state_usage.py
@@ -1,7 +1,14 @@
-"""Unit tests for WorkflowState LLM-usage plumbing (correlation id + sink semantics)"""
+"""WorkflowState LLM-usage plumbing (correlation id + sink semantics) and the
+prompt-caching diagnostics collection, which must stay invisible to every
+operational consumer of a run: metrics, failed nodes, and the state's wire shape"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.modules.workflow.engine import prompt_cache_diagnostics as diagnostics
+from app.modules.workflow.engine.llm_usage_tracking import merge_llm_usage_from_result
 from app.modules.workflow.engine.workflow_state import WorkflowState
 
 WF = {"config": {"id": "wf-1"}, "nodes": [], "edges": []}
@@ -10,6 +17,16 @@ THREAD = "11111111-1111-1111-1111-111111111111"
 
 def _state() -> WorkflowState:
     return WorkflowState(workflow=WF, thread_id=THREAD, initial_values={"message": "hi"})
+
+
+def _caching_provider_injector():
+    provider = SimpleNamespace(
+        llm_model_provider="Anthropic",
+        llm_model="claude-3-opus",
+        connection_data={"prompt_caching_enabled": True},
+    )
+    service = MagicMock(get_by_id=AsyncMock(return_value=provider))
+    return patch("app.dependencies.injector.injector", MagicMock(get=MagicMock(return_value=service)))
 
 
 class TestAddLlmUsage:
@@ -31,6 +48,81 @@ class TestAddLlmUsage:
         assert entry["purpose"] is None
         assert entry["token_details"] is None
         assert entry["llm_provider_id"] is None
+        assert entry["prompt_caching_enabled"] is False
+
+
+class TestTotalLlmUsageCacheTokens:
+    def test_cache_keys_are_omitted_when_caching_is_off(self):
+        s = _state()
+        s.add_llm_usage(10, 5, provider="anthropic", model="claude-3-5-sonnet")
+        usage = s.get_total_llm_usage()
+        assert "cache_read_tokens" not in usage
+        assert "cache_creation_tokens" not in usage
+        assert usage["input_tokens"] == 10 and usage["calls"] == 1
+
+    def test_toggle_on_but_nothing_cached_still_reports_zeros(self):
+        s = _state()
+        s.add_llm_usage(10, 5, provider="anthropic", model="claude-3-5-sonnet", prompt_caching_enabled=True)
+        usage = s.get_total_llm_usage()
+        assert usage["cache_read_tokens"] == 0
+        assert usage["cache_creation_tokens"] == 0
+
+    def test_reported_cache_activity_surfaces_without_a_toggle(self):
+        s = _state()
+        details = {"input_token_details": {"cache_read": 1200}}
+        s.add_llm_usage(10, 5, provider="openai", model="gpt-4o", token_details=details)
+        usage = s.get_total_llm_usage()
+        assert usage["cache_read_tokens"] == 1200
+        assert usage["cache_creation_tokens"] == 0
+
+    def test_one_caching_provider_surfaces_the_keys_for_the_run(self):
+        s = _state()
+        s.add_llm_usage(10, 5, provider="openai", model="gpt-4o")
+        s.add_llm_usage(10, 5, provider="anthropic", model="claude-3-5-sonnet", prompt_caching_enabled=True)
+        assert "cache_read_tokens" in s.get_total_llm_usage()
+
+    def test_toggle_on_with_cache_activity_reports_real_counts(self):
+        s = _state()
+        details = {"input_token_details": {"cache_read": 300, "cache_creation": 20}}
+        s.add_llm_usage(10, 5, provider="anthropic", token_details=details, prompt_caching_enabled=True)
+        usage = s.get_total_llm_usage()
+        assert (usage["cache_read_tokens"], usage["cache_creation_tokens"]) == (300, 20)
+
+    def test_cache_counts_are_summed_across_entries(self):
+        s = _state()
+        details = {"input_token_details": {"cache_read": 300, "cache_creation": 20}}
+        s.add_llm_usage(10, 5, provider="anthropic", model="claude-3-5-sonnet", token_details=details)
+        s.add_llm_usage(10, 5, provider="anthropic", model="claude-3-5-sonnet", token_details=details)
+        usage = s.get_total_llm_usage()
+        assert usage["cache_read_tokens"] == 600
+        assert usage["cache_creation_tokens"] == 40
+
+
+class TestTheNodeRequestDrivesTheTotals:
+
+    async def _merge_one_call(self, requested: bool) -> WorkflowState:
+        s = _state()
+        with _caching_provider_injector():
+            await merge_llm_usage_from_result(
+                s, {"llm_usage": [{"input_tokens": 10, "output_tokens": 5}]}, "n1", "p1", requested
+            )
+        return s
+
+    @pytest.mark.asyncio
+    async def test_an_unrequested_run_keeps_cache_fields_out_of_the_totals(self):
+        s = await self._merge_one_call(False)
+        usage = s.get_total_llm_usage()
+
+        assert s.llm_usage[0]["prompt_caching_enabled"] is False
+        assert "cache_read_tokens" not in usage and "cache_creation_tokens" not in usage
+
+    @pytest.mark.asyncio
+    async def test_a_requested_run_reports_the_zeroed_cache_fields(self):
+        s = await self._merge_one_call(True)
+        usage = s.get_total_llm_usage()
+
+        assert s.llm_usage[0]["prompt_caching_enabled"] is True
+        assert usage["cache_read_tokens"] == 0 and usage["cache_creation_tokens"] == 0
 
 
 class TestFormatIncludesExecutionId:
@@ -61,3 +153,162 @@ class TestUpdateNodesDoesNotMergeUsage:
         child.add_llm_usage(2, 2, node_id="child")
         parent.llm_usage.extend(child.llm_usage)
         assert [e["node_id"] for e in parent.llm_usage] == ["parent", "child"]
+
+
+_APPLIED = {"requested": True, "applied": True, "reason": None}
+_WITHHELD = {"requested": True, "applied": False, "reason": "unsupported_mode"}
+
+
+def _run(*, with_diagnostics: bool) -> WorkflowState:
+    state = _state()
+    state.node_execution_status = {
+        "ok": {"type": "llmModelNode", "name": "LLM", "status": "success", "startTime": 100, "endTime": 150},
+        "bad": {"type": "apiNode", "name": "API", "status": "failed", "startTime": 150, "endTime": 200,
+                "error": "boom"},
+    }
+    if with_diagnostics:
+        state.prompt_caching_diagnostics = {"child": _WITHHELD, "grandchild": _APPLIED}
+    return state
+
+
+class TestMetricsAndFailuresAreUnchanged:
+    def test_performance_metrics_are_byte_identical(self):
+        plain, annotated = _run(with_diagnostics=False), _run(with_diagnostics=True)
+
+        plain._update_performance_metrics()
+        annotated._update_performance_metrics()
+
+        assert annotated.performance_metrics == plain.performance_metrics
+
+    def test_the_success_rate_denominator_is_untouched(self):
+        annotated = _run(with_diagnostics=True)
+        annotated._update_performance_metrics()
+
+        assert annotated.performance_metrics["successRate"] == 50.0
+
+    def test_the_failed_node_list_is_untouched(self):
+        plain, annotated = _run(with_diagnostics=False), _run(with_diagnostics=True)
+
+        assert annotated._collect_failed_nodes() == plain._collect_failed_nodes()
+        assert [n["node_id"] for n in annotated._collect_failed_nodes()] == ["bad"]
+
+
+class TestWireShape:
+    def test_the_key_is_absent_when_nothing_was_collected(self):
+        assert "promptCachingDiagnostics" not in _run(with_diagnostics=False).get_full_state()
+
+    def test_a_run_without_diagnostics_serializes_identically(self):
+        plain, annotated = _run(with_diagnostics=False), _run(with_diagnostics=True)
+
+        assert set(annotated.get_full_state()) - set(plain.get_full_state()) == {"promptCachingDiagnostics"}
+
+    def test_the_collection_rides_its_own_key(self):
+        full = _run(with_diagnostics=True).get_full_state()
+
+        assert full["promptCachingDiagnostics"] == {"child": _WITHHELD, "grandchild": _APPLIED}
+        assert set(full["nodeExecutionStatus"]) == {"ok", "bad"}
+
+
+class TestRecordWritesTheSingleStore:
+    def test_a_recorded_diagnostic_lands_in_the_collection_not_the_entry(self):
+        state = _run(with_diagnostics=False)
+        diagnostics.record(state, "ok", applied=True)
+
+        assert state.prompt_caching_diagnostics == {"ok": _APPLIED}
+        assert "prompt_caching" not in state.node_execution_status["ok"]
+
+    def test_a_node_that_never_ran_still_records(self):
+        state = _run(with_diagnostics=False)
+        diagnostics.record(state, "never-ran", applied=False, reason="unsupported_mode")
+
+        assert state.prompt_caching_diagnostics == {"never-ran": _WITHHELD}
+        assert set(state.node_execution_status) == {"ok", "bad"}
+
+
+class TestDelegationTurnsMergeIntoOneEntry:
+
+    def test_one_applied_turn_marks_the_node_applied(self):
+        state = _state()
+        diagnostics.record(state, "agent", applied=True)
+        diagnostics.record(state, "agent", applied=False, reason="unsupported_mode")
+
+        assert state.prompt_caching_diagnostics == {"agent": _APPLIED}
+
+    def test_observed_counts_survive_the_next_turns_re_record(self):
+        state = _state()
+        diagnostics.record(state, "agent", applied=True)
+        diagnostics.record_observed_cache_tokens(state, "agent", [{"token_details": {"cache_read": 900}}])
+        diagnostics.record(state, "agent", applied=True)
+
+        assert state.prompt_caching_diagnostics["agent"] == {
+            **_APPLIED,
+            "cache_read_tokens": 900,
+            "cache_creation_tokens": 0,
+        }
+
+    def test_observed_counts_accumulate_across_turns(self):
+        state = _state()
+        diagnostics.record(state, "agent", applied=True)
+        diagnostics.record_observed_cache_tokens(
+            state, "agent", [{"token_details": {"cache_read": 900, "cache_creation": 100}}]
+        )
+        diagnostics.record(state, "agent", applied=True)
+        diagnostics.record_observed_cache_tokens(state, "agent", [{"token_details": {"cache_read": 50}}])
+
+        assert state.prompt_caching_diagnostics["agent"] == {
+            **_APPLIED,
+            "cache_read_tokens": 950,
+            "cache_creation_tokens": 100,
+        }
+
+    def test_a_turn_with_no_usage_keeps_earlier_counts(self):
+        state = _state()
+        diagnostics.record(state, "agent", applied=True)
+        diagnostics.record_observed_cache_tokens(state, "agent", [{"token_details": {"cache_read": 900}}])
+        diagnostics.record(state, "agent", applied=True)
+        diagnostics.record_observed_cache_tokens(state, "agent", [])
+
+        assert state.prompt_caching_diagnostics["agent"]["cache_read_tokens"] == 900
+
+
+class TestCollectionLifecycle:
+    def test_a_fresh_state_starts_empty(self):
+        assert _state().prompt_caching_diagnostics == {}
+
+    def test_reset_clears_it(self):
+        state = _run(with_diagnostics=True)
+        state.reset_execution_state()
+
+        assert state.prompt_caching_diagnostics == {}
+
+    def test_a_sub_flow_merge_carries_it_incoming_wins(self):
+        parent = _state()
+        parent.prompt_caching_diagnostics = {"a": _APPLIED, "b": _APPLIED}
+        child = _state()
+        child.prompt_caching_diagnostics = {"b": _WITHHELD, "c": _WITHHELD}
+
+        parent.update_nodes_from_another_state(child)
+
+        assert parent.prompt_caching_diagnostics == {"a": _APPLIED, "b": _WITHHELD, "c": _WITHHELD}
+
+    def test_the_merge_still_leaves_usage_alone(self):
+        parent, child = _state(), _state()
+        parent.add_llm_usage(1, 1, node_id="parent")
+        child.add_llm_usage(2, 2, node_id="child")
+        child.prompt_caching_diagnostics = {"c": _WITHHELD}
+
+        parent.update_nodes_from_another_state(child)
+
+        assert [e["node_id"] for e in parent.llm_usage] == ["parent"]
+        assert parent.prompt_caching_diagnostics == {"c": _WITHHELD}
+
+
+class TestOwnDiagnosticsSurviveTheSubFlowMerge:
+    def test_the_childs_own_recording_reaches_the_parent_collection(self):
+        parent = _state()
+        child = _run(with_diagnostics=False)
+        diagnostics.record(child, "ok", applied=True)
+
+        parent.update_nodes_from_another_state(child)
+
+        assert parent.prompt_caching_diagnostics == {"ok": _APPLIED}

--- a/backend/tests/unit/test_workflow_state_usage.py
+++ b/backend/tests/unit/test_workflow_state_usage.py
@@ -155,8 +155,8 @@ class TestUpdateNodesDoesNotMergeUsage:
         assert [e["node_id"] for e in parent.llm_usage] == ["parent", "child"]
 
 
-_APPLIED = {"requested": True, "applied": True, "reason": None}
-_WITHHELD = {"requested": True, "applied": False, "reason": "unsupported_mode"}
+_APPLIED = {"requested": True, "applied": True}
+_WITHHELD = {"requested": True, "applied": False}
 
 
 def _run(*, with_diagnostics: bool) -> WorkflowState:

--- a/backend/tests/unit/workflow/test_agent_node_delegation.py
+++ b/backend/tests/unit/workflow/test_agent_node_delegation.py
@@ -36,6 +36,7 @@ def _patch_runtime(*, result=None, resolve_error=None):
 
     instance = MagicMock()
     instance.invoke = AsyncMock(return_value=result or {})
+    instance.cache_split_decision = (False, None)
     stack.enter_context(patch(f"{_RUNTIME}.ToolAgent", MagicMock(return_value=instance)))
 
     provider = MagicMock()
@@ -703,3 +704,150 @@ async def test_pause_frame_does_not_nest_prior_resume_marker():
     stack = await sub_session.read_frame_strict(node.get_memory())
     captured = stack.top().parent_resume.request_context.get("initial_values", {})
     assert SUB_AGENT_RESUME_KEY not in captured
+
+
+_CHILD_DIAG = {"requested": True, "applied": False, "reason": "unsupported_mode"}
+_DIAG_KEY = "__prompt_caching_diagnostics"
+
+
+def _child_state_with_diagnostic(node_id="child", diagnostic=None):
+    return SimpleNamespace(
+        get_node_output=lambda _id: {"message": "child answer"},
+        get_last_node_output=lambda: {"message": "child answer"},
+        node_execution_status={node_id: {"status": "success"}},
+        prompt_caching_diagnostics={node_id: diagnostic or _CHILD_DIAG},
+        sub_agent_control={"result": "child answer"},
+        get_memory=MagicMock(return_value=MagicMock(add_input_output=AsyncMock())),
+    )
+
+
+async def _delegate_once(node, child_state):
+    fn = node._make_delegation_function(child_id="child", mode="single_turn", timeout_seconds=120)
+    with patch(_ORCH_RUN, AsyncMock(return_value=child_state)), patch(_ORCH_DISCARD, MagicMock()):
+        return await fn({"parameters": {"task": "do x"}})
+
+
+@pytest.mark.asyncio
+async def test_in_turn_delegation_lands_the_child_diagnostic_in_the_parent_collection():
+    node = _parent_node(thread_id="t-diag")
+    await _delegate_once(node, _child_state_with_diagnostic())
+
+    assert node.get_state().prompt_caching_diagnostics == {"child": _CHILD_DIAG}
+
+
+@pytest.mark.asyncio
+async def test_the_parents_execution_map_never_gains_the_child():
+    node = _parent_node(thread_id="t-diag-map")
+    await _delegate_once(node, _child_state_with_diagnostic())
+
+    assert set(node.get_state().node_execution_status) == {"parent"}
+
+
+@pytest.mark.asyncio
+async def test_nested_diagnostics_chain_up_through_the_delegation():
+    node = _parent_node(thread_id="t-diag-nested")
+    child = _child_state_with_diagnostic()
+    child.prompt_caching_diagnostics["grandchild"] = {"requested": True, "applied": True, "reason": None}
+    await _delegate_once(node, child)
+
+    assert set(node.get_state().prompt_caching_diagnostics) == {"child", "grandchild"}
+
+
+@pytest.mark.asyncio
+async def test_a_child_without_a_diagnostic_leaves_the_collection_empty():
+    node = _parent_node(thread_id="t-diag-none")
+    child = _child_state_with_diagnostic()
+    child.prompt_caching_diagnostics = {}
+    await _delegate_once(node, child)
+
+    assert node.get_state().prompt_caching_diagnostics == {}
+
+
+async def _pause_after_delegating(node, *, seed_diagnostics=None):
+    if seed_diagnostics:
+        node.get_state().prompt_caching_diagnostics.update(seed_diagnostics)
+    dmap = {"request_task_child": {"child_node_id": "child", "mode": "task"}}
+    results = [_rr(_env("active", "a question", mode="task", invocation_id="inv9"),
+                   return_direct=True, tool="request_task_child")]
+    with pytest.raises(WorkflowPausedException):
+        await _run_loop(node, results, delegation_map=dmap)
+    stack = await sub_session.read_frame_strict(node.get_memory())
+    return stack.top().parent_resume.request_context
+
+
+@pytest.mark.asyncio
+async def test_a_pause_carries_an_earlier_childs_diagnostic_in_the_frame():
+    context = await _pause_after_delegating(_parent_node(mode="task"), seed_diagnostics={"child-a": _CHILD_DIAG})
+
+    assert context[_DIAG_KEY] == {"child-a": _CHILD_DIAG}
+
+
+@pytest.mark.asyncio
+async def test_a_pause_with_no_diagnostics_writes_a_frame_identical_to_before():
+    context = await _pause_after_delegating(_parent_node(mode="task"))
+
+    assert _DIAG_KEY not in context
+    assert set(context) == {"initial_values", "session"}
+
+
+@pytest.mark.asyncio
+async def test_the_resume_merges_the_carried_diagnostics_back():
+    resume = {
+        "node_outputs": {},
+        "node_execution_status": {},
+        "request_context": {"initial_values": {}, "session": {}, _DIAG_KEY: {"child-a": _CHILD_DIAG}},
+        "completed_count": 1,
+        "accumulated_steps": [],
+        "accumulated_tools_used": [],
+        "child_node_id": "child",
+        "mode": "task",
+        "child_task": "task B",
+        "child_result": "result B",
+    }
+    node = _parent_node(
+        mode="task", initial_values={"message": "hi", "agent_id": "agentA", "__sub_agent_resume": resume}
+    )
+    dmap = {"request_task_child": {"child_node_id": "child", "mode": "task"}}
+    await _run_loop(node, [_rr("final")], delegation_map=dmap)
+
+    assert node.get_state().prompt_caching_diagnostics == {"child-a": _CHILD_DIAG}
+    assert _DIAG_KEY not in node.get_state().session
+
+
+@pytest.mark.asyncio
+async def test_an_old_frame_without_the_key_resumes_with_an_empty_collection():
+    resume = {
+        "node_outputs": {},
+        "node_execution_status": {},
+        "request_context": {"initial_values": {}, "session": {}},
+        "completed_count": 1,
+        "accumulated_steps": [],
+        "accumulated_tools_used": [],
+        "child_node_id": "child",
+        "mode": "task",
+        "child_task": "task B",
+        "child_result": "result B",
+    }
+    node = _parent_node(
+        mode="task", initial_values={"message": "hi", "agent_id": "agentA", "__sub_agent_resume": resume}
+    )
+    dmap = {"request_task_child": {"child_node_id": "child", "mode": "task"}}
+    await _run_loop(node, [_rr("final")], delegation_map=dmap)
+
+    assert node.get_state().prompt_caching_diagnostics == {}
+
+
+@pytest.mark.asyncio
+async def test_a_new_frame_still_validates_and_restores_on_an_old_build():
+    node = _parent_node(mode="task")
+    context = await _pause_after_delegating(node, seed_diagnostics={"child-a": _CHILD_DIAG})
+
+    stored = node.get_memory().metadata[sub_session.STACK_KEY]
+    json.dumps(stored)
+    assert SubAgentStack.model_validate(stored).top().parent_resume.request_context[_DIAG_KEY]
+
+    fresh = _parent_node(mode="task", thread_id="t-old-pod")
+    fresh.get_state().restore_resume_context(context, drop_keys={"message"})
+
+    assert _DIAG_KEY not in fresh.get_state().session
+    assert _DIAG_KEY not in fresh.get_state().initial_values

--- a/backend/tests/unit/workflow/test_agent_node_delegation.py
+++ b/backend/tests/unit/workflow/test_agent_node_delegation.py
@@ -706,7 +706,7 @@ async def test_pause_frame_does_not_nest_prior_resume_marker():
     assert SUB_AGENT_RESUME_KEY not in captured
 
 
-_CHILD_DIAG = {"requested": True, "applied": False, "reason": "unsupported_mode"}
+_CHILD_DIAG = {"requested": True, "applied": False}
 _DIAG_KEY = "__prompt_caching_diagnostics"
 
 
@@ -747,7 +747,7 @@ async def test_the_parents_execution_map_never_gains_the_child():
 async def test_nested_diagnostics_chain_up_through_the_delegation():
     node = _parent_node(thread_id="t-diag-nested")
     child = _child_state_with_diagnostic()
-    child.prompt_caching_diagnostics["grandchild"] = {"requested": True, "applied": True, "reason": None}
+    child.prompt_caching_diagnostics["grandchild"] = {"requested": True, "applied": True}
     await _delegate_once(node, child)
 
     assert set(node.get_state().prompt_caching_diagnostics) == {"child", "grandchild"}

--- a/backend/tests/unit/workflow/test_agent_node_prompt_caching.py
+++ b/backend/tests/unit/workflow/test_agent_node_prompt_caching.py
@@ -1,0 +1,254 @@
+"""Agent and sub-agent nodes forward the prompt parts only for cache-eligible prompts"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.modules.workflow.agents.agent_runtime import AgentRunResult
+from app.modules.workflow.engine.nodes.agent_node import AgentNode
+from app.modules.workflow.engine.nodes.sub_agent_node import SubAgentNode
+
+_AGENT_NODE = "app.modules.workflow.engine.nodes.agent_node"
+_SUB_NODE = "app.modules.workflow.engine.nodes.sub_agent_node"
+
+_STABLE = "You are a helpful assistant with a long stable prefix."
+_VOLATILE_VARS = [
+    "{{session.message}}",
+    "{{session.language}}",
+    "{{message}}",
+    "{{source.text}}",
+    "{{node_outputs.n1}}",
+    "{{timestamp}}",
+]
+
+_AGENT_CONFIG = {"providerId": "prov-1", "type": "ToolSelector", "memory": False}
+_SUB_CONFIG = {"providerId": "prov-1", "mode": "single_turn", "timeoutSeconds": 120}
+
+
+def _state():
+    return SimpleNamespace(
+        set_node_input=MagicMock(),
+        workflow={"nodes": [], "edges": []},
+        initial_values={},
+        get_memory=MagicMock(return_value=None),
+    )
+
+
+def _run_result():
+    return AgentRunResult(
+        response="answer",
+        steps=[],
+        tools_used=[],
+        status="success",
+        error=None,
+        raw={"response": "answer"},
+        llm_model="m",
+    )
+
+
+async def _run(node_cls, module, config, *, node_data, resolved=None, tools=()):
+    node = node_cls("node-1", {"type": "agentNode", "data": node_data}, _state())
+    merged = dict(config)
+    if resolved is not None:
+        merged["systemPrompt"] = resolved
+
+    once = AsyncMock(return_value=_run_result())
+    with patch(f"{module}.run_agent_once", once), patch.object(
+        node_cls, "get_connected_nodes", return_value=list(tools)
+    ):
+        await node.process(merged)
+    return once.await_args.kwargs
+
+
+_NODES = [
+    pytest.param(AgentNode, _AGENT_NODE, _AGENT_CONFIG, id="agent"),
+    pytest.param(SubAgentNode, _SUB_NODE, _SUB_CONFIG, id="sub_agent"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("node_cls,module,config", _NODES)
+class TestVolatilityGate:
+    async def test_stable_prompt_forwards_the_prompt_parts(self, node_cls, module, config):
+        kwargs = await _run(node_cls, module, config, node_data={"systemPrompt": _STABLE}, resolved=_STABLE)
+
+        stable, volatile = kwargs["stable_volatile_parts"]
+        assert stable.startswith(_STABLE)
+        assert volatile.startswith(" Current time: ")
+
+    @pytest.mark.parametrize("var", _VOLATILE_VARS)
+    async def test_volatile_prompt_withholds_the_parts(self, node_cls, module, config, var):
+        kwargs = await _run(
+            node_cls,
+            module,
+            config,
+            node_data={"systemPrompt": f"Answer about {var}"},
+            resolved="Answer about a bug report",
+        )
+
+        assert kwargs["stable_volatile_parts"] is None
+        assert kwargs["system_prompt"].startswith("Answer about a bug report")
+        assert " Current time: " in kwargs["system_prompt"]
+
+    async def test_absent_raw_prompt_forwards_the_parts(self, node_cls, module, config):
+        kwargs = await _run(node_cls, module, config, node_data={"name": "Agent"})
+
+        assert kwargs["stable_volatile_parts"] is not None
+        assert kwargs["system_prompt"].startswith("You are a helpful assistant.")
+
+
+class TestTimestampedSystemPromptHelper:
+
+    @staticmethod
+    def _node(raw):
+        return AgentNode("node-1", {"type": "agentNode", "data": {"systemPrompt": raw}}, _state())
+
+    def test_stable_template_returns_parts_that_rebuild_the_prompt(self):
+        full, parts = self._node(_STABLE)._timestamped_system_prompt(_STABLE)
+
+        assert parts == (_STABLE, full[len(_STABLE) :])
+        assert "".join(parts) == full
+        assert parts[1].startswith(" Current time: ")
+
+    @pytest.mark.parametrize("var", _VOLATILE_VARS)
+    def test_volatile_template_withholds_the_parts(self, var):
+        full, parts = self._node(f"Answer about {var}")._timestamped_system_prompt("Answer about a bug report")
+
+        assert parts is None
+        assert full.startswith("Answer about a bug report")
+        assert " Current time: " in full
+
+    def test_the_sub_agent_node_inherits_it(self):
+        assert SubAgentNode._timestamped_system_prompt is AgentNode._timestamped_system_prompt
+
+
+@pytest.mark.asyncio
+class TestDelegationPathThreading:
+    @staticmethod
+    def _delegation_kwargs(**over):
+        kwargs = dict(
+            config={},
+            provider_id="prov-1",
+            fallback_chain_id=None,
+            agent_type="ToolSelector",
+            system_prompt="sys Current time: X",
+            prompt="hi",
+            all_tools=[],
+            delegation_map={},
+            max_iterations=7,
+            chat_history=[],
+        )
+        kwargs.update(over)
+        return kwargs
+
+    async def test_parts_reach_run_agent_once(self):
+        node = AgentNode("node-1", {"type": "agentNode", "data": {}}, _state())
+        once = AsyncMock(return_value=_run_result())
+        parts = ("sys", " Current time: X")
+
+        with patch(f"{_AGENT_NODE}.run_agent_once", once):
+            await node._run_agent_with_delegations(**self._delegation_kwargs(stable_volatile_parts=parts))
+
+        assert once.await_args.kwargs["stable_volatile_parts"] == parts
+
+    async def test_callers_omitting_the_kwarg_send_none(self):
+        node = AgentNode("node-1", {"type": "agentNode", "data": {}}, _state())
+        once = AsyncMock(return_value=_run_result())
+
+        with patch(f"{_AGENT_NODE}.run_agent_once", once):
+            await node._run_agent_with_delegations(**self._delegation_kwargs())
+
+        assert once.await_args.kwargs["stable_volatile_parts"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("node_cls,module,config", _NODES)
+class TestPartsInvariant:
+
+    @staticmethod
+    def _assert_parts_rebuild_the_prompt(kwargs):
+        parts = kwargs["stable_volatile_parts"]
+        assert parts, "a stable prompt must still forward them"
+        assert "".join(parts) == kwargs["system_prompt"]
+
+    async def test_holds_for_a_plain_run(self, node_cls, module, config):
+        kwargs = await _run(node_cls, module, config, node_data={"systemPrompt": _STABLE}, resolved=_STABLE)
+
+        self._assert_parts_rebuild_the_prompt(kwargs)
+
+    async def test_holds_with_memory_enabled(self, node_cls, module, config):
+        with patch.object(node_cls, "_get_chat_history_for_agent", AsyncMock(return_value=[])):
+            kwargs = await _run(
+                node_cls,
+                module,
+                {**config, "memory": True},
+                node_data={"systemPrompt": _STABLE},
+                resolved=_STABLE,
+            )
+
+        self._assert_parts_rebuild_the_prompt(kwargs)
+
+    async def test_holds_with_pii_masking_and_tools(self, node_cls, module, config):
+        kwargs = await _run(
+            node_cls,
+            module,
+            {**config, "piiMasking": True},
+            node_data={"systemPrompt": _STABLE},
+            resolved=_STABLE,
+            tools=[MagicMock(name="tool")],
+        )
+
+        self._assert_parts_rebuild_the_prompt(kwargs)
+
+    async def test_holds_on_the_delegation_branch(self, node_cls, module, config):
+        node = node_cls("node-1", {"type": "agentNode", "data": {"systemPrompt": _STABLE}}, _state())
+        delegating = AsyncMock(return_value={"message": "answer"})
+
+        with patch.object(node_cls, "get_connected_nodes", return_value=[]), patch.object(
+            node_cls, "_build_delegation_tools", return_value=([MagicMock(name="delegation")], {"child-1": {}})
+        ), patch.object(node_cls, "_run_agent_with_delegations", delegating):
+            await node.process({**config, "systemPrompt": _STABLE})
+
+        self._assert_parts_rebuild_the_prompt(delegating.await_args.kwargs)
+
+
+async def _run_delegating(node_cls, module, config, *, node_data):
+    node = node_cls("node-1", {"type": "agentNode", "data": node_data}, _state())
+    delegated = AsyncMock(return_value={"message": "ok"})
+    with patch.object(node_cls, "_build_delegation_tools", return_value=([], {"ask_child": {}})), patch.object(
+        node_cls, "_run_agent_with_delegations", delegated
+    ), patch.object(node_cls, "get_connected_nodes", return_value=[]):
+        await node.process(dict(config))
+    return delegated.await_args.kwargs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("node_cls,module,config", _NODES)
+class TestPromptCachingOptInForwarding:
+
+    async def test_the_toggle_travels_to_the_runtime(self, node_cls, module, config):
+        kwargs = await _run(
+            node_cls, module, {**config, "promptCaching": True}, node_data={"systemPrompt": _STABLE}
+        )
+
+        assert kwargs["prompt_caching_enabled"] is True
+
+    @pytest.mark.parametrize("raw", [None, False, "true", "True", 1, "1"], ids=repr)
+    async def test_only_a_real_true_requests_caching(self, node_cls, module, config, raw):
+        extra = {} if raw is None else {"promptCaching": raw}
+        kwargs = await _run(node_cls, module, {**config, **extra}, node_data={"systemPrompt": _STABLE})
+
+        assert kwargs["prompt_caching_enabled"] is False
+
+    async def test_the_delegation_branch_forwards_it_too(self, node_cls, module, config):
+        kwargs = await _run_delegating(
+            node_cls, module, {**config, "promptCaching": True}, node_data={"systemPrompt": _STABLE}
+        )
+
+        assert kwargs["prompt_caching_enabled"] is True
+
+    async def test_the_delegation_branch_defaults_off(self, node_cls, module, config):
+        kwargs = await _run_delegating(node_cls, module, config, node_data={"systemPrompt": _STABLE})
+
+        assert kwargs["prompt_caching_enabled"] is False

--- a/backend/tests/unit/workflow/test_agent_node_prompt_caching.py
+++ b/backend/tests/unit/workflow/test_agent_node_prompt_caching.py
@@ -161,6 +161,31 @@ class TestDelegationPathThreading:
 
         assert once.await_args.kwargs["stable_volatile_parts"] is None
 
+    async def test_stable_tool_names_are_the_prefix_before_the_first_delegation(self):
+        node = AgentNode("node-1", {"type": "agentNode", "data": {}}, _state())
+        once = AsyncMock(return_value=_run_result())
+        tools = [SimpleNamespace(name="weather"), SimpleNamespace(name="delegate_to_a"),
+                 SimpleNamespace(name="finish_task")]
+        delegation_map = {"delegate_to_a": {"child_node_id": "child-a", "mode": "single_turn"}}
+
+        with patch(f"{_AGENT_NODE}.run_agent_once", once):
+            await node._run_agent_with_delegations(
+                **self._delegation_kwargs(all_tools=tools, delegation_map=delegation_map)
+            )
+
+        assert once.await_args.kwargs["stable_tool_names"] == frozenset({"weather"})
+
+    async def test_a_run_without_delegations_sends_no_stable_tool_names(self):
+        node = AgentNode("node-1", {"type": "agentNode", "data": {}}, _state())
+        once = AsyncMock(return_value=_run_result())
+
+        with patch(f"{_AGENT_NODE}.run_agent_once", once):
+            await node._run_agent_with_delegations(
+                **self._delegation_kwargs(all_tools=[SimpleNamespace(name="weather")])
+            )
+
+        assert once.await_args.kwargs["stable_tool_names"] is None
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("node_cls,module,config", _NODES)

--- a/backend/tests/unit/workflow/test_agent_runtime.py
+++ b/backend/tests/unit/workflow/test_agent_runtime.py
@@ -194,7 +194,8 @@ async def test_supplied_llm_model_skips_provider_resolution():
     assert run.llm_model == "reused-model"
     cls, _ = classes["ToolAgent"]
     cls.assert_called_once_with(
-        llm_model="reused-model", system_prompt="sys", tools=[], max_iterations=7, stable_volatile_parts=None
+        llm_model="reused-model", system_prompt="sys", tools=[], max_iterations=7,
+        stable_volatile_parts=None, stable_tool_names=None,
     )
 
 
@@ -209,6 +210,17 @@ async def test_tool_agent_receives_the_prompt_parts():
 
 
 @pytest.mark.asyncio
+async def test_tool_agent_receives_the_stable_tool_names():
+    stack, classes, _, _ = _patch_runtime({"response": "ok"})
+    names = frozenset({"weather"})
+    with stack:
+        await run_agent_once(**_base_kwargs(stable_tool_names=names))
+
+    cls, _ = classes["ToolAgent"]
+    assert cls.call_args.kwargs["stable_tool_names"] == names
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "agent_type,expected",
     [
@@ -220,10 +232,17 @@ async def test_tool_agent_receives_the_prompt_parts():
 async def test_other_agents_never_receive_the_parts(agent_type, expected):
     stack, classes, _, _ = _patch_runtime({"response": "ok"})
     with stack:
-        await run_agent_once(**_base_kwargs(agent_type=agent_type, stable_volatile_parts=_PARTS))
+        await run_agent_once(
+            **_base_kwargs(
+                agent_type=agent_type,
+                stable_volatile_parts=_PARTS,
+                stable_tool_names=frozenset({"weather"}),
+            )
+        )
 
     cls, _ = classes[expected]
     assert "stable_volatile_parts" not in cls.call_args.kwargs
+    assert "stable_tool_names" not in cls.call_args.kwargs
 
 
 def _caching_model():
@@ -440,34 +459,16 @@ class TestARaisingInvocationRecordsNoAppliedMarker:
 
 
 @pytest.mark.asyncio
-class TestObservedCacheTokens:
+class TestTheEntryStaysFlagOnly:
 
-    async def test_an_applied_run_records_what_the_provider_reported(self):
+    async def test_an_applied_run_records_the_flags_only(self):
         result = {
             "response": "ok",
             "llm_usage": [
                 {"input_tokens": 5, "output_tokens": 2, "token_details": {"cache_read": 900, "cache_creation": 100}},
-                {"input_tokens": 5, "output_tokens": 2, "token_details": {"cache_read": 50}},
             ],
         }
         diagnostic = await _diagnose(tool_agent_split=True, result=result)
-
-        assert diagnostic == {
-            "requested": True,
-            "applied": True,
-            "cache_read_tokens": 950,
-            "cache_creation_tokens": 100,
-        }
-
-    async def test_zero_activity_is_stamped_as_zero_not_left_absent(self):
-        result = {"response": "ok", "llm_usage": [{"input_tokens": 5, "output_tokens": 2}]}
-        diagnostic = await _diagnose(tool_agent_split=True, result=result)
-
-        assert diagnostic["cache_read_tokens"] == 0
-        assert diagnostic["cache_creation_tokens"] == 0
-
-    async def test_a_run_with_no_usage_stays_unstamped(self):
-        diagnostic = await _diagnose(tool_agent_split=True)
 
         assert diagnostic == {"requested": True, "applied": True}
 
@@ -478,7 +479,31 @@ class TestObservedCacheTokens:
         }
         diagnostic = await _diagnose(tool_agent_split=False, result=result)
 
-        assert "cache_read_tokens" not in diagnostic
+        assert diagnostic == {"requested": True, "applied": False}
+
+
+@pytest.mark.asyncio
+class TestAnErrorResultRecordsNoAppliedMarker:
+
+    async def test_an_error_with_no_usage_leaves_no_diagnostic(self):
+        diagnostic = await _diagnose(tool_agent_split=True, result={"status": "error", "response": "boom"})
+
+        assert diagnostic is None
+
+    async def test_an_error_after_real_calls_still_records_applied(self):
+        result = {
+            "status": "error",
+            "response": "max iterations reached",
+            "llm_usage": [{"input_tokens": 5, "output_tokens": 2}],
+        }
+        diagnostic = await _diagnose(tool_agent_split=True, result=result)
+
+        assert diagnostic == {"requested": True, "applied": True}
+
+    async def test_a_withheld_verdict_survives_an_error_result(self):
+        diagnostic = await _diagnose(tool_agent_split=False, result={"status": "error", "response": "boom"})
+
+        assert diagnostic == {"requested": True, "applied": False}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/workflow/test_agent_runtime.py
+++ b/backend/tests/unit/workflow/test_agent_runtime.py
@@ -357,7 +357,7 @@ class TestDiagnosticPerDispatchBranch:
             agent_type=agent_type, llm_model=_caching_model(), stable_volatile_parts=_PARTS
         )
 
-        assert diagnostic == {"requested": True, "applied": False, "reason": "unsupported_mode"}
+        assert diagnostic == {"requested": True, "applied": False}
 
     async def test_react_lc_applied_tracks_the_split_it_actually_got(self):
         diagnostic = await _diagnose(
@@ -367,15 +367,15 @@ class TestDiagnosticPerDispatchBranch:
             stable_volatile_parts=_PARTS,
         )
 
-        assert diagnostic == {"requested": True, "applied": True, "reason": None}
+        assert diagnostic == {"requested": True, "applied": True}
 
-    async def test_react_lc_without_parts_names_the_volatile_gate(self):
+    async def test_react_lc_without_parts_is_withheld(self):
         diagnostic = await _diagnose(agent_type="ReActAgentLC", llm_model=_caching_model())
 
-        assert diagnostic == {"requested": True, "applied": False, "reason": "volatile_prompt"}
+        assert diagnostic == {"requested": True, "applied": False}
 
     @pytest.mark.parametrize("base", ["", "  \n"], ids=repr)
-    async def test_react_lc_with_a_blank_stable_half_names_the_empty_prompt(self, base):
+    async def test_react_lc_with_a_blank_stable_half_is_withheld(self, base):
         diagnostic = await _diagnose(
             agent_type="ReActAgentLC",
             llm_model=_caching_model(),
@@ -383,18 +383,18 @@ class TestDiagnosticPerDispatchBranch:
             stable_volatile_parts=(base, _SUFFIX),
         )
 
-        assert diagnostic == {"requested": True, "applied": False, "reason": "empty_prompt"}
+        assert diagnostic == {"requested": True, "applied": False}
 
-    async def test_react_lc_on_a_plain_model_names_the_provider(self):
+    async def test_react_lc_on_a_plain_model_is_withheld(self):
         diagnostic = await _diagnose(agent_type="ReActAgentLC", stable_volatile_parts=_PARTS)
 
-        assert diagnostic["reason"] == "unsupported_cache_markers"
+        assert diagnostic == {"requested": True, "applied": False}
 
-    async def test_react_lc_on_a_mixed_chain_is_distinguished(self):
+    async def test_react_lc_on_a_mixed_chain_is_withheld(self):
         chain = FallbackChatModel(models=[MagicMock(name="plain"), _caching_model()])
         diagnostic = await _diagnose(agent_type="ReActAgentLC", llm_model=chain, stable_volatile_parts=_PARTS)
 
-        assert diagnostic["reason"] == "mixed_fallback_chain"
+        assert diagnostic == {"requested": True, "applied": False}
 
     @pytest.mark.parametrize("split", [True, False], ids=["split", "fused"])
     async def test_tool_agent_applied_mirrors_its_own_decision(self, split):
@@ -404,12 +404,12 @@ class TestDiagnosticPerDispatchBranch:
 
         assert diagnostic["applied"] is split
 
-    async def test_an_unexplained_withheld_split_reports_no_reason(self):
+    async def test_an_unexplained_withheld_split_still_records(self):
         diagnostic = await _diagnose(
             tool_agent_split=False, llm_model=_caching_model(), stable_volatile_parts=_PARTS
         )
 
-        assert diagnostic == {"requested": True, "applied": False, "reason": None}
+        assert diagnostic == {"requested": True, "applied": False}
 
 
 @pytest.mark.asyncio
@@ -436,7 +436,7 @@ class TestARaisingInvocationRecordsNoAppliedMarker:
             with pytest.raises(RuntimeError):
                 await run_agent_once(**_base_kwargs(state=state, prompt_caching_enabled=True))
 
-        assert state.prompt_caching_diagnostics == {"node-1": {"requested": True, "applied": False, "reason": None}}
+        assert state.prompt_caching_diagnostics == {"node-1": {"requested": True, "applied": False}}
 
 
 @pytest.mark.asyncio
@@ -455,7 +455,6 @@ class TestObservedCacheTokens:
         assert diagnostic == {
             "requested": True,
             "applied": True,
-            "reason": None,
             "cache_read_tokens": 950,
             "cache_creation_tokens": 100,
         }
@@ -470,7 +469,7 @@ class TestObservedCacheTokens:
     async def test_a_run_with_no_usage_stays_unstamped(self):
         diagnostic = await _diagnose(tool_agent_split=True)
 
-        assert diagnostic == {"requested": True, "applied": True, "reason": None}
+        assert diagnostic == {"requested": True, "applied": True}
 
     async def test_a_withheld_split_never_gains_token_fields(self):
         result = {
@@ -511,6 +510,4 @@ class TestDiagnosticIsRequestGated:
                     **_base_kwargs(state=state, agent_type="ReActAgent", prompt_caching_enabled=True)
                 )
 
-        assert state.prompt_caching_diagnostics == {"node-1": {
-            "requested": True, "applied": False, "reason": "unsupported_mode"
-        }}
+        assert state.prompt_caching_diagnostics == {"node-1": {"requested": True, "applied": False}}

--- a/backend/tests/unit/workflow/test_agent_runtime.py
+++ b/backend/tests/unit/workflow/test_agent_runtime.py
@@ -5,17 +5,26 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain_core.messages import SystemMessage
 
 from app.modules.workflow.agents.agent_runtime import AgentRunResult, run_agent_once
+from app.modules.workflow.llm.fallback_chat_model import FallbackChatModel
+from app.modules.workflow.llm.prompt_caching_chat_model import (
+    PROMPT_CACHE_OPT_IN_KEY,
+    PromptCachingChatModel,
+)
 
 _RUNTIME = "app.modules.workflow.agents.agent_runtime"
 _MERGE = "app.modules.workflow.engine.llm_usage_tracking.merge_llm_usage_from_result"
 _AGENT_NAMES = ("ReActAgent", "ReActAgentLC", "SimpleToolAgent", "ToolAgent")
+_SUFFIX = " Current time: 2026-08-17 12:00:00"
+_PARTS = ("base prompt", _SUFFIX)
 
 
 def _fake_agent_class(result):
     instance = MagicMock()
     instance.invoke = AsyncMock(return_value=result)
+    instance.cache_split_decision = (False, None)
     return MagicMock(return_value=instance), instance
 
 
@@ -127,7 +136,7 @@ async def test_merges_usage_from_result():
     with stack:
         await run_agent_once(**_base_kwargs(state=state))
 
-    merge.assert_awaited_once_with(state, result, "node-1", "prov-1")
+    merge.assert_awaited_once_with(state, result, "node-1", "prov-1", False)
 
 
 @pytest.mark.asyncio
@@ -184,4 +193,324 @@ async def test_supplied_llm_model_skips_provider_resolution():
     injector.get.assert_not_called()
     assert run.llm_model == "reused-model"
     cls, _ = classes["ToolAgent"]
-    cls.assert_called_once_with(llm_model="reused-model", system_prompt="sys", tools=[], max_iterations=7)
+    cls.assert_called_once_with(
+        llm_model="reused-model", system_prompt="sys", tools=[], max_iterations=7, stable_volatile_parts=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_agent_receives_the_prompt_parts():
+    stack, classes, _, _ = _patch_runtime({"response": "ok"})
+    with stack:
+        await run_agent_once(**_base_kwargs(stable_volatile_parts=_PARTS))
+
+    cls, _ = classes["ToolAgent"]
+    assert cls.call_args.kwargs["stable_volatile_parts"] == _PARTS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "agent_type,expected",
+    [
+        ("ReActAgent", "ReActAgent"),
+        ("ReActAgentLC", "ReActAgentLC"),
+        ("SimpleToolExecutor", "SimpleToolAgent"),
+    ],
+)
+async def test_other_agents_never_receive_the_parts(agent_type, expected):
+    stack, classes, _, _ = _patch_runtime({"response": "ok"})
+    with stack:
+        await run_agent_once(**_base_kwargs(agent_type=agent_type, stable_volatile_parts=_PARTS))
+
+    cls, _ = classes[expected]
+    assert "stable_volatile_parts" not in cls.call_args.kwargs
+
+
+def _caching_model():
+    return PromptCachingChatModel(inner=MagicMock(name="inner-model"), cache_style="anthropic")
+
+
+async def _react_lc_prompt(**overrides):
+    """The system_prompt ReActAgentLC was constructed with"""
+    stack, classes, _, _ = _patch_runtime({"response": "ok"})
+    with stack:
+        await run_agent_once(**_base_kwargs(agent_type="ReActAgentLC", **overrides))
+
+    cls, _ = classes["ReActAgentLC"]
+    return cls.call_args.kwargs["system_prompt"]
+
+
+@pytest.mark.asyncio
+class TestReActAgentLCSplit:
+    async def test_cacheable_parts_become_two_blocks(self):
+        prompt = await _react_lc_prompt(
+            llm_model=_caching_model(), system_prompt="base prompt" + _SUFFIX, stable_volatile_parts=_PARTS
+        )
+
+        assert isinstance(prompt, SystemMessage)
+        assert prompt.content == [
+            {"type": "text", "text": "base prompt"},
+            {"type": "text", "text": _SUFFIX},
+        ]
+        assert prompt.additional_kwargs == {PROMPT_CACHE_OPT_IN_KEY: True}
+
+    async def test_blocks_render_back_to_the_original_string(self):
+        prompt = await _react_lc_prompt(
+            llm_model=_caching_model(), system_prompt="base prompt" + _SUFFIX, stable_volatile_parts=_PARTS
+        )
+
+        assert "".join(block["text"] for block in prompt.content) == "base prompt" + _SUFFIX
+
+    async def test_model_without_caching_keeps_the_string(self):
+        prompt = await _react_lc_prompt(system_prompt="base prompt" + _SUFFIX, stable_volatile_parts=_PARTS)
+
+        assert prompt == "base prompt" + _SUFFIX
+
+    async def test_missing_parts_keep_the_string(self):
+        prompt = await _react_lc_prompt(llm_model=_caching_model(), system_prompt="base prompt" + _SUFFIX)
+
+        assert prompt == "base prompt" + _SUFFIX
+
+    @pytest.mark.parametrize("base", ["", " ", "\n\t "], ids=repr)
+    async def test_blank_base_keeps_the_string(self, base):
+        prompt = await _react_lc_prompt(
+            llm_model=_caching_model(), system_prompt=base + _SUFFIX, stable_volatile_parts=(base, _SUFFIX)
+        )
+
+        assert prompt == base + _SUFFIX
+
+    async def test_mixed_fallback_chain_keeps_the_string(self):
+        chain = FallbackChatModel(models=[MagicMock(name="plain"), _caching_model()])
+        prompt = await _react_lc_prompt(
+            llm_model=chain, system_prompt="base prompt" + _SUFFIX, stable_volatile_parts=_PARTS
+        )
+
+        assert prompt == "base prompt" + _SUFFIX
+
+    async def test_homogeneous_fallback_chain_splits(self):
+        chain = FallbackChatModel(models=[_caching_model(), _caching_model()])
+        prompt = await _react_lc_prompt(
+            llm_model=chain, system_prompt="base prompt" + _SUFFIX, stable_volatile_parts=_PARTS
+        )
+
+        assert isinstance(prompt, SystemMessage)
+
+
+@pytest.mark.asyncio
+class TestPromptCachingOptIn:
+
+    @pytest.mark.parametrize("requested", [True, False], ids=["opted-in", "default-off"])
+    async def test_the_request_reaches_the_model_build(self, requested):
+        stack, _, injector, _ = _patch_runtime({"response": "ok"})
+        with stack:
+            await run_agent_once(**_base_kwargs(prompt_caching_enabled=requested))
+
+        provider = injector.get.return_value
+        assert provider.get_model_for_node.await_args.args == ("prov-1", None, requested)
+
+    @pytest.mark.parametrize("requested", [True, False], ids=["opted-in", "default-off"])
+    async def test_the_request_marks_the_usage_merge(self, requested):
+        stack, _, _, merge = _patch_runtime({"response": "ok"})
+        with stack:
+            await run_agent_once(**_base_kwargs(prompt_caching_enabled=requested))
+
+        assert merge.await_args.args[-1] is requested
+
+    async def test_a_reused_model_skips_the_build_but_still_marks_usage(self):
+        stack, _, injector, merge = _patch_runtime({"response": "ok"})
+        with stack:
+            await run_agent_once(**_base_kwargs(llm_model="reused-model", prompt_caching_enabled=True))
+
+        injector.get.assert_not_called()
+        assert merge.await_args.args[-1] is True
+
+    async def test_omitting_the_argument_defaults_to_off(self):
+        stack, _, injector, _ = _patch_runtime({"response": "ok"})
+        with stack:
+            await run_agent_once(**_base_kwargs())
+
+        assert injector.get.return_value.get_model_for_node.await_args.args == ("prov-1", None, False)
+
+
+class _DiagState:
+
+    def __init__(self):
+        self.prompt_caching_diagnostics: dict = {}
+
+
+async def _diagnose(*, tool_agent_split=None, result=None, **overrides):
+    state = _DiagState()
+    stack, classes, _, _ = _patch_runtime(result if result is not None else {"response": "ok"})
+    if tool_agent_split is not None:
+        classes["ToolAgent"][1].cache_split_decision = (tool_agent_split, None)
+    with stack:
+        await run_agent_once(**_base_kwargs(state=state, prompt_caching_enabled=True, **overrides))
+    return state.prompt_caching_diagnostics.get("node-1")
+
+
+@pytest.mark.asyncio
+class TestDiagnosticPerDispatchBranch:
+
+    @pytest.mark.parametrize("agent_type", ["ReActAgent", "SimpleToolExecutor"])
+    async def test_a_mode_that_never_splits_says_so(self, agent_type):
+        diagnostic = await _diagnose(
+            agent_type=agent_type, llm_model=_caching_model(), stable_volatile_parts=_PARTS
+        )
+
+        assert diagnostic == {"requested": True, "applied": False, "reason": "unsupported_mode"}
+
+    async def test_react_lc_applied_tracks_the_split_it_actually_got(self):
+        diagnostic = await _diagnose(
+            agent_type="ReActAgentLC",
+            llm_model=_caching_model(),
+            system_prompt="base prompt" + _SUFFIX,
+            stable_volatile_parts=_PARTS,
+        )
+
+        assert diagnostic == {"requested": True, "applied": True, "reason": None}
+
+    async def test_react_lc_without_parts_names_the_volatile_gate(self):
+        diagnostic = await _diagnose(agent_type="ReActAgentLC", llm_model=_caching_model())
+
+        assert diagnostic == {"requested": True, "applied": False, "reason": "volatile_prompt"}
+
+    @pytest.mark.parametrize("base", ["", "  \n"], ids=repr)
+    async def test_react_lc_with_a_blank_stable_half_names_the_empty_prompt(self, base):
+        diagnostic = await _diagnose(
+            agent_type="ReActAgentLC",
+            llm_model=_caching_model(),
+            system_prompt=base + _SUFFIX,
+            stable_volatile_parts=(base, _SUFFIX),
+        )
+
+        assert diagnostic == {"requested": True, "applied": False, "reason": "empty_prompt"}
+
+    async def test_react_lc_on_a_plain_model_names_the_provider(self):
+        diagnostic = await _diagnose(agent_type="ReActAgentLC", stable_volatile_parts=_PARTS)
+
+        assert diagnostic["reason"] == "unsupported_cache_markers"
+
+    async def test_react_lc_on_a_mixed_chain_is_distinguished(self):
+        chain = FallbackChatModel(models=[MagicMock(name="plain"), _caching_model()])
+        diagnostic = await _diagnose(agent_type="ReActAgentLC", llm_model=chain, stable_volatile_parts=_PARTS)
+
+        assert diagnostic["reason"] == "mixed_fallback_chain"
+
+    @pytest.mark.parametrize("split", [True, False], ids=["split", "fused"])
+    async def test_tool_agent_applied_mirrors_its_own_decision(self, split):
+        diagnostic = await _diagnose(
+            tool_agent_split=split, llm_model=_caching_model(), stable_volatile_parts=_PARTS
+        )
+
+        assert diagnostic["applied"] is split
+
+    async def test_an_unexplained_withheld_split_reports_no_reason(self):
+        diagnostic = await _diagnose(
+            tool_agent_split=False, llm_model=_caching_model(), stable_volatile_parts=_PARTS
+        )
+
+        assert diagnostic == {"requested": True, "applied": False, "reason": None}
+
+
+@pytest.mark.asyncio
+class TestARaisingInvocationRecordsNoAppliedMarker:
+
+    async def test_an_applied_split_leaves_no_diagnostic_when_the_agent_raises(self):
+        state = _DiagState()
+        stack, classes, _, _ = _patch_runtime({"response": "ok"})
+        classes["ToolAgent"][1].cache_split_decision = (True, None)
+        classes["ToolAgent"][1].invoke.side_effect = RuntimeError("provider down")
+
+        with stack:
+            with pytest.raises(RuntimeError):
+                await run_agent_once(**_base_kwargs(state=state, prompt_caching_enabled=True))
+
+        assert state.prompt_caching_diagnostics == {}
+
+    async def test_a_withheld_verdict_survives_the_raise(self):
+        state = _DiagState()
+        stack, classes, _, _ = _patch_runtime({"response": "ok"})
+        classes["ToolAgent"][1].invoke.side_effect = RuntimeError("provider down")
+
+        with stack:
+            with pytest.raises(RuntimeError):
+                await run_agent_once(**_base_kwargs(state=state, prompt_caching_enabled=True))
+
+        assert state.prompt_caching_diagnostics == {"node-1": {"requested": True, "applied": False, "reason": None}}
+
+
+@pytest.mark.asyncio
+class TestObservedCacheTokens:
+
+    async def test_an_applied_run_records_what_the_provider_reported(self):
+        result = {
+            "response": "ok",
+            "llm_usage": [
+                {"input_tokens": 5, "output_tokens": 2, "token_details": {"cache_read": 900, "cache_creation": 100}},
+                {"input_tokens": 5, "output_tokens": 2, "token_details": {"cache_read": 50}},
+            ],
+        }
+        diagnostic = await _diagnose(tool_agent_split=True, result=result)
+
+        assert diagnostic == {
+            "requested": True,
+            "applied": True,
+            "reason": None,
+            "cache_read_tokens": 950,
+            "cache_creation_tokens": 100,
+        }
+
+    async def test_zero_activity_is_stamped_as_zero_not_left_absent(self):
+        result = {"response": "ok", "llm_usage": [{"input_tokens": 5, "output_tokens": 2}]}
+        diagnostic = await _diagnose(tool_agent_split=True, result=result)
+
+        assert diagnostic["cache_read_tokens"] == 0
+        assert diagnostic["cache_creation_tokens"] == 0
+
+    async def test_a_run_with_no_usage_stays_unstamped(self):
+        diagnostic = await _diagnose(tool_agent_split=True)
+
+        assert diagnostic == {"requested": True, "applied": True, "reason": None}
+
+    async def test_a_withheld_split_never_gains_token_fields(self):
+        result = {
+            "response": "ok",
+            "llm_usage": [{"input_tokens": 5, "output_tokens": 2, "token_details": {"cache_read": 900}}],
+        }
+        diagnostic = await _diagnose(tool_agent_split=False, result=result)
+
+        assert "cache_read_tokens" not in diagnostic
+
+
+@pytest.mark.asyncio
+class TestDiagnosticIsRequestGated:
+
+    async def test_an_unrequested_run_writes_nothing(self):
+        state = _DiagState()
+        stack, _, _, _ = _patch_runtime({"response": "ok"})
+        with stack:
+            await run_agent_once(**_base_kwargs(state=state, agent_type="ReActAgent"))
+
+        assert state.prompt_caching_diagnostics == {}
+
+    async def test_a_state_without_the_hook_never_breaks_the_run(self):
+        stack, _, _, _ = _patch_runtime({"response": "ok"})
+        with stack:
+            run = await run_agent_once(
+                **_base_kwargs(state=SimpleNamespace(), agent_type="ReActAgent", prompt_caching_enabled=True)
+            )
+
+        assert run.response == "ok"
+
+    async def test_repeated_runs_stay_idempotent(self):
+        state = _DiagState()
+        stack, _, _, _ = _patch_runtime({"response": "ok"})
+        with stack:
+            for _ in range(3):
+                await run_agent_once(
+                    **_base_kwargs(state=state, agent_type="ReActAgent", prompt_caching_enabled=True)
+                )
+
+        assert state.prompt_caching_diagnostics == {"node-1": {
+            "requested": True, "applied": False, "reason": "unsupported_mode"
+        }}

--- a/backend/tests/unit/workflow/test_sub_agent_orchestrator.py
+++ b/backend/tests/unit/workflow/test_sub_agent_orchestrator.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -299,3 +300,77 @@ async def test_run_child_turn_without_usage_threading_stays_uncaptured():
 
     _, kwargs = engine.execute_from_node.call_args
     assert kwargs["usage_sink"] is None and kwargs["usage_context"] is None
+
+
+def _diag(applied=False, reason="unsupported_mode"):
+    return {"requested": True, "applied": applied, "reason": reason}
+
+
+def _state_with(entries=None, collected=None):
+    return SimpleNamespace(
+        node_execution_status=entries if entries is not None else {},
+        prompt_caching_diagnostics=collected if collected is not None else {},
+    )
+
+
+class TestPropagatePromptCacheDiagnostics:
+
+    def test_the_childs_collection_reaches_the_parent(self):
+        child = _state_with(collected={"child": _diag()})
+        parent = _state_with()
+
+        orchestrator.propagate_prompt_cache_diagnostics(child, parent)
+
+        assert parent.prompt_caching_diagnostics == {"child": _diag()}
+
+    def test_the_parents_execution_map_is_left_alone(self):
+        child = _state_with({"child": {"status": "failed"}}, {"child": _diag()})
+        parent = _state_with({"parent": {"status": "success"}})
+
+        orchestrator.propagate_prompt_cache_diagnostics(child, parent)
+
+        assert parent.node_execution_status == {"parent": {"status": "success"}}
+
+    def test_descendant_diagnostics_chain_upward(self):
+        child = _state_with(collected={"child": _diag(), "grandchild": _diag(reason="volatile_prompt")})
+        parent = _state_with()
+
+        orchestrator.propagate_prompt_cache_diagnostics(child, parent)
+
+        assert set(parent.prompt_caching_diagnostics) == {"child", "grandchild"}
+
+    def test_the_childs_entry_wins_over_a_stale_parent_copy(self):
+        child = _state_with(collected={"child": _diag(applied=True, reason=None)})
+        parent = _state_with(collected={"child": _diag(reason="volatile_prompt")})
+
+        orchestrator.propagate_prompt_cache_diagnostics(child, parent)
+
+        assert parent.prompt_caching_diagnostics["child"]["applied"] is True
+
+    def test_existing_parent_entries_survive(self):
+        child = _state_with(collected={"child": _diag()})
+        parent = _state_with(collected={"earlier": _diag()})
+
+        orchestrator.propagate_prompt_cache_diagnostics(child, parent)
+
+        assert set(parent.prompt_caching_diagnostics) == {"earlier", "child"}
+
+    def test_a_child_without_diagnostics_writes_nothing(self):
+        parent = _state_with()
+
+        orchestrator.propagate_prompt_cache_diagnostics(_state_with({"child": {"status": "success"}}), parent)
+
+        assert parent.prompt_caching_diagnostics == {}
+
+    def test_a_malformed_child_collection_is_ignored(self):
+        parent = _state_with()
+
+        orchestrator.propagate_prompt_cache_diagnostics(_state_with(collected="junk"), parent)
+
+        assert parent.prompt_caching_diagnostics == {}
+
+    def test_a_state_without_the_collection_never_raises(self):
+        child = _state_with(collected={"child": _diag()})
+
+        orchestrator.propagate_prompt_cache_diagnostics(child, SimpleNamespace())
+        orchestrator.propagate_prompt_cache_diagnostics(SimpleNamespace(), _state_with())

--- a/backend/tests/unit/workflow/test_sub_agent_orchestrator.py
+++ b/backend/tests/unit/workflow/test_sub_agent_orchestrator.py
@@ -302,8 +302,8 @@ async def test_run_child_turn_without_usage_threading_stays_uncaptured():
     assert kwargs["usage_sink"] is None and kwargs["usage_context"] is None
 
 
-def _diag(applied=False, reason="unsupported_mode"):
-    return {"requested": True, "applied": applied, "reason": reason}
+def _diag(applied=False):
+    return {"requested": True, "applied": applied}
 
 
 def _state_with(entries=None, collected=None):
@@ -332,7 +332,7 @@ class TestPropagatePromptCacheDiagnostics:
         assert parent.node_execution_status == {"parent": {"status": "success"}}
 
     def test_descendant_diagnostics_chain_upward(self):
-        child = _state_with(collected={"child": _diag(), "grandchild": _diag(reason="volatile_prompt")})
+        child = _state_with(collected={"child": _diag(), "grandchild": _diag()})
         parent = _state_with()
 
         orchestrator.propagate_prompt_cache_diagnostics(child, parent)
@@ -340,8 +340,8 @@ class TestPropagatePromptCacheDiagnostics:
         assert set(parent.prompt_caching_diagnostics) == {"child", "grandchild"}
 
     def test_the_childs_entry_wins_over_a_stale_parent_copy(self):
-        child = _state_with(collected={"child": _diag(applied=True, reason=None)})
-        parent = _state_with(collected={"child": _diag(reason="volatile_prompt")})
+        child = _state_with(collected={"child": _diag(applied=True)})
+        parent = _state_with(collected={"child": _diag()})
 
         orchestrator.propagate_prompt_cache_diagnostics(child, parent)
 

--- a/backend/tests/unit/workflow/test_sub_agent_turn_router.py
+++ b/backend/tests/unit/workflow/test_sub_agent_turn_router.py
@@ -283,3 +283,77 @@ async def test_child_still_awaiting_does_not_resume_the_parent():
 
     run_child.assert_awaited_once()
     router.workflow_engine.execute_from_node.assert_not_awaited()
+
+
+_CHILD_DIAG = {"requested": True, "applied": False, "reason": "unsupported_mode"}
+
+
+def _completed_child_state(**extra):
+    return SimpleNamespace(
+        sub_agent_control={"result": "child done"},
+        get_last_node_output=lambda: {"message": "child done"},
+        node_outputs={"child": {"message": "child done"}},
+        node_execution_status={},
+        prompt_caching_diagnostics={},
+        **extra,
+    )
+
+
+async def _resume_with(child_state, parent_state):
+    router = _make_router()
+    router.workflow_engine.execute_from_node = AsyncMock(return_value=parent_state)
+    with (
+        patch.object(ConversationMemory, "get_instance", return_value=_seed_stack()),
+        patch(f"{_ORCH}.run_child_turn", AsyncMock(return_value=child_state)),
+    ):
+        await router.route_turn("a reply", "t1", {"message": "a reply"}, persist=True)
+    return parent_state
+
+
+def _fresh_parent_state():
+    state = _fake_state({"status": "success", "output": {"message": "parent final"}})
+    state.node_execution_status = {"parent": {"status": "success"}}
+    state.prompt_caching_diagnostics = {}
+    return state
+
+
+@pytest.mark.asyncio
+async def test_completion_turn_carries_the_child_diagnostic_to_the_fresh_parent():
+    child = _completed_child_state()
+    child.node_execution_status = {"child": {"status": "success"}}
+    child.prompt_caching_diagnostics = {"child": _CHILD_DIAG}
+
+    parent = await _resume_with(child, _fresh_parent_state())
+
+    assert parent.prompt_caching_diagnostics == {"child": _CHILD_DIAG}
+    assert parent.node_execution_status == {"parent": {"status": "success"}}
+
+
+@pytest.mark.asyncio
+async def test_a_completion_turn_without_diagnostics_stays_empty():
+    parent = await _resume_with(_completed_child_state(), _fresh_parent_state())
+
+    assert parent.prompt_caching_diagnostics == {}
+
+
+@pytest.mark.asyncio
+async def test_a_mid_conversation_turn_returns_the_childs_own_response():
+    router = _make_router()
+    router.workflow_engine.execute_from_node = AsyncMock()
+    child = SimpleNamespace(
+        sub_agent_control=None,
+        get_last_node_output=lambda: {"message": "still working"},
+        format_state_as_response=lambda: {
+            "status": "success",
+            "output": {"message": "still working"},
+            "state": {"nodeExecutionStatus": {"child": {"prompt_caching": _CHILD_DIAG}}},
+        },
+    )
+    with (
+        patch.object(ConversationMemory, "get_instance", return_value=_seed_stack()),
+        patch(f"{_ORCH}.run_child_turn", AsyncMock(return_value=child)),
+    ):
+        result = await router.route_turn("a reply", "t1", {"message": "a reply"}, persist=True)
+
+    router.workflow_engine.execute_from_node.assert_not_awaited()
+    assert result["state"]["nodeExecutionStatus"]["child"]["prompt_caching"] == _CHILD_DIAG

--- a/backend/tests/unit/workflow/test_sub_agent_turn_router.py
+++ b/backend/tests/unit/workflow/test_sub_agent_turn_router.py
@@ -285,7 +285,7 @@ async def test_child_still_awaiting_does_not_resume_the_parent():
     router.workflow_engine.execute_from_node.assert_not_awaited()
 
 
-_CHILD_DIAG = {"requested": True, "applied": False, "reason": "unsupported_mode"}
+_CHILD_DIAG = {"requested": True, "applied": False}
 
 
 def _completed_child_state(**extra):

--- a/backend/tests/unit/workflow/test_workflow_executor_usage_rollup.py
+++ b/backend/tests/unit/workflow/test_workflow_executor_usage_rollup.py
@@ -54,14 +54,17 @@ def _patch_workflow_service():
     return patch("app.dependencies.injector.injector", inj)
 
 
-def _patch_engine(entries, error=None):
+def _patch_engine(entries, error=None, child_diagnostics=None):
 
     async def _execute(self, *, usage_sink=None, **kwargs):
         if usage_sink is not None:
             usage_sink.extend(entries)
         if error is not None:
             raise error
-        return _state(CHILD_WF)
+        child = _state(CHILD_WF)
+        if child_diagnostics:
+            child.prompt_caching_diagnostics = child_diagnostics
+        return child
 
     return patch.object(WorkflowEngine, "execute_from_node", _execute)
 
@@ -139,6 +142,41 @@ async def test_child_entries_are_copied_not_aliased():
 
     assert state.llm_usage[0] is not entries[0]
     assert entries[0]["node_id"] == "child-n1"
+
+
+@pytest.mark.asyncio
+async def test_child_caching_diagnostics_collapse_onto_the_executor():
+    state = _state()
+    diagnostics = {
+        "child-n1": {"requested": True, "applied": True},
+        "child-n2": {"requested": True, "applied": False},
+    }
+
+    with _patch_workflow_service(), _patch_engine([_entry("child-n1")], child_diagnostics=diagnostics):
+        await _node(state).process(CONFIG)
+
+    assert state.prompt_caching_diagnostics == {"exec-1": {"requested": True, "applied": True}}
+
+
+@pytest.mark.asyncio
+async def test_an_all_withheld_child_still_surfaces_a_withheld_entry():
+    state = _state()
+    diagnostics = {"child-n1": {"requested": True, "applied": False}}
+
+    with _patch_workflow_service(), _patch_engine([_entry("child-n1")], child_diagnostics=diagnostics):
+        await _node(state).process(CONFIG)
+
+    assert state.prompt_caching_diagnostics == {"exec-1": {"requested": True, "applied": False}}
+
+
+@pytest.mark.asyncio
+async def test_a_child_without_diagnostics_leaves_none_on_the_executor():
+    state = _state()
+
+    with _patch_workflow_service(), _patch_engine([_entry("child-n1")]):
+        await _node(state).process(CONFIG)
+
+    assert state.prompt_caching_diagnostics == {}
 
 
 @pytest.mark.asyncio

--- a/frontend/src/interfaces/llmProvider.interface.ts
+++ b/frontend/src/interfaces/llmProvider.interface.ts
@@ -11,6 +11,7 @@ export interface LLMProvider {
   is_active: number;
   created_at: string;
   updated_at: string;
+  prompt_caching_mode?: "explicit" | "automatic" | "none";
 }
 
 export interface LLMProviderMinimal {

--- a/frontend/src/interfaces/workflow-execution.interface.ts
+++ b/frontend/src/interfaces/workflow-execution.interface.ts
@@ -162,6 +162,27 @@ export interface RawNodeExecutionEntry {
   input?: unknown;
   output?: unknown;
   error?: string | null;
+  /** Present only when the node asked for prompt caching. */
+  prompt_caching?: RawPromptCachingDiagnostic;
+}
+
+/** What a node asked of prompt caching, and what it got. `reason` is a code, or null. */
+export interface RawPromptCachingDiagnostic {
+  requested?: boolean;
+  applied?: boolean;
+  reason?: string | null;
+  /** Provider-reported cache activity, stamped after the call */
+  cache_read_tokens?: number;
+  cache_creation_tokens?: number;
+}
+
+/** Normalized diagnostic; `reasonText` is absent when the reason code is unknown or missing. */
+export interface PromptCachingDiagnostic {
+  requested: boolean;
+  applied: boolean;
+  reasonText?: string;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
 }
 
 /** Normalized, display-ready status used by the Execution view. */
@@ -186,6 +207,7 @@ export interface NodeExecutionView {
   error?: string | null;
   /** 0-based execution order, when derivable from startTime. */
   order?: number;
+  promptCaching?: PromptCachingDiagnostic;
 }
 
 /** Everything the Execution view needs, derived once from the test response. */
@@ -203,6 +225,12 @@ export interface ExecutionViewModel {
   overallDurationMs?: number;
   /** Node id with the largest duration, when any node has a duration. */
   slowestNodeId?: string;
+  /**
+   * Diagnostics propagated up from sub-agent runs, keyed by the child node id. These nodes
+   * never appear in `nodes`/`byId` — the parent run did not execute them — so they are
+   * surfaced by the run-level notice rather than by selection.
+   */
+  promptCachingDiagnostics: Record<string, PromptCachingDiagnostic>;
 }
 
 /** Which of the four interactive states the Execution view should render. */

--- a/frontend/src/interfaces/workflow-execution.interface.ts
+++ b/frontend/src/interfaces/workflow-execution.interface.ts
@@ -162,25 +162,20 @@ export interface RawNodeExecutionEntry {
   input?: unknown;
   output?: unknown;
   error?: string | null;
-  /** Present only when the node asked for prompt caching. */
-  prompt_caching?: RawPromptCachingDiagnostic;
 }
 
-/** What a node asked of prompt caching, and what it got. `reason` is a code, or null. */
+/** What a node asked of prompt caching, and what it got. */
 export interface RawPromptCachingDiagnostic {
   requested?: boolean;
   applied?: boolean;
-  reason?: string | null;
   /** Provider-reported cache activity, stamped after the call */
   cache_read_tokens?: number;
   cache_creation_tokens?: number;
 }
 
-/** Normalized diagnostic; `reasonText` is absent when the reason code is unknown or missing. */
 export interface PromptCachingDiagnostic {
   requested: boolean;
   applied: boolean;
-  reasonText?: string;
   cacheReadTokens?: number;
   cacheCreationTokens?: number;
 }
@@ -226,9 +221,8 @@ export interface ExecutionViewModel {
   /** Node id with the largest duration, when any node has a duration. */
   slowestNodeId?: string;
   /**
-   * Diagnostics propagated up from sub-agent runs, keyed by the child node id. These nodes
-   * never appear in `nodes`/`byId` — the parent run did not execute them — so they are
-   * surfaced by the run-level notice rather than by selection.
+   * Prompt-caching diagnostics keyed by node id. Sub-agent children appear here too,
+   * though they are absent from `nodes`/`byId` — the parent run did not execute them.
    */
   promptCachingDiagnostics: Record<string, PromptCachingDiagnostic>;
 }

--- a/frontend/src/services/workflows.ts
+++ b/frontend/src/services/workflows.ts
@@ -64,6 +64,18 @@ export interface FailedNode {
   error: string;
 }
 
+/** Per-run token totals. Counts are provider-reported, so cache buckets may or may not
+ *  be contained in input_tokens depending on the provider. */
+export interface WorkflowTokenUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  total_tokens?: number;
+  cache_read_tokens?: number;
+  cache_creation_tokens?: number;
+  cost_usd?: number;
+  calls?: number;
+}
+
 export interface WorkflowTestResponse {
   status: string;
   input: string;
@@ -72,6 +84,7 @@ export interface WorkflowTestResponse {
   has_failures?: boolean;
   /** Details of the nodes that failed, if any. */
   failed_nodes?: FailedNode[];
+  token_usage?: WorkflowTokenUsage;
   [key: string]: any;
 }
 

--- a/frontend/src/views/AIAgents/Workflows/components/ModelConfiguration.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/ModelConfiguration.tsx
@@ -498,8 +498,7 @@ export const ModelConfiguration: React.FC<ModelConfigurationProps> = ({
               Enable Prompt Caching
             </Label>
             <span className="text-xs text-muted-foreground">
-              Caches the stable start of the system prompt — and, for
-              tool-calling agents, the growing conversation — for 5 minutes so
+              Caches the stable start of the system prompt for 5 minutes so
               repeat calls read it at a reduced rate
             </span>
           </div>

--- a/frontend/src/views/AIAgents/Workflows/components/ModelConfiguration.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/ModelConfiguration.tsx
@@ -28,6 +28,12 @@ import { Badge } from "@/components/badge";
 import RagVectorConfigSection from "@/views/KnowledgeBase/components/RagVectorConfigSection";
 import { useWorkflow } from "../context/WorkflowContext";
 import { PromptEditorButton } from "./PromptEditor/PromptEditorButton";
+import { PromptCachingHint, fallbackChainProviders, promptCachingHint } from "../utils/promptCachingHint";
+
+const PROMPT_CACHING_TONE_CLASS: Record<PromptCachingHint["tone"], string> = {
+  info: "text-muted-foreground",
+  warning: "text-amber-700 dark:text-amber-400",
+};
 
 const DEFAULT_AGENT_TYPE_OPTIONS: string[] = [
   "ReActAgent",
@@ -65,11 +71,13 @@ export const ModelConfiguration: React.FC<ModelConfigurationProps> = ({
   const queryClient = useQueryClient();
   const { workflow } = useWorkflow();
 
-  const { data: providers = [] } = useQuery({
+  const { data: allProviders = [] } = useQuery({
     queryKey: ["llmProviders"],
     queryFn: getAllLLMProviders,
-    select: (data: LLMProvider[]) => data.filter((p) => p.is_active === 1),
   });
+  // Active-only for the selectable options; capability checks resolve from the full
+  // list, since a saved node or chain can still reference an inactive provider.
+  const providers = allProviders.filter((p: LLMProvider) => p.is_active === 1);
 
   const { data: allFallbackChains = [] } = useQuery({
     queryKey: ["fallbackChains"],
@@ -156,6 +164,23 @@ export const ModelConfiguration: React.FC<ModelConfigurationProps> = ({
       piiMasking: checked,
     });
   };
+
+  const handlePromptCachingChange = (checked: boolean) => {
+    onConfigChange({
+      ...config,
+      promptCaching: checked,
+    });
+  };
+
+  // The runtime chain is the node's provider plus the chain's others, so the hint
+  // judges that same effective set.
+  const promptCachingNotice = promptCachingHint(
+    config.promptCaching,
+    allProviders.find((p) => p.id === config.providerId),
+    typeSelect,
+    config.type,
+    fallbackChainProviders(allProviders, config.providerId, selectedFallbackChain)
+  );
 
   const handleMemoryTrimmingModeChange = (mode: "message_count" | "token_budget" | "message_compacting" | "rag_retrieval") => {
     onConfigChange({
@@ -465,6 +490,31 @@ export const ModelConfiguration: React.FC<ModelConfigurationProps> = ({
           checked={config.piiMasking ?? false}
           onCheckedChange={handlePiiMaskingChange}
         />
+      </div>
+      <div className="space-y-2 w-full">
+        <div className="flex items-center gap-2 w-full">
+          <div className="flex flex-col gap-0.5">
+            <Label htmlFor={`prompt-caching-switch-${id}`}>
+              Enable Prompt Caching
+            </Label>
+            <span className="text-xs text-muted-foreground">
+              Caches the stable start of the system prompt — and, for
+              tool-calling agents, the growing conversation — for 5 minutes so
+              repeat calls read it at a reduced rate
+            </span>
+          </div>
+          <div className="flex-1" />
+          <Switch
+            id={`prompt-caching-switch-${id}`}
+            checked={config.promptCaching === true}
+            onCheckedChange={handlePromptCachingChange}
+          />
+        </div>
+        {promptCachingNotice && (
+          <p className={`text-xs ${PROMPT_CACHING_TONE_CLASS[promptCachingNotice.tone]}`}>
+            {promptCachingNotice.text}
+          </p>
+        )}
       </div>
       {config.memory && (
         <>

--- a/frontend/src/views/AIAgents/Workflows/components/WorkflowTestPanel.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/WorkflowTestPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { Button } from "@/components/button";
 import { RichInput } from "@/components/richInput";
 import { Label } from "@/components/label";
@@ -44,6 +44,7 @@ import { getAudioUrl, stripAudioDataForDisplay } from "../hooks/useAudioTest";
 import { STTAudioInput } from "./TestInputFields";
 import JsonViewer from "@/components/JsonViewer";
 import NodeExecutionView from "./execution/NodeExecutionView";
+import { collectPromptCachingWarnings } from "../utils/executionView";
 
 type TestViewMode = "response" | "debug" | "execution";
 
@@ -124,6 +125,12 @@ const WorkflowTestPanel: React.FC<WorkflowTestPanelProps> = ({
   );
   // Which history entry is currently shown in the results panel (highlights the list item).
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+
+  // Nodes that asked for prompt caching and ran uncached.
+  const promptCachingWarnings = useMemo(
+    () => collectPromptCachingWarnings(response, workflow),
+    [response, workflow]
+  );
 
   // Dynamic pause/resume state
   const [pausedFormSchema, setPausedFormSchema] = useState<PausedFormSchema | null>(null);
@@ -1087,6 +1094,25 @@ const WorkflowTestPanel: React.FC<WorkflowTestPanelProps> = ({
                             </div>
                           </div>
                         )}
+                      {promptCachingWarnings.length > 0 && (
+                        <div className="rounded-md border border-border bg-muted/50 p-3 text-sm text-muted-foreground">
+                          <div className="font-medium text-foreground">
+                            Prompt caching was requested but not applied on:
+                          </div>
+                          <ul className="mt-1.5 list-disc space-y-1 pl-6">
+                            {promptCachingWarnings.map((w) => (
+                              <li key={w.nodeId}>
+                                <span className="font-medium">{w.name}</span>
+                                {w.reasonText ? <span> — {w.reasonText}</span> : null}
+                              </li>
+                            ))}
+                          </ul>
+                          <div className="mt-1.5 text-xs">
+                            The run completed normally, just uncached. Open the Execution tab
+                            to inspect each node.
+                          </div>
+                        </div>
+                      )}
                       {response?.status === "success" ? (
                         <>
                           {/* The user's test message */}

--- a/frontend/src/views/AIAgents/Workflows/components/WorkflowTestPanel.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/WorkflowTestPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect } from "react";
 import { Button } from "@/components/button";
 import { RichInput } from "@/components/richInput";
 import { Label } from "@/components/label";
@@ -44,7 +44,6 @@ import { getAudioUrl, stripAudioDataForDisplay } from "../hooks/useAudioTest";
 import { STTAudioInput } from "./TestInputFields";
 import JsonViewer from "@/components/JsonViewer";
 import NodeExecutionView from "./execution/NodeExecutionView";
-import { collectPromptCachingWarnings } from "../utils/executionView";
 
 type TestViewMode = "response" | "debug" | "execution";
 
@@ -125,12 +124,6 @@ const WorkflowTestPanel: React.FC<WorkflowTestPanelProps> = ({
   );
   // Which history entry is currently shown in the results panel (highlights the list item).
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
-
-  // Nodes that asked for prompt caching and ran uncached.
-  const promptCachingWarnings = useMemo(
-    () => collectPromptCachingWarnings(response, workflow),
-    [response, workflow]
-  );
 
   // Dynamic pause/resume state
   const [pausedFormSchema, setPausedFormSchema] = useState<PausedFormSchema | null>(null);
@@ -1094,25 +1087,6 @@ const WorkflowTestPanel: React.FC<WorkflowTestPanelProps> = ({
                             </div>
                           </div>
                         )}
-                      {promptCachingWarnings.length > 0 && (
-                        <div className="rounded-md border border-border bg-muted/50 p-3 text-sm text-muted-foreground">
-                          <div className="font-medium text-foreground">
-                            Prompt caching was requested but not applied on:
-                          </div>
-                          <ul className="mt-1.5 list-disc space-y-1 pl-6">
-                            {promptCachingWarnings.map((w) => (
-                              <li key={w.nodeId}>
-                                <span className="font-medium">{w.name}</span>
-                                {w.reasonText ? <span> — {w.reasonText}</span> : null}
-                              </li>
-                            ))}
-                          </ul>
-                          <div className="mt-1.5 text-xs">
-                            The run completed normally, just uncached. Open the Execution tab
-                            to inspect each node.
-                          </div>
-                        </div>
-                      )}
                       {response?.status === "success" ? (
                         <>
                           {/* The user's test message */}

--- a/frontend/src/views/AIAgents/Workflows/components/execution/NodeDetailPanel.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/execution/NodeDetailPanel.tsx
@@ -26,7 +26,7 @@ const toJsonValue = (value: unknown): React.ComponentProps<typeof JsonViewer>['d
  */
 const promptCachingLine = (diagnostic: NonNullable<NodeExecutionView['promptCaching']>): string => {
   if (!diagnostic.applied) {
-    return `Prompt caching: requested but not applied${diagnostic.reasonText ? ` — ${diagnostic.reasonText}` : ''}`;
+    return 'Prompt caching: requested but not applied';
   }
   const { cacheReadTokens, cacheCreationTokens } = diagnostic;
   if (cacheReadTokens === undefined && cacheCreationTokens === undefined) {

--- a/frontend/src/views/AIAgents/Workflows/components/execution/NodeDetailPanel.tsx
+++ b/frontend/src/views/AIAgents/Workflows/components/execution/NodeDetailPanel.tsx
@@ -19,6 +19,27 @@ const toJsonValue = (value: unknown): React.ComponentProps<typeof JsonViewer>['d
   // JsonViewer accepts any JSON-serializable value; narrow here to satisfy its prop type.
   value as React.ComponentProps<typeof JsonViewer>['data'];
 
+/**
+ * "Marker applied" is our decision to cache, not the outcome. The provider may
+ * still reject it (e.g., short prompt below minimum). The actual result comes from
+ * what the run reported.
+ */
+const promptCachingLine = (diagnostic: NonNullable<NodeExecutionView['promptCaching']>): string => {
+  if (!diagnostic.applied) {
+    return `Prompt caching: requested but not applied${diagnostic.reasonText ? ` — ${diagnostic.reasonText}` : ''}`;
+  }
+  const { cacheReadTokens, cacheCreationTokens } = diagnostic;
+  if (cacheReadTokens === undefined && cacheCreationTokens === undefined) {
+    return 'Prompt caching: cache marker applied';
+  }
+  if (!cacheReadTokens && !cacheCreationTokens) {
+    return 'Prompt caching: cache marker applied — the provider reported no cache activity';
+  }
+  const read = (cacheReadTokens ?? 0).toLocaleString();
+  const written = (cacheCreationTokens ?? 0).toLocaleString();
+  return `Prompt caching: cache marker applied — ${read} tokens read from cache, ${written} written`;
+};
+
 const NodeDetailPanel: React.FC<NodeDetailPanelProps> = ({ node, onClose }) => {
   if (!node) {
     return (
@@ -53,6 +74,9 @@ const NodeDetailPanel: React.FC<NodeDetailPanelProps> = ({ node, onClose }) => {
               Duration: <span className="tabular-nums">{formatDuration(node.durationMs)}</span>
             </span>
           </div>
+          {node.promptCaching && (
+            <div className="mt-1 text-xs text-muted-foreground">{promptCachingLine(node.promptCaching)}</div>
+          )}
         </div>
         <button
           type="button"

--- a/frontend/src/views/AIAgents/Workflows/nodeTypes/llm/definitions.ts
+++ b/frontend/src/views/AIAgents/Workflows/nodeTypes/llm/definitions.ts
@@ -44,6 +44,7 @@ export const AGENT_NODE_DEFINITION: NodeTypeDefinition<AgentNodeData> = {
     type: "ToolSelector",
     memory: false,
     piiMasking: false,
+    promptCaching: false,
     systemPrompt: "",
     userPrompt: "{{source.message}}",
     maxIterations: 7,
@@ -104,6 +105,7 @@ export const SUB_AGENT_NODE_DEFINITION: NodeTypeDefinition<SubAgentNodeData> = {
     description: "",
     memory: true,
     piiMasking: false,
+    promptCaching: false,
     systemPrompt: "",
     // Kept in data (hidden in the dialog): the child always runs on the delegated task
     userPrompt: "{{session.message}}",
@@ -215,6 +217,7 @@ export const MODEL_NODE_DEFINITION: NodeTypeDefinition<LLMModelNodeData> = {
     providerId: undefined,
     memory: false,
     piiMasking: false,
+    promptCaching: false,
     type: "Base",
     systemPrompt: "",
     userPrompt: "{{source.message}}",

--- a/frontend/src/views/AIAgents/Workflows/types/nodes.ts
+++ b/frontend/src/views/AIAgents/Workflows/types/nodes.ts
@@ -267,6 +267,7 @@ export interface BaseLLMNodeData extends BaseNodeData {
   fallbackChainId?: string;
   memory: boolean;
   piiMasking?: boolean;
+  promptCaching?: boolean;
   systemPrompt?: string;
   userPrompt?: string;
   type:

--- a/frontend/src/views/AIAgents/Workflows/utils/executionView.ts
+++ b/frontend/src/views/AIAgents/Workflows/utils/executionView.ts
@@ -90,42 +90,17 @@ const stripArchivedKeys = (map: Record<string, unknown>): Record<string, RawNode
   return result;
 };
 
-/**
- * Reason codes the backend emits when a requested split was withheld. An unmapped or absent
- * code leaves `reasonText` undefined, and the UI falls back to a plain "not applied".
- */
-const PROMPT_CACHING_REASON_TEXT: Record<string, string> = {
-  unsupported_mode: 'this agent type never splits its prompt',
-  volatile_prompt: 'the system prompt changes on every request',
-  mixed_fallback_chain: 'not every model in the fallback chain can cache',
-  unsupported_cache_markers: 'the provider or model does not accept explicit cache markers',
-  empty_prompt: 'there is no stable prompt to cache',
-};
-
 const normalizePromptCaching = (value: unknown): PromptCachingDiagnostic | undefined => {
   if (!isRecord(value)) return undefined;
   if (typeof value.requested !== 'boolean' || typeof value.applied !== 'boolean') return undefined;
-  const reason = asString(value.reason);
-  const reasonText = reason ? PROMPT_CACHING_REASON_TEXT[reason] : undefined;
   const cacheReadTokens = asNumber(value.cache_read_tokens);
   const cacheCreationTokens = asNumber(value.cache_creation_tokens);
   return {
     requested: value.requested,
     applied: value.applied,
-    ...(reasonText ? { reasonText } : {}),
     ...(cacheReadTokens !== undefined ? { cacheReadTokens } : {}),
     ...(cacheCreationTokens !== undefined ? { cacheCreationTokens } : {}),
   };
-};
-
-/** Fallback display names from the workflow graph, for nodes the run never executed. */
-const buildNameLookup = (workflow?: Workflow | null): Map<string, string> => {
-  const nameById = new Map<string, string>();
-  for (const node of workflow?.nodes ?? []) {
-    const data = node.data as { name?: string } | undefined;
-    if (node.id && data?.name) nameById.set(node.id, data.name);
-  }
-  return nameById;
 };
 
 const deriveDuration = (entry: RawNodeExecutionEntry): number | undefined => {
@@ -148,7 +123,11 @@ export const buildExecutionViewModel = (response: unknown, workflow?: Workflow |
   const entries = stripArchivedKeys(rawMap);
 
   // Fallback name lookup from the workflow structure (backend usually includes `name`).
-  const nameById = buildNameLookup(workflow);
+  const nameById = new Map<string, string>();
+  for (const node of workflow?.nodes ?? []) {
+    const data = node.data as { name?: string } | undefined;
+    if (node.id && data?.name) nameById.set(node.id, data.name);
+  }
 
   const rawDiagnostics = isRecord(bag.promptCachingDiagnostics) ? bag.promptCachingDiagnostics : {};
 
@@ -163,7 +142,7 @@ export const buildExecutionViewModel = (response: unknown, workflow?: Workflow |
     input: entry.input,
     output: entry.output,
     error: asString(entry.error) ?? null,
-    promptCaching: normalizePromptCaching(rawDiagnostics[nodeId]) ?? normalizePromptCaching(entry.prompt_caching),
+    promptCaching: normalizePromptCaching(rawDiagnostics[nodeId]),
   }));
 
   // Execution order by startTime (nodes without a startTime sort last, stable by id).
@@ -225,40 +204,6 @@ export const buildExecutionViewModel = (response: unknown, workflow?: Workflow |
     slowestNodeId,
     promptCachingDiagnostics,
   };
-};
-
-export interface PromptCachingWarning {
-  nodeId: string;
-  name: string;
-  reasonText?: string;
-}
-
-/**
- * Every node that asked for prompt caching and did not get it, from the nodes this run
- * executed and from the sub-agent diagnostics propagated in.
- */
-export const collectPromptCachingWarnings = (
-  response: unknown,
-  workflow?: Workflow | null
-): PromptCachingWarning[] => {
-  const model = buildExecutionViewModel(response, workflow);
-  const warnings: PromptCachingWarning[] = [];
-  const seen = new Set<string>();
-
-  for (const node of model.nodes) {
-    const diagnostic = node.promptCaching;
-    if (!diagnostic?.requested || diagnostic.applied) continue;
-    warnings.push({ nodeId: node.nodeId, name: node.name, reasonText: diagnostic.reasonText });
-    seen.add(node.nodeId);
-  }
-
-  const nameById = buildNameLookup(workflow);
-  for (const [nodeId, diagnostic] of Object.entries(model.promptCachingDiagnostics)) {
-    if (seen.has(nodeId) || !diagnostic.requested || diagnostic.applied) continue;
-    warnings.push({ nodeId, name: nameById.get(nodeId) ?? nodeId, reasonText: diagnostic.reasonText });
-  }
-
-  return warnings;
 };
 
 /**

--- a/frontend/src/views/AIAgents/Workflows/utils/executionView.ts
+++ b/frontend/src/views/AIAgents/Workflows/utils/executionView.ts
@@ -3,6 +3,7 @@ import {
   ExecutionViewModel,
   ExecutionViewState,
   NodeExecutionView,
+  PromptCachingDiagnostic,
   RawNodeExecutionEntry,
 } from '@/interfaces/workflow-execution.interface';
 import { Workflow } from '@/interfaces/workflow.interface';
@@ -67,21 +68,64 @@ const resolveStateBag = (response: unknown): Record<string, unknown> => {
 };
 
 /**
- * Collapse archived re-run keys (`"{id}_N"`) to the latest entry. A key is treated as archived
- * only when it ends in `_<digit>+` AND its base id also exists as a key — this avoids
- * misclassifying legitimate ids like `r2_destmissing` or a lone `step_0`.
+ * A key is an archived earlier run only when it ends in `_<digit>+` AND its base id also
+ * exists in the same map — this avoids misclassifying legitimate ids like `r2_destmissing`
+ * or a lone `step_0`.
  */
+const isArchivedKey = (key: string, keys: Set<string>): boolean => {
+  const match = key.match(/^(.+)_(\d+)$/);
+  return Boolean(match && keys.has(match[1]));
+};
+
+/** Collapse archived re-run keys (`"{id}_N"`) to the latest entry. */
 const stripArchivedKeys = (map: Record<string, unknown>): Record<string, RawNodeExecutionEntry> => {
   const keys = Object.keys(map);
   const keySet = new Set(keys);
   const result: Record<string, RawNodeExecutionEntry> = {};
   for (const key of keys) {
-    const match = key.match(/^(.+)_(\d+)$/);
-    if (match && keySet.has(match[1])) continue; // archived earlier run of match[1]
+    if (isArchivedKey(key, keySet)) continue;
     const entry = map[key];
     result[key] = isRecord(entry) ? (entry as RawNodeExecutionEntry) : {};
   }
   return result;
+};
+
+/**
+ * Reason codes the backend emits when a requested split was withheld. An unmapped or absent
+ * code leaves `reasonText` undefined, and the UI falls back to a plain "not applied".
+ */
+const PROMPT_CACHING_REASON_TEXT: Record<string, string> = {
+  unsupported_mode: 'this agent type never splits its prompt',
+  volatile_prompt: 'the system prompt changes on every request',
+  mixed_fallback_chain: 'not every model in the fallback chain can cache',
+  unsupported_cache_markers: 'the provider or model does not accept explicit cache markers',
+  empty_prompt: 'there is no stable prompt to cache',
+};
+
+const normalizePromptCaching = (value: unknown): PromptCachingDiagnostic | undefined => {
+  if (!isRecord(value)) return undefined;
+  if (typeof value.requested !== 'boolean' || typeof value.applied !== 'boolean') return undefined;
+  const reason = asString(value.reason);
+  const reasonText = reason ? PROMPT_CACHING_REASON_TEXT[reason] : undefined;
+  const cacheReadTokens = asNumber(value.cache_read_tokens);
+  const cacheCreationTokens = asNumber(value.cache_creation_tokens);
+  return {
+    requested: value.requested,
+    applied: value.applied,
+    ...(reasonText ? { reasonText } : {}),
+    ...(cacheReadTokens !== undefined ? { cacheReadTokens } : {}),
+    ...(cacheCreationTokens !== undefined ? { cacheCreationTokens } : {}),
+  };
+};
+
+/** Fallback display names from the workflow graph, for nodes the run never executed. */
+const buildNameLookup = (workflow?: Workflow | null): Map<string, string> => {
+  const nameById = new Map<string, string>();
+  for (const node of workflow?.nodes ?? []) {
+    const data = node.data as { name?: string } | undefined;
+    if (node.id && data?.name) nameById.set(node.id, data.name);
+  }
+  return nameById;
 };
 
 const deriveDuration = (entry: RawNodeExecutionEntry): number | undefined => {
@@ -104,11 +148,9 @@ export const buildExecutionViewModel = (response: unknown, workflow?: Workflow |
   const entries = stripArchivedKeys(rawMap);
 
   // Fallback name lookup from the workflow structure (backend usually includes `name`).
-  const nameById = new Map<string, string>();
-  for (const node of workflow?.nodes ?? []) {
-    const data = node.data as { name?: string } | undefined;
-    if (node.id && data?.name) nameById.set(node.id, data.name);
-  }
+  const nameById = buildNameLookup(workflow);
+
+  const rawDiagnostics = isRecord(bag.promptCachingDiagnostics) ? bag.promptCachingDiagnostics : {};
 
   const nodes: NodeExecutionView[] = Object.entries(entries).map(([nodeId, entry]) => ({
     nodeId,
@@ -121,6 +163,7 @@ export const buildExecutionViewModel = (response: unknown, workflow?: Workflow |
     input: entry.input,
     output: entry.output,
     error: asString(entry.error) ?? null,
+    promptCaching: normalizePromptCaching(rawDiagnostics[nodeId]) ?? normalizePromptCaching(entry.prompt_caching),
   }));
 
   // Execution order by startTime (nodes without a startTime sort last, stable by id).
@@ -145,6 +188,13 @@ export const buildExecutionViewModel = (response: unknown, workflow?: Workflow |
       slowestDuration = node.durationMs;
       slowestNodeId = node.nodeId;
     }
+  }
+
+  // Diagnostics ride their own key, so no node count or status derives from them.
+  const promptCachingDiagnostics: Record<string, PromptCachingDiagnostic> = {};
+  for (const [nodeId, raw] of Object.entries(rawDiagnostics)) {
+    const diagnostic = normalizePromptCaching(raw);
+    if (diagnostic) promptCachingDiagnostics[nodeId] = diagnostic;
   }
 
   const executionStartTime = asNumber(bag.execution_start_time);
@@ -173,7 +223,42 @@ export const buildExecutionViewModel = (response: unknown, workflow?: Workflow |
     executionEndTime,
     overallDurationMs,
     slowestNodeId,
+    promptCachingDiagnostics,
   };
+};
+
+export interface PromptCachingWarning {
+  nodeId: string;
+  name: string;
+  reasonText?: string;
+}
+
+/**
+ * Every node that asked for prompt caching and did not get it, from the nodes this run
+ * executed and from the sub-agent diagnostics propagated in.
+ */
+export const collectPromptCachingWarnings = (
+  response: unknown,
+  workflow?: Workflow | null
+): PromptCachingWarning[] => {
+  const model = buildExecutionViewModel(response, workflow);
+  const warnings: PromptCachingWarning[] = [];
+  const seen = new Set<string>();
+
+  for (const node of model.nodes) {
+    const diagnostic = node.promptCaching;
+    if (!diagnostic?.requested || diagnostic.applied) continue;
+    warnings.push({ nodeId: node.nodeId, name: node.name, reasonText: diagnostic.reasonText });
+    seen.add(node.nodeId);
+  }
+
+  const nameById = buildNameLookup(workflow);
+  for (const [nodeId, diagnostic] of Object.entries(model.promptCachingDiagnostics)) {
+    if (seen.has(nodeId) || !diagnostic.requested || diagnostic.applied) continue;
+    warnings.push({ nodeId, name: nameById.get(nodeId) ?? nodeId, reasonText: diagnostic.reasonText });
+  }
+
+  return warnings;
 };
 
 /**

--- a/frontend/src/views/AIAgents/Workflows/utils/promptCachingHint.ts
+++ b/frontend/src/views/AIAgents/Workflows/utils/promptCachingHint.ts
@@ -1,0 +1,98 @@
+/** A builder-time note under the prompt-caching switch, with the tone it should be shown in */
+export interface PromptCachingHint {
+  text: string;
+  tone: "info" | "warning";
+}
+
+/** The provider fields the hint consults; a full LLMProvider satisfies it. */
+export interface PromptCachingHintProvider {
+  llm_model_provider?: string;
+  prompt_caching_mode?: string;
+}
+
+type CachingMode = "explicit" | "automatic" | "none";
+
+const AUTOMATIC_HINT: PromptCachingHint = {
+  text: "Recent models on this provider cache long prompts automatically, so this setting has no effect.",
+  tone: "info",
+};
+
+const UNSUPPORTED_PROVIDER_HINT: PromptCachingHint = {
+  text: "This provider does not support prompt caching, so the setting has no effect.",
+  tone: "warning",
+};
+
+const UNSUPPORTED_MODEL_HINT: PromptCachingHint = {
+  text: "This model does not support prompt caching, so the setting has no effect.",
+  tone: "warning",
+};
+
+const MIXED_CHAIN_HINT: PromptCachingHint = {
+  text: "Not every model in the fallback chain can cache, so nothing is cached.",
+  tone: "warning",
+};
+
+/**
+ * Every provider the chain references excep the primary, 
+ * resolved from the COMPLETE provider list, the runtime does not skip a
+ * provider an existing chain references merely because it is inactive.
+ */
+export function fallbackChainProviders<T extends { id: string }>(
+  allProviders: T[],
+  primaryProviderId: string | undefined,
+  chain: { provider_ids: string[] } | null | undefined,
+): T[] {
+  return (chain?.provider_ids ?? [])
+    .filter((id) => id !== primaryProviderId)
+    .map((id) => allProviders.find((p) => p.id === id))
+    .filter((p): p is T => p !== undefined);
+}
+
+const resolveMode = (provider: PromptCachingHintProvider | undefined): CachingMode | undefined => {
+  const mode = provider?.prompt_caching_mode;
+  if (mode === "explicit" || mode === "automatic" || mode === "none") return mode;
+  // The backend serves prompt_caching_mode on every provider read and owns the
+  // classification (it is model-conditional for Bedrock)
+  return undefined;
+};
+
+/**
+ * Builder-time note for a node that asked for prompt caching but will not get it.
+ */
+export function promptCachingHint(
+  promptCaching: unknown,
+  provider: PromptCachingHintProvider | undefined,
+  nodeKind: "agent" | "model",
+  type: string | undefined,
+  fallbackProviders: Array<PromptCachingHintProvider | undefined> = [],
+): PromptCachingHint | null {
+  if (promptCaching !== true) return null;
+
+  // Providers the hint cannot classify (none selected, or deleted chain members the
+  // runtime would skip anyway) stay out of the verdict.
+  const classified = [provider, ...fallbackProviders]
+    .map((p) => ({ family: (p?.llm_model_provider ?? "").toLowerCase(), mode: resolveMode(p) }))
+    .filter((c): c is { family: string; mode: CachingMode } => c.mode !== undefined);
+
+  if (classified.length > 0) {
+    const modes = classified.map((c) => c.mode);
+    if (modes.every((mode) => mode === "automatic")) return AUTOMATIC_HINT;
+    if (!modes.every((mode) => mode === "explicit")) {
+      if (classified.length > 1) return MIXED_CHAIN_HINT;
+      return classified[0].family === "bedrock" ? UNSUPPORTED_MODEL_HINT : UNSUPPORTED_PROVIDER_HINT;
+    }
+  }
+
+  const nonSplitting =
+    nodeKind === "model"
+      ? ["Chain-of-Thought"]
+      : ["ReActAgent", "SimpleToolExecutor"];
+  if (type && nonSplitting.includes(type)) {
+    return {
+      text: `${type} does not split its system prompt, so nothing is cached.`,
+      tone: "warning",
+    };
+  }
+
+  return null;
+}

--- a/frontend/tests/views/AIAgents/Workflows/utils/executionView.test.ts
+++ b/frontend/tests/views/AIAgents/Workflows/utils/executionView.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { buildExecutionViewModel, deriveExecutionViewState, formatDuration } from '@/views/AIAgents/Workflows/utils/executionView';
+import {
+  buildExecutionViewModel,
+  collectPromptCachingWarnings,
+  deriveExecutionViewState,
+  formatDuration,
+} from '@/views/AIAgents/Workflows/utils/executionView';
 
 // A representative nested response mirroring the real backend wire format
 // (`response.state.nodeExecutionStatus`, snake_case run-level fields).
@@ -153,5 +158,196 @@ describe('formatDuration', () => {
     expect(formatDuration(123_000)).toBe('2 m 03 s');
     expect(formatDuration(undefined)).toBe('—');
     expect(formatDuration(-5)).toBe('—');
+  });
+});
+
+const WITHHELD = { requested: true, applied: false, reason: 'unsupported_mode' };
+const APPLIED = { requested: true, applied: true, reason: null };
+
+const workflowWith = (nodes: Array<{ id: string; name: string }>) =>
+  ({
+    name: 'wf',
+    nodes: nodes.map((n) => ({ id: n.id, type: 'x', position: { x: 0, y: 0 }, data: { name: n.name } })),
+    edges: [],
+  }) as unknown as Parameters<typeof buildExecutionViewModel>[1];
+
+const responseWith = (state: Record<string, unknown>) => ({ status: 'success', state });
+
+describe('buildExecutionViewModel — prompt caching', () => {
+  it('normalizes a per-entry diagnostic and maps its reason to display text', () => {
+    const m = buildExecutionViewModel(
+      responseWith({ nodeExecutionStatus: { llm: { status: 'success', prompt_caching: WITHHELD } } })
+    );
+    expect(m.byId.llm.promptCaching).toEqual({
+      requested: true,
+      applied: false,
+      reasonText: 'this agent type never splits its prompt',
+    });
+  });
+
+  it('leaves reasonText off for an applied diagnostic and for an unknown code', () => {
+    const m = buildExecutionViewModel(
+      responseWith({
+        nodeExecutionStatus: {
+          a: { status: 'success', prompt_caching: APPLIED },
+          b: { status: 'success', prompt_caching: { requested: true, applied: false, reason: 'from_the_future' } },
+        },
+      })
+    );
+    expect(m.byId.a.promptCaching).toEqual({ requested: true, applied: true });
+    expect(m.byId.b.promptCaching).toEqual({ requested: true, applied: false });
+  });
+
+  it('drops malformed diagnostics rather than half-rendering them', () => {
+    const m = buildExecutionViewModel(
+      responseWith({
+        nodeExecutionStatus: {
+          a: { status: 'success', prompt_caching: 'yes' },
+          b: { status: 'success', prompt_caching: { requested: 'true', applied: false } },
+          c: { status: 'success' },
+        },
+      })
+    );
+    expect(m.byId.a.promptCaching).toBeUndefined();
+    expect(m.byId.b.promptCaching).toBeUndefined();
+    expect(m.byId.c.promptCaching).toBeUndefined();
+  });
+
+  it('exposes standalone sub-agent diagnostics without touching counts', () => {
+    const withDiagnostics = buildExecutionViewModel(
+      responseWith({
+        nodeExecutionStatus: { llm: { status: 'success', startTime: 1, endTime: 2 } },
+        promptCachingDiagnostics: { child: WITHHELD, grandchild: APPLIED },
+      })
+    );
+    const plain = buildExecutionViewModel(
+      responseWith({ nodeExecutionStatus: { llm: { status: 'success', startTime: 1, endTime: 2 } } })
+    );
+
+    expect(Object.keys(withDiagnostics.promptCachingDiagnostics).sort()).toEqual(['child', 'grandchild']);
+    expect(withDiagnostics.totalNodes).toBe(plain.totalNodes);
+    expect(withDiagnostics.counts).toEqual(plain.counts);
+    expect(Object.keys(withDiagnostics.byId)).toEqual(['llm']);
+  });
+
+  it('keeps every key — the backend never archives entries in this map', () => {
+    const m = buildExecutionViewModel(
+      responseWith({ nodeExecutionStatus: {}, promptCachingDiagnostics: { step: WITHHELD, step_2: APPLIED } })
+    );
+    expect(Object.keys(m.promptCachingDiagnostics).sort()).toEqual(['step', 'step_2']);
+  });
+
+  it('yields an empty collection for a malformed or absent bag', () => {
+    for (const bad of [undefined, {}, responseWith({ promptCachingDiagnostics: 'x' })]) {
+      expect(buildExecutionViewModel(bad as unknown).promptCachingDiagnostics).toEqual({});
+    }
+  });
+
+  it('attaches a diagnostic from the standalone collection to its executed node', () => {
+    const m = buildExecutionViewModel(
+      responseWith({
+        nodeExecutionStatus: { llm: { status: 'success' } },
+        promptCachingDiagnostics: { llm: WITHHELD },
+      })
+    );
+    expect(m.byId.llm.promptCaching).toEqual({
+      requested: true,
+      applied: false,
+      reasonText: 'this agent type never splits its prompt',
+    });
+  });
+
+  it('prefers the collection over a legacy per-entry annotation', () => {
+    const m = buildExecutionViewModel(
+      responseWith({
+        nodeExecutionStatus: { llm: { status: 'success', prompt_caching: WITHHELD } },
+        promptCachingDiagnostics: { llm: APPLIED },
+      })
+    );
+    expect(m.byId.llm.promptCaching?.applied).toBe(true);
+  });
+
+  it('normalizes observed cache activity and drops non-numeric values', () => {
+    const m = buildExecutionViewModel(
+      responseWith({
+        nodeExecutionStatus: { a: { status: 'success' }, b: { status: 'success' } },
+        promptCachingDiagnostics: {
+          a: { ...APPLIED, cache_read_tokens: 950, cache_creation_tokens: 0 },
+          b: { ...APPLIED, cache_read_tokens: 'lots' },
+        },
+      })
+    );
+    expect(m.byId.a.promptCaching).toEqual({
+      requested: true,
+      applied: true,
+      cacheReadTokens: 950,
+      cacheCreationTokens: 0,
+    });
+    expect(m.byId.b.promptCaching).toEqual({ requested: true, applied: true });
+  });
+});
+
+describe('collectPromptCachingWarnings', () => {
+  it('reports a node that asked for caching and did not get it', () => {
+    const warnings = collectPromptCachingWarnings(
+      responseWith({ nodeExecutionStatus: { llm: { name: 'LLM', status: 'success', prompt_caching: WITHHELD } } })
+    );
+    expect(warnings).toEqual([
+      { nodeId: 'llm', name: 'LLM', reasonText: 'this agent type never splits its prompt' },
+    ]);
+  });
+
+  it('excludes applied nodes and nodes that never asked', () => {
+    const warnings = collectPromptCachingWarnings(
+      responseWith({
+        nodeExecutionStatus: {
+          a: { status: 'success', prompt_caching: APPLIED },
+          b: { status: 'success' },
+        },
+      })
+    );
+    expect(warnings).toEqual([]);
+  });
+
+  it('combines entry annotations with standalone sub-agent diagnostics', () => {
+    const warnings = collectPromptCachingWarnings(
+      responseWith({
+        nodeExecutionStatus: { llm: { name: 'LLM', status: 'success', prompt_caching: WITHHELD } },
+        promptCachingDiagnostics: {
+          child: { requested: true, applied: false, reason: 'volatile_prompt' },
+          fine: APPLIED,
+        },
+      }),
+      workflowWith([{ id: 'child', name: 'Research Sub-Agent' }])
+    );
+    expect(warnings.map((w) => w.nodeId)).toEqual(['llm', 'child']);
+    expect(warnings[1]).toEqual({
+      nodeId: 'child',
+      name: 'Research Sub-Agent',
+      reasonText: 'the system prompt changes on every request',
+    });
+  });
+
+  it('never lists the same node twice when both sources carry it', () => {
+    const warnings = collectPromptCachingWarnings(
+      responseWith({
+        nodeExecutionStatus: { child: { name: 'Child', status: 'success', prompt_caching: WITHHELD } },
+        promptCachingDiagnostics: { child: WITHHELD },
+      })
+    );
+    expect(warnings).toHaveLength(1);
+  });
+
+  it('falls back to the node id when no name is available', () => {
+    const warnings = collectPromptCachingWarnings(
+      responseWith({ nodeExecutionStatus: {}, promptCachingDiagnostics: { child: WITHHELD } })
+    );
+    expect(warnings[0].name).toBe('child');
+  });
+
+  it('returns an empty list for missing or malformed input (never throws)', () => {
+    for (const bad of [undefined, null, {}, 42, 'nope', { state: { nodeExecutionStatus: 'x' } }]) {
+      expect(collectPromptCachingWarnings(bad as unknown)).toEqual([]);
+    }
   });
 });

--- a/frontend/tests/views/AIAgents/Workflows/utils/executionView.test.ts
+++ b/frontend/tests/views/AIAgents/Workflows/utils/executionView.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildExecutionViewModel,
-  collectPromptCachingWarnings,
   deriveExecutionViewState,
   formatDuration,
 } from '@/views/AIAgents/Workflows/utils/executionView';
@@ -161,51 +160,17 @@ describe('formatDuration', () => {
   });
 });
 
-const WITHHELD = { requested: true, applied: false, reason: 'unsupported_mode' };
-const APPLIED = { requested: true, applied: true, reason: null };
-
-const workflowWith = (nodes: Array<{ id: string; name: string }>) =>
-  ({
-    name: 'wf',
-    nodes: nodes.map((n) => ({ id: n.id, type: 'x', position: { x: 0, y: 0 }, data: { name: n.name } })),
-    edges: [],
-  }) as unknown as Parameters<typeof buildExecutionViewModel>[1];
+const WITHHELD = { requested: true, applied: false };
+const APPLIED = { requested: true, applied: true };
 
 const responseWith = (state: Record<string, unknown>) => ({ status: 'success', state });
 
 describe('buildExecutionViewModel — prompt caching', () => {
-  it('normalizes a per-entry diagnostic and maps its reason to display text', () => {
-    const m = buildExecutionViewModel(
-      responseWith({ nodeExecutionStatus: { llm: { status: 'success', prompt_caching: WITHHELD } } })
-    );
-    expect(m.byId.llm.promptCaching).toEqual({
-      requested: true,
-      applied: false,
-      reasonText: 'this agent type never splits its prompt',
-    });
-  });
-
-  it('leaves reasonText off for an applied diagnostic and for an unknown code', () => {
-    const m = buildExecutionViewModel(
-      responseWith({
-        nodeExecutionStatus: {
-          a: { status: 'success', prompt_caching: APPLIED },
-          b: { status: 'success', prompt_caching: { requested: true, applied: false, reason: 'from_the_future' } },
-        },
-      })
-    );
-    expect(m.byId.a.promptCaching).toEqual({ requested: true, applied: true });
-    expect(m.byId.b.promptCaching).toEqual({ requested: true, applied: false });
-  });
-
   it('drops malformed diagnostics rather than half-rendering them', () => {
     const m = buildExecutionViewModel(
       responseWith({
-        nodeExecutionStatus: {
-          a: { status: 'success', prompt_caching: 'yes' },
-          b: { status: 'success', prompt_caching: { requested: 'true', applied: false } },
-          c: { status: 'success' },
-        },
+        nodeExecutionStatus: { a: { status: 'success' }, b: { status: 'success' }, c: { status: 'success' } },
+        promptCachingDiagnostics: { a: 'yes', b: { requested: 'true', applied: false } },
       })
     );
     expect(m.byId.a.promptCaching).toBeUndefined();
@@ -250,21 +215,7 @@ describe('buildExecutionViewModel — prompt caching', () => {
         promptCachingDiagnostics: { llm: WITHHELD },
       })
     );
-    expect(m.byId.llm.promptCaching).toEqual({
-      requested: true,
-      applied: false,
-      reasonText: 'this agent type never splits its prompt',
-    });
-  });
-
-  it('prefers the collection over a legacy per-entry annotation', () => {
-    const m = buildExecutionViewModel(
-      responseWith({
-        nodeExecutionStatus: { llm: { status: 'success', prompt_caching: WITHHELD } },
-        promptCachingDiagnostics: { llm: APPLIED },
-      })
-    );
-    expect(m.byId.llm.promptCaching?.applied).toBe(true);
+    expect(m.byId.llm.promptCaching).toEqual({ requested: true, applied: false });
   });
 
   it('normalizes observed cache activity and drops non-numeric values', () => {
@@ -284,70 +235,5 @@ describe('buildExecutionViewModel — prompt caching', () => {
       cacheCreationTokens: 0,
     });
     expect(m.byId.b.promptCaching).toEqual({ requested: true, applied: true });
-  });
-});
-
-describe('collectPromptCachingWarnings', () => {
-  it('reports a node that asked for caching and did not get it', () => {
-    const warnings = collectPromptCachingWarnings(
-      responseWith({ nodeExecutionStatus: { llm: { name: 'LLM', status: 'success', prompt_caching: WITHHELD } } })
-    );
-    expect(warnings).toEqual([
-      { nodeId: 'llm', name: 'LLM', reasonText: 'this agent type never splits its prompt' },
-    ]);
-  });
-
-  it('excludes applied nodes and nodes that never asked', () => {
-    const warnings = collectPromptCachingWarnings(
-      responseWith({
-        nodeExecutionStatus: {
-          a: { status: 'success', prompt_caching: APPLIED },
-          b: { status: 'success' },
-        },
-      })
-    );
-    expect(warnings).toEqual([]);
-  });
-
-  it('combines entry annotations with standalone sub-agent diagnostics', () => {
-    const warnings = collectPromptCachingWarnings(
-      responseWith({
-        nodeExecutionStatus: { llm: { name: 'LLM', status: 'success', prompt_caching: WITHHELD } },
-        promptCachingDiagnostics: {
-          child: { requested: true, applied: false, reason: 'volatile_prompt' },
-          fine: APPLIED,
-        },
-      }),
-      workflowWith([{ id: 'child', name: 'Research Sub-Agent' }])
-    );
-    expect(warnings.map((w) => w.nodeId)).toEqual(['llm', 'child']);
-    expect(warnings[1]).toEqual({
-      nodeId: 'child',
-      name: 'Research Sub-Agent',
-      reasonText: 'the system prompt changes on every request',
-    });
-  });
-
-  it('never lists the same node twice when both sources carry it', () => {
-    const warnings = collectPromptCachingWarnings(
-      responseWith({
-        nodeExecutionStatus: { child: { name: 'Child', status: 'success', prompt_caching: WITHHELD } },
-        promptCachingDiagnostics: { child: WITHHELD },
-      })
-    );
-    expect(warnings).toHaveLength(1);
-  });
-
-  it('falls back to the node id when no name is available', () => {
-    const warnings = collectPromptCachingWarnings(
-      responseWith({ nodeExecutionStatus: {}, promptCachingDiagnostics: { child: WITHHELD } })
-    );
-    expect(warnings[0].name).toBe('child');
-  });
-
-  it('returns an empty list for missing or malformed input (never throws)', () => {
-    for (const bad of [undefined, null, {}, 42, 'nope', { state: { nodeExecutionStatus: 'x' } }]) {
-      expect(collectPromptCachingWarnings(bad as unknown)).toEqual([]);
-    }
   });
 });

--- a/frontend/tests/views/AIAgents/Workflows/utils/promptCachingHint.test.ts
+++ b/frontend/tests/views/AIAgents/Workflows/utils/promptCachingHint.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import { fallbackChainProviders, promptCachingHint } from "@/views/AIAgents/Workflows/utils/promptCachingHint";
+
+const anthropic = { llm_model_provider: "anthropic" };
+const openai = { llm_model_provider: "OpenAI" };
+const cohere = { llm_model_provider: "cohere" };
+const automaticFamilies = ["OpenAI", "azure_openai", "google_genai", "google_vertexai"];
+
+describe("promptCachingHint", () => {
+  it("stays silent while the toggle is off", () => {
+    expect(promptCachingHint(false, openai, "agent", "ReActAgent")).toBeNull();
+    expect(promptCachingHint(undefined, openai, "agent", "ReActAgent")).toBeNull();
+  });
+
+  it("treats truthy non-boolean values as off, like the backend does", () => {
+    expect(promptCachingHint("true", openai, "model", "Base")).toBeNull();
+    expect(promptCachingHint(1, openai, "model", "Base")).toBeNull();
+  });
+
+  it("warns about a provider that reports no caching support", () => {
+    const served = { llm_model_provider: "cohere", prompt_caching_mode: "none" as const };
+    expect(promptCachingHint(true, served, "model", "Base")).toEqual({
+      text: "This provider does not support prompt caching, so the setting has no effect.",
+      tone: "warning",
+    });
+  });
+
+  it("tells a provider that caches on its own the setting is moot, never that caching is unavailable", () => {
+    for (const family of automaticFamilies) {
+      const served = { llm_model_provider: family, prompt_caching_mode: "automatic" as const };
+      const hint = promptCachingHint(true, served, "model", "Base");
+      expect(hint?.tone).toBe("info");
+      expect(hint?.text).toMatch(/cache long prompts automatically/);
+      expect(hint?.text).not.toMatch(/does not support|cannot cache|no caching/i);
+    }
+  });
+
+  it("passes served explicit providers through", () => {
+    const anthropicExplicit = { llm_model_provider: "anthropic", prompt_caching_mode: "explicit" as const };
+    const bedrockExplicit = { llm_model_provider: "bedrock", prompt_caching_mode: "explicit" as const };
+    expect(promptCachingHint(true, anthropicExplicit, "model", "Base")).toBeNull();
+    expect(promptCachingHint(true, bedrockExplicit, "model", "Base")).toBeNull();
+  });
+
+  it("says nothing when no provider is selected yet", () => {
+    expect(promptCachingHint(true, undefined, "model", "Base")).toBeNull();
+    expect(promptCachingHint(true, {}, "model", "Base")).toBeNull();
+  });
+
+  it("warns about agent types that never split the prompt", () => {
+    expect(promptCachingHint(true, anthropic, "agent", "ReActAgent")).toEqual({
+      text: "ReActAgent does not split its system prompt, so nothing is cached.",
+      tone: "warning",
+    });
+    expect(promptCachingHint(true, anthropic, "agent", "SimpleToolExecutor")?.text).toMatch(/does not split/);
+    expect(promptCachingHint(true, anthropic, "agent", "ToolSelector")).toBeNull();
+    expect(promptCachingHint(true, anthropic, "agent", "ReActAgentLC")).toBeNull();
+  });
+
+  it("warns about Chain-of-Thought on the model node only", () => {
+    expect(promptCachingHint(true, anthropic, "model", "Chain-of-Thought")?.text).toMatch(/does not split/);
+    expect(promptCachingHint(true, anthropic, "agent", "Chain-of-Thought")).toBeNull();
+  });
+
+  it("reports the provider first when both apply", () => {
+    const noneCohere = { llm_model_provider: "cohere", prompt_caching_mode: "none" as const };
+    const autoOpenai = { llm_model_provider: "OpenAI", prompt_caching_mode: "automatic" as const };
+    expect(promptCachingHint(true, noneCohere, "agent", "ReActAgent")?.text).toMatch(/does not support prompt caching/);
+    expect(promptCachingHint(true, autoOpenai, "agent", "ReActAgent")?.tone).toBe("info");
+  });
+
+  describe("backend-served prompt_caching_mode", () => {
+    it("warns about the model, not the provider, on a non-cacheable Bedrock model", () => {
+      const provider = { llm_model_provider: "bedrock", prompt_caching_mode: "none" as const };
+      expect(promptCachingHint(true, provider, "model", "Base")).toEqual({
+        text: "This model does not support prompt caching, so the setting has no effect.",
+        tone: "warning",
+      });
+    });
+
+    it("warns about the provider when a non-Bedrock family reports none", () => {
+      const provider = { llm_model_provider: "cohere", prompt_caching_mode: "none" as const };
+      expect(promptCachingHint(true, provider, "model", "Base")?.text).toMatch(/provider does not support/);
+    });
+
+    it("trusts the served mode for any family", () => {
+      const provider = { llm_model_provider: "cohere", prompt_caching_mode: "automatic" as const };
+      expect(promptCachingHint(true, provider, "model", "Base")?.tone).toBe("info");
+    });
+
+    it("an explicit mode still runs the agent-type check", () => {
+      const provider = { llm_model_provider: "bedrock", prompt_caching_mode: "explicit" as const };
+      expect(promptCachingHint(true, provider, "agent", "ToolSelector")).toBeNull();
+      expect(promptCachingHint(true, provider, "agent", "ReActAgent")?.text).toMatch(/does not split/);
+    });
+
+    it("stays silent when the field is absent — no client-side family fallback", () => {
+      expect(promptCachingHint(true, { llm_model_provider: "bedrock" }, "model", "Base")).toBeNull();
+      expect(promptCachingHint(true, cohere, "model", "Base")).toBeNull();
+      expect(
+        promptCachingHint(true, { llm_model_provider: "bedrock", prompt_caching_mode: "none" }, "model", "Base")
+      ).toEqual({
+        text: "This model does not support prompt caching, so the setting has no effect.",
+        tone: "warning",
+      });
+    });
+  });
+
+  describe("fallback chains", () => {
+    const explicit = { llm_model_provider: "anthropic", prompt_caching_mode: "explicit" as const };
+    const bedrockNone = { llm_model_provider: "bedrock", prompt_caching_mode: "none" as const };
+    const automatic = { llm_model_provider: "OpenAI", prompt_caching_mode: "automatic" as const };
+    const none = { llm_model_provider: "cohere", prompt_caching_mode: "none" as const };
+
+    it("warns when a capable primary carries an unsupported fallback", () => {
+      expect(promptCachingHint(true, explicit, "model", "Base", [none])).toEqual({
+        text: "Not every model in the fallback chain can cache, so nothing is cached.",
+        tone: "warning",
+      });
+    });
+
+    it("names the chain, not the model, when the primary is the unsupported one", () => {
+      const hint = promptCachingHint(true, bedrockNone, "model", "Base", [explicit]);
+      expect(hint?.text).toMatch(/fallback chain/);
+      expect(hint?.text).not.toMatch(/This model/);
+    });
+
+    it("an all-capable chain stays silent and still runs the agent-type check", () => {
+      expect(promptCachingHint(true, explicit, "agent", "ToolSelector", [explicit])).toBeNull();
+      expect(promptCachingHint(true, explicit, "agent", "ReActAgent", [explicit])?.text).toMatch(/does not split/);
+    });
+
+    it("an all-automatic chain gets the informational hint, never a warning", () => {
+      expect(promptCachingHint(true, automatic, "model", "Base", [openai])?.tone).toBe("info");
+    });
+
+    it("mixed automatic and unsupported members warn about the chain", () => {
+      expect(promptCachingHint(true, automatic, "model", "Base", [none])?.text).toMatch(/fallback chain/);
+    });
+
+    it("unclassifiable chain members are ignored, like the runtime skipping unbuildable providers", () => {
+      expect(promptCachingHint(true, explicit, "model", "Base", [undefined, {}, cohere])).toBeNull();
+    });
+  });
+
+  describe("fallbackChainProviders", () => {
+    const primary = { id: "p1", llm_model_provider: "anthropic", prompt_caching_mode: "explicit" as const, is_active: 1 };
+    const inactiveCohere = { id: "p2", llm_model_provider: "cohere", prompt_caching_mode: "none" as const, is_active: 0 };
+    const all = [primary, inactiveCohere];
+    const chain = { provider_ids: ["p1", "p2"] };
+
+    it("resolves inactive members — the runtime still builds them", () => {
+      expect(fallbackChainProviders(all, "p1", chain)).toEqual([inactiveCohere]);
+    });
+
+    it("an inactive unsupported fallback still poisons the chain verdict", () => {
+      const hint = promptCachingHint(true, primary, "model", "Base", fallbackChainProviders(all, "p1", chain));
+      expect(hint?.text).toMatch(/fallback chain/);
+      expect(hint?.tone).toBe("warning");
+    });
+
+    it("excludes the primary and drops ids with no provider object", () => {
+      expect(fallbackChainProviders([primary], "p1", { provider_ids: ["p1", "ghost"] })).toEqual([]);
+    });
+
+    it("yields nothing without a selected chain", () => {
+      expect(fallbackChainProviders(all, "p1", undefined)).toEqual([]);
+      expect(fallbackChainProviders(all, "p1", null)).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds optional prompt caching to Agent, Sub-Agent and Language Model nodes. When enabled, the unchanging start of a node's system prompt is marked so Anthropic and cache-capable Bedrock models keep it and bill it at a reduced rate instead of re-reading it on every call. The switch is per node and off by default. A workflow that never turns it on behaves exactly as it did before. Only the stable system prefix is cached. The prompt is split at the boundary between operator-authored text and the volatile tail (timestamp, chat history), and a prompt containing `{{template variables}}` is never cached, because its rendered text differs per run.

## Type of Change


- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

- `PromptCachingChatModel` wraps a provider model and stamps the cache marker on an opted-in system prefix — `cache_control: {"type": "ephemeral"}` for Anthropic, a `{"cachePoint": ...}` block for Bedrock Converse. `bind_tools` re-wraps, so a tool loop keeps caching its prefix across turns.
- `build_cacheable_system_message` is the only sanctioned constructor for a cache-eligible system message; the wrapper refuses to mark anything that did not come through it.
- `llm_prompt_cache_capabilities.py` classifies which Bedrock models accept a cache marker. Bedrock fails the whole call on a marker an unsupported model does not accept, so unclassified ids silently run uncached.
- Fallback chains cache **only when every model in the chain is cache-capable** — a mixed chain sends the prompt exactly as it does today.
- Language Model node splits system prompt from chat history; Agent / Sub-Agent nodes split the operator prompt from the appended timestamp; `ToolAgent` moves its tool guidance out of the fused user turn into a cacheable system turn.
- Every split site decides from one shared gate (`cache_split_decision`) plus `model_has_prompt_caching`. Nothing re-derives the opt-in downstream.
- Builder-time hint under the switch when the selected provider/model/mode cannot cache.
- Per-run `promptCachingDiagnostics` (`requested` / `applied` + observed cache tokens), surfaced in the Execution tab detail panel. `applied` is always read back from the split that actually happened, so a node can never claim caching that did not occur.
- Sub-agent children propagate their diagnostics into the parent run.
- `ReActAgentLC` streaming path no longer appends a duplicate `SystemMessage` — `create_agent(system_prompt=...)` already injects it, so the streaming path was sending the system prompt twice.
- `FallbackChatModel` now threads a child callback config, so a delegated call nests under the caller's run instead of detaching from the trace.

## Testing


- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] Multi-tenant considerations addressed (if applicable)

## Related Issues


Closes #

## Screenshots (if applicable)



---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
