### PR TITLE
fix: include a supervisor's own group in group-scoped reads

### DIFF
--- a/backend/app/api/v1/routes/notification.py
+++ b/backend/app/api/v1/routes/notification.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, Request
 from fastapi_injector import Injected
 
 from app.auth.dependencies import auth
+from app.auth.utils import authorized_supervised_group_ids
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.schemas.notification import (
@@ -26,9 +27,7 @@ def _user_group_context(request: Request) -> tuple[UUID | None, list[UUID]]:
     user = getattr(request.state, "user", None)
     if not user:
         return None, []
-    gid = getattr(user, "group_id", None)
-    supervised = list(getattr(user, "supervised_group_ids", None) or [])
-    return gid, supervised
+    return getattr(user, "group_id", None), authorized_supervised_group_ids(user)
 
 
 @router.get(

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -8,7 +8,13 @@ from fastapi_injector import Injected
 from jwt.exceptions import ExpiredSignatureError, InvalidTokenError
 from starlette_context import context
 
-from app.auth.utils import api_key_header, current_user_is_admin, has_permission, oauth2
+from app.auth.utils import (
+    api_key_header,
+    authorized_supervised_group_ids,
+    current_user_is_admin,
+    has_permission,
+    oauth2,
+)
 from app.core.config.settings import settings
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
@@ -52,11 +58,7 @@ def _set_user_context(user, roles) -> None:
     context["user_roles"] = roles
     context["operator_id"] = user.operator.id if user and user.operator else None
     context["group_id"] = user.group_id if user and hasattr(user, "group_id") else None
-    context["supervised_group_ids"] = (
-        list(user.supervised_group_ids)
-        if user and hasattr(user, "supervised_group_ids")
-        else []
-    )
+    context["supervised_group_ids"] = authorized_supervised_group_ids(user)
 
 
 async def auth(

--- a/backend/app/auth/utils.py
+++ b/backend/app/auth/utils.py
@@ -64,6 +64,16 @@ def current_user_is_supervisor() -> bool:
      return False
 
 
+def authorized_supervised_group_ids(user) -> list[UUID]:
+    """Supervised-group assignments only count while the user still holds the supervisor role."""
+    if user is None:
+        return []
+    role_names = {role.name for role in (getattr(user, "roles", None) or [])}
+    if "supervisor" not in role_names:
+        return []
+    return list(getattr(user, "supervised_group_ids", None) or [])
+
+
 def current_user_is_admin() -> bool:
     roles = context.get("user_roles") if context.exists() else None
     if roles:

--- a/backend/app/db/events/group_scope.py
+++ b/backend/app/db/events/group_scope.py
@@ -31,14 +31,24 @@ class GroupScopedMixin:
     pass
 
 
+def _scoped_group_ids(group_id, supervised_group_ids):
+    """Groups a caller may read: their own membership plus any groups they supervise"""
+    ids = list(supervised_group_ids)
+    if group_id and group_id not in ids:
+        ids.insert(0, group_id)
+    return ids
+
+
 def _build_criteria(model_cls, group_id, supervised_group_ids, user_id):
     """Build the WHERE clause for a given user context."""
     from app.db.models.user import UserModel
 
     if supervised_group_ids:
-        # Supervisor: records created by users in any of their supervised groups
+        # Supervisor: records created by users in their own group or any supervised group
         return model_cls.created_by.in_(
-            select(UserModel.id).where(UserModel.group_id.in_(supervised_group_ids))
+            select(UserModel.id).where(
+                UserModel.group_id.in_(_scoped_group_ids(group_id, supervised_group_ids))
+            )
         )
     if group_id:
         # Regular user in a group: records created by anyone in same group
@@ -58,11 +68,12 @@ def _build_conversation_criteria(model_cls, group_id, supervised_group_ids, user
     from app.db.models.user import UserModel
 
     if supervised_group_ids:
+        group_ids = _scoped_group_ids(group_id, supervised_group_ids)
         legacy = model_cls.created_by.in_(
-            select(UserModel.id).where(UserModel.group_id.in_(supervised_group_ids))
+            select(UserModel.id).where(UserModel.group_id.in_(group_ids))
         )
         return or_(
-            model_cls.group_id.in_(supervised_group_ids),
+            model_cls.group_id.in_(group_ids),
             and_(model_cls.group_id.is_(None), legacy),
         )
     if group_id:
@@ -147,7 +158,7 @@ def _group_scope_filter(execute_state):
     from app.db.models.user import UserModel
 
     if supervised_group_ids:
-        _ids = tuple(supervised_group_ids)  # capture for closure
+        _ids = tuple(_scoped_group_ids(group_id, supervised_group_ids))
 
         def default_criteria(cls):
             return cls.created_by.in_(

--- a/backend/app/repositories/notification.py
+++ b/backend/app/repositories/notification.py
@@ -323,10 +323,15 @@ class NotificationRepository:
                             UserSupervisedGroupModel,
                             UserSupervisedGroupModel.user_id == UserModel.id,
                         )
+                        .join(UserRoleModel, UserRoleModel.user_id == UserModel.id)
+                        .join(RoleModel, RoleModel.id == UserRoleModel.role_id)
                         .where(
                             UserSupervisedGroupModel.group_id.in_(explicit_group_ids),
+                            UserSupervisedGroupModel.is_deleted == 0,
+                            RoleModel.name == "supervisor",
                             UserModel.is_deleted == 0,
                         )
+                        .distinct()
                     )
                 ).all()
                 user_rows.extend(supervisors)
@@ -349,9 +354,13 @@ class NotificationRepository:
             pre_group_filter = dict(dedup)
             supervisors_for_group = (
                 await self.db.execute(
-                    select(UserSupervisedGroupModel.user_id).where(
+                    select(UserSupervisedGroupModel.user_id)
+                    .join(UserRoleModel, UserRoleModel.user_id == UserSupervisedGroupModel.user_id)
+                    .join(RoleModel, RoleModel.id == UserRoleModel.role_id)
+                    .where(
                         UserSupervisedGroupModel.group_id == group_id,
                         UserSupervisedGroupModel.is_deleted == 0,
+                        RoleModel.name == "supervisor",
                     )
                 )
             ).scalars().all()

--- a/backend/app/repositories/user_groups.py
+++ b/backend/app/repositories/user_groups.py
@@ -58,10 +58,15 @@ class UserGroupRepository(DbRepository[UserGroupModel]):
         await self.db.flush()
 
     async def get_supervisor_user_ids(self, group_id: UUID) -> List[UUID]:
-        """Return the user IDs of all supervisors of the group."""
+        """Return the user IDs supervising the group, excluding anyone who has lost the supervisor role."""
         result = await self.db.execute(
-            select(UserSupervisedGroupModel.user_id).where(
-                UserSupervisedGroupModel.group_id == group_id
+            select(UserSupervisedGroupModel.user_id)
+            .join(UserRoleModel, UserRoleModel.user_id == UserSupervisedGroupModel.user_id)
+            .join(RoleModel, RoleModel.id == UserRoleModel.role_id)
+            .where(
+                UserSupervisedGroupModel.group_id == group_id,
+                RoleModel.name == "supervisor",
             )
+            .distinct()
         )
         return list(result.scalars().all())

--- a/backend/app/repositories/users.py
+++ b/backend/app/repositories/users.py
@@ -23,6 +23,7 @@ from app.db.models.api_key_role import ApiKeyRoleModel
 from app.db.models.role import RoleModel
 from app.db.models.role_permission import RolePermissionModel
 from app.db.models.user import UserModel
+from app.db.models.user_supervised_group import UserSupervisedGroupModel
 from app.db.models.user_type import UserTypeModel
 from app.repositories.db_repository import DbRepository
 from app.schemas.filter import BaseFilterModel
@@ -255,14 +256,34 @@ class UserRepository(DbRepository[UserModel]):
 
         # Update roles
         if data.role_ids is not None:
+            was_supervisor = (
+                await self.db.execute(
+                    select(RoleModel.name)
+                    .join(UserRoleModel, UserRoleModel.role_id == RoleModel.id)
+                    .where(UserRoleModel.user_id == user.id, RoleModel.name == "supervisor")
+                    .limit(1)
+                )
+            ).scalars().first() is not None
+
             await self.db.execute(
                     delete(UserRoleModel).where(UserRoleModel.user_id == user.id)
                     )
+            role_names = set()
             for role_id in data.role_ids:
                 role = await self.db.get(RoleModel, role_id)
                 if not role:
                     raise AppException(error_key=ErrorKey.ROLE_NOT_FOUND)
+                role_names.add(role.name)
                 self.db.add(UserRoleModel(user_id=user.id, role_id=role_id))
+
+            # Demotion drops the assignments; promotion starts from a clean slate so
+            # assignments from an earlier stint cannot silently reactivate.
+            if "supervisor" not in role_names or not was_supervisor:
+                await self.db.execute(
+                    delete(UserSupervisedGroupModel).where(
+                        UserSupervisedGroupModel.user_id == user.id
+                    )
+                )
 
         await self.db.flush()
         await self.db.refresh(user)

--- a/backend/app/services/user_groups.py
+++ b/backend/app/services/user_groups.py
@@ -2,6 +2,7 @@ from uuid import UUID
 
 from injector import inject
 
+from app.cache.redis_cache import invalidate_user_cache
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.db.models.user_group import UserGroupModel
@@ -57,8 +58,10 @@ class UserGroupService:
             )
         # Check not already assigned
         if await self.repository.is_supervisor(group_id, user_id):
+            await invalidate_user_cache(user_id)
             return {"message": "User is already a supervisor of this group"}
         await self.repository.add_supervisor(group_id, user_id)
+        await invalidate_user_cache(user_id)
         return {"message": f"User {user_id} added as supervisor of group {group_id}"}
 
     async def remove_supervisor(self, group_id: UUID, user_id: UUID) -> dict:
@@ -66,6 +69,7 @@ class UserGroupService:
         if not group:
             raise AppException(error_key=ErrorKey.NOT_FOUND, status_code=404)
         await self.repository.remove_supervisor(group_id, user_id)
+        await invalidate_user_cache(user_id)
         return {"message": f"User {user_id} removed as supervisor of group {group_id}"}
 
     async def get_supervisors(self, group_id: UUID) -> list[UUID]:

--- a/backend/tests/integration/analytics/test_group_authorization.py
+++ b/backend/tests/integration/analytics/test_group_authorization.py
@@ -459,13 +459,13 @@ async def test_group_agent_dropdown_only_lists_agents_the_caller_can_see(world):
 
 
 @pytest.mark.asyncio(loop_scope="module")
-async def test_supervisor_context_grants_all_supervised_groups(world):
+async def test_supervisor_context_grants_supervised_groups_and_their_own(world):
     async with world.maker() as session:
         repo = AnalyticsReadRepository(session)
         with caller(
             user_id=world.user_id("u1"),
             group_id=world.group_id("g1"),
-            supervised=[world.group_id("g1"), world.group_id("g2")],
+            supervised=[world.group_id("g2")],
         ):
             rows = await repo.get_agent_daily_stats(from_date=world.day, to_date=world.day)
 

--- a/backend/tests/integration/security/test_supervised_group_lifecycle.py
+++ b/backend/tests/integration/security/test_supervised_group_lifecycle.py
@@ -1,0 +1,124 @@
+"""Integration tests for the supervisor-role transitions that own supervised-group rows"""
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config.settings import settings
+from app.db.models.role import RoleModel
+from app.db.models.user import UserModel
+from app.db.models.user_group import UserGroupModel
+from app.db.models.user_role import UserRoleModel
+from app.db.models.user_supervised_group import UserSupervisedGroupModel
+from app.repositories.users import UserRepository
+from app.schemas.user import UserUpdate
+
+
+class World:
+    def __init__(self, maker, user_id, group_ids, role_ids):
+        self.maker = maker
+        self.user_id = user_id
+        self.group_ids = group_ids
+        self.role_ids = role_ids
+
+    async def supervised(self) -> set:
+        async with self.maker() as session:
+            rows = await session.execute(
+                select(UserSupervisedGroupModel.group_id).where(UserSupervisedGroupModel.user_id == self.user_id)
+            )
+            return set(rows.scalars().all())
+
+    async def grant_supervised(self, *group_ids):
+        async with self.maker() as session:
+            session.add_all(
+                UserSupervisedGroupModel(id=uuid4(), user_id=self.user_id, group_id=gid) for gid in group_ids
+            )
+            await session.commit()
+
+    async def update(self, **kwargs):
+        async with self.maker() as session:
+            await UserRepository(session).update(self.user_id, UserUpdate(**kwargs))
+            await session.commit()
+
+
+async def _skip_cache_clear(self, user_id):
+    """FastAPI-Cache has no backend in the test harness — the repository would assert."""
+
+
+@pytest_asyncio.fixture
+async def world(app_def, monkeypatch):
+    monkeypatch.setattr(UserRepository, "_clear_user_full_cache", _skip_cache_clear)
+
+    engine = create_async_engine(settings.DATABASE_URL)
+    maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    suffix = uuid4().hex[:12]
+    user_id = uuid4()
+    group_ids = [uuid4(), uuid4()]
+
+    async with maker() as session:
+        role_ids = {
+            name: (await session.execute(select(RoleModel.id).where(RoleModel.name == name))).scalars().first()
+            for name in ("supervisor", "operator")
+        }
+        assert all(role_ids.values()), "seeded supervisor/operator roles are required"
+
+        user_type_id = (await session.execute(select(UserModel.user_type_id).limit(1))).scalar_one()
+        session.add_all(UserGroupModel(id=gid, name=f"sglife-{gid.hex[:8]}", is_deleted=0) for gid in group_ids)
+        session.add(
+            UserModel(
+                id=user_id,
+                username=f"sglife-{suffix}",
+                email=f"sglife-{suffix}@example.test",
+                hashed_password="x",
+                user_type_id=user_type_id,
+                is_active=1,
+                group_id=group_ids[0],
+                is_deleted=0,
+            )
+        )
+        await session.flush()
+        session.add(UserRoleModel(id=uuid4(), user_id=user_id, role_id=role_ids["supervisor"]))
+        session.add_all(UserSupervisedGroupModel(id=uuid4(), user_id=user_id, group_id=gid) for gid in group_ids)
+        await session.commit()
+
+    try:
+        yield World(maker, user_id, group_ids, role_ids)
+    finally:
+        async with maker() as session:
+            await session.execute(delete(UserSupervisedGroupModel).where(UserSupervisedGroupModel.user_id == user_id))
+            await session.execute(delete(UserRoleModel).where(UserRoleModel.user_id == user_id))
+            await session.execute(delete(UserModel).where(UserModel.id == user_id))
+            await session.execute(delete(UserGroupModel).where(UserGroupModel.id.in_(group_ids)))
+            await session.commit()
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_keeping_the_supervisor_role_preserves_the_assignments(world):
+    await world.update(role_ids=[world.role_ids["supervisor"], world.role_ids["operator"]])
+    assert await world.supervised() == set(world.group_ids)
+
+
+@pytest.mark.asyncio
+async def test_losing_the_supervisor_role_drops_the_assignments(world):
+    await world.update(role_ids=[world.role_ids["operator"]])
+    assert await world.supervised() == set()
+
+
+@pytest.mark.asyncio
+async def test_re_promotion_does_not_reactivate_an_earlier_stints_assignments(world):
+    await world.update(role_ids=[world.role_ids["operator"]])
+    # Rows written before the cleanup shipped outlive the demotion that should have cleared them.
+    await world.grant_supervised(*world.group_ids)
+    await world.update(role_ids=[world.role_ids["supervisor"]])
+    assert await world.supervised() == set()
+
+
+@pytest.mark.asyncio
+async def test_an_update_without_roles_leaves_the_assignments_untouched(world):
+    await world.update(notes="unrelated edit")
+    assert await world.supervised() == set(world.group_ids)

--- a/backend/tests/unit/test_analytics_agent_scope.py
+++ b/backend/tests/unit/test_analytics_agent_scope.py
@@ -158,14 +158,15 @@ async def test_groupless_user_sees_only_their_own_agents():
 
 
 @pytest.mark.asyncio
-async def test_supervisor_sees_every_supervised_group():
+async def test_supervisor_sees_every_supervised_group_and_their_own():
     db = CapturingDb()
+    own_group = uuid4()
     supervised = [uuid4(), uuid4()]
-    with caller(user_id=uuid4(), group_id=uuid4(), supervised=supervised):
+    with caller(user_id=uuid4(), group_id=own_group, supervised=supervised):
         await resolve_authorized_agent_ids(db)
         sql = _sql(db.statements[0])
         assert "users.group_id IN" in sql
-        for gid in supervised:
+        for gid in [own_group, *supervised]:
             assert f"'{gid}'" in sql
 
 

--- a/backend/tests/unit/test_group_scope.py
+++ b/backend/tests/unit/test_group_scope.py
@@ -1,0 +1,81 @@
+"""Unit tests for group-scoped row filtering, asserting the SQL it emits"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.dialects import postgresql
+from starlette_context import context, request_cycle_context
+
+import app.db.models  # noqa: F401 — registers mappers for ORM compilation
+import app.db.models.test_suite  # noqa: F401
+from app.db.events.group_scope import _group_scope_filter, get_group_scope_clause
+from app.db.models.agent import AgentModel
+from app.db.models.conversation import ConversationModel
+
+
+def _sql(stmt) -> str:
+    return str(stmt.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}))
+
+
+@contextmanager
+def caller(*, user_id=None, group_id=None, supervised=()):
+    with request_cycle_context():
+        context["user_id"] = user_id
+        context["group_id"] = group_id
+        context["supervised_group_ids"] = list(supervised)
+        context["user_roles"] = [SimpleNamespace(name="operator")]
+        yield
+
+
+def _listener_sql(model_cls):
+    """Run the do_orm_execute listener over a bare ORM select and compile the result."""
+    state = SimpleNamespace(is_select=True, execution_options={}, statement=select(model_cls))
+    _group_scope_filter(state)
+    return _sql(state.statement)
+
+
+def test_supervisor_criteria_union_own_group_with_supervised_groups():
+    own_group = uuid4()
+    supervised = [uuid4(), uuid4()]
+    with caller(user_id=uuid4(), group_id=own_group, supervised=supervised):
+        sql = _sql(select(AgentModel.id).where(get_group_scope_clause(AgentModel)))
+
+    for group_id in [own_group, *supervised]:
+        assert f"'{group_id}'" in sql
+
+
+def test_supervisor_conversation_criteria_union_own_group_with_supervised_groups():
+    own_group = uuid4()
+    supervised = [uuid4()]
+    with caller(user_id=uuid4(), group_id=own_group, supervised=supervised):
+        sql = _sql(select(ConversationModel.id).where(get_group_scope_clause(ConversationModel)))
+
+    assert "conversations.group_id IN" in sql
+    for group_id in [own_group, *supervised]:
+        assert f"'{group_id}'" in sql
+
+
+def test_listener_criteria_carry_no_groups_from_the_previous_caller():
+    """The lambda is compiled once per class — its group ids must stay per-request."""
+    first_group, first_supervised = uuid4(), uuid4()
+    with caller(user_id=uuid4(), group_id=first_group, supervised=[first_supervised]):
+        first = _listener_sql(AgentModel)
+
+    second_group, second_supervised = uuid4(), uuid4()
+    with caller(user_id=uuid4(), group_id=second_group, supervised=[second_supervised, uuid4()]):
+        second = _listener_sql(AgentModel)
+
+    assert f"'{first_group}'" in first and f"'{first_supervised}'" in first
+    assert f"'{second_group}'" in second and f"'{second_supervised}'" in second
+    assert str(first_group) not in second
+    assert str(first_supervised) not in second
+
+
+@pytest.mark.parametrize("model_cls", [AgentModel, ConversationModel])
+def test_non_supervisors_keep_the_group_equality_form(model_cls):
+    group_id = uuid4()
+    with caller(user_id=uuid4(), group_id=group_id):
+        assert f"users.group_id = '{group_id}'" in _listener_sql(model_cls)

--- a/backend/tests/unit/test_supervised_group_guard.py
+++ b/backend/tests/unit/test_supervised_group_guard.py
@@ -1,0 +1,167 @@
+"""Unit tests asserting that supervised-group assignments require the supervisor role"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+import app.db.models  # noqa: F401 — registers mappers for ORM compilation
+import app.db.models.test_suite  # noqa: F401
+from app.auth.utils import authorized_supervised_group_ids
+from app.repositories.notification import NotificationRepository
+from app.repositories.user_groups import UserGroupRepository
+from app.services import user_groups as user_groups_service
+from app.services.user_groups import UserGroupService
+
+
+class _Result:
+    def scalars(self):
+        return self
+
+    def all(self):
+        return []
+
+
+class CapturingDb:
+    def __init__(self):
+        self.statements = []
+
+    async def execute(self, stmt):
+        self.statements.append(stmt)
+        return _Result()
+
+
+def _sql(stmt) -> str:
+    return str(stmt.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}))
+
+
+def _user(*role_names, supervised=()):
+    return SimpleNamespace(
+        roles=[SimpleNamespace(name=name) for name in role_names],
+        supervised_group_ids=list(supervised),
+    )
+
+
+def test_stale_assignments_are_dropped_once_the_supervisor_role_is_gone():
+    assert authorized_supervised_group_ids(_user("operator", supervised=[uuid4()])) == []
+
+
+def test_a_supervisor_keeps_their_assignments():
+    supervised = [uuid4(), uuid4()]
+    assert authorized_supervised_group_ids(_user("supervisor", supervised=supervised)) == supervised
+
+
+@pytest.mark.parametrize(
+    "principal",
+    [None, SimpleNamespace(id=uuid4()), _user("supervisor")],
+    ids=["no user", "api-key principal", "supervisor with no assignments"],
+)
+def test_principals_without_assignments_resolve_to_an_empty_scope(principal):
+    assert authorized_supervised_group_ids(principal) == []
+
+
+@pytest.mark.asyncio
+async def test_group_supervisor_read_requires_the_role():
+    db = CapturingDb()
+    group_id = uuid4()
+    await UserGroupRepository(db).get_supervisor_user_ids(group_id)
+
+    sql = _sql(db.statements[0])
+    assert "roles.name = 'supervisor'" in sql
+    assert f"user_supervised_groups.group_id = '{group_id}'" in sql
+
+
+def _notification_repo(monkeypatch, db, target_group_id):
+    notification_type = SimpleNamespace(
+        id=uuid4(),
+        type="conversation_started",
+        is_enabled=True,
+        is_tenant=False,
+        allow_all_tenant_users=False,
+    )
+    repo = NotificationRepository(db)
+
+    async def _types():
+        return {notification_type.type: notification_type}
+
+    async def _recipients(type_ids):
+        return {}, {notification_type.id: {target_group_id}}
+
+    monkeypatch.setattr(repo, "ensure_notification_types", _types)
+    monkeypatch.setattr(repo, "_recipients_by_type_id", _recipients)
+    return repo
+
+
+def _statement_matching(db, needle: str) -> str:
+    matches = [sql for sql in map(_sql, db.statements) if needle in sql]
+    assert len(matches) == 1, f"expected exactly one statement touching {needle}"
+    return matches[0]
+
+
+@pytest.mark.asyncio
+async def test_notification_delivery_only_reaches_users_who_still_supervise(monkeypatch):
+    db = CapturingDb()
+    group_id = uuid4()
+    await _notification_repo(monkeypatch, db, group_id).resolve_recipient_user_ids(
+        type_key="conversation_started", group_id=group_id
+    )
+
+    targeted = _statement_matching(db, "user_supervised_groups.group_id IN")
+    assert "roles.name = 'supervisor'" in targeted
+
+    retained = _statement_matching(db, f"user_supervised_groups.group_id = '{group_id}'")
+    assert "roles.name = 'supervisor'" in retained
+
+
+class _StubUserGroupRepository:
+
+    def __init__(self, *, already_supervisor: bool):
+        self.already_supervisor = already_supervisor
+        self.added = []
+        self.removed = []
+
+    async def get_by_id(self, group_id):
+        return SimpleNamespace(id=group_id)
+
+    async def user_has_supervisor_role(self, user_id):
+        return True
+
+    async def is_supervisor(self, group_id, user_id):
+        return self.already_supervisor
+
+    async def add_supervisor(self, group_id, user_id):
+        self.added.append((group_id, user_id))
+
+    async def remove_supervisor(self, group_id, user_id):
+        self.removed.append((group_id, user_id))
+
+
+@pytest.fixture
+def invalidated(monkeypatch):
+    calls = []
+
+    async def _record(user_id):
+        calls.append(user_id)
+
+    monkeypatch.setattr(user_groups_service, "invalidate_user_cache", _record)
+    return calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("already_supervisor", [False, True], ids=["new", "already assigned"])
+async def test_adding_a_supervisor_invalidates_their_auth_cache(invalidated, already_supervisor):
+    user_id = uuid4()
+    service = UserGroupService(_StubUserGroupRepository(already_supervisor=already_supervisor))
+    await service.add_supervisor(uuid4(), user_id)
+
+    assert invalidated == [user_id]
+
+
+@pytest.mark.asyncio
+async def test_removing_a_supervisor_invalidates_their_auth_cache(invalidated):
+    user_id = uuid4()
+    service = UserGroupService(_StubUserGroupRepository(already_supervisor=True))
+    await service.remove_supervisor(uuid4(), user_id)
+
+    assert invalidated == [user_id]

--- a/docs/features/analytics-reporting.md
+++ b/docs/features/analytics-reporting.md
@@ -201,11 +201,11 @@ All endpoints require `auth` + `read:dashboard` permission.
 **Agent-attributed aggregates** — agent and node daily stats, the node breakdown, custom-attribute keys, every LLM-usage read, and the dashboard's total cost and average response time — are limited to the agents the caller can see:
 
 - regular users see agents created by anyone in their own group;
-- supervisors see agents across all their supervised groups (supervision takes precedence over their own group);
+- supervisors see agents across all their supervised groups **plus their own group**;
 - users with no group see only agents they created themselves;
 - admins are unrestricted, and are the only callers whose totals include unattributed ledger rows (LLM calls with no owning agent).
 
-Soft-deleted agents are excluded for non-admins. The `agent_id` and `group_id` query parameters **narrow** this scope and never widen it: an unauthorized filter yields empty agent-scoped data rather than a `403`, so the endpoints cannot be used to probe for the existence of another group's agents. Scoping is evaluated per request against current group membership — historical rows follow whoever can see the agent *today*, and membership changes take effect immediately (there is no cache).
+Soft-deleted agents are excluded for non-admins. The `agent_id` and `group_id` query parameters **narrow** this scope and never widen it: an unauthorized filter yields empty agent-scoped data rather than a `403`, so the endpoints cannot be used to probe for the existence of another group's agents. Scoping is evaluated per request against current group membership — historical rows follow whoever can see the agent *today*. The membership a request scopes by comes from the `users:get_by_id_for_auth` cache (300s TTL).
 
 **Conversation-derived metrics** — the conversation counts in `/analytics/agents/summary`, the dashboard conversation lists, and the `/analytics/metrics` endpoints — keep their existing conversation-level group visibility instead. A caller's summary can therefore report conversations while its authorized *agent* scope is empty (for example, conversations that outlived their agent); foreign groups' conversations are never revealed.
 

--- a/frontend/src/views/Analytics/components/reports/AgentExecutionChart.tsx
+++ b/frontend/src/views/Analytics/components/reports/AgentExecutionChart.tsx
@@ -61,12 +61,23 @@ export function AgentExecutionChart({ items, loading, agentNameMap }: AgentExecu
     ...pivot.get(date),
   }));
 
+  const totalConversations = items.reduce((s, i) => s + i.unique_conversations, 0);
+
   return (
     <Card className={cn("bg-card dark:bg-zinc-900 shadow-sm", analyticsFadeUpClass)}>
       <CardHeader className="pb-0">
-        <CardTitle className="text-sm font-semibold text-muted-foreground">
-          Daily Conversations
-        </CardTitle>
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <CardTitle className="text-sm font-semibold text-muted-foreground">
+            Daily Conversations
+          </CardTitle>
+          <div className="flex items-center gap-4 text-xs text-muted-foreground">
+            <span className="flex items-center gap-1.5">
+              <span className="w-2.5 h-2.5 rounded-full bg-emerald-500 inline-block" />
+              Total
+              <span className="font-semibold text-muted-foreground ml-0.5">{totalConversations.toLocaleString()}</span>
+            </span>
+          </div>
+        </div>
       </CardHeader>
       <CardContent className="pt-4">
         {data.length === 0 ? (

--- a/frontend/src/views/Analytics/components/reports/AgentExecutionChart.tsx
+++ b/frontend/src/views/Analytics/components/reports/AgentExecutionChart.tsx
@@ -61,23 +61,12 @@ export function AgentExecutionChart({ items, loading, agentNameMap }: AgentExecu
     ...pivot.get(date),
   }));
 
-  const totalConversations = items.reduce((s, i) => s + i.unique_conversations, 0);
-
   return (
     <Card className={cn("bg-card dark:bg-zinc-900 shadow-sm", analyticsFadeUpClass)}>
       <CardHeader className="pb-0">
-        <div className="flex items-center justify-between flex-wrap gap-3">
-          <CardTitle className="text-sm font-semibold text-muted-foreground">
-            Daily Conversations
-          </CardTitle>
-          <div className="flex items-center gap-4 text-xs text-muted-foreground">
-            <span className="flex items-center gap-1.5">
-              <span className="w-2.5 h-2.5 rounded-full bg-emerald-500 inline-block" />
-              Total
-              <span className="font-semibold text-muted-foreground ml-0.5">{totalConversations.toLocaleString()}</span>
-            </span>
-          </div>
-        </div>
+        <CardTitle className="text-sm font-semibold text-muted-foreground">
+          Daily Conversations
+        </CardTitle>
       </CardHeader>
       <CardContent className="pt-4">
         {data.length === 0 ? (

--- a/frontend/src/views/Users/components/UserDialog.tsx
+++ b/frontend/src/views/Users/components/UserDialog.tsx
@@ -27,6 +27,7 @@ import { getApiUrl } from "@/config/api";
 import { isAxiosError } from "axios";
 import { FormField } from "@/components/ui/form-field";
 import { CRUDDialog, FieldErrors } from "@/components/ui/crud-dialog";
+import { isSupervisorUser } from "../helpers/supervision";
 
 // Value for the "No group" option, since Radix SelectItem cannot use an empty string value.
 const NO_GROUP_VALUE = "__none__";
@@ -110,7 +111,9 @@ export function UserDialog({
   const applyUser = (user: User) => {
     setEditUser(user);
     setGroupId(user.group_id ?? "");
-    setSupervisedGroupIds(user.supervised_group_ids ?? []);
+    // Assignments only survive while the role does, a demoted user starts empty
+    // so re-promotion cannot silently restore a previous stint's groups.
+    setSupervisedGroupIds(isSupervisorUser(user) ? (user.supervised_group_ids ?? []) : []);
     setResetSeq((seq) => seq + 1);
   };
 
@@ -229,6 +232,9 @@ export function UserDialog({
         if ((err as { __userIdMissing?: boolean })?.__userIdMissing) {
           return "User ID is required.";
         }
+        if ((err as { __supervisedSyncFailed?: boolean })?.__supervisedSyncFailed) {
+          return "User saved, but supervised groups could not be updated. Reopen to retry.";
+        }
         const data = isAxiosError(err)
           ? (err.response?.data as Record<string, unknown> | undefined)
           : undefined;
@@ -309,27 +315,34 @@ export function UserDialog({
           }
           await updateUser(uid, userData);
 
-          // Sync supervised groups: add newly selected, remove deselected
-          const previousIds = userToEdit?.supervised_group_ids ?? [];
-          const toAdd = supervisedGroupIds.filter((id) => !previousIds.includes(id));
-          const toRemove = previousIds.filter((id) => !supervisedGroupIds.includes(id));
-          await Promise.all([
-            ...toAdd.map((gid) => addGroupSupervisor(gid, uid)),
-            ...toRemove.map((gid) => removeGroupSupervisor(gid, uid)),
-          ]);
+          const stillSupervisor = roles
+            .filter((r) => values.selectedRoleIds.includes(r.id))
+            .some((r) => r.name?.toLowerCase() === "supervisor");
 
-          // Call onUserUpdated for edit mode with userData
-          if (onUserUpdated && userToEdit) {
-            const updatedUser: User = {
-              ...userToEdit,
-              ...userData,
-              user_type:
-                userTypes.find((type) => type.id === values.userTypeId) ||
-                userToEdit.user_type,
-              roles: roles.filter((role) => values.selectedRoleIds.includes(role.id)),
-              supervised_group_ids: supervisedGroupIds,
-            };
-            onUserUpdated(updatedUser);
+          if (stillSupervisor) {
+            // The PUT resolves before these run, and a promotion clears prior
+            // assignments server-side, so the diff needs the post-update record.
+            // Without it a deselection would diff against nothing and be dropped.
+            const current = await getUser(uid).catch(() => null);
+            if (!current) {
+              throw Object.assign(new Error("Supervised groups not synced."), {
+                __supervisedSyncFailed: true,
+              });
+            }
+            const previousIds = current.supervised_group_ids ?? [];
+            const toAdd = supervisedGroupIds.filter((id) => !previousIds.includes(id));
+            const toRemove = previousIds.filter((id) => !supervisedGroupIds.includes(id));
+            await Promise.all([
+              ...toAdd.map((gid) => addGroupSupervisor(gid, uid)),
+              ...toRemove.map((gid) => removeGroupSupervisor(gid, uid)),
+            ]);
+          }
+
+          if (onUserUpdated) {
+            // The save is already committed — a failed read-back only leaves the
+            // row stale, so it must not surface as a failed edit.
+            const finalUser = await getUser(uid).catch(() => null);
+            if (finalUser) onUserUpdated(finalUser);
           }
         }
       }}

--- a/frontend/src/views/Users/components/UsersCard.tsx
+++ b/frontend/src/views/Users/components/UsersCard.tsx
@@ -12,6 +12,7 @@ import { currentUserIsAdmin, getCurrentUserId } from "@/services/auth";
 import { toast } from "react-hot-toast";
 import { User } from "@/interfaces/user.interface";
 import { UserGroup } from "@/interfaces/userGroup.interface";
+import { activeSupervisedGroupIds } from "../helpers/supervision";
 
 interface UsersCardProps {
   searchQuery: string;
@@ -168,11 +169,7 @@ export function UsersCard({
       key: "group",
       className: "truncate",
       cell: (user) => {
-        const additionalGroupCount = new Set(
-          (user.supervised_group_ids ?? []).filter(
-            (id) => id && id !== user.group_id
-          )
-        ).size;
+        const additionalGroupCount = new Set(activeSupervisedGroupIds(user)).size;
         return user.group_id ? (
           <div className="inline-flex items-center gap-1">
             <span>{groupMap[user.group_id] ?? "—"}</span>

--- a/frontend/src/views/Users/helpers/supervision.ts
+++ b/frontend/src/views/Users/helpers/supervision.ts
@@ -1,0 +1,14 @@
+import type { User } from "@/interfaces/user.interface";
+
+/** Supervision only counts while the user still holds the supervisor role. */
+export function isSupervisorUser(user: Pick<User, "roles">): boolean {
+  return !!user.roles?.some((role) => role.name?.toLowerCase() === "supervisor");
+}
+
+/** Supervised groups a user actively holds, excluding their own group. */
+export function activeSupervisedGroupIds(
+  user: Pick<User, "roles" | "supervised_group_ids" | "group_id">,
+): string[] {
+  if (!isSupervisorUser(user)) return [];
+  return (user.supervised_group_ids ?? []).filter((id) => id && id !== user.group_id);
+}

--- a/frontend/tests/views/Users/helpers/supervision.test.ts
+++ b/frontend/tests/views/Users/helpers/supervision.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import type { Role } from "@/interfaces/role.interface";
+import type { User } from "@/interfaces/user.interface";
+import { activeSupervisedGroupIds, isSupervisorUser } from "@/views/Users/helpers/supervision";
+
+const role = (name: string) => ({ id: `role-${name}`, name }) as Role;
+
+const user = (overrides: Partial<User> = {}): User => ({
+  username: "someone",
+  email: "someone@example.test",
+  is_active: 1,
+  roles: [role("supervisor")],
+  group_id: "own-group",
+  supervised_group_ids: ["own-group", "other-group"],
+  ...overrides,
+});
+
+describe("isSupervisorUser", () => {
+  it("matches the role regardless of casing", () => {
+    expect(isSupervisorUser(user({ roles: [role("Supervisor")] }))).toBe(true);
+  });
+
+  it("is false once the role is gone", () => {
+    expect(isSupervisorUser(user({ roles: [role("operator")] }))).toBe(false);
+  });
+});
+
+describe("activeSupervisedGroupIds", () => {
+  it("drops stale assignments held by a non-supervisor", () => {
+    expect(activeSupervisedGroupIds(user({ roles: [role("operator")] }))).toEqual([]);
+  });
+
+  it("returns a supervisor's assignments without their own group", () => {
+    expect(activeSupervisedGroupIds(user())).toEqual(["other-group"]);
+  });
+
+  it("treats a missing roles list as no supervision", () => {
+    expect(activeSupervisedGroupIds(user({ roles: undefined }))).toEqual([]);
+  });
+
+  it("treats missing assignments as none", () => {
+    expect(activeSupervisedGroupIds(user({ supervised_group_ids: undefined }))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Description

A supervisor's own group was dropped from every scoped read. A user who belongs to a group and supervises others had their own group replaced by the supervised ones rather than extended by them.
Supervised-group assignments outlived the supervisor role. `add_supervisor` requires the role, but nothing removed the rows when it was revoked, so a demoted user kept read scope over, and notifications for groups they no longer supervised.

## Type of Change


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

- Visible groups are now the caller's own group plus any they supervise, applied at all three places the old precedence was duplicated.
- Supervised-group assignments only count while the user still holds the supervisor role, enforced both in the request context and in the queries that read the assignment table directly.
- Assignments are cleared when the role is revoked, and again on re-promotion so an earlier stint cannot reactivate; preserved when the role is kept.
- The auth cache is invalidated when supervisor assignments change, so edits apply on the next request instead of up to five minutes later.
- Users screen no longer presents stale assignments as active, and the supervised-group sync now diffs against the saved record so deselections stop silently failing.
- Documentation updated, the scoping rule was written the opposite way round.

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues


Closes #

## Screenshots (if applicable)


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
