### PR TITLE
fix: restrict tenant config permissions to admin role only

### DIFF
--- a/backend/app/core/exceptions/error_messages.py
+++ b/backend/app/core/exceptions/error_messages.py
@@ -64,6 +64,7 @@ class ErrorKey(Enum):
     PERMISSION_ALREADY_EXISTS = "PERMISSION_ALREADY_EXISTS"
     ROLE_PERMISSION_NOT_FOUND = "ROLE_PERMISSION_NOT_FOUND"
     ROLE_NOT_ALLOWED = "ROLE_NOT_ALLOWED"
+    ADMIN_ONLY_PERMISSION = "ADMIN_ONLY_PERMISSION"
     CONVERSATION_NOT_FOUND = "CONVERSATION_NOT_FOUND"
     CONVERSATIONS_NOT_FOUND = "CONVERSATIONS_NOT_FOUND"
     CONVERSATION_FINALIZED = "CONVERSATION_FINALIZED"
@@ -242,6 +243,7 @@ ERROR_MESSAGES = {
         ErrorKey.PERMISSION_ALREADY_EXISTS: "Permission already exists.",
         ErrorKey.ROLE_PERMISSION_NOT_FOUND: "Role Permission not found.",
         ErrorKey.ROLE_NOT_ALLOWED: "You're not allowed to assign this role.",
+        ErrorKey.ADMIN_ONLY_PERMISSION: "This permission can only be assigned to the admin role.",
         ErrorKey.CONVERSATION_NOT_FOUND: "Conversation not found.",
         ErrorKey.CONVERSATION_FINALIZED: "Conversation already finalized.",
         ErrorKey.CONVERSATION_TAKEN_OVER: "Conversation already taken over.",

--- a/backend/app/core/permissions/constants.py
+++ b/backend/app/core/permissions/constants.py
@@ -294,6 +294,32 @@ class LegacyPermissions:
     WRITE_APP_SETTINGS = "write:app_settings"
 
 
+# Name of the built-in role that is allowed to hold admin-only permissions.
+ADMIN_ROLE_NAME = "admin"
+
+
+# Permissions that must never be granted to a non-admin role. These govern
+# tenant-wide configuration (File Manager provider, Security/data-residency
+# settings, and Feature Flags) and are reserved for the `admin` role only.
+ADMIN_ONLY_PERMISSIONS: set[str] = {
+    AppSettingsPermissions.CREATE,
+    AppSettingsPermissions.READ,
+    AppSettingsPermissions.WRITE,
+    AppSettingsPermissions.UPDATE,
+    AppSettingsPermissions.DELETE,
+    LegacyPermissions.WRITE_APP_SETTINGS,
+    FeatureFlagPermissions.CREATE,
+    FeatureFlagPermissions.READ,
+    FeatureFlagPermissions.UPDATE,
+    FeatureFlagPermissions.DELETE,
+}
+
+
+def is_admin_only_permission(permission_name: str) -> bool:
+    """Return True if the permission is reserved for the admin role."""
+    return permission_name in ADMIN_ONLY_PERMISSIONS
+
+
 def get_all_permission_constants() -> set[str]:
     """
     Get all permission string constants defined in this module.

--- a/backend/app/services/role_permissions.py
+++ b/backend/app/services/role_permissions.py
@@ -3,9 +3,12 @@ from injector import inject
 
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
+from app.core.permissions.constants import ADMIN_ROLE_NAME, is_admin_only_permission
 from app.schemas.role_permission import RolePermissionCreate, RolePermissionUpdate
 
+from app.repositories.permissions import PermissionsRepository
 from app.repositories.role_permissions import RolePermissionsRepository
+from app.repositories.roles import RolesRepository
 from uuid import UUID
 
 @inject
@@ -16,11 +19,33 @@ class RolePermissionsService:
 
     def __init__(
         self,
-        repository: RolePermissionsRepository
+        repository: RolePermissionsRepository,
+        roles_repository: RolesRepository,
+        permissions_repository: PermissionsRepository,
     ):
         self.repository = repository
+        self.roles_repository = roles_repository
+        self.permissions_repository = permissions_repository
+
+    async def _guard_admin_only_permission(self, role_id: UUID, permission_id: UUID):
+        """Reject assigning an admin-only permission to any non-admin role.
+
+        Configuration permissions (File Manager provider, Security settings,
+        Feature Flags) must stay reserved for the admin role.
+        """
+        if role_id is None or permission_id is None:
+            return
+
+        permission = await self.permissions_repository.get_by_id(permission_id)
+        if permission is None or not is_admin_only_permission(permission.name):
+            return
+
+        role = await self.roles_repository.get_by_id(role_id)
+        if role is None or role.name != ADMIN_ROLE_NAME:
+            raise AppException(ErrorKey.ADMIN_ONLY_PERMISSION, status_code=403)
 
     async def create(self, data: RolePermissionCreate):
+        await self._guard_admin_only_permission(data.role_id, data.permission_id)
         model = await self.repository.create(data)
         return model
 
@@ -35,6 +60,17 @@ class RolePermissionsService:
         return models
 
     async def update(self, rp_id: UUID, data: RolePermissionUpdate):
+        existing = await self.repository.get_by_id(rp_id)
+        if not existing:
+            raise AppException(ErrorKey.ROLE_PERMISSION_NOT_FOUND, status_code=404)
+
+        # Validate the resulting (role, permission) pair after applying the patch.
+        target_role_id = data.role_id if data.role_id is not None else existing.role_id
+        target_permission_id = (
+            data.permission_id if data.permission_id is not None else existing.permission_id
+        )
+        await self._guard_admin_only_permission(target_role_id, target_permission_id)
+
         updated = await self.repository.update(rp_id, data)
         if not updated:
             raise AppException(ErrorKey.ROLE_PERMISSION_NOT_FOUND, status_code=404)

--- a/backend/tests/unit/test_role_permission_admin_guard.py
+++ b/backend/tests/unit/test_role_permission_admin_guard.py
@@ -1,0 +1,90 @@
+"""Unit tests for the admin-only permission guard in RolePermissionsService.
+
+These tests mock the repositories, so no database or app bootstrap is needed.
+They verify that configuration permissions (app_settings / feature_flag) can
+only be assigned to the `admin` role.
+"""
+import asyncio
+import types
+from uuid import uuid4
+
+import pytest
+from unittest.mock import AsyncMock
+
+from app.core.exceptions.error_messages import ErrorKey
+from app.core.exceptions.exception_classes import AppException
+from app.schemas.role_permission import RolePermissionCreate, RolePermissionUpdate
+from app.services.role_permissions import RolePermissionsService
+
+
+def _make_service(role_name: str, permission_name: str):
+    repo = AsyncMock()
+    roles_repo = AsyncMock()
+    permissions_repo = AsyncMock()
+
+    roles_repo.get_by_id.return_value = types.SimpleNamespace(name=role_name)
+    permissions_repo.get_by_id.return_value = types.SimpleNamespace(name=permission_name)
+
+    # For the update path, the existing row carries a role/permission pair.
+    repo.get_by_id.return_value = types.SimpleNamespace(
+        role_id=uuid4(), permission_id=uuid4()
+    )
+    repo.create.return_value = "created"
+    repo.update.return_value = "updated"
+
+    service = RolePermissionsService(repo, roles_repo, permissions_repo)
+    return service, repo
+
+
+def test_admin_only_permission_blocked_for_non_admin_role():
+    service, repo = _make_service("supervisor", "read:feature_flag")
+    data = RolePermissionCreate(role_id=uuid4(), permission_id=uuid4())
+
+    with pytest.raises(AppException) as exc_info:
+        asyncio.run(service.create(data))
+
+    assert exc_info.value.error_key == ErrorKey.ADMIN_ONLY_PERMISSION
+    assert exc_info.value.status_code == 403
+    repo.create.assert_not_called()
+
+
+def test_app_settings_permission_blocked_for_non_admin_role():
+    service, repo = _make_service("operator", "update:app_settings")
+    data = RolePermissionCreate(role_id=uuid4(), permission_id=uuid4())
+
+    with pytest.raises(AppException) as exc_info:
+        asyncio.run(service.create(data))
+
+    assert exc_info.value.error_key == ErrorKey.ADMIN_ONLY_PERMISSION
+    repo.create.assert_not_called()
+
+
+def test_admin_only_permission_allowed_for_admin_role():
+    service, repo = _make_service("admin", "read:feature_flag")
+    data = RolePermissionCreate(role_id=uuid4(), permission_id=uuid4())
+
+    result = asyncio.run(service.create(data))
+
+    assert result == "created"
+    repo.create.assert_awaited_once()
+
+
+def test_non_admin_only_permission_allowed_for_non_admin_role():
+    service, repo = _make_service("supervisor", "read:operator")
+    data = RolePermissionCreate(role_id=uuid4(), permission_id=uuid4())
+
+    result = asyncio.run(service.create(data))
+
+    assert result == "created"
+    repo.create.assert_awaited_once()
+
+
+def test_update_to_admin_only_permission_blocked_for_non_admin_role():
+    service, repo = _make_service("supervisor", "delete:feature_flag")
+    data = RolePermissionUpdate(permission_id=uuid4())
+
+    with pytest.raises(AppException) as exc_info:
+        asyncio.run(service.update(uuid4(), data))
+
+    assert exc_info.value.error_key == ErrorKey.ADMIN_ONLY_PERMISSION
+    repo.update.assert_not_called()

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -308,3 +308,7 @@ export const probeApiHealth = async (): Promise<boolean> => {
  *  Note: Vite reads env at dev server start / build time; restart the dev server after changing .env. */
 export const isPollEnabled =
   (import.meta.env.VITE_USE_POLL ?? "true").toString().toLowerCase() === "true" && !isWsEnabled;
+
+/** Whether notification polling is enabled (VITE_NOTIFICATION_POLLING_ENABLED=true/false). Defaults to false when unset. */
+export const isNotificationPollingEnabled =
+  (import.meta.env.VITE_NOTIFICATION_POLLING_ENABLED ?? "false").toString().toLowerCase() === "true";

--- a/frontend/src/views/Settings/pages/Settings.tsx
+++ b/frontend/src/views/Settings/pages/Settings.tsx
@@ -53,8 +53,10 @@ const SettingsPage = () => {
       setSecuritySettings(settings);
     };
     fetchProfile();
-    fetchFileManagerSettings();
-    fetchSecuritySettings();
+    if (hasPermission('write:app_settings')) {
+      fetchFileManagerSettings();
+      fetchSecuritySettings();
+    }
   }, []);
 
   const profileSection = useMemo(() => {
@@ -98,8 +100,8 @@ const SettingsPage = () => {
           { key: 'feature-flags', label: 'Feature Flags', show: hasPermission('read:feature_flag') },
           { key: 'translations', label: 'Translations', show: hasPermission('read:app_setting') },
           { key: 'languages', label: 'Languages', show: hasPermission('read:app_setting') },
-          { key: 'file-manager', label: 'File Manager', show: true },
-          { key: 'security', label: 'Security', show: true },
+          { key: 'file-manager', label: 'File Manager', show: hasPermission('write:app_settings') },
+          { key: 'security', label: 'Security', show: hasPermission('write:app_settings') },
           { key: 'maintenance', label: 'Maintenance', show: hasPermission('write:app_settings') },
         ] as { key: TabKey; label: string; show: boolean }[]
       ).filter((t) => t.show),
@@ -179,26 +181,30 @@ const SettingsPage = () => {
               </TabsContent>
             )}
 
-            <TabsContent value="file-manager" className="mt-0">
-              {fileManagerEnabled && fileManagerSettings ? (
-                <FileManagerSettingsCard settings={fileManagerSettings} />
-              ) : (
-                <Card className="p-6 shadow-sm animate-fade-up bg-card dark:bg-zinc-900">
-                  <h2 className="text-base sm:text-lg font-semibold mb-2">File Manager Settings</h2>
-                  <p className="text-sm text-muted-foreground">
-                    File manager is not enabled or is disabled in the database. Please contact your
-                    administrator to enable it.
-                  </p>
-                </Card>
-              )}
-            </TabsContent>
+            {hasPermission('write:app_settings') && (
+              <TabsContent value="file-manager" className="mt-0">
+                {fileManagerEnabled && fileManagerSettings ? (
+                  <FileManagerSettingsCard settings={fileManagerSettings} />
+                ) : (
+                  <Card className="p-6 shadow-sm animate-fade-up bg-card dark:bg-zinc-900">
+                    <h2 className="text-base sm:text-lg font-semibold mb-2">File Manager Settings</h2>
+                    <p className="text-sm text-muted-foreground">
+                      File manager is not enabled or is disabled in the database. Please contact your
+                      administrator to enable it.
+                    </p>
+                  </Card>
+                )}
+              </TabsContent>
+            )}
 
-            <TabsContent value="security" className="mt-0">
-              <SecuritySettingsCard
-                settings={securitySettings}
-                onSaved={(updated) => setSecuritySettings(updated)}
-              />
-            </TabsContent>
+            {hasPermission('write:app_settings') && (
+              <TabsContent value="security" className="mt-0">
+                <SecuritySettingsCard
+                  settings={securitySettings}
+                  onSaved={(updated) => setSecuritySettings(updated)}
+                />
+              </TabsContent>
+            )}
 
             {hasPermission('write:app_settings') && (
               <TabsContent value="maintenance" className="mt-0">


### PR DESCRIPTION
## Summary

Two fixes on this branch:

### 1. Restrict configuration permissions to the admin role
In production, the **Supervisor** role (and other non-admin roles) could be granted permissions to change **File Manager provider**, **Security settings**, and **Feature Flags**. These tenant-wide configuration permissions are now reserved for the `admin` role.

- `core/permissions/constants.py` — add `ADMIN_ONLY_PERMISSIONS` set + `is_admin_only_permission()` helper (app_settings CRUD, legacy `write:app_settings`, feature_flag CRUD)
- `services/role_permissions.py` — `_guard_admin_only_permission()` rejects assigning an admin-only permission to any non-admin role (`403`) on both `create` and `update`
- `core/exceptions/error_messages.py` — new `ADMIN_ONLY_PERMISSION` error key
- `views/Settings/pages/Settings.tsx` — gate the **File Manager** and **Security** tabs behind `write:app_settings` (previously hardcoded `show: true`); skip fetching their settings when the user lacks the permission
- `tests/unit/test_role_permission_admin_guard.py` — unit coverage for the guard (create + update, block for non-admin, allow for admin)

### 2. Restore missing `isNotificationPollingEnabled` export
PR #1030 (commit `20064f6b`) accidentally removed the `isNotificationPollingEnabled` export from `config/api.ts` during a merge, while `hooks/useNotifications.ts` still imports it. A missing ESM export throws a `SyntaxError` at module load, so **the entire app rendered a blank screen on every route**. Restored the export with its original definition (`VITE_NOTIFICATION_POLLING_ENABLED`, default `false`) — distinct from `isPollEnabled`.

## Testing
- Backend: unit tests for the admin-only guard (mocked repos, no DB).
- Manual (dev, logged in as `supervisor1`): Settings page renders and shows only **Profile** + **Notifications**; File Manager / Security / Feature Flags tabs are not rendered. App no longer blanks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)