### PR TITLE
fix: allow role-less console user updates

### DIFF
--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -96,7 +96,7 @@ class UserUpdate(BaseModel):
     is_active: int | None = None
     password: str | None = None
     user_type_id: UUID | None = None
-    role_ids: list[UUID] | None = Field(default=None, min_length=1)
+    role_ids: list[UUID] | None = None
     notes: str | None = None
     group_id: UUID | None = None
     entra_oid: str | None = Field(None, max_length=64, description="Microsoft Entra object id (oid) for SSO")

--- a/backend/app/services/users.py
+++ b/backend/app/services/users.py
@@ -12,6 +12,7 @@ from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.core.tenant_scope import get_tenant_context
 from app.core.utils.date_time_utils import shift_datetime
+from app.repositories.user_types import UserTypesRepository
 from app.repositories.users import UserRepository
 from app.schemas.filter import BaseFilterModel
 from app.schemas.user import UserCreate, UserRead, UserReadAuth, UserUpdate
@@ -25,9 +26,14 @@ userid_key_builder = make_key_builder("user_id")
 class UserService:
     """Handles user-related business logic."""
 
-    def __init__(self, repository: UserRepository = Injected(UserRepository)):
+    def __init__(
+        self,
+        repository: UserRepository = Injected(UserRepository),
+        user_types_repository: UserTypesRepository = Injected(UserTypesRepository),
+    ):
         # repository
         self.repository = repository
+        self.user_types_repository = user_types_repository
 
     async def create(self, user: UserCreate):
         """Register a user with business logic validation."""
@@ -136,9 +142,24 @@ class UserService:
             raise AppException(error_key=ErrorKey.USER_NOT_FOUND)
         return full
 
+    async def _validate_empty_role_ids(self, user_id: UUID, user_data: UserUpdate) -> None:
+        # Console users are blocked from logging in, so they are the only type allowed to stay roleless.
+        if user_data.user_type_id is not None:
+            user_type = await self.user_types_repository.get_by_id(user_data.user_type_id)
+            if not user_type:
+                raise AppException(error_key=ErrorKey.USER_TYPE_NOT_FOUND)
+        else:
+            user = await self.repository.get_full(user_id)
+            if not user:
+                raise AppException(error_key=ErrorKey.USER_NOT_FOUND)
+            user_type = user.user_type
+
+        if not user_type or user_type.name != "console":
+            raise AppException(error_key=ErrorKey.USER_ROLES_REQUIRED, status_code=400)
+
     async def update(self, user_id: UUID, user_data: UserUpdate):
         if user_data.role_ids is not None and len(user_data.role_ids) == 0:
-            raise AppException(error_key=ErrorKey.USER_ROLES_REQUIRED, status_code=400)
+            await self._validate_empty_role_ids(user_id, user_data)
 
         if user_data.email is not None:
             existing = await self.repository.get_by_email(

--- a/backend/app/services/users.py
+++ b/backend/app/services/users.py
@@ -142,24 +142,35 @@ class UserService:
             raise AppException(error_key=ErrorKey.USER_NOT_FOUND)
         return full
 
-    async def _validate_empty_role_ids(self, user_id: UUID, user_data: UserUpdate) -> None:
-        # Console users are blocked from logging in, so they are the only type allowed to stay roleless.
+    async def _validate_roles_after_update(self, user_id: UUID, user_data: UserUpdate) -> None:
+        """Reject an update that would leave a login-capable user without any role"""
+        if user_data.role_ids:
+            return
+        if user_data.role_ids is None and user_data.user_type_id is None:
+            return
+
+        user = await self.repository.get_full(user_id)
+        if not user:
+            raise AppException(error_key=ErrorKey.USER_NOT_FOUND)
+
         if user_data.user_type_id is not None:
             user_type = await self.user_types_repository.get_by_id(user_data.user_type_id)
             if not user_type:
                 raise AppException(error_key=ErrorKey.USER_TYPE_NOT_FOUND)
         else:
-            user = await self.repository.get_full(user_id)
-            if not user:
-                raise AppException(error_key=ErrorKey.USER_NOT_FOUND)
             user_type = user.user_type
 
-        if not user_type or user_type.name != "console":
-            raise AppException(error_key=ErrorKey.USER_ROLES_REQUIRED, status_code=400)
+        # Console users are blocked from logging in, so they are the only type allowed to stay roleless.
+        if user_type and user_type.name == "console":
+            return
+
+        if user_data.role_ids is None and user.roles:
+            return
+
+        raise AppException(error_key=ErrorKey.USER_ROLES_REQUIRED, status_code=400)
 
     async def update(self, user_id: UUID, user_data: UserUpdate):
-        if user_data.role_ids is not None and len(user_data.role_ids) == 0:
-            await self._validate_empty_role_ids(user_id, user_data)
+        await self._validate_roles_after_update(user_id, user_data)
 
         if user_data.email is not None:
             existing = await self.repository.get_by_email(

--- a/backend/tests/unit/test_user_service.py
+++ b/backend/tests/unit/test_user_service.py
@@ -7,6 +7,7 @@ import os
 
 from app.schemas.filter import BaseFilterModel
 from app.services.users import UserService
+from app.repositories.user_types import UserTypesRepository
 from app.repositories.users import UserRepository
 from app.schemas.user import UserCreate, UserRead, UserTypeRead, UserUpdate
 from app.core.exceptions.error_messages import ErrorKey
@@ -25,8 +26,15 @@ def mock_repository():
     return AsyncMock(spec=UserRepository)
 
 @pytest.fixture
-def user_service(mock_repository):
-    return UserService(repository=mock_repository)
+def mock_user_types_repository():
+    return AsyncMock(spec=UserTypesRepository)
+
+@pytest.fixture
+def user_service(mock_repository, mock_user_types_repository):
+    return UserService(
+        repository=mock_repository,
+        user_types_repository=mock_user_types_repository,
+    )
 
 @pytest.fixture
 def sample_user_data():
@@ -195,7 +203,7 @@ async def test_get_user_by_username_not_found_no_throw(user_service, mock_reposi
     assert result is None
 
 @pytest.mark.asyncio
-async def test_update_user_success(user_service, mock_repository):
+async def test_update_user_success(user_service, mock_repository, mock_user_types_repository):
     # Setup
     user_id = uuid4()
     update_data = UserUpdate(
@@ -225,22 +233,102 @@ async def test_update_user_success(user_service, mock_repository):
     )
     mock_repository.update.assert_called_once_with(user_id, update_data)
     mock_repository.get_full.assert_called_once_with(mock_updated_user.id)
+    mock_user_types_repository.get_by_id.assert_not_called()
     assert result == mock_updated_user
 
-def test_user_update_rejects_empty_role_ids():
+CONSOLE_TYPE_ID = UUID("00000196-edb1-2b80-a681-167fc2a697de")
+INTERACTIVE_TYPE_ID = UUID("00000196-edb1-2b80-a681-167fc2a697dd")
+
+def _user_type(type_id: UUID, name: str) -> UserTypeRead:
+    return UserTypeRead(id=type_id, name=name, created_at=datetime.now(), updated_at=datetime.now())
+
+def _user(user_id: UUID, user_type: UserTypeRead, group_id: UUID | None = None) -> UserRead:
+    return UserRead(
+        id=user_id,
+        username="testuser",
+        email="test@example.com",
+        is_active=1,
+        roles=[],
+        user_type=user_type,
+        api_keys=[],
+        group_id=group_id,
+    )
+
+def test_user_update_allows_empty_role_ids():
+    assert UserUpdate(role_ids=[]).role_ids == []
+    assert UserUpdate().role_ids is None
+
+def test_user_create_still_rejects_empty_role_ids(sample_user_data):
     with pytest.raises(ValidationError):
-        UserUpdate(role_ids=[])
+        UserCreate(**{**sample_user_data, "role_ids": []})
+
+@pytest.mark.asyncio
+async def test_update_console_user_empty_role_ids_allowed(user_service, mock_repository, mock_user_types_repository):
+    user_id = uuid4()
+    group_id = uuid4()
+    update_data = UserUpdate(role_ids=[], user_type_id=CONSOLE_TYPE_ID, group_id=group_id)
+    updated_user = _user(user_id, _user_type(CONSOLE_TYPE_ID, "console"), group_id=group_id)
+    mock_user_types_repository.get_by_id.return_value = _user_type(CONSOLE_TYPE_ID, "console")
+    mock_repository.update.return_value = updated_user
+    mock_repository.get_full.return_value = updated_user
+
+    result = await user_service.update(user_id, update_data)
+
+    mock_user_types_repository.get_by_id.assert_called_once_with(CONSOLE_TYPE_ID)
+    mock_repository.update.assert_called_once_with(user_id, update_data)
+    assert update_data.role_ids == []
+    assert result.group_id == group_id
+
+@pytest.mark.asyncio
+async def test_update_console_user_empty_role_ids_without_type_allowed(user_service, mock_repository, mock_user_types_repository):
+    user_id = uuid4()
+    update_data = UserUpdate(role_ids=[])
+    console_user = _user(user_id, _user_type(CONSOLE_TYPE_ID, "console"))
+    mock_repository.get_full.return_value = console_user
+    mock_repository.update.return_value = console_user
+
+    result = await user_service.update(user_id, update_data)
+
+    mock_user_types_repository.get_by_id.assert_not_called()
+    mock_repository.update.assert_called_once_with(user_id, update_data)
+    assert result == console_user
 
 @pytest.mark.asyncio
 async def test_update_user_empty_role_ids(user_service, mock_repository):
     user_id = uuid4()
-    update_data = UserUpdate.model_construct(role_ids=[])
+    update_data = UserUpdate(role_ids=[])
+    mock_repository.get_full.return_value = _user(user_id, _user_type(INTERACTIVE_TYPE_ID, "interactive"))
 
     with pytest.raises(AppException) as exc_info:
         await user_service.update(user_id, update_data)
 
     assert exc_info.value.error_key == ErrorKey.USER_ROLES_REQUIRED
     assert exc_info.value.status_code == 400
+    mock_repository.update.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_update_console_to_interactive_empty_role_ids_rejected(user_service, mock_repository, mock_user_types_repository):
+    user_id = uuid4()
+    update_data = UserUpdate(role_ids=[], user_type_id=INTERACTIVE_TYPE_ID)
+    mock_repository.get_full.return_value = _user(user_id, _user_type(CONSOLE_TYPE_ID, "console"))
+    mock_user_types_repository.get_by_id.return_value = _user_type(INTERACTIVE_TYPE_ID, "interactive")
+
+    with pytest.raises(AppException) as exc_info:
+        await user_service.update(user_id, update_data)
+
+    assert exc_info.value.error_key == ErrorKey.USER_ROLES_REQUIRED
+    mock_repository.update.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_update_user_empty_role_ids_unknown_user_type(user_service, mock_repository, mock_user_types_repository):
+    user_id = uuid4()
+    update_data = UserUpdate(role_ids=[], user_type_id=uuid4())
+    mock_user_types_repository.get_by_id.return_value = None
+
+    with pytest.raises(AppException) as exc_info:
+        await user_service.update(user_id, update_data)
+
+    assert exc_info.value.error_key == ErrorKey.USER_TYPE_NOT_FOUND
     mock_repository.update.assert_not_called()
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_user_service.py
+++ b/backend/tests/unit/test_user_service.py
@@ -9,6 +9,7 @@ from app.schemas.filter import BaseFilterModel
 from app.services.users import UserService
 from app.repositories.user_types import UserTypesRepository
 from app.repositories.users import UserRepository
+from app.schemas.role import RoleRead
 from app.schemas.user import UserCreate, UserRead, UserTypeRead, UserUpdate
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
@@ -216,13 +217,14 @@ async def test_update_user_success(user_service, mock_repository, mock_user_type
             username="testuser",
             email="updated@example.com",
             is_active=0,
-            roles=[],
+            roles=[RoleRead(id=uuid4(), name="admin", created_at=datetime.now(), updated_at=datetime.now())],
             user_type=UserTypeRead(id=UUID("00000196-edb1-2b80-a681-167fc2a697dd"), name="interactive", created_at=datetime.now(), updated_at=datetime.now()),
             api_keys=[]
             )
     mock_repository.get_by_email.return_value = None
     mock_repository.update.return_value = mock_updated_user
     mock_repository.get_full.return_value = mock_updated_user
+    mock_user_types_repository.get_by_id.return_value = mock_updated_user.user_type
 
     # Execute
     result = await user_service.update(user_id, update_data)
@@ -232,8 +234,8 @@ async def test_update_user_success(user_service, mock_repository, mock_user_type
         update_data.email, include_deleted=True
     )
     mock_repository.update.assert_called_once_with(user_id, update_data)
-    mock_repository.get_full.assert_called_once_with(mock_updated_user.id)
-    mock_user_types_repository.get_by_id.assert_not_called()
+    mock_repository.get_full.assert_called_with(mock_updated_user.id)
+    mock_user_types_repository.get_by_id.assert_called_once_with(update_data.user_type_id)
     assert result == mock_updated_user
 
 CONSOLE_TYPE_ID = UUID("00000196-edb1-2b80-a681-167fc2a697de")
@@ -318,6 +320,35 @@ async def test_update_console_to_interactive_empty_role_ids_rejected(user_servic
 
     assert exc_info.value.error_key == ErrorKey.USER_ROLES_REQUIRED
     mock_repository.update.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_update_roleless_console_to_interactive_without_role_ids_rejected(user_service, mock_repository, mock_user_types_repository):
+    user_id = uuid4()
+    update_data = UserUpdate(user_type_id=INTERACTIVE_TYPE_ID)
+    mock_repository.get_full.return_value = _user(user_id, _user_type(CONSOLE_TYPE_ID, "console"))
+    mock_user_types_repository.get_by_id.return_value = _user_type(INTERACTIVE_TYPE_ID, "interactive")
+
+    with pytest.raises(AppException) as exc_info:
+        await user_service.update(user_id, update_data)
+
+    assert exc_info.value.error_key == ErrorKey.USER_ROLES_REQUIRED
+    assert exc_info.value.status_code == 400
+    mock_repository.update.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_update_roleless_console_keeping_console_type_allowed(user_service, mock_repository, mock_user_types_repository):
+    user_id = uuid4()
+    update_data = UserUpdate(user_type_id=CONSOLE_TYPE_ID, email="console@example.com")
+    console_user = _user(user_id, _user_type(CONSOLE_TYPE_ID, "console"))
+    mock_repository.get_by_email.return_value = None
+    mock_repository.get_full.return_value = console_user
+    mock_repository.update.return_value = console_user
+    mock_user_types_repository.get_by_id.return_value = _user_type(CONSOLE_TYPE_ID, "console")
+
+    result = await user_service.update(user_id, update_data)
+
+    mock_repository.update.assert_called_once_with(user_id, update_data)
+    assert result == console_user
 
 @pytest.mark.asyncio
 async def test_update_user_empty_role_ids_unknown_user_type(user_service, mock_repository, mock_user_types_repository):

--- a/frontend/src/views/Users/components/UserDialog.tsx
+++ b/frontend/src/views/Users/components/UserDialog.tsx
@@ -27,6 +27,7 @@ import { getApiUrl } from "@/config/api";
 import { isAxiosError } from "axios";
 import { FormField } from "@/components/ui/form-field";
 import { CRUDDialog, FieldErrors } from "@/components/ui/crud-dialog";
+import { areUserRolesRequired } from "@/views/Users/helpers/userFormRules";
 
 // Value for the "No group" option, since Radix SelectItem cannot use an empty string value.
 const NO_GROUP_VALUE = "__none__";
@@ -273,7 +274,10 @@ export function UserDialog({
         if (passwordRequired && !values.password) {
           validationErrors.password = "Password is required.";
         }
-        if (values.selectedRoleIds.length === 0) {
+        if (
+          areUserRolesRequired(dialogMode, selectedUserType?.name) &&
+          values.selectedRoleIds.length === 0
+        ) {
           validationErrors.selectedRoleIds = "Roles is required.";
         }
 
@@ -347,9 +351,12 @@ export function UserDialog({
             r.name?.toLowerCase() === "supervisor"
         );
 
+        const rolesRequired = areUserRolesRequired(m, selectedUserType?.name);
+
         const handleRoleToggle = (roleId: string) => {
           form.setValues((prev) => {
             if (
+              rolesRequired &&
               prev.selectedRoleIds.includes(roleId) &&
               prev.selectedRoleIds.length === 1
             ) {
@@ -422,7 +429,10 @@ export function UserDialog({
                 ) : (
                   <Select
                     value={values.userTypeId}
-                    onValueChange={(value) => setField("userTypeId", value)}
+                    onValueChange={(value) => {
+                      setField("userTypeId", value);
+                      form.setFieldError("selectedRoleIds", undefined);
+                    }}
                   >
                     <SelectTrigger>
                       <SelectValue placeholder="Select type" />

--- a/frontend/src/views/Users/helpers/userFormRules.ts
+++ b/frontend/src/views/Users/helpers/userFormRules.ts
@@ -1,0 +1,9 @@
+import type { CRUDDialogMode } from "@/components/ui/crud-dialog";
+
+/**
+ * Roles are mandatory everywhere except when editing a canonical `console` user
+ */
+export const areUserRolesRequired = (
+  mode: CRUDDialogMode,
+  userTypeName?: string
+): boolean => mode === "create" || userTypeName !== "console";

--- a/frontend/tests/views/Users/helpers/userFormRules.test.ts
+++ b/frontend/tests/views/Users/helpers/userFormRules.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { areUserRolesRequired } from "@/views/Users/helpers/userFormRules";
+
+describe("areUserRolesRequired", () => {
+  it("always requires roles in create mode", () => {
+    expect(areUserRolesRequired("create", "console")).toBe(true);
+    expect(areUserRolesRequired("create", "interactive")).toBe(true);
+  });
+
+  it("exempts only console users on edit", () => {
+    expect(areUserRolesRequired("edit", "console")).toBe(false);
+    expect(areUserRolesRequired("edit", "interactive")).toBe(true);
+  });
+
+  it("matches the console type name exactly", () => {
+    expect(areUserRolesRequired("edit", "Console")).toBe(true);
+  });
+
+  it("requires roles when the type is unknown", () => {
+    expect(areUserRolesRequired("edit", undefined)).toBe(true);
+  });
+});

--- a/ui_tests/tests/users.spec.ts
+++ b/ui_tests/tests/users.spec.ts
@@ -51,6 +51,8 @@ test("Users › Functionality", async ({ page }) => {
     .first()
     .click();
 
+  await page.getByRole("checkbox", { name: "api" }).uncheck();
+
   await page.getByRole("button", { name: /update user/i }).click();
   await page.waitForTimeout(3000);
 
@@ -58,5 +60,6 @@ test("Users › Functionality", async ({ page }) => {
 
   await expect(userRow).toContainText(username);
   await expect(page.getByText("User updated successfully")).toBeVisible();
+  await expect(userRow.getByText("api", { exact: true })).toHaveCount(0);
   await page.waitForTimeout(5000);
 });


### PR DESCRIPTION
## Description

Fix user updates so workflow-generated `console` users can remain role-less while preserving role requirements for other user types.

## Type of Change


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [x] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

- Allow empty `role_ids` during user updates at the schema level.
- Allow role-less updates only for users whose resulting type is exactly `console`.
- Preserve required-role validation for non-console users and user creation.
- Update the user dialog’s edit validation and last-role removal behavior.
- Add backend and frontend unit-test coverage.
- Extend the users E2E test to verify removing the last role from a console user.

## Testing


- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] Multi-tenant considerations addressed (if applicable)

## Related Issues


Closes #

## Screenshots (if applicable)


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
