### PR TITLE
fix: block insecure pickle deserialization in ML model loader

### DIFF
--- a/backend/app/services/ml_model_manager.py
+++ b/backend/app/services/ml_model_manager.py
@@ -8,7 +8,6 @@ avoiding repeated file I/O and deserialization overhead.
 import asyncio
 import logging
 import os
-import pickle
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import Any, Dict, Optional, Set
@@ -17,6 +16,7 @@ from uuid import UUID
 from injector import inject
 
 from app.core.project_path import DATA_VOLUME
+from app.core.utils.safe_pickle import safe_pickle_load
 
 logger = logging.getLogger(__name__)
 
@@ -31,24 +31,31 @@ ML_MODELS_UPLOAD_DIR = str(DATA_VOLUME / "ml_models")
 
 def _load_pickle_sync(pkl_file: str) -> Any:
     """
-    Synchronous function to load pickle file.
+    Synchronous function to load a pickle file.
     This will be executed in a thread pool to avoid blocking the event loop.
+
+    Deserialization goes through ``safe_pickle_load`` (a restricted unpickler
+    with an ML-framework allowlist) rather than the stdlib ``pickle.load``, so
+    only classes from known-safe modules are reconstructed. This prevents
+    ``__reduce__``-based code execution from a maliciously crafted .pkl file
+    at the point of deserialization itself, independent of the pre-load
+    opcode scan performed by ``validate_pickle_file_safe``.
     """
     load_errors = []
 
-    # Method 1: pickle with default encoding
+    # Method 1: restricted unpickler with default encoding
     try:
         with open(pkl_file, "rb") as f:
-            model = pickle.load(f)
+            model = safe_pickle_load(f)
         logger.info("Loaded model from %s", pkl_file)
         return model
     except Exception as e:
         load_errors.append(f"pickle (default) failed: {type(e).__name__}")
 
-    # Method 2: pickle with latin1 encoding
+    # Method 2: restricted unpickler with latin1 encoding (legacy Python 2 pickles)
     try:
         with open(pkl_file, "rb") as f:
-            model = pickle.load(f, encoding="latin1")
+            model = safe_pickle_load(f, encoding="latin1")
         logger.info("Loaded model (latin1) from %s", pkl_file)
         return model
     except Exception as e:

--- a/backend/tests/unit/core/utils/test_safe_pickle.py
+++ b/backend/tests/unit/core/utils/test_safe_pickle.py
@@ -1,0 +1,94 @@
+"""Security regression tests for the restricted ML-model unpickler.
+
+These cover CWE-502 (insecure deserialization): the loader must reconstruct
+benign ML artefacts while refusing pickles that reach for dangerous modules
+via ``__reduce__``-based code-execution payloads.
+"""
+
+import io
+import os
+import pickle
+
+import pytest
+
+from app.core.utils.safe_pickle import RestrictedUnpickler, safe_pickle_load
+
+
+class _EvilReduce:
+    """Object whose unpickling would run ``os.system`` under stdlib pickle."""
+
+    def __reduce__(self):
+        return (os.system, ("echo pwned",))
+
+
+class _EvilSubprocess:
+    def __reduce__(self):
+        import subprocess
+
+        return (subprocess.call, (["echo", "pwned"],))
+
+
+class _EvilEval:
+    def __reduce__(self):
+        return (eval, ("__import__('os').system('echo pwned')",))
+
+
+class TestBenignPayloadsLoad:
+    def test_primitive_container_roundtrips(self):
+        payload = {"model": [1, 2, 3], "metadata": {"version": "v2.0"}, "flag": True}
+        data = pickle.dumps(payload)
+        assert safe_pickle_load(io.BytesIO(data)) == payload
+
+    def test_nested_builtins_roundtrip(self):
+        payload = {"a": (1, 2), "b": {"c": [None, "x", 3.5]}, "s": {1, 2, 3}}
+        data = pickle.dumps(payload)
+        assert safe_pickle_load(io.BytesIO(data)) == payload
+
+
+class TestMaliciousPayloadsBlocked:
+    @pytest.mark.parametrize("evil", [_EvilReduce, _EvilSubprocess, _EvilEval])
+    def test_reduce_based_rce_is_blocked(self, evil):
+        data = pickle.dumps(evil())
+        with pytest.raises(pickle.UnpicklingError):
+            safe_pickle_load(io.BytesIO(data))
+
+    def test_os_system_global_is_blocked(self):
+        # STACK_GLOBAL reference to os.system directly.
+        data = pickle.dumps(os.system)
+        with pytest.raises(pickle.UnpicklingError):
+            safe_pickle_load(io.BytesIO(data))
+
+    def test_unlisted_module_is_blocked(self):
+        # A module that is neither explicitly blocked nor on the allowlist
+        # must still be refused (allowlist, not blocklist, semantics).
+        with pytest.raises(pickle.UnpicklingError):
+            RestrictedUnpickler(io.BytesIO()).find_class("shutil", "rmtree")
+
+    def test_pickle_module_itself_is_blocked(self):
+        with pytest.raises(pickle.UnpicklingError):
+            RestrictedUnpickler(io.BytesIO()).find_class("pickle", "loads")
+
+    def test_no_side_effect_on_blocked_load(self, tmp_path):
+        # Prove code execution never happens: the payload would create a file,
+        # but loading must raise before __reduce__ runs.
+        marker = tmp_path / "pwned"
+
+        class _WriteFile:
+            def __reduce__(self):
+                return (os.system, (f"touch {marker}",))
+
+        data = pickle.dumps(_WriteFile())
+        with pytest.raises(pickle.UnpicklingError):
+            safe_pickle_load(io.BytesIO(data))
+        assert not marker.exists()
+
+
+class TestBuiltinClassRestriction:
+    def test_allowed_builtin_class(self):
+        # dict is on the builtins allowlist.
+        assert RestrictedUnpickler(io.BytesIO()).find_class("builtins", "dict") is dict
+
+    def test_disallowed_builtin_class(self):
+        # eval/exec/getattr are not on the builtins class allowlist.
+        with pytest.raises(pickle.UnpicklingError):
+            RestrictedUnpickler(io.BytesIO()).find_class("builtins", "eval")


### PR DESCRIPTION
## Summary

Fixes a **High** severity SAST finding (Semgrep / Bandit **B301**, **CWE-502** — Insecure Deserialization) in the ML model loader.

`_load_pickle_sync` in `backend/app/services/ml_model_manager.py` deserialized model files with the stdlib `pickle.load`, which executes arbitrary code via `__reduce__`. The only guard was an opcode **pre-scan** (`validate_pickle_file_safe`) — a *blocklist* (default-allow) run separately from the load, so it is bypassable and has a TOCTOU gap.

The repo already contained the correct fix — `safe_pickle_load` / `RestrictedUnpickler`, an **allowlist** (default-deny) enforced at `find_class` time — but it was dead code, never wired in. This PR routes loading through it.

## Changes

- `ml_model_manager.py` — both deserialization call sites now use `safe_pickle_load` instead of `pickle.load`; drop the unused `import pickle`. The pre-scan stays as defense in depth.
- `tests/unit/core/utils/test_safe_pickle.py` — security regression tests: benign roundtrips, `__reduce__` RCE payloads blocked, blocked/unlisted modules rejected, and a no-side-effect assertion.

## Verification

Tested against the running backend (real sklearn), exercising the exact `_load_pickle_sync` / `get_model` path the ML Inference node uses:

- **Benign** model → loads and predicts correctly (no regression).
- **Malicious** `__reduce__`/`os.system` payload → **blocked** (`UnpicklingError`), marker file never created → no code executed.
- **`pydoc.pipepager` gadget** → **passes** the old opcode pre-scan (proving the blocklist gap) but is **blocked** by the restricted unpickler → demonstrates the fix adds protection the pre-scan did not provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)