### PR TITLE
feat: add prompt-cache costs accounting

### DIFF
--- a/backend/alembic/versions/00110_add_llm_usage_cache_tokens_and_cache_rates.py
+++ b/backend/alembic/versions/00110_add_llm_usage_cache_tokens_and_cache_rates.py
@@ -1,8 +1,7 @@
 """add llm usage cache tokens and cache rates
 
 The rate columns are nullable because NULL and 0 are distinct states: NULL
-means "not configured" (a provider default applies) while an explicit 0
-means "free".
+means "not configured" while an explicit 0 means "free".
 
 Revision ID: d37941010920
 Revises: c41d7ab35f92
@@ -24,6 +23,7 @@ depends_on: Union[str, Sequence[str], None] = None
 _EVENTS = "llm_usage_events"
 _RATES = "llm_cost_rates"
 _CACHE_TOKENS_CHECK = "ck_llm_usage_events_cache_tokens_non_negative"
+_PROMPT_GE_INPUT_CHECK = "ck_llm_usage_events_prompt_ge_input"
 
 
 def upgrade() -> None:
@@ -37,6 +37,10 @@ def upgrade() -> None:
     op.add_column(_EVENTS, sa.Column("cache_read_per_1k", sa.Numeric(18, 10), nullable=True))
     op.add_column(_EVENTS, sa.Column("cache_creation_per_1k", sa.Numeric(18, 10), nullable=True))
 
+    op.add_column(_EVENTS, sa.Column("prompt_tokens", sa.BigInteger(), nullable=False, server_default=sa.text("0")))
+    op.execute(f"UPDATE {_EVENTS} SET prompt_tokens = input_tokens")
+    op.create_check_constraint(_PROMPT_GE_INPUT_CHECK, _EVENTS, "prompt_tokens >= input_tokens")
+
     op.add_column(_RATES, sa.Column("cache_read_per_1k", sa.Numeric(18, 10), nullable=True))
     op.add_column(_RATES, sa.Column("cache_creation_per_1k", sa.Numeric(18, 10), nullable=True))
 
@@ -44,6 +48,9 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_column(_RATES, "cache_creation_per_1k")
     op.drop_column(_RATES, "cache_read_per_1k")
+
+    op.drop_constraint(_PROMPT_GE_INPUT_CHECK, _EVENTS, type_="check")
+    op.drop_column(_EVENTS, "prompt_tokens")
 
     op.drop_column(_EVENTS, "cache_creation_per_1k")
     op.drop_column(_EVENTS, "cache_read_per_1k")

--- a/backend/alembic/versions/00110_add_llm_usage_cache_tokens_and_cache_rates.py
+++ b/backend/alembic/versions/00110_add_llm_usage_cache_tokens_and_cache_rates.py
@@ -1,0 +1,52 @@
+"""add llm usage cache tokens and cache rates
+
+The rate columns are nullable because NULL and 0 are distinct states: NULL
+means "not configured" (a provider default applies) while an explicit 0
+means "free".
+
+Revision ID: d37941010920
+Revises: c41d7ab35f92
+Create Date: 2026-08-19 11:36:40.419380
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d37941010920"
+down_revision: Union[str, None] = "c41d7ab35f92"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_EVENTS = "llm_usage_events"
+_RATES = "llm_cost_rates"
+_CACHE_TOKENS_CHECK = "ck_llm_usage_events_cache_tokens_non_negative"
+
+
+def upgrade() -> None:
+    op.add_column(
+        _EVENTS, sa.Column("cache_read_tokens", sa.BigInteger(), nullable=False, server_default=sa.text("0"))
+    )
+    op.add_column(
+        _EVENTS, sa.Column("cache_creation_tokens", sa.BigInteger(), nullable=False, server_default=sa.text("0"))
+    )
+    op.create_check_constraint(_CACHE_TOKENS_CHECK, _EVENTS, "cache_read_tokens >= 0 AND cache_creation_tokens >= 0")
+    op.add_column(_EVENTS, sa.Column("cache_read_per_1k", sa.Numeric(18, 10), nullable=True))
+    op.add_column(_EVENTS, sa.Column("cache_creation_per_1k", sa.Numeric(18, 10), nullable=True))
+
+    op.add_column(_RATES, sa.Column("cache_read_per_1k", sa.Numeric(18, 10), nullable=True))
+    op.add_column(_RATES, sa.Column("cache_creation_per_1k", sa.Numeric(18, 10), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column(_RATES, "cache_creation_per_1k")
+    op.drop_column(_RATES, "cache_read_per_1k")
+
+    op.drop_column(_EVENTS, "cache_creation_per_1k")
+    op.drop_column(_EVENTS, "cache_read_per_1k")
+    op.drop_constraint(_CACHE_TOKENS_CHECK, _EVENTS, type_="check")
+    op.drop_column(_EVENTS, "cache_creation_tokens")
+    op.drop_column(_EVENTS, "cache_read_tokens")

--- a/backend/app/api/v1/routes/llm_cost_rates.py
+++ b/backend/app/api/v1/routes/llm_cost_rates.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
 from fastapi.responses import StreamingResponse
 from fastapi_injector import Injected
 
@@ -15,7 +15,11 @@ from app.schemas.llm_cost_rate import (
     LlmCostRateRead,
     LlmCostRateUpdate,
 )
-from app.services.llm_cost_rates import LlmCostRateService
+from app.services.llm_cost_rates import (
+    MAX_IMPORT_BYTES,
+    LlmCostRateService,
+    import_exceeds_byte_cap,
+)
 
 router = APIRouter()
 
@@ -77,9 +81,15 @@ async def import_cost_rates_csv(
 ):
     if not file.filename or not file.filename.lower().endswith(".csv"):
         raise AppException(error_key=ErrorKey.INVALID_FILE_FORMAT, status_code=400, error_detail="File must be a CSV file")
-    raw = await file.read()
+    raw = await file.read(MAX_IMPORT_BYTES + 1)
     if not raw:
         raise AppException(error_key=ErrorKey.INVALID_FILE_FORMAT, status_code=400, error_detail="Empty file")
+    if import_exceeds_byte_cap(raw):
+        raise AppException(
+            error_key=ErrorKey.INVALID_FILE_FORMAT,
+            status_code=400,
+            error_detail=f"File must be {MAX_IMPORT_BYTES // (1024 * 1024)} MB or smaller",
+        )
     try:
         text = raw.decode("utf-8-sig")
     except UnicodeDecodeError as e:
@@ -96,9 +106,12 @@ async def import_cost_rates_csv(
     dependencies=[Depends(auth), Depends(permissions(P.LlmProvider.READ))],
 )
 async def export_cost_rates_csv(
+    include_cache_rates: bool = Query(
+        False, description="Add the cache rate columns. Off keeps the 4-column layout older tools expect."
+    ),
     service: LlmCostRateService = Injected(LlmCostRateService),
 ):
-    csv_text = await service.export_csv()
+    csv_text = await service.export_csv(include_cache_rates)
     return StreamingResponse(
         iter([csv_text]),
         media_type="text/csv; charset=utf-8",

--- a/backend/app/core/config/llm_pricing.py
+++ b/backend/app/core/config/llm_pricing.py
@@ -372,7 +372,14 @@ def resolve_live_pricing(provider: str, model: str) -> LivePricing:
             if selected is not None:
                 break
     if selected is None:
-        return LivePricing(DEFAULT_PRICING.copy())
+        default_input = Decimal(str(DEFAULT_PRICING["input_per_1k"]))
+        cache_read = _family_cache_rate(provider_key, model_key, default_input, CACHE_READ_MULTIPLIER)
+        cache_creation = _family_cache_rate(provider_key, model_key, default_input, CACHE_WRITE_5M_MULTIPLIER)
+        return LivePricing(
+            DEFAULT_PRICING.copy(),
+            None if cache_read is None else float(cache_read),
+            None if cache_creation is None else float(cache_creation),
+        )
 
     cache_read, cache_creation = _resolve_cache_bucket_rates(provider_key, model_key, selected, _bundled_match(matches))
     return LivePricing(
@@ -380,8 +387,3 @@ def resolve_live_pricing(provider: str, model: str) -> LivePricing:
         None if cache_read is None else float(cache_read),
         None if cache_creation is None else float(cache_creation),
     )
-
-
-def find_pricing(provider: str, model: str) -> Dict[str, float]:
-    """Returns float rates or DEFAULT_PRICING if unknown."""
-    return resolve_live_pricing(provider, model).display_rates

--- a/backend/app/core/config/llm_pricing.py
+++ b/backend/app/core/config/llm_pricing.py
@@ -55,8 +55,13 @@ STATIC_LLM_PRICING_FALLBACK: Dict[str, Dict[str, Dict[str, float]]] = {
         "eu.amazon.nova-2-lite-v1:0": {"input_per_1k": 0.0001, "output_per_1k": 0.0004},
         "ca.amazon.nova-2-lite-v1:0": {"input_per_1k": 0.0001, "output_per_1k": 0.0004},
         "us.amazon.nova-2-lite-v1:0": {"input_per_1k": 0.0001, "output_per_1k": 0.0004},
+        "apac.amazon.nova-2-lite-v1:0": {"input_per_1k": 0.0001, "output_per_1k": 0.0004},
         "us.amazon.nova-2-pro-v1:0": {"input_per_1k": 0.0002, "output_per_1k": 0.0008},
+        "eu.amazon.nova-2-pro-v1:0": {"input_per_1k": 0.0002, "output_per_1k": 0.0008},
+        "apac.amazon.nova-2-pro-v1:0": {"input_per_1k": 0.0002, "output_per_1k": 0.0008},
         "us.amazon.nova-2-flash-v1:0": {"input_per_1k": 0.0004, "output_per_1k": 0.0016},
+        "eu.amazon.nova-2-flash-v1:0": {"input_per_1k": 0.0004, "output_per_1k": 0.0016},
+        "apac.amazon.nova-2-flash-v1:0": {"input_per_1k": 0.0004, "output_per_1k": 0.0016},
     },
 }
 

--- a/backend/app/core/config/llm_pricing.py
+++ b/backend/app/core/config/llm_pricing.py
@@ -5,16 +5,18 @@ DB rows override static defaults for the same provider/model keys.
 """
 
 import re
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, TypeVar
 
+from app.core.config.llm_prompt_cache_capabilities import CLAUDE_FAMILY, bedrock_cache_family
 from app.core.tenant_scope import get_tenant_context
 from app.services.llm_pricing_cache import get_db_pricing_nested
 
 _BEDROCK_REGION_PREFIX = re.compile(r"^(?:us|eu|apac|us-gov)\.")
+_Rate = TypeVar("_Rate", Decimal, float)
 
 # Static fallback when DB is empty or missing a row (also used before first migration).
 STATIC_LLM_PRICING_FALLBACK: Dict[str, Dict[str, Dict[str, float]]] = {
@@ -50,6 +52,8 @@ STATIC_LLM_PRICING_FALLBACK: Dict[str, Dict[str, Dict[str, float]]] = {
         "_default": {"input_per_1k": 0.0, "output_per_1k": 0.0},
     },
     "bedrock": {
+        "eu.amazon.nova-2-lite-v1:0": {"input_per_1k": 0.0001, "output_per_1k": 0.0004},
+        "ca.amazon.nova-2-lite-v1:0": {"input_per_1k": 0.0001, "output_per_1k": 0.0004},
         "us.amazon.nova-2-lite-v1:0": {"input_per_1k": 0.0001, "output_per_1k": 0.0004},
         "us.amazon.nova-2-pro-v1:0": {"input_per_1k": 0.0002, "output_per_1k": 0.0008},
         "us.amazon.nova-2-flash-v1:0": {"input_per_1k": 0.0004, "output_per_1k": 0.0016},
@@ -57,6 +61,17 @@ STATIC_LLM_PRICING_FALLBACK: Dict[str, Dict[str, Dict[str, float]]] = {
 }
 
 DEFAULT_PRICING = {"input_per_1k": 0.001, "output_per_1k": 0.002}
+CACHE_EXCLUSIVE_PROVIDERS = frozenset({"bedrock"})
+ANTHROPIC_CACHE_READ_MULTIPLIER = Decimal("0.1")
+ANTHROPIC_CACHE_WRITE_MULTIPLIER = Decimal("1.25")
+
+_MATCH_EXACT = "exact"
+_MATCH_LONGEST_PREFIX = "longest_prefix"
+_MATCH_REGION_AGNOSTIC = "region_agnostic"
+_MATCH_DEFAULT_ROW = "default_row"
+
+CACHE_READ_KEY = "cache_read_per_1k"
+CACHE_CREATION_KEY = "cache_creation_per_1k"
 
 
 class PricingStatus(str, Enum):
@@ -72,6 +87,27 @@ class PricingResolution:
     input_per_1k: Optional[Decimal]
     output_per_1k: Optional[Decimal]
     matched_model_key: Optional[str]
+    cache_read_per_1k: Optional[Decimal] = None
+    cache_creation_per_1k: Optional[Decimal] = None
+
+
+@dataclass(frozen=True)
+class LivePricing:
+    """Resolves rates and cache buckets using the ledger's ladder. Returns None
+    if no rate exists."""
+
+    display_rates: Dict[str, float]
+    cache_read_per_1k: Optional[float] = None
+    cache_creation_per_1k: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class _LayerMatch:
+    status: PricingStatus
+    matched_key: str
+    rates: tuple[Decimal, Decimal]
+    row: Mapping[str, Any]
+    match_kind: str
 
 
 def _normalize_model_name(model: str) -> str:
@@ -80,37 +116,49 @@ def _normalize_model_name(model: str) -> str:
     return str(model).lower().strip()
 
 
-def _merged_provider_pricing(provider_key: str, tenant: str) -> Dict[str, Dict[str, float]]:
-    static = dict(STATIC_LLM_PRICING_FALLBACK.get(provider_key, {}))
-    db_nested = get_db_pricing_nested(tenant)
-    db_prov = db_nested.get(provider_key, {})
-    static.update(db_prov)
-    return static
+def cache_rate_or_input(rate: Optional[_Rate], input_per_1k: _Rate) -> _Rate:
+    """An unresolved cache bucket bills at the input rate"""
+    return input_per_1k if rate is None else rate
 
 
-def find_pricing(provider: str, model: str) -> Dict[str, float]:
-    """Response-cost/display helper: float rates, DEFAULT_PRICING when unknown"""
-    tenant = get_tenant_context()
-    provider_key = (provider or "").lower()
-    model_key = _normalize_model_name(model)
+def inclusive_cache_fallback(provider_key: str, rate: Optional[_Rate], input_per_1k: _Rate) -> Optional[_Rate]:
+    if rate is None and provider_key in CACHE_EXCLUSIVE_PROVIDERS:
+        return None
+    return cache_rate_or_input(rate, input_per_1k)
 
-    provider_pricing = _merged_provider_pricing(provider_key, tenant)
-    if not provider_pricing:
-        return DEFAULT_PRICING.copy()
 
-    if model_key and model_key in provider_pricing:
-        return provider_pricing[model_key].copy()
+def blended_token_cost(
+    provider_key: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int,
+    cache_creation_tokens: int,
+    input_per_1k: _Rate,
+    output_per_1k: _Rate,
+    cache_read_per_1k: Optional[_Rate],
+    cache_creation_per_1k: Optional[_Rate],
+    thousand: _Rate,
+) -> Optional[_Rate]:
+    """The blended cost, or None when an active cache bucket has no resolved rate"""
+    cache_read = max(int(cache_read_tokens), 0)
+    cache_creation = max(int(cache_creation_tokens), 0)
+    if not cache_read and not cache_creation:
+        return (int(input_tokens) / thousand) * input_per_1k + (int(output_tokens) / thousand) * output_per_1k
 
-    for known_model, pricing in provider_pricing.items():
-        if known_model.startswith("_"):
-            continue
-        if model_key and model_key.startswith(known_model):
-            return pricing.copy()
+    if (cache_read and cache_read_per_1k is None) or (cache_creation and cache_creation_per_1k is None):
+        return None
 
-    default_row = provider_pricing.get("_default")
-    if default_row:
-        return default_row.copy()
-    return DEFAULT_PRICING.copy()
+    if provider_key in CACHE_EXCLUSIVE_PROVIDERS:
+        uncached = max(int(input_tokens), 0)
+    else:
+        uncached = max(int(input_tokens) - cache_read - cache_creation, 0)
+
+    cost = (uncached / thousand) * input_per_1k + (int(output_tokens) / thousand) * output_per_1k
+    if cache_read:
+        cost += (cache_read / thousand) * cache_read_per_1k
+    if cache_creation:
+        cost += (cache_creation / thousand) * cache_creation_per_1k
+    return cost
 
 
 def _rate_pair(row: Any) -> Optional[tuple[Decimal, Decimal]]:
@@ -124,6 +172,21 @@ def _rate_pair(row: Any) -> Optional[tuple[Decimal, Decimal]]:
     if any(r.is_nan() or r.is_infinite() or r < 0 for r in rates):
         return None
     return rates
+
+
+def _cache_rate(row: Any, key: str) -> Optional[Decimal]:
+    if not isinstance(row, Mapping):
+        return None
+    value = row.get(key)
+    if value is None:
+        return None
+    try:
+        rate = Decimal(str(value))
+    except (TypeError, ArithmeticError, ValueError):
+        return None
+    if rate.is_nan() or rate.is_infinite() or rate < 0:
+        return None
+    return rate
 
 
 def _exact_or_longest_prefix(model_key: str, table: Mapping[str, Any]) -> Optional[str]:
@@ -151,6 +214,101 @@ def _match_bedrock_region_agnostic(model_key: str, table: Mapping[str, Any]) -> 
     return None
 
 
+def _matchers_for(
+    provider_key: str, status: PricingStatus
+) -> list[tuple[str, Callable[[str, Mapping[str, Any]], Optional[str]]]]:
+    """Matchers within one layer. Bedrock retries per-tenant; rates are
+    region-specific."""
+    matchers = [(_MATCH_LONGEST_PREFIX, _exact_or_longest_prefix)]
+    if provider_key == "bedrock" and status is PricingStatus.CONFIGURED:
+        matchers.append((_MATCH_REGION_AGNOSTIC, _match_bedrock_region_agnostic))
+    return matchers
+
+
+def _pricing_layers(
+    provider_key: str, configured: Optional[Mapping[str, Mapping[str, Any]]]
+) -> tuple[Mapping[str, Any], Mapping[str, Any], tuple[tuple[Mapping[str, Any], PricingStatus], ...]]:
+    configured_table = (configured or {}).get(provider_key) or {}
+    bundled_table = STATIC_LLM_PRICING_FALLBACK.get(provider_key, {})
+    layers = ((configured_table, PricingStatus.CONFIGURED), (bundled_table, PricingStatus.FALLBACK))
+    return configured_table, bundled_table, layers
+
+
+def _collect_layer_matches(
+    provider_key: str,
+    model_key: str,
+    layers: tuple[tuple[Mapping[str, Any], PricingStatus], ...],
+) -> list[_LayerMatch]:
+    matches: list[_LayerMatch] = []
+    for table, status in layers:
+        for inexact_kind, matcher in _matchers_for(provider_key, status):
+            matched_key = matcher(model_key, table)
+            if matched_key is None:
+                continue
+            row = table[matched_key]
+            rates = _rate_pair(row)
+            if rates is not None:
+                kind = _MATCH_EXACT if matched_key == model_key else inexact_kind
+                matches.append(_LayerMatch(status, matched_key, rates, row, kind))
+                break
+    return matches
+
+
+def _default_row_match(table: Mapping[str, Any], status: PricingStatus) -> Optional[_LayerMatch]:
+    row = table.get("_default")
+    rates = _rate_pair(row)
+    if rates is None:
+        return None
+    return _LayerMatch(status, "_default", rates, row, _MATCH_DEFAULT_ROW)
+
+
+def _select_base_rates(matches: list[_LayerMatch]) -> Optional[_LayerMatch]:
+    return matches[0] if matches else None
+
+
+def _bundled_match(matches: list[_LayerMatch]) -> Optional[_LayerMatch]:
+    return next((match for match in matches if match.status is PricingStatus.FALLBACK), None)
+
+
+def _row_cache_rate(match: Optional[_LayerMatch], key: str) -> Optional[Decimal]:
+    if match is None:
+        return None
+    if match.status is PricingStatus.FALLBACK and match.match_kind != _MATCH_EXACT:
+        return None
+    return _cache_rate(match.row, key)
+
+
+def _family_cache_rate(
+    provider_key: str, model_key: str, input_per_1k: Decimal, multiplier: Decimal
+) -> Optional[Decimal]:
+    if provider_key == "anthropic":
+        return input_per_1k * multiplier
+    if provider_key == "bedrock" and bedrock_cache_family(model_key) == CLAUDE_FAMILY:
+        return input_per_1k * multiplier
+    return None
+
+
+def _resolve_cache_bucket_rates(
+    provider_key: str,
+    model_key: str,
+    selected: _LayerMatch,
+    bundled: Optional[_LayerMatch],
+) -> tuple[Optional[Decimal], Optional[Decimal]]:
+    """Read and write resolve separately: base rates row → bundled row → family default."""
+    resolved: list[Optional[Decimal]] = []
+    for key, multiplier in (
+        (CACHE_READ_KEY, ANTHROPIC_CACHE_READ_MULTIPLIER),
+        (CACHE_CREATION_KEY, ANTHROPIC_CACHE_WRITE_MULTIPLIER),
+    ):
+        rate = _row_cache_rate(selected, key)
+        if rate is None and bundled is not selected:
+            rate = _row_cache_rate(bundled, key)
+        if rate is None:
+            rate = _family_cache_rate(provider_key, model_key, selected.rates[0], multiplier)
+        resolved.append(rate)
+    return resolved[0], resolved[1]
+
+
 def resolve_pricing(
     provider: str,
     model: str,
@@ -160,25 +318,59 @@ def resolve_pricing(
     provider_key = (provider or "").strip().lower()
     model_key = _normalize_model_name(model)
 
-    configured_table = (configured or {}).get(provider_key) or {}
-    bundled_table = STATIC_LLM_PRICING_FALLBACK.get(provider_key, {})
-    layers = ((configured_table, PricingStatus.CONFIGURED), (bundled_table, PricingStatus.FALLBACK))
+    configured_table, _, layers = _pricing_layers(provider_key, configured)
 
-    matchers = [_exact_or_longest_prefix]
-    if provider_key == "bedrock":
-        matchers.append(_match_bedrock_region_agnostic)
+    matches = _collect_layer_matches(provider_key, model_key, layers)
+    selected = _select_base_rates(matches) or _default_row_match(configured_table, PricingStatus.CONFIGURED)
+    if selected is None:
+        return PricingResolution(PricingStatus.UNPRICED, None, None, None)
 
-    for matcher in matchers:
+    cache_read, cache_creation = _resolve_cache_bucket_rates(provider_key, model_key, selected, _bundled_match(matches))
+    return PricingResolution(
+        selected.status,
+        selected.rates[0],
+        selected.rates[1],
+        selected.matched_key,
+        cache_read_per_1k=cache_read,
+        cache_creation_per_1k=cache_creation,
+    )
+
+
+def _float_rates(rates: tuple[Decimal, Decimal], row: Mapping[str, Any]) -> Dict[str, float]:
+    """Display-shaped rates. Cache keys appear only when the matched row carries them"""
+    pricing = {"input_per_1k": float(rates[0]), "output_per_1k": float(rates[1])}
+    for key in (CACHE_READ_KEY, CACHE_CREATION_KEY):
+        rate = _cache_rate(row, key)
+        if rate is not None:
+            pricing[key] = float(rate)
+    return pricing
+
+
+def resolve_live_pricing(provider: str, model: str) -> LivePricing:
+    tenant = get_tenant_context()
+    provider_key = (provider or "").strip().lower()
+    model_key = _normalize_model_name(model)
+
+    _, _, layers = _pricing_layers(provider_key, get_db_pricing_nested(tenant))
+
+    matches = _collect_layer_matches(provider_key, model_key, layers)
+    selected = _select_base_rates(matches)
+    if selected is None:
         for table, status in layers:
-            matched_key = matcher(model_key, table)
-            if matched_key is None:
-                continue
-            rates = _rate_pair(table[matched_key])
-            if rates is not None:
-                return PricingResolution(status, rates[0], rates[1], matched_key)
+            selected = _default_row_match(table, status)
+            if selected is not None:
+                break
+    if selected is None:
+        return LivePricing(DEFAULT_PRICING.copy())
 
-    default_rates = _rate_pair(configured_table.get("_default"))
-    if default_rates is not None:
-        return PricingResolution(PricingStatus.CONFIGURED, default_rates[0], default_rates[1], "_default")
+    cache_read, cache_creation = _resolve_cache_bucket_rates(provider_key, model_key, selected, _bundled_match(matches))
+    return LivePricing(
+        _float_rates(selected.rates, selected.row),
+        None if cache_read is None else float(cache_read),
+        None if cache_creation is None else float(cache_creation),
+    )
 
-    return PricingResolution(PricingStatus.UNPRICED, None, None, None)
+
+def find_pricing(provider: str, model: str) -> Dict[str, float]:
+    """Returns float rates or DEFAULT_PRICING if unknown."""
+    return resolve_live_pricing(provider, model).display_rates

--- a/backend/app/core/config/llm_pricing.py
+++ b/backend/app/core/config/llm_pricing.py
@@ -11,7 +11,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Any, Dict, Optional, TypeVar
 
-from app.core.config.llm_prompt_cache_capabilities import CLAUDE_FAMILY, bedrock_cache_family
+from app.core.config.llm_prompt_cache_capabilities import bedrock_cache_family
 from app.core.tenant_scope import get_tenant_context
 from app.services.llm_pricing_cache import get_db_pricing_nested
 
@@ -62,8 +62,9 @@ STATIC_LLM_PRICING_FALLBACK: Dict[str, Dict[str, Dict[str, float]]] = {
 
 DEFAULT_PRICING = {"input_per_1k": 0.001, "output_per_1k": 0.002}
 CACHE_EXCLUSIVE_PROVIDERS = frozenset({"bedrock"})
-ANTHROPIC_CACHE_READ_MULTIPLIER = Decimal("0.1")
-ANTHROPIC_CACHE_WRITE_MULTIPLIER = Decimal("1.25")
+# Cache ratios off the input rate, shared by Anthropic and the cache-capable Bedrock families
+CACHE_READ_MULTIPLIER = Decimal("0.1")
+CACHE_WRITE_5M_MULTIPLIER = Decimal("1.25")
 
 _MATCH_EXACT = "exact"
 _MATCH_LONGEST_PREFIX = "longest_prefix"
@@ -125,6 +126,16 @@ def inclusive_cache_fallback(provider_key: str, rate: Optional[_Rate], input_per
     if rate is None and provider_key in CACHE_EXCLUSIVE_PROVIDERS:
         return None
     return cache_rate_or_input(rate, input_per_1k)
+
+
+def canonical_prompt_tokens(
+    provider_key: str, input_tokens: int, cache_read_tokens: int, cache_creation_tokens: int
+) -> int:
+    """Prompt tokens sent, normalized across providers"""
+    prompt = max(int(input_tokens), 0)
+    if provider_key in CACHE_EXCLUSIVE_PROVIDERS:
+        prompt += max(int(cache_read_tokens), 0) + max(int(cache_creation_tokens), 0)
+    return prompt
 
 
 def blended_token_cost(
@@ -283,7 +294,7 @@ def _family_cache_rate(
 ) -> Optional[Decimal]:
     if provider_key == "anthropic":
         return input_per_1k * multiplier
-    if provider_key == "bedrock" and bedrock_cache_family(model_key) == CLAUDE_FAMILY:
+    if provider_key == "bedrock" and bedrock_cache_family(model_key):
         return input_per_1k * multiplier
     return None
 
@@ -297,8 +308,8 @@ def _resolve_cache_bucket_rates(
     """Read and write resolve separately: base rates row → bundled row → family default."""
     resolved: list[Optional[Decimal]] = []
     for key, multiplier in (
-        (CACHE_READ_KEY, ANTHROPIC_CACHE_READ_MULTIPLIER),
-        (CACHE_CREATION_KEY, ANTHROPIC_CACHE_WRITE_MULTIPLIER),
+        (CACHE_READ_KEY, CACHE_READ_MULTIPLIER),
+        (CACHE_CREATION_KEY, CACHE_WRITE_5M_MULTIPLIER),
     ):
         rate = _row_cache_rate(selected, key)
         if rate is None and bundled is not selected:

--- a/backend/app/core/config/llm_pricing.py
+++ b/backend/app/core/config/llm_pricing.py
@@ -71,11 +71,6 @@ CACHE_EXCLUSIVE_PROVIDERS = frozenset({"bedrock"})
 CACHE_READ_MULTIPLIER = Decimal("0.1")
 CACHE_WRITE_5M_MULTIPLIER = Decimal("1.25")
 
-_MATCH_EXACT = "exact"
-_MATCH_LONGEST_PREFIX = "longest_prefix"
-_MATCH_REGION_AGNOSTIC = "region_agnostic"
-_MATCH_DEFAULT_ROW = "default_row"
-
 CACHE_READ_KEY = "cache_read_per_1k"
 CACHE_CREATION_KEY = "cache_creation_per_1k"
 
@@ -113,7 +108,7 @@ class _LayerMatch:
     matched_key: str
     rates: tuple[Decimal, Decimal]
     row: Mapping[str, Any]
-    match_kind: str
+    is_exact: bool
 
 
 def _normalize_model_name(model: str) -> str:
@@ -230,14 +225,12 @@ def _match_bedrock_region_agnostic(model_key: str, table: Mapping[str, Any]) -> 
     return None
 
 
-def _matchers_for(
-    provider_key: str, status: PricingStatus
-) -> list[tuple[str, Callable[[str, Mapping[str, Any]], Optional[str]]]]:
+def _matchers_for(provider_key: str, status: PricingStatus) -> list[Callable[[str, Mapping[str, Any]], Optional[str]]]:
     """Matchers within one layer. Bedrock retries per-tenant; rates are
     region-specific."""
-    matchers = [(_MATCH_LONGEST_PREFIX, _exact_or_longest_prefix)]
+    matchers = [_exact_or_longest_prefix]
     if provider_key == "bedrock" and status is PricingStatus.CONFIGURED:
-        matchers.append((_MATCH_REGION_AGNOSTIC, _match_bedrock_region_agnostic))
+        matchers.append(_match_bedrock_region_agnostic)
     return matchers
 
 
@@ -257,15 +250,14 @@ def _collect_layer_matches(
 ) -> list[_LayerMatch]:
     matches: list[_LayerMatch] = []
     for table, status in layers:
-        for inexact_kind, matcher in _matchers_for(provider_key, status):
+        for matcher in _matchers_for(provider_key, status):
             matched_key = matcher(model_key, table)
             if matched_key is None:
                 continue
             row = table[matched_key]
             rates = _rate_pair(row)
             if rates is not None:
-                kind = _MATCH_EXACT if matched_key == model_key else inexact_kind
-                matches.append(_LayerMatch(status, matched_key, rates, row, kind))
+                matches.append(_LayerMatch(status, matched_key, rates, row, matched_key == model_key))
                 break
     return matches
 
@@ -275,7 +267,7 @@ def _default_row_match(table: Mapping[str, Any], status: PricingStatus) -> Optio
     rates = _rate_pair(row)
     if rates is None:
         return None
-    return _LayerMatch(status, "_default", rates, row, _MATCH_DEFAULT_ROW)
+    return _LayerMatch(status, "_default", rates, row, False)
 
 
 def _select_base_rates(matches: list[_LayerMatch]) -> Optional[_LayerMatch]:
@@ -289,7 +281,7 @@ def _bundled_match(matches: list[_LayerMatch]) -> Optional[_LayerMatch]:
 def _row_cache_rate(match: Optional[_LayerMatch], key: str) -> Optional[Decimal]:
     if match is None:
         return None
-    if match.status is PricingStatus.FALLBACK and match.match_kind != _MATCH_EXACT:
+    if match.status is PricingStatus.FALLBACK and not match.is_exact:
         return None
     return _cache_rate(match.row, key)
 

--- a/backend/app/db/models/llm_cost_rate.py
+++ b/backend/app/db/models/llm_cost_rate.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from typing import Optional
 
 from sqlalchemy import Index, Numeric, PrimaryKeyConstraint, String, text
 from sqlalchemy.orm import Mapped, mapped_column
@@ -26,3 +27,5 @@ class LlmCostRateModel(Base):
     model_key: Mapped[str] = mapped_column(String(512), nullable=False)
     input_per_1k: Mapped[Decimal] = mapped_column(Numeric(18, 10), nullable=False)
     output_per_1k: Mapped[Decimal] = mapped_column(Numeric(18, 10), nullable=False)
+    cache_read_per_1k: Mapped[Optional[Decimal]] = mapped_column(Numeric(18, 10), nullable=True)
+    cache_creation_per_1k: Mapped[Optional[Decimal]] = mapped_column(Numeric(18, 10), nullable=True)

--- a/backend/app/db/models/llm_usage.py
+++ b/backend/app/db/models/llm_usage.py
@@ -67,6 +67,7 @@ class LlmUsageEventModel(Base):
             name="ck_llm_usage_events_cache_tokens_non_negative",
         ),
         CheckConstraint("total_tokens >= input_tokens + output_tokens", name="ck_llm_usage_events_total_ge_parts"),
+        CheckConstraint("prompt_tokens >= input_tokens", name="ck_llm_usage_events_prompt_ge_input"),
     )
 
     execution_id: Mapped[str] = mapped_column(String(64), nullable=False)
@@ -105,6 +106,7 @@ class LlmUsageEventModel(Base):
     token_details: Mapped[Optional[dict[str, Any]]] = mapped_column(JSONB, nullable=True)
     cache_read_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0, server_default="0")
     cache_creation_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0, server_default="0")
+    prompt_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0, server_default="0")
 
     input_per_1k: Mapped[Optional[Decimal]] = mapped_column(Numeric(18, 10), nullable=True)
     output_per_1k: Mapped[Optional[Decimal]] = mapped_column(Numeric(18, 10), nullable=True)

--- a/backend/app/db/models/llm_usage.py
+++ b/backend/app/db/models/llm_usage.py
@@ -62,6 +62,10 @@ class LlmUsageEventModel(Base):
             "input_tokens >= 0 AND output_tokens >= 0 AND total_tokens >= 0 AND call_index >= 0",
             name="ck_llm_usage_events_non_negative",
         ),
+        CheckConstraint(
+            "cache_read_tokens >= 0 AND cache_creation_tokens >= 0",
+            name="ck_llm_usage_events_cache_tokens_non_negative",
+        ),
         CheckConstraint("total_tokens >= input_tokens + output_tokens", name="ck_llm_usage_events_total_ge_parts"),
     )
 
@@ -99,9 +103,13 @@ class LlmUsageEventModel(Base):
     output_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
     total_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
     token_details: Mapped[Optional[dict[str, Any]]] = mapped_column(JSONB, nullable=True)
+    cache_read_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0, server_default="0")
+    cache_creation_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0, server_default="0")
 
     input_per_1k: Mapped[Optional[Decimal]] = mapped_column(Numeric(18, 10), nullable=True)
     output_per_1k: Mapped[Optional[Decimal]] = mapped_column(Numeric(18, 10), nullable=True)
+    cache_read_per_1k: Mapped[Optional[Decimal]] = mapped_column(Numeric(18, 10), nullable=True)
+    cache_creation_per_1k: Mapped[Optional[Decimal]] = mapped_column(Numeric(18, 10), nullable=True)
     cost_usd: Mapped[Optional[Decimal]] = mapped_column(Numeric(18, 10), nullable=True)
     pricing_status: Mapped[str] = mapped_column(String(20), nullable=False)
 

--- a/backend/app/modules/workflow/engine/workflow_state.py
+++ b/backend/app/modules/workflow/engine/workflow_state.py
@@ -359,13 +359,14 @@ class WorkflowState:
         total_cost_usd = 0.0
         total_cache_read = 0
         total_cache_creation = 0
+        unpriced_calls = 0
         from app.services.llm_cost_calculator import LlmCostCalculator
         self.llm_cost_calculator = LlmCostCalculator()
         for u in self.llm_usage:
             cache_read, cache_creation = extract_cache_tokens(u.get("token_details"))
             total_cache_read += cache_read
             total_cache_creation += cache_creation
-            total_cost_usd += self.llm_cost_calculator.calculate_cost(
+            cost = self.llm_cost_calculator.calculate_cost(
                 u.get("provider", ""),
                 u.get("model", ""),
                 u.get("input_tokens", 0),
@@ -373,6 +374,10 @@ class WorkflowState:
                 cache_read,
                 cache_creation,
             )
+            if cost is None:
+                unpriced_calls += 1
+            else:
+                total_cost_usd += cost
         totals = {
             "input_tokens": total_input,
             "output_tokens": total_output,
@@ -380,6 +385,7 @@ class WorkflowState:
             "cache_read_tokens": total_cache_read,
             "cache_creation_tokens": total_cache_creation,
             "cost_usd": round(total_cost_usd, 6),
+            "cost_is_partial": unpriced_calls > 0,
             "calls": len(self.llm_usage),
         }
         if not (total_cache_read or total_cache_creation or self._prompt_caching_requested()):

--- a/backend/app/modules/workflow/engine/workflow_state.py
+++ b/backend/app/modules/workflow/engine/workflow_state.py
@@ -820,6 +820,7 @@ class WorkflowState:
         failed_nodes = self._collect_failed_nodes()
 
         token_usage = self.get_total_llm_usage()
+        cost_is_partial = bool(token_usage.get("cost_is_partial"))
         response = {
             "status": status,
             "has_failures": len(failed_nodes) > 0,
@@ -829,7 +830,7 @@ class WorkflowState:
             "performance_metrics": performance_metrics,
             "state": state,
             "token_usage": token_usage,
-            "cost_usd": token_usage.get("cost_usd", 0.0),
+            "cost_usd": None if cost_is_partial else token_usage.get("cost_usd", 0.0),
             "execution_id": self.execution_id,
             "tool_events": self.tool_events,
         }

--- a/backend/app/modules/workflow/engine/workflow_state.py
+++ b/backend/app/modules/workflow/engine/workflow_state.py
@@ -370,6 +370,8 @@ class WorkflowState:
                 u.get("model", ""),
                 u.get("input_tokens", 0),
                 u.get("output_tokens", 0),
+                cache_read,
+                cache_creation,
             )
         totals = {
             "input_tokens": total_input,

--- a/backend/app/repositories/llm_usage_backfill.py
+++ b/backend/app/repositories/llm_usage_backfill.py
@@ -19,6 +19,7 @@ from app.repositories.db_repository import DbRepository
 # Includes attribution so a re-run restamps rows backfilled before the agent fix.
 _FORCE_UPDATE_COLUMNS = (
     "input_tokens",
+    "prompt_tokens",
     "output_tokens",
     "total_tokens",
     "cost_usd",

--- a/backend/app/repositories/llm_usage_read.py
+++ b/backend/app/repositories/llm_usage_read.py
@@ -2,10 +2,10 @@ from datetime import date, datetime, timedelta, timezone
 from uuid import UUID
 
 from injector import inject
-from sqlalchemy import Date, case, cast, distinct, func, select
+from sqlalchemy import Date, cast, distinct, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config.llm_pricing import CACHE_EXCLUSIVE_PROVIDERS, PricingStatus
+from app.core.config.llm_pricing import PricingStatus
 from app.core.utils.analytics_agent_scope import resolve_authorized_agent_ids
 from app.db.models.llm_usage import LlmUsageEventModel
 from app.repositories.db_repository import DbRepository
@@ -16,18 +16,9 @@ _STATUS = LlmUsageEventModel.pricing_status
 _SOURCE = LlmUsageEventModel.source
 _CACHE_READ = LlmUsageEventModel.cache_read_tokens
 _CACHE_WRITE = LlmUsageEventModel.cache_creation_tokens
-_IS_EXCLUSIVE = LlmUsageEventModel.provider_key.in_(sorted(CACHE_EXCLUSIVE_PROVIDERS))
-
-# Prompt tokens sent. Exclusive providers store input_tokens without cache, so we add those buckets back
-_PROMPT_TOKENS = LlmUsageEventModel.input_tokens + case((_IS_EXCLUSIVE, _CACHE_READ + _CACHE_WRITE), else_=0)
-
-_TOKENS = case(
-    (
-        _IS_EXCLUSIVE,
-        func.greatest(LlmUsageEventModel.total_tokens, _PROMPT_TOKENS + LlmUsageEventModel.output_tokens),
-    ),
-    else_=LlmUsageEventModel.total_tokens,
-)
+# Normalized at write time, so reads never reapply per-provider reporting rules
+_PROMPT_TOKENS = LlmUsageEventModel.prompt_tokens
+_TOKENS = func.greatest(LlmUsageEventModel.total_tokens, _PROMPT_TOKENS + LlmUsageEventModel.output_tokens)
 
 AGENT_STUDIO_TEST_SOURCES = ("workflow_test", "node_test")
 

--- a/backend/app/repositories/llm_usage_read.py
+++ b/backend/app/repositories/llm_usage_read.py
@@ -2,19 +2,32 @@ from datetime import date, datetime, timedelta, timezone
 from uuid import UUID
 
 from injector import inject
-from sqlalchemy import Date, cast, distinct, func, select
+from sqlalchemy import Date, case, cast, distinct, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config.llm_pricing import PricingStatus
+from app.core.config.llm_pricing import CACHE_EXCLUSIVE_PROVIDERS, PricingStatus
 from app.core.utils.analytics_agent_scope import resolve_authorized_agent_ids
 from app.db.models.llm_usage import LlmUsageEventModel
 from app.repositories.db_repository import DbRepository
 
 _COST = LlmUsageEventModel.cost_usd
 _CONV = LlmUsageEventModel.conversation_id
-_TOKENS = LlmUsageEventModel.total_tokens
 _STATUS = LlmUsageEventModel.pricing_status
 _SOURCE = LlmUsageEventModel.source
+_CACHE_READ = LlmUsageEventModel.cache_read_tokens
+_CACHE_WRITE = LlmUsageEventModel.cache_creation_tokens
+_IS_EXCLUSIVE = LlmUsageEventModel.provider_key.in_(sorted(CACHE_EXCLUSIVE_PROVIDERS))
+
+# Prompt tokens sent. Exclusive providers store input_tokens without cache, so we add those buckets back
+_PROMPT_TOKENS = LlmUsageEventModel.input_tokens + case((_IS_EXCLUSIVE, _CACHE_READ + _CACHE_WRITE), else_=0)
+
+_TOKENS = case(
+    (
+        _IS_EXCLUSIVE,
+        func.greatest(LlmUsageEventModel.total_tokens, _PROMPT_TOKENS + LlmUsageEventModel.output_tokens),
+    ),
+    else_=LlmUsageEventModel.total_tokens,
+)
 
 AGENT_STUDIO_TEST_SOURCES = ("workflow_test", "node_test")
 
@@ -62,21 +75,25 @@ class LlmUsageReadRepository(DbRepository[LlmUsageEventModel]):
 
     async def summary(self, params, scope: list[UUID] | None):
         stmt = select(
-            func.coalesce(func.sum(_COST), 0),
-            func.coalesce(func.sum(LlmUsageEventModel.input_tokens), 0),
-            func.coalesce(func.sum(LlmUsageEventModel.output_tokens), 0),
-            func.coalesce(func.sum(_TOKENS), 0),
-            func.count(),
-            func.count().filter(_COST.is_(None)),
-            _calls_with_status(PricingStatus.CONFIGURED),
-            _calls_with_status(PricingStatus.FALLBACK),
-            _calls_with_status(PricingStatus.LEGACY_ESTIMATE),
-            func.coalesce(func.sum(_TOKENS).filter(_COST.isnot(None)), 0),
-            func.coalesce(func.sum(_COST).filter(_CONV.isnot(None)), 0),
-            func.coalesce(func.sum(_COST).filter(_SOURCE.in_(AGENT_STUDIO_TEST_SOURCES)), 0),
-            func.count(distinct(_CONV)),
+            func.coalesce(func.sum(_COST), 0).label("sum_cost"),
+            func.coalesce(func.sum(_PROMPT_TOKENS), 0).label("input_tokens"),
+            func.coalesce(func.sum(LlmUsageEventModel.output_tokens), 0).label("output_tokens"),
+            func.coalesce(func.sum(_TOKENS), 0).label("total_tokens"),
+            func.count().label("total_calls"),
+            func.count().filter(_COST.is_(None)).label("unpriced_calls"),
+            _calls_with_status(PricingStatus.CONFIGURED).label("configured_calls"),
+            _calls_with_status(PricingStatus.FALLBACK).label("fallback_calls"),
+            _calls_with_status(PricingStatus.LEGACY_ESTIMATE).label("legacy_estimate_calls"),
+            func.coalesce(func.sum(_TOKENS).filter(_COST.isnot(None)), 0).label("priced_tokens"),
+            func.coalesce(func.sum(_COST).filter(_CONV.isnot(None)), 0).label("conversation_cost"),
+            func.coalesce(func.sum(_COST).filter(_SOURCE.in_(AGENT_STUDIO_TEST_SOURCES)), 0).label(
+                "agent_studio_test_cost"
+            ),
+            func.count(distinct(_CONV)).label("distinct_conversations"),
+            func.coalesce(func.sum(_CACHE_READ), 0).label("cache_read_tokens"),
+            func.coalesce(func.sum(_CACHE_WRITE), 0).label("cache_creation_tokens"),
         ).where(*self._conditions(params, scope))
-        return (await self.db.execute(stmt)).one()
+        return (await self.db.execute(stmt)).mappings().one()
 
     async def last_unpriced_at(self) -> datetime | None:
         """Return when the tenant last recorded an unpriced call, ignoring read filters"""

--- a/backend/app/schemas/llm_cost_rate.py
+++ b/backend/app/schemas/llm_cost_rate.py
@@ -1,11 +1,20 @@
 from datetime import datetime
 from decimal import Decimal
-from typing import Annotated
+from typing import Annotated, Any
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, field_serializer, field_validator
 
 RateDecimal = Annotated[Decimal, Field(ge=0, max_digits=18, decimal_places=10)]
+
+
+def _blank_to_none(value: Any) -> Any:
+    if isinstance(value, str) and not value.strip():
+        return None
+    return value
+
+
+CacheRateDecimal = Annotated[RateDecimal | None, BeforeValidator(_blank_to_none)]
 
 
 def format_rate(value: Decimal | float | str) -> str:
@@ -27,11 +36,17 @@ class LlmCostRateRead(BaseModel):
     model_key: str
     input_per_1k: Decimal
     output_per_1k: Decimal
+    cache_read_per_1k: Decimal | None = None
+    cache_creation_per_1k: Decimal | None = None
     updated_at: datetime
 
     @field_serializer("input_per_1k", "output_per_1k")
     def serialize_input_output_per_1k(self, value: Decimal) -> str:
         return format_rate(value)
+
+    @field_serializer("cache_read_per_1k", "cache_creation_per_1k")
+    def serialize_cache_per_1k(self, value: Decimal | None) -> str | None:
+        return None if value is None else format_rate(value)
 
 
 class LlmCostRateImportResult(BaseModel):
@@ -48,6 +63,8 @@ class LlmCostRateCreate(BaseModel):
     model: str = Field(min_length=1, max_length=512)
     input_per_1k: RateDecimal
     output_per_1k: RateDecimal
+    cache_read_per_1k: CacheRateDecimal = None
+    cache_creation_per_1k: CacheRateDecimal = None
 
     @field_validator("provider", "model")
     @classmethod
@@ -56,7 +73,11 @@ class LlmCostRateCreate(BaseModel):
 
 
 class LlmCostRateUpdate(BaseModel):
-    """Rate edit. Identity (provider/model) is fixed, delete + recreate to move a rate"""
+    """Rate edit. Identity (provider/model) is fixed, delete + recreate to move a rate.
+    Base rates are full-replace; a cache rate is only touched when the payload carries
+    its key. Sent blank it clears back to the provider default, omitted it is kept"""
 
     input_per_1k: RateDecimal
     output_per_1k: RateDecimal
+    cache_read_per_1k: CacheRateDecimal = None
+    cache_creation_per_1k: CacheRateDecimal = None

--- a/backend/app/schemas/llm_usage.py
+++ b/backend/app/schemas/llm_usage.py
@@ -43,7 +43,11 @@ class LlmUsageSummaryResponse(BaseModel):
 
     ``last_unpriced_at`` is when an unpriced call was last *recorded* tenant-wide,
     ignoring the filters, so a client can tell whether one has landed since it last
-    reported the gap. It is only populated when the filtered window has unpriced calls"""
+    reported the gap. It is only populated when the filtered window has unpriced calls.
+
+    Prompt tokens sent, normalized across providers. Includes cache (already
+    in total_input_tokens). If provider reports input minus cache, we add it back
+    so input + output = total_tokens."""
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -56,6 +60,8 @@ class LlmUsageSummaryResponse(BaseModel):
     total_input_tokens: int
     total_output_tokens: int
     total_tokens: int
+    total_cache_read_tokens: int = 0
+    total_cache_creation_tokens: int = 0
     total_calls: int
     configured_calls: int
     fallback_calls: int

--- a/backend/app/services/llm_cost_calculator.py
+++ b/backend/app/services/llm_cost_calculator.py
@@ -4,7 +4,7 @@ LLM cost calculation service.
 Calculates cost in USD from token usage using provider/model pricing.
 """
 
-from app.core.config.llm_pricing import blended_token_cost, cache_rate_or_input, resolve_live_pricing
+from app.core.config.llm_pricing import blended_token_cost, inclusive_cache_fallback, resolve_live_pricing
 
 
 class LlmCostCalculator:
@@ -16,7 +16,7 @@ class LlmCostCalculator:
         output_tokens: int,
         cache_read_tokens: int = 0,
         cache_creation_tokens: int = 0,
-    ) -> float:
+    ) -> float | None:
         """
         Calculate cost in USD for given token usage.
 
@@ -29,18 +29,19 @@ class LlmCostCalculator:
             cache_creation_tokens: Prompt tokens written to the provider's cache
 
         Returns:
-            Cost in USD
+            Cost in USD, or None when an active cache bucket has no resolvable rate
         """
         if input_tokens < 0 or output_tokens < 0:
             return 0.0
+        provider_key = (provider or "").strip().lower()
         pricing = resolve_live_pricing(provider, model)
         input_per_1k = pricing.display_rates.get("input_per_1k", 0.001)
         output_per_1k = pricing.display_rates.get("output_per_1k", 0.002)
-        read_rate = cache_rate_or_input(pricing.cache_read_per_1k, input_per_1k)
-        creation_rate = cache_rate_or_input(pricing.cache_creation_per_1k, input_per_1k)
+        read_rate = inclusive_cache_fallback(provider_key, pricing.cache_read_per_1k, input_per_1k)
+        creation_rate = inclusive_cache_fallback(provider_key, pricing.cache_creation_per_1k, input_per_1k)
 
         cost = blended_token_cost(
-            (provider or "").strip().lower(),
+            provider_key,
             input_tokens,
             output_tokens,
             cache_read_tokens,
@@ -51,4 +52,4 @@ class LlmCostCalculator:
             creation_rate,
             1000.0,
         )
-        return round(cost, 6)
+        return None if cost is None else round(cost, 6)

--- a/backend/app/services/llm_cost_calculator.py
+++ b/backend/app/services/llm_cost_calculator.py
@@ -4,11 +4,19 @@ LLM cost calculation service.
 Calculates cost in USD from token usage using provider/model pricing.
 """
 
-from app.core.config.llm_pricing import find_pricing
+from app.core.config.llm_pricing import blended_token_cost, cache_rate_or_input, resolve_live_pricing
 
 
 class LlmCostCalculator:
-    def calculate_cost(self, provider: str, model: str, input_tokens: int, output_tokens: int) -> float:
+    def calculate_cost(
+        self,
+        provider: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cache_read_tokens: int = 0,
+        cache_creation_tokens: int = 0,
+    ) -> float:
         """
         Calculate cost in USD for given token usage.
 
@@ -17,13 +25,30 @@ class LlmCostCalculator:
             model: Model name (e.g. gpt-4o, claude-3-sonnet)
             input_tokens: Number of input/prompt tokens
             output_tokens: Number of output/completion tokens
+            cache_read_tokens: Prompt tokens served from the provider's cache
+            cache_creation_tokens: Prompt tokens written to the provider's cache
 
         Returns:
             Cost in USD
         """
         if input_tokens < 0 or output_tokens < 0:
             return 0.0
-        pricing = find_pricing(provider, model)
-        input_per_1k = pricing.get("input_per_1k", 0.001)
-        output_per_1k = pricing.get("output_per_1k", 0.002)
-        return round((input_tokens / 1000.0) * input_per_1k + (output_tokens / 1000.0) * output_per_1k, 6)
+        pricing = resolve_live_pricing(provider, model)
+        input_per_1k = pricing.display_rates.get("input_per_1k", 0.001)
+        output_per_1k = pricing.display_rates.get("output_per_1k", 0.002)
+        read_rate = cache_rate_or_input(pricing.cache_read_per_1k, input_per_1k)
+        creation_rate = cache_rate_or_input(pricing.cache_creation_per_1k, input_per_1k)
+
+        cost = blended_token_cost(
+            (provider or "").strip().lower(),
+            input_tokens,
+            output_tokens,
+            cache_read_tokens,
+            cache_creation_tokens,
+            input_per_1k,
+            output_per_1k,
+            read_rate,
+            creation_rate,
+            1000.0,
+        )
+        return round(cost, 6)

--- a/backend/app/services/llm_cost_rates.py
+++ b/backend/app/services/llm_cost_rates.py
@@ -2,6 +2,7 @@ import csv
 import io
 import logging
 from collections import Counter
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from decimal import Decimal
 from uuid import UUID
@@ -56,6 +57,68 @@ def _rate_key(provider_key: str | None, model_key: str | None) -> tuple[str, str
 
 def _optional_rate(value: Decimal | None) -> str:
     return "" if value is None else format_rate(value)
+
+
+def _parse_header(fieldnames: Sequence[str] | None) -> tuple[dict[str, str], set[str], str | None]:
+    """Original-case column lookup and normalized names, or why the header is unusable"""
+    if not fieldnames:
+        return {}, set(), "CSV has no header row"
+
+    names = [(h or "").strip().lower() for h in fieldnames]
+    counts = Counter(name for name in names if name)
+    if any(count > 1 for count in counts.values()):
+        duplicates = sorted(h for h, count in counts.items() if count > 1)
+        return {}, set(), f"Duplicate columns: {', '.join(duplicates)}"
+
+    headers = set(counts)
+    if not _REQUIRED_COLUMNS.issubset(headers):
+        missing = _REQUIRED_COLUMNS - headers
+        return {}, set(), f"Missing columns: {', '.join(sorted(missing))}"
+
+    original_header: dict[str, str] = {}
+    for name, raw in zip(names, fieldnames):
+        if name:
+            original_header.setdefault(name, raw)
+    return original_header, headers, None
+
+
+def _parse_rows(
+    reader: csv.DictReader, original_header: dict[str, str]
+) -> tuple[list[LlmCostRateCreate], list[str], str | None]:
+    """Accepted rows plus per-row errors, or why the whole file is rejected"""
+
+    def col(row: dict[str, str], name: str) -> str:
+        key = original_header.get(name)
+        return "" if key is None else (row.get(key) or "").strip()
+
+    errors: list[str] = []
+    seen_keys: dict[tuple[str, str], int] = {}
+    parsed: list[LlmCostRateCreate] = []
+    for i, row in enumerate(reader, start=2):
+        if i - 1 > MAX_IMPORT_ROWS:
+            return [], [], f"CSV has more than {MAX_IMPORT_ROWS} data rows"
+        # Every row goes through the create schema, so CSV and JSON reject
+        # blank keys, negatives, non-finite and over-precise rates alike
+        try:
+            dto = LlmCostRateCreate(
+                provider=col(row, "provider"),
+                model=col(row, "model"),
+                input_per_1k=col(row, "input_per_1k"),
+                output_per_1k=col(row, "output_per_1k"),
+                cache_read_per_1k=col(row, "cache_read_per_1k"),
+                cache_creation_per_1k=col(row, "cache_creation_per_1k"),
+            )
+        except ValidationError:
+            errors.append(f"Row {i}: invalid provider, model or rate value")
+            continue
+
+        key = (dto.provider, dto.model)
+        if key in seen_keys:
+            errors.append(f"Row {i}: duplicate of row {seen_keys[key]} for {dto.provider}/{dto.model}")
+            continue
+        seen_keys[key] = i
+        parsed.append(dto)
+    return parsed, errors, None
 
 
 @inject
@@ -133,76 +196,11 @@ class LlmCostRateService:
             invalidate_llm_cost_rates_cache_after_commit(self.repo.db, tenant)
         return ok
 
-    async def import_csv(self, text: str) -> LlmCostRateImportResult:
-        tenant = get_tenant_context()
+    async def _apply_rows(self, parsed: list[LlmCostRateCreate], headers: set[str]) -> tuple[int, int]:
+        """Stage inserts and updates. Cache columns absent from the header keep their stored value"""
+        index = {_rate_key(r.provider_key, r.model_key): r for r in await self.repo.list_active()}
         inserted = 0
         updated = 0
-        errors: list[str] = []
-
-        reader = csv.DictReader(io.StringIO(text))
-        if not reader.fieldnames:
-            return LlmCostRateImportResult(
-                inserted=0, updated=0, errors=["CSV has no header row"]
-            )
-        header_names = [(h or "").strip().lower() for h in reader.fieldnames]
-        header_counts = Counter(name for name in header_names if name)
-        headers = set(header_counts)
-        if any(count > 1 for count in header_counts.values()):
-            duplicates = sorted(h for h, count in header_counts.items() if count > 1)
-            return LlmCostRateImportResult(
-                inserted=0,
-                updated=0,
-                errors=[f"Duplicate columns: {', '.join(duplicates)}"],
-            )
-        if not _REQUIRED_COLUMNS.issubset(headers):
-            missing = _REQUIRED_COLUMNS - headers
-            return LlmCostRateImportResult(
-                inserted=0,
-                updated=0,
-                errors=[f"Missing columns: {', '.join(sorted(missing))}"],
-            )
-
-        original_header: dict[str, str] = {}
-        for name, raw in zip(header_names, reader.fieldnames):
-            if name:
-                original_header.setdefault(name, raw)
-
-        def col(row: dict[str, str], name: str) -> str:
-            key = original_header.get(name)
-            return "" if key is None else (row.get(key) or "").strip()
-
-        seen_keys: dict[tuple[str, str], int] = {}
-        parsed: list[LlmCostRateCreate] = []
-        for i, row in enumerate(reader, start=2):
-            if i - 1 > MAX_IMPORT_ROWS:
-                return LlmCostRateImportResult(
-                    inserted=0,
-                    updated=0,
-                    errors=[f"CSV has more than {MAX_IMPORT_ROWS} data rows"],
-                )
-            # Every row goes through the create schema, so CSV and JSON reject
-            # blank keys, negatives, non-finite and over-precise rates alike
-            try:
-                dto = LlmCostRateCreate(
-                    provider=col(row, "provider"),
-                    model=col(row, "model"),
-                    input_per_1k=col(row, "input_per_1k"),
-                    output_per_1k=col(row, "output_per_1k"),
-                    cache_read_per_1k=col(row, "cache_read_per_1k"),
-                    cache_creation_per_1k=col(row, "cache_creation_per_1k"),
-                )
-            except ValidationError:
-                errors.append(f"Row {i}: invalid provider, model or rate value")
-                continue
-
-            key = (dto.provider, dto.model)
-            if key in seen_keys:
-                errors.append(f"Row {i}: duplicate of row {seen_keys[key]} for {dto.provider}/{dto.model}")
-                continue
-            seen_keys[key] = i
-            parsed.append(dto)
-
-        index = {_rate_key(r.provider_key, r.model_key): r for r in await self.repo.list_active()}
 
         for dto in parsed:
             existing = index.get((dto.provider, dto.model))
@@ -231,6 +229,21 @@ class LlmCostRateService:
                 index[(dto.provider, dto.model)] = created
                 inserted += 1
 
+        return inserted, updated
+
+    async def import_csv(self, text: str) -> LlmCostRateImportResult:
+        tenant = get_tenant_context()
+        reader = csv.DictReader(io.StringIO(text))
+
+        original_header, headers, header_error = _parse_header(reader.fieldnames)
+        if header_error:
+            return LlmCostRateImportResult(inserted=0, updated=0, errors=[header_error])
+
+        parsed, errors, file_error = _parse_rows(reader, original_header)
+        if file_error:
+            return LlmCostRateImportResult(inserted=0, updated=0, errors=[file_error])
+
+        inserted, updated = await self._apply_rows(parsed, headers)
         errors = _capped_errors(errors)
 
         try:

--- a/backend/app/services/llm_cost_rates.py
+++ b/backend/app/services/llm_cost_rates.py
@@ -22,7 +22,10 @@ from app.schemas.llm_cost_rate import (
     LlmCostRateUpdate,
     format_rate,
 )
-from app.services.llm_pricing_cache import invalidate_llm_cost_rates_cache
+from app.services.llm_pricing_cache import (
+    invalidate_llm_cost_rates_cache,
+    invalidate_llm_cost_rates_cache_after_commit,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +106,7 @@ class LlmCostRateService:
                 updated_at=datetime.now(timezone.utc),
             )
         )
-        invalidate_llm_cost_rates_cache(tenant)
+        invalidate_llm_cost_rates_cache_after_commit(self.repo.db, tenant)
         return LlmCostRateRead.model_validate(created, from_attributes=True)
 
     async def update_rate(self, rate_id: UUID, dto: LlmCostRateUpdate) -> LlmCostRateRead | None:
@@ -120,14 +123,14 @@ class LlmCostRateService:
             row.cache_creation_per_1k = dto.cache_creation_per_1k
         row.updated_at = datetime.now(timezone.utc)
         updated = await self.repo.update(row)
-        invalidate_llm_cost_rates_cache(tenant)
+        invalidate_llm_cost_rates_cache_after_commit(self.repo.db, tenant)
         return LlmCostRateRead.model_validate(updated, from_attributes=True)
 
     async def delete_by_id(self, rate_id: UUID) -> bool:
         tenant = get_tenant_context()
         ok = await self.repo.soft_delete_by_id(rate_id)
         if ok:
-            invalidate_llm_cost_rates_cache(tenant)
+            invalidate_llm_cost_rates_cache_after_commit(self.repo.db, tenant)
         return ok
 
     async def import_csv(self, text: str) -> LlmCostRateImportResult:

--- a/backend/app/services/llm_cost_rates.py
+++ b/backend/app/services/llm_cost_rates.py
@@ -1,7 +1,9 @@
 import csv
 import io
 import logging
+from collections import Counter
 from datetime import datetime, timezone
+from decimal import Decimal
 from uuid import UUID
 
 from injector import inject
@@ -24,7 +26,33 @@ from app.services.llm_pricing_cache import invalidate_llm_cost_rates_cache
 
 logger = logging.getLogger(__name__)
 
+# Cache rate columns stay optional so files written for the 4-column format still import
 _REQUIRED_COLUMNS = frozenset({"provider", "model", "input_per_1k", "output_per_1k"})
+_BASE_COLUMNS = ["provider", "model", "input_per_1k", "output_per_1k"]
+_CACHE_COLUMNS = ["cache_read_per_1k", "cache_creation_per_1k"]
+
+MAX_IMPORT_BYTES = 1 * 1024 * 1024
+MAX_IMPORT_ROWS = 10_000
+MAX_IMPORT_ERRORS = 100
+
+
+def import_exceeds_byte_cap(raw: bytes) -> bool:
+    return len(raw) > MAX_IMPORT_BYTES
+
+
+def _capped_errors(errors: list[str]) -> list[str]:
+    if len(errors) <= MAX_IMPORT_ERRORS:
+        return errors
+    omitted = len(errors) - MAX_IMPORT_ERRORS
+    return [*errors[:MAX_IMPORT_ERRORS], f"… {omitted} additional errors omitted"]
+
+
+def _rate_key(provider_key: str | None, model_key: str | None) -> tuple[str, str]:
+    return (provider_key or "").strip().lower(), (model_key or "").strip().lower()
+
+
+def _optional_rate(value: Decimal | None) -> str:
+    return "" if value is None else format_rate(value)
 
 
 @inject
@@ -35,23 +63,25 @@ class LlmCostRateService:
     async def list_active(self) -> list[LlmCostRateModel]:
         return await self.repo.list_active()
 
-    async def export_csv(self) -> str:
+    async def export_csv(self, include_cache_rates: bool) -> str:
         """
-        Export the current rates in the same 4-column format the importer accepts.
+        Export the current rates in a format the importer accepts. Unconfigured cache rates export blank, so a
+        round-trip keeps them unset.
         """
         rows = await self.repo.list_active()
         out = io.StringIO()
         writer = csv.writer(out, lineterminator="\n")
-        writer.writerow(["provider", "model", "input_per_1k", "output_per_1k"])
+        writer.writerow((_BASE_COLUMNS + _CACHE_COLUMNS) if include_cache_rates else _BASE_COLUMNS)
         for r in rows:
-            writer.writerow(
-                [
-                    (r.provider_key or "").strip(),
-                    (r.model_key or "").strip(),
-                    format_rate(r.input_per_1k),
-                    format_rate(r.output_per_1k),
-                ]
-            )
+            values = [
+                (r.provider_key or "").strip(),
+                (r.model_key or "").strip(),
+                format_rate(r.input_per_1k),
+                format_rate(r.output_per_1k),
+            ]
+            if include_cache_rates:
+                values += [_optional_rate(r.cache_read_per_1k), _optional_rate(r.cache_creation_per_1k)]
+            writer.writerow(values)
         return out.getvalue()
 
     async def create_rate(self, dto: LlmCostRateCreate) -> LlmCostRateRead:
@@ -68,6 +98,8 @@ class LlmCostRateService:
                 model_key=model,
                 input_per_1k=dto.input_per_1k,
                 output_per_1k=dto.output_per_1k,
+                cache_read_per_1k=dto.cache_read_per_1k,
+                cache_creation_per_1k=dto.cache_creation_per_1k,
                 updated_at=datetime.now(timezone.utc),
             )
         )
@@ -82,6 +114,10 @@ class LlmCostRateService:
             return None
         row.input_per_1k = dto.input_per_1k
         row.output_per_1k = dto.output_per_1k
+        if "cache_read_per_1k" in dto.model_fields_set:
+            row.cache_read_per_1k = dto.cache_read_per_1k
+        if "cache_creation_per_1k" in dto.model_fields_set:
+            row.cache_creation_per_1k = dto.cache_creation_per_1k
         row.updated_at = datetime.now(timezone.utc)
         updated = await self.repo.update(row)
         invalidate_llm_cost_rates_cache(tenant)
@@ -105,7 +141,16 @@ class LlmCostRateService:
             return LlmCostRateImportResult(
                 inserted=0, updated=0, errors=["CSV has no header row"]
             )
-        headers = {h.strip().lower() for h in reader.fieldnames if h}
+        header_names = [(h or "").strip().lower() for h in reader.fieldnames]
+        header_counts = Counter(name for name in header_names if name)
+        headers = set(header_counts)
+        if any(count > 1 for count in header_counts.values()):
+            duplicates = sorted(h for h, count in header_counts.items() if count > 1)
+            return LlmCostRateImportResult(
+                inserted=0,
+                updated=0,
+                errors=[f"Duplicate columns: {', '.join(duplicates)}"],
+            )
         if not _REQUIRED_COLUMNS.issubset(headers):
             missing = _REQUIRED_COLUMNS - headers
             return LlmCostRateImportResult(
@@ -114,14 +159,24 @@ class LlmCostRateService:
                 errors=[f"Missing columns: {', '.join(sorted(missing))}"],
             )
 
+        original_header: dict[str, str] = {}
+        for name, raw in zip(header_names, reader.fieldnames):
+            if name:
+                original_header.setdefault(name, raw)
+
         def col(row: dict[str, str], name: str) -> str:
-            for k, v in row.items():
-                if k and k.strip().lower() == name:
-                    return (v or "").strip()
-            return ""
+            key = original_header.get(name)
+            return "" if key is None else (row.get(key) or "").strip()
 
         seen_keys: dict[tuple[str, str], int] = {}
+        parsed: list[LlmCostRateCreate] = []
         for i, row in enumerate(reader, start=2):
+            if i - 1 > MAX_IMPORT_ROWS:
+                return LlmCostRateImportResult(
+                    inserted=0,
+                    updated=0,
+                    errors=[f"CSV has more than {MAX_IMPORT_ROWS} data rows"],
+                )
             # Every row goes through the create schema, so CSV and JSON reject
             # blank keys, negatives, non-finite and over-precise rates alike
             try:
@@ -130,9 +185,11 @@ class LlmCostRateService:
                     model=col(row, "model"),
                     input_per_1k=col(row, "input_per_1k"),
                     output_per_1k=col(row, "output_per_1k"),
+                    cache_read_per_1k=col(row, "cache_read_per_1k"),
+                    cache_creation_per_1k=col(row, "cache_creation_per_1k"),
                 )
             except ValidationError:
-                errors.append(f"Row {i}: invalid provider, model, input_per_1k or output_per_1k")
+                errors.append(f"Row {i}: invalid provider, model or rate value")
                 continue
 
             key = (dto.provider, dto.model)
@@ -140,26 +197,38 @@ class LlmCostRateService:
                 errors.append(f"Row {i}: duplicate of row {seen_keys[key]} for {dto.provider}/{dto.model}")
                 continue
             seen_keys[key] = i
+            parsed.append(dto)
 
-            existing = await self.repo.get_active_by_provider_model(dto.provider, dto.model)
+        index = {_rate_key(r.provider_key, r.model_key): r for r in await self.repo.list_active()}
+
+        for dto in parsed:
+            existing = index.get((dto.provider, dto.model))
             if existing:
                 existing.input_per_1k = dto.input_per_1k
                 existing.output_per_1k = dto.output_per_1k
+                if "cache_read_per_1k" in headers:
+                    existing.cache_read_per_1k = dto.cache_read_per_1k
+                if "cache_creation_per_1k" in headers:
+                    existing.cache_creation_per_1k = dto.cache_creation_per_1k
                 # Defensive: older schema/model mismatch could leave this NULL.
                 existing.updated_at = datetime.now(timezone.utc)
                 self.repo.db.add(existing)
                 updated += 1
             else:
-                self.repo.db.add(
-                    LlmCostRateModel(
-                        provider_key=dto.provider,
-                        model_key=dto.model,
-                        input_per_1k=dto.input_per_1k,
-                        output_per_1k=dto.output_per_1k,
-                        updated_at=datetime.now(timezone.utc),
-                    )
+                created = LlmCostRateModel(
+                    provider_key=dto.provider,
+                    model_key=dto.model,
+                    input_per_1k=dto.input_per_1k,
+                    output_per_1k=dto.output_per_1k,
+                    cache_read_per_1k=dto.cache_read_per_1k,
+                    cache_creation_per_1k=dto.cache_creation_per_1k,
+                    updated_at=datetime.now(timezone.utc),
                 )
+                self.repo.db.add(created)
+                index[(dto.provider, dto.model)] = created
                 inserted += 1
+
+        errors = _capped_errors(errors)
 
         try:
             await self.repo.db.commit()
@@ -169,5 +238,6 @@ class LlmCostRateService:
             errors.append("No rows were imported: the file conflicts with existing rates")
             return LlmCostRateImportResult(inserted=0, updated=0, errors=errors)
 
-        invalidate_llm_cost_rates_cache(tenant)
+        if inserted or updated:
+            invalidate_llm_cost_rates_cache(tenant)
         return LlmCostRateImportResult(inserted=inserted, updated=updated, errors=errors)

--- a/backend/app/services/llm_pricing_cache.py
+++ b/backend/app/services/llm_pricing_cache.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from typing import Any
 
 from sqlalchemy import create_engine, select
@@ -20,7 +21,14 @@ from app.db.models.llm_cost_rate import LlmCostRateModel
 logger = logging.getLogger(__name__)
 
 _lock = threading.Lock()
-_cache: dict[str, dict[str, dict[str, dict[str, float]]]] = {}
+_condition = threading.Condition(_lock)
+_TTL_SECONDS = 60.0
+_FAILURE_COOLDOWN_SECONDS = 5.0
+_cache: dict[str, tuple[float, dict[str, dict[str, dict[str, float]]]]] = {}
+_next_retry: dict[str, float] = {}
+_refreshing: set[str] = set()
+_global_generation = 0
+_tenant_generation: dict[str, int] = {}
 _sync_session_factories: dict[str, sessionmaker[Any]] = {}
 
 
@@ -39,11 +47,16 @@ def _session_factory_for_tenant(tenant: str) -> sessionmaker[Any]:
 
 
 def invalidate_llm_cost_rates_cache(tenant: str | None = None) -> None:
+    global _global_generation
     with _lock:
         if tenant is None:
+            _global_generation += 1
             _cache.clear()
+            _next_retry.clear()
         else:
+            _tenant_generation[tenant] = _tenant_generation.get(tenant, 0) + 1
             _cache.pop(tenant, None)
+            _next_retry.pop(tenant, None)
 
 
 def _load_db_nested(tenant: str) -> dict[str, dict[str, dict[str, float]]] | None:
@@ -57,6 +70,8 @@ def _load_db_nested(tenant: str) -> dict[str, dict[str, dict[str, float]]] | Non
                     LlmCostRateModel.model_key,
                     LlmCostRateModel.input_per_1k,
                     LlmCostRateModel.output_per_1k,
+                    LlmCostRateModel.cache_read_per_1k,
+                    LlmCostRateModel.cache_creation_per_1k,
                 ).where(LlmCostRateModel.is_deleted == 0)
             ).all()
             for r in rows:
@@ -64,24 +79,86 @@ def _load_db_nested(tenant: str) -> dict[str, dict[str, dict[str, float]]] | Non
                 mk = (r.model_key or "").lower().strip()
                 if not pk or not mk:
                     continue
-                nested.setdefault(pk, {})[mk] = {
+                rates = {
                     "input_per_1k": float(r.input_per_1k),
                     "output_per_1k": float(r.output_per_1k),
                 }
+                # Left out when unconfigured, so pricing falls back to its provider default
+                if r.cache_read_per_1k is not None:
+                    rates["cache_read_per_1k"] = float(r.cache_read_per_1k)
+                if r.cache_creation_per_1k is not None:
+                    rates["cache_creation_per_1k"] = float(r.cache_creation_per_1k)
+                nested.setdefault(pk, {})[mk] = rates
     except Exception as e:
         logger.warning("Failed loading llm_cost_rates for tenant %s: %s", tenant, e)
         return None
     return nested
 
 
+def _refresh(tenant: str, generation: tuple) -> tuple:
+    loaded = None
+    current = generation
+    try:
+        loaded = _load_db_nested(tenant)
+    finally:
+        with _condition:
+            _refreshing.discard(tenant)
+            current = (_global_generation, _tenant_generation.get(tenant, 0))
+            if current == generation:
+                if loaded is None:
+                    _next_retry[tenant] = time.monotonic() + _FAILURE_COOLDOWN_SECONDS
+                else:
+                    _cache[tenant] = (time.monotonic() + _TTL_SECONDS, loaded)
+                    _next_retry.pop(tenant, None)
+            _condition.notify_all()
+    return loaded, current
+
+
+def _refresh_in_background(tenant: str, generation: tuple) -> None:
+    try:
+        _refresh(tenant, generation)
+    except Exception:
+        # Bookkeeping already ran in _refresh's finally; the next caller retries
+        logger.warning("Background llm_cost_rates refresh failed for tenant %s", tenant, exc_info=True)
+
+
 def get_db_pricing_nested(tenant: str) -> dict[str, dict[str, dict[str, float]]]:
-    """Cached {provider: {model: {input_per_1k, output_per_1k}}} from llm_cost_rates."""
-    with _lock:
-        if tenant in _cache:
-            return _cache[tenant]
-    loaded = _load_db_nested(tenant)
-    if loaded is None:
-        return {}
-    with _lock:
-        _cache[tenant] = loaded
-    return loaded
+    """Cached {provider: {model: rates}} from llm_cost_rates, refreshed every _TTL_SECONDS.
+    One DB load at a time per tenant. An expired warm entry is served stale while a
+    background thread refreshes. Only a cold miss blocks, rather than pricing with an empty table"""
+    while True:
+        with _condition:
+            while True:
+                now = time.monotonic()
+                entry = _cache.get(tenant)
+                if entry is not None and now < entry[0]:
+                    return entry[1]
+                stale = entry[1] if entry is not None else None
+                if now < _next_retry.get(tenant, 0.0):
+                    return stale if stale is not None else {}
+                if tenant not in _refreshing:
+                    break
+                if stale is not None:
+                    return stale
+                _condition.wait()
+            _refreshing.add(tenant)
+            generation = (_global_generation, _tenant_generation.get(tenant, 0))
+
+        if stale is not None:
+            try:
+                threading.Thread(
+                    target=_refresh_in_background,
+                    args=(tenant, generation),
+                    name=f"llm-cost-rates-refresh-{tenant}",
+                    daemon=True,
+                ).start()
+            except Exception:
+                with _condition:
+                    _refreshing.discard(tenant)
+                    _condition.notify_all()
+                logger.warning("Could not start the llm_cost_rates refresh thread for tenant %s", tenant, exc_info=True)
+            return stale
+
+        loaded, current = _refresh(tenant, generation)
+        if current == generation:
+            return loaded if loaded is not None else {}

--- a/backend/app/services/llm_pricing_cache.py
+++ b/backend/app/services/llm_pricing_cache.py
@@ -1,7 +1,7 @@
 """
 In-memory cache of llm_cost_rates loaded via sync SQLAlchemy (per tenant).
 
-Used by find_pricing from synchronous workflow code without an async session.
+Read by resolve_live_pricing from synchronous workflow code without an async session.
 Invalidated when rates are updated via the API.
 """
 

--- a/backend/app/services/llm_pricing_cache.py
+++ b/backend/app/services/llm_pricing_cache.py
@@ -12,8 +12,8 @@ import threading
 import time
 from typing import Any
 
-from sqlalchemy import create_engine, select
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy import create_engine, event, select
+from sqlalchemy.orm import Session, sessionmaker
 
 from app.core.config.settings import settings
 from app.db.models.llm_cost_rate import LlmCostRateModel
@@ -57,6 +57,30 @@ def invalidate_llm_cost_rates_cache(tenant: str | None = None) -> None:
             _tenant_generation[tenant] = _tenant_generation.get(tenant, 0) + 1
             _cache.pop(tenant, None)
             _next_retry.pop(tenant, None)
+
+
+_PENDING_INVALIDATIONS = "llm_cost_rate_invalidations"
+
+
+def invalidate_llm_cost_rates_cache_after_commit(session: Any, tenant: str | None = None) -> None:
+    """Queue ``tenant``'s invalidation until ``session`` commits"""
+    info = getattr(session, "sync_session", session).info
+    info.setdefault(_PENDING_INVALIDATIONS, set()).add(tenant)
+
+
+@event.listens_for(Session, "after_commit")
+def _invalidate_committed_rate_changes(session: Session) -> None:
+    if session.in_nested_transaction():
+        return
+    for tenant in session.info.pop(_PENDING_INVALIDATIONS, ()):
+        invalidate_llm_cost_rates_cache(tenant)
+
+
+@event.listens_for(Session, "after_rollback")
+def _drop_rolled_back_rate_changes(session: Session) -> None:
+    if session.in_nested_transaction():
+        return
+    session.info.pop(_PENDING_INVALIDATIONS, None)
 
 
 def _load_db_nested(tenant: str) -> dict[str, dict[str, dict[str, float]]] | None:

--- a/backend/app/services/llm_usage_backfill.py
+++ b/backend/app/services/llm_usage_backfill.py
@@ -186,6 +186,7 @@ class LlmUsageBackfillService:
                         "conversation_id": row.conversation_id if row.conversation_id in valid_conversations else None,
                         "legacy_response_log_id": row.id,
                         "input_tokens": resolved.input_tokens,
+                        "prompt_tokens": resolved.input_tokens,
                         "output_tokens": resolved.output_tokens,
                         "total_tokens": resolved.total_tokens,
                         "cost_usd": resolved.cost_usd,

--- a/backend/app/services/llm_usage_export.py
+++ b/backend/app/services/llm_usage_export.py
@@ -36,6 +36,8 @@ def _summary_rows(summary: LlmUsageSummaryResponse) -> list[tuple[str, str]]:
         ("Cost per conversation (USD)", _usd(summary.cost_per_conversation_usd)),
         ("Agent Studio test cost (USD)", _usd(summary.agent_studio_test_cost_usd)),
         ("Total tokens", str(summary.total_tokens)),
+        ("Cache read tokens", str(summary.total_cache_read_tokens)),
+        ("Cache write tokens", str(summary.total_cache_creation_tokens)),
         ("Total calls", str(summary.total_calls)),
         ("Calls priced at configured rates", str(summary.configured_calls)),
         ("Calls priced at bundled fallback rates", str(summary.fallback_calls)),

--- a/backend/app/services/llm_usage_read.py
+++ b/backend/app/services/llm_usage_read.py
@@ -153,40 +153,31 @@ class LlmUsageReadService:
         row = None if _is_empty_scope(scope) else await self.repo.summary(params, scope)
         if row is None:
             return self._empty_summary(params)
-        (
-            sum_cost,
-            input_tokens,
-            output_tokens,
-            total_tokens,
-            total_calls,
-            unpriced_calls,
-            configured_calls,
-            fallback_calls,
-            legacy_estimate_calls,
-            priced_tokens,
-            conversation_cost,
-            agent_studio_test_cost,
-            distinct_conversations,
-        ) = row
+        total_calls = int(row["total_calls"])
+        total_tokens = int(row["total_tokens"])
+        unpriced_calls = int(row["unpriced_calls"])
+        distinct_conversations = row["distinct_conversations"]
         return LlmUsageSummaryResponse(
             from_date=params.from_date,
             to_date=params.to_date,
-            total_cost_usd=float(sum_cost),
+            total_cost_usd=float(row["sum_cost"]),
             cost_is_partial=unpriced_calls > 0,
             cost_per_conversation_usd=(
-                float(conversation_cost) / distinct_conversations if distinct_conversations else None
+                float(row["conversation_cost"]) / distinct_conversations if distinct_conversations else None
             ),
-            agent_studio_test_cost_usd=float(agent_studio_test_cost),
-            total_input_tokens=int(input_tokens),
-            total_output_tokens=int(output_tokens),
-            total_tokens=int(total_tokens),
-            total_calls=int(total_calls),
-            configured_calls=int(configured_calls),
-            fallback_calls=int(fallback_calls),
-            legacy_estimate_calls=int(legacy_estimate_calls),
-            unpriced_calls=int(unpriced_calls),
+            agent_studio_test_cost_usd=float(row["agent_studio_test_cost"]),
+            total_input_tokens=int(row["input_tokens"]),
+            total_output_tokens=int(row["output_tokens"]),
+            total_tokens=total_tokens,
+            total_cache_read_tokens=int(row["cache_read_tokens"]),
+            total_cache_creation_tokens=int(row["cache_creation_tokens"]),
+            total_calls=total_calls,
+            configured_calls=int(row["configured_calls"]),
+            fallback_calls=int(row["fallback_calls"]),
+            legacy_estimate_calls=int(row["legacy_estimate_calls"]),
+            unpriced_calls=unpriced_calls,
             priced_token_coverage_pct=_coverage_pct(
-                int(total_calls), int(total_tokens), int(priced_tokens), int(unpriced_calls)
+                total_calls, total_tokens, int(row["priced_tokens"]), unpriced_calls
             ),
             last_unpriced_at=(await self.repo.last_unpriced_at() if unpriced_calls else None),
         )

--- a/backend/app/services/llm_usage_recorder.py
+++ b/backend/app/services/llm_usage_recorder.py
@@ -10,10 +10,15 @@ from sqlalchemy import exists, func, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config.llm_pricing import PricingStatus, resolve_pricing
+from app.core.config.llm_pricing import (
+    PricingStatus,
+    blended_token_cost,
+    inclusive_cache_fallback,
+    resolve_pricing,
+)
 from app.core.utils.date_time_utils import utc_now
 from app.core.utils.db_connection_utils import create_tenant_request_scope
-from app.core.utils.llm_usage_utils import is_usage_metadata_missing, usage_or_placeholder
+from app.core.utils.llm_usage_utils import extract_cache_tokens, is_usage_metadata_missing, usage_or_placeholder
 from app.core.utils.uuid_utils import coerce_uuid
 from app.db.events.group_scope import GROUP_SCOPE_BYPASS_FLAG
 from app.db.models.agent import AgentModel
@@ -35,6 +40,8 @@ logger = logging.getLogger(__name__)
 _UNPRICED = {
     "input_per_1k": None,
     "output_per_1k": None,
+    "cache_read_per_1k": None,
+    "cache_creation_per_1k": None,
     "cost_usd": None,
     "pricing_status": PricingStatus.UNPRICED.value,
 }
@@ -85,6 +92,19 @@ def _total_tokens(entry: dict[str, Any], input_tokens: int, output_tokens: int) 
     return max(reported, input_tokens + output_tokens)
 
 
+def _token_columns(entry: dict[str, Any], input_tokens: int, output_tokens: int, token_details: Any) -> dict[str, Any]:
+    """Store the provider's token counts as reported"""
+    cache_read, cache_creation = extract_cache_tokens(token_details)
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": _total_tokens(entry, input_tokens, output_tokens),
+        "token_details": token_details,
+        "cache_read_tokens": cache_read,
+        "cache_creation_tokens": cache_creation,
+    }
+
+
 def _resolve_cost(
     provider: str,
     model: str,
@@ -92,22 +112,39 @@ def _resolve_cost(
     output_tokens: int,
     configured_rates: Optional[dict[str, Any]] = None,
     usage_missing: bool = False,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
 ) -> dict[str, Any]:
-    """Snapshot the rate + cost for one call. No rate, or no reported usage → NULL cost"""
+    """Snapshot the rates + cost for one call. No rate, or no reported usage → NULL cost"""
     if usage_missing:
         return dict(_UNPRICED)
     resolution = resolve_pricing(provider, model, configured_rates)
     if resolution.status is PricingStatus.UNPRICED:
         return dict(_UNPRICED)
-    thousand = Decimal(1000)
-    cost = (Decimal(int(input_tokens)) / thousand) * resolution.input_per_1k + (
-        Decimal(int(output_tokens)) / thousand
-    ) * resolution.output_per_1k
+
+    provider_key = (provider or "").strip().lower()
+    read_rate = inclusive_cache_fallback(provider_key, resolution.cache_read_per_1k, resolution.input_per_1k)
+    creation_rate = inclusive_cache_fallback(provider_key, resolution.cache_creation_per_1k, resolution.input_per_1k)
+    cost = blended_token_cost(
+        provider_key,
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        cache_creation_tokens,
+        resolution.input_per_1k,
+        resolution.output_per_1k,
+        read_rate,
+        creation_rate,
+        Decimal(1000),
+    )
+    cached = max(int(cache_read_tokens), 0) > 0 or max(int(cache_creation_tokens), 0) > 0
     return {
         "input_per_1k": resolution.input_per_1k,
         "output_per_1k": resolution.output_per_1k,
+        "cache_read_per_1k": read_rate if cached else None,
+        "cache_creation_per_1k": creation_rate if cached else None,
         "cost_usd": cost,
-        "pricing_status": resolution.status.value,
+        "pricing_status": resolution.status.value if cost is not None else PricingStatus.UNPRICED.value,
     }
 
 
@@ -144,6 +181,8 @@ class LlmUsageRecorder:
             nested.setdefault(provider_key, {})[model_key] = {
                 "input_per_1k": row.input_per_1k,
                 "output_per_1k": row.output_per_1k,
+                "cache_read_per_1k": getattr(row, "cache_read_per_1k", None),
+                "cache_creation_per_1k": getattr(row, "cache_creation_per_1k", None),
             }
         return nested
 
@@ -222,6 +261,7 @@ class LlmUsageRecorder:
                             output_tokens = int(entry.get("output_tokens", 0) or 0)
                             provider_id = coerce_uuid(entry.get("llm_provider_id"))
                             token_details = entry.get("token_details")
+                            token_columns = _token_columns(entry, input_tokens, output_tokens, token_details)
                             pricing = _resolve_cost(
                                 provider,
                                 model,
@@ -229,6 +269,8 @@ class LlmUsageRecorder:
                                 output_tokens,
                                 configured_rates,
                                 usage_missing=is_usage_metadata_missing(token_details),
+                                cache_read_tokens=token_columns["cache_read_tokens"],
+                                cache_creation_tokens=token_columns["cache_creation_tokens"],
                             )
                             event_rows.append(
                                 {
@@ -245,10 +287,7 @@ class LlmUsageRecorder:
                                     "node_id": _clamp(entry.get("node_id"), 128),
                                     "provider_key": _normalize(provider, 64),
                                     "model_key": _normalize(model, 512),
-                                    "input_tokens": input_tokens,
-                                    "output_tokens": output_tokens,
-                                    "total_tokens": _total_tokens(entry, input_tokens, output_tokens),
-                                    "token_details": token_details,
+                                    **token_columns,
                                     "occurred_at": occurred_at,
                                     **pricing,
                                 }
@@ -334,6 +373,7 @@ class LlmUsageRecorder:
                             provider = entry.get("provider", "") or ""
                             model = entry.get("model", "") or ""
                             provider_id = coerce_uuid(entry.get("llm_provider_id"))
+                            token_columns = _token_columns(usage, input_tokens, output_tokens, token_details)
                             pricing = _resolve_cost(
                                 provider,
                                 model,
@@ -341,6 +381,8 @@ class LlmUsageRecorder:
                                 output_tokens,
                                 configured_rates,
                                 usage_missing=is_usage_metadata_missing(token_details),
+                                cache_read_tokens=token_columns["cache_read_tokens"],
+                                cache_creation_tokens=token_columns["cache_creation_tokens"],
                             )
                             event_rows.append(
                                 {
@@ -357,10 +399,7 @@ class LlmUsageRecorder:
                                     "node_id": None,
                                     "provider_key": _normalize(provider, 64),
                                     "model_key": _normalize(model, 512),
-                                    "input_tokens": input_tokens,
-                                    "output_tokens": output_tokens,
-                                    "total_tokens": _total_tokens(usage, input_tokens, output_tokens),
-                                    "token_details": token_details,
+                                    **token_columns,
                                     "occurred_at": occurred_at,
                                     **pricing,
                                 }
@@ -469,6 +508,7 @@ class LlmUsageRecorder:
                     output_tokens = int(entry.get("output_tokens") or 0)
                     token_details = entry.get("token_details")
                     configured_rates = await self._configured_rates(session)
+                    token_columns = _token_columns(entry, input_tokens, output_tokens, token_details)
                     pricing = _resolve_cost(
                         provider,
                         model,
@@ -476,6 +516,8 @@ class LlmUsageRecorder:
                         output_tokens,
                         configured_rates,
                         usage_missing=is_usage_metadata_missing(token_details),
+                        cache_read_tokens=token_columns["cache_read_tokens"],
+                        cache_creation_tokens=token_columns["cache_creation_tokens"],
                     )
                     event = (
                         insert(LlmUsageEventModel)
@@ -492,10 +534,7 @@ class LlmUsageRecorder:
                                 "conversation_id": conversation_id,
                                 "provider_key": _normalize(provider, 64),
                                 "model_key": _normalize(model, 512),
-                                "input_tokens": input_tokens,
-                                "output_tokens": output_tokens,
-                                "total_tokens": _total_tokens(entry, input_tokens, output_tokens),
-                                "token_details": token_details,
+                                **token_columns,
                                 "occurred_at": occurred_at,
                                 **pricing,
                             }

--- a/backend/app/services/llm_usage_recorder.py
+++ b/backend/app/services/llm_usage_recorder.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config.llm_pricing import (
     PricingStatus,
     blended_token_cost,
+    canonical_prompt_tokens,
     inclusive_cache_fallback,
     resolve_pricing,
 )
@@ -92,9 +93,12 @@ def _total_tokens(entry: dict[str, Any], input_tokens: int, output_tokens: int) 
     return max(reported, input_tokens + output_tokens)
 
 
-def _token_columns(entry: dict[str, Any], input_tokens: int, output_tokens: int, token_details: Any) -> dict[str, Any]:
-    """Store the provider's token counts as reported"""
+def _token_columns(
+    provider: str, entry: dict[str, Any], input_tokens: int, output_tokens: int, token_details: Any
+) -> dict[str, Any]:
+    """Store the provider's token counts as reported, plus the canonical prompt total"""
     cache_read, cache_creation = extract_cache_tokens(token_details)
+    provider_key = (provider or "").strip().lower()
     return {
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
@@ -102,6 +106,7 @@ def _token_columns(entry: dict[str, Any], input_tokens: int, output_tokens: int,
         "token_details": token_details,
         "cache_read_tokens": cache_read,
         "cache_creation_tokens": cache_creation,
+        "prompt_tokens": canonical_prompt_tokens(provider_key, input_tokens, cache_read, cache_creation),
     }
 
 
@@ -261,7 +266,7 @@ class LlmUsageRecorder:
                             output_tokens = int(entry.get("output_tokens", 0) or 0)
                             provider_id = coerce_uuid(entry.get("llm_provider_id"))
                             token_details = entry.get("token_details")
-                            token_columns = _token_columns(entry, input_tokens, output_tokens, token_details)
+                            token_columns = _token_columns(provider, entry, input_tokens, output_tokens, token_details)
                             pricing = _resolve_cost(
                                 provider,
                                 model,
@@ -373,7 +378,7 @@ class LlmUsageRecorder:
                             provider = entry.get("provider", "") or ""
                             model = entry.get("model", "") or ""
                             provider_id = coerce_uuid(entry.get("llm_provider_id"))
-                            token_columns = _token_columns(usage, input_tokens, output_tokens, token_details)
+                            token_columns = _token_columns(provider, usage, input_tokens, output_tokens, token_details)
                             pricing = _resolve_cost(
                                 provider,
                                 model,
@@ -508,7 +513,7 @@ class LlmUsageRecorder:
                     output_tokens = int(entry.get("output_tokens") or 0)
                     token_details = entry.get("token_details")
                     configured_rates = await self._configured_rates(session)
-                    token_columns = _token_columns(entry, input_tokens, output_tokens, token_details)
+                    token_columns = _token_columns(provider, entry, input_tokens, output_tokens, token_details)
                     pricing = _resolve_cost(
                         provider,
                         model,

--- a/backend/tests/integration/analytics/test_group_authorization.py
+++ b/backend/tests/integration/analytics/test_group_authorization.py
@@ -354,8 +354,8 @@ async def test_admin_reads_remain_tenant_wide_including_unattributed_spend(world
             row = await repo.summary(world.params, scope)
 
     assert scope is None
-    assert float(row[0]) == pytest.approx(TOTAL_COST)
-    assert row[4] == len(COST)
+    assert float(row["sum_cost"]) == pytest.approx(TOTAL_COST)
+    assert row["total_calls"] == len(COST)
 
 
 @pytest.mark.asyncio(loop_scope="module")
@@ -537,8 +537,8 @@ async def test_llm_usage_scope_excludes_foreign_and_unattributed_events(world):
             row = await repo.summary(world.params, scope)
 
     assert scope == [world.agent_id("a1")]
-    assert row[4] == 1
-    assert float(row[0]) == pytest.approx(float(COST["a1"]))
+    assert row["total_calls"] == 1
+    assert float(row["sum_cost"]) == pytest.approx(float(COST["a1"]))
 
 
 @pytest.mark.asyncio(loop_scope="module")

--- a/backend/tests/integration/analytics/test_group_authorization.py
+++ b/backend/tests/integration/analytics/test_group_authorization.py
@@ -93,6 +93,7 @@ def _event(agent_id, *, provider: str, occurred_at: datetime, cost: Decimal) -> 
         provider_key=provider,
         model_key=f"{provider}-model",
         input_tokens=100,
+        prompt_tokens=100,
         output_tokens=50,
         total_tokens=150,
         cost_usd=cost,

--- a/backend/tests/integration/llm_usage/test_dashboard_ledger_cost.py
+++ b/backend/tests/integration/llm_usage/test_dashboard_ledger_cost.py
@@ -44,6 +44,7 @@ def _event(**overrides) -> LlmUsageEventModel:
         "source_type": "workflow",
         "source": "chat",
         "input_tokens": 100,
+        "prompt_tokens": 100,
         "output_tokens": 50,
         "total_tokens": 150,
         "cost_usd": Decimal("0.25"),

--- a/backend/tests/integration/llm_usage/test_llm_usage_attribution.py
+++ b/backend/tests/integration/llm_usage/test_llm_usage_attribution.py
@@ -234,8 +234,8 @@ async def test_agent_filtered_summary_sees_derived_studio_test_cost(world):
     async with world.maker() as session:
         row = await LlmUsageReadRepository(session).summary(LlmUsageQueryParams(), [world.agent_id("owner")])
 
-    total_cost, _, _, _, total_calls = row[:5]
-    studio_test_cost = row[11]
+    total_cost, total_calls = row["sum_cost"], row["total_calls"]
+    studio_test_cost = row["agent_studio_test_cost"]
     assert total_calls == 1, "the other agent's run and the unattributed run must stay out of scope"
     assert float(total_cost) == pytest.approx(CALL_COST)
     assert float(studio_test_cost) == pytest.approx(CALL_COST)
@@ -250,8 +250,8 @@ async def test_studio_test_cost_counts_only_studio_test_sources(world):
     async with world.maker() as session:
         row = await LlmUsageReadRepository(session).summary(LlmUsageQueryParams(), [world.agent_id("owner")])
 
-    total_cost, _, _, _, total_calls = row[:5]
-    studio_test_cost = row[11]
+    total_cost, total_calls = row["sum_cost"], row["total_calls"]
+    studio_test_cost = row["agent_studio_test_cost"]
     assert total_calls == 5
     assert float(total_cost) == pytest.approx(CALL_COST * 5)
     assert float(studio_test_cost) == pytest.approx(CALL_COST * 2), "only /test and /test-node runs count"

--- a/backend/tests/integration/llm_usage/test_llm_usage_backfill_repo.py
+++ b/backend/tests/integration/llm_usage/test_llm_usage_backfill_repo.py
@@ -34,6 +34,7 @@ def _backfill_row(execution_id: str, **overrides) -> dict:
         "source_type": "workflow",
         "source": "chat",
         "input_tokens": 10,
+        "prompt_tokens": 10,
         "output_tokens": 5,
         "total_tokens": 15,
         "cost_usd": Decimal("0.001"),

--- a/backend/tests/integration/llm_usage/test_llm_usage_drill_down_dimensions.py
+++ b/backend/tests/integration/llm_usage/test_llm_usage_drill_down_dimensions.py
@@ -62,6 +62,7 @@ def _event(agent_id, source_type, purpose, provider, model, cost) -> LlmUsageEve
         provider_key=provider,
         model_key=model,
         input_tokens=10,
+        prompt_tokens=10,
         output_tokens=5,
         total_tokens=15,
         cost_usd=None if cost is None else Decimal(cost),

--- a/backend/tests/integration/llm_usage/test_llm_usage_ledger.py
+++ b/backend/tests/integration/llm_usage/test_llm_usage_ledger.py
@@ -39,6 +39,7 @@ def _event_row(**overrides) -> dict:
         "source_type": "workflow",
         "source": "chat",
         "input_tokens": 10,
+        "prompt_tokens": 10,
         "output_tokens": 5,
         "total_tokens": 15,
         "pricing_status": "fallback",
@@ -202,6 +203,14 @@ async def test_total_ge_parts_check(db):
     db.add(
         LlmUsageEventModel(**_event_row(input_tokens=10, output_tokens=10, total_tokens=5))
     )
+    with pytest.raises(IntegrityError):
+        await db.flush()
+    await db.rollback()
+
+
+@pytest.mark.asyncio
+async def test_prompt_tokens_below_input_rejected(db):
+    db.add(LlmUsageEventModel(**_event_row(input_tokens=10, prompt_tokens=9)))
     with pytest.raises(IntegrityError):
         await db.flush()
     await db.rollback()

--- a/backend/tests/integration/llm_usage/test_llm_usage_unpriced_watermark.py
+++ b/backend/tests/integration/llm_usage/test_llm_usage_unpriced_watermark.py
@@ -47,6 +47,7 @@ async def _record(db, *, cost, occurred_at) -> None:
             source_type="workflow",
             source="chat",
             input_tokens=10,
+            prompt_tokens=10,
             output_tokens=5,
             total_tokens=15,
             cost_usd=cost,

--- a/backend/tests/unit/test_llm_cost_calculator.py
+++ b/backend/tests/unit/test_llm_cost_calculator.py
@@ -257,8 +257,13 @@ class TestResolvePricingBedrockRegions:
             ("eu.amazon.nova-2-lite-v1:0", "0.0001", "0.0004"),
             ("ca.amazon.nova-2-lite-v1:0", "0.0001", "0.0004"),
             ("us.amazon.nova-2-lite-v1:0", "0.0001", "0.0004"),
+            ("apac.amazon.nova-2-lite-v1:0", "0.0001", "0.0004"),
             ("us.amazon.nova-2-pro-v1:0", "0.0002", "0.0008"),
+            ("eu.amazon.nova-2-pro-v1:0", "0.0002", "0.0008"),
+            ("apac.amazon.nova-2-pro-v1:0", "0.0002", "0.0008"),
             ("us.amazon.nova-2-flash-v1:0", "0.0004", "0.0016"),
+            ("eu.amazon.nova-2-flash-v1:0", "0.0004", "0.0016"),
+            ("apac.amazon.nova-2-flash-v1:0", "0.0004", "0.0016"),
         ],
     )
     def test_known_profiles_price_from_the_bundled_table(self, model, input_rate, output_rate):
@@ -270,9 +275,10 @@ class TestResolvePricingBedrockRegions:
     @pytest.mark.parametrize(
         "model",
         [
-            "apac.amazon.nova-2-lite-v1:0",
+            "jp.amazon.nova-2-lite-v1:0",
+            "global.amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0",
-            "eu.amazon.nova-2-pro-v1:0",
+            "ca.amazon.nova-2-pro-v1:0",
         ],
     )
     def test_another_geography_never_inherits_a_bundled_rate(self, model):
@@ -302,7 +308,7 @@ class TestResolvePricingBedrockRegions:
 
     def test_a_tenant_default_answers_a_geography_the_bundled_table_cannot(self):
         configured = {"bedrock": {"_default": {"input_per_1k": "0.5", "output_per_1k": "0.9"}}}
-        res = resolve_pricing("bedrock", "apac.amazon.nova-2-lite-v1:0", configured)
+        res = resolve_pricing("bedrock", "jp.amazon.nova-2-lite-v1:0", configured)
         assert res.status is PricingStatus.CONFIGURED
         assert res.matched_model_key == "_default"
 
@@ -498,8 +504,13 @@ class TestBundledCacheRateProvenance:
             "eu.amazon.nova-2-lite-v1:0",
             "ca.amazon.nova-2-lite-v1:0",
             "us.amazon.nova-2-lite-v1:0",
+            "apac.amazon.nova-2-lite-v1:0",
             "us.amazon.nova-2-pro-v1:0",
+            "eu.amazon.nova-2-pro-v1:0",
+            "apac.amazon.nova-2-pro-v1:0",
             "us.amazon.nova-2-flash-v1:0",
+            "eu.amazon.nova-2-flash-v1:0",
+            "apac.amazon.nova-2-flash-v1:0",
         }
         for row in bundled.values():
             assert set(row) == {"input_per_1k", "output_per_1k"}, "no invented cache rates"

--- a/backend/tests/unit/test_llm_cost_calculator.py
+++ b/backend/tests/unit/test_llm_cost_calculator.py
@@ -12,11 +12,23 @@ from app.core.config.llm_pricing import (
     resolve_pricing,
 )
 from app.services.llm_cost_calculator import LlmCostCalculator
+from app.services.llm_usage_recorder import _resolve_cost
 
 
 @pytest.fixture
 def no_db_rates(monkeypatch):
     monkeypatch.setattr(llm_pricing, "get_db_pricing_nested", lambda tenant: {})
+
+MIRRORED_BEDROCK_RATES = {
+    "bedrock": {
+        "us.amazon.nova-2-lite-v1:0": {
+            "input_per_1k": "0.0001",
+            "output_per_1k": "0.0004",
+            "cache_read_per_1k": "0.0001",
+            "cache_creation_per_1k": "0.0001",
+        }
+    }
+}
 
 
 class TestCalculateCost:
@@ -44,13 +56,73 @@ class TestCalculateCost:
         cost = self.calculator.calculate_cost("openai", "unknown-model-xyz", 1000, 1000)
         assert cost > 0
 
-    def test_bedrock_nova_lite(self):
+    def test_a_known_bedrock_profile_prices_from_the_bundled_table(self):
+        assert resolve_pricing("bedrock", "us.amazon.nova-2-lite-v1:0", {}).status is PricingStatus.FALLBACK
         cost = self.calculator.calculate_cost("bedrock", "us.amazon.nova-2-lite-v1:0", 1000, 1000)
-        assert abs(cost - 0.0005) < 0.0001
+        assert cost == round(0.0001 + 0.0004, 6)
+
+
+class TestCalculateCostWithCacheTokens:
+    @pytest.fixture(autouse=True)
+    def _no_db_rates(self, no_db_rates):
+        pass
+
+    def setup_method(self):
+        self.calculator = LlmCostCalculator()
+
+    def test_zero_cache_counts_keep_the_legacy_result(self):
+        legacy = self.calculator.calculate_cost("openai", "gpt-4o", 1000, 500)
+        assert self.calculator.calculate_cost("openai", "gpt-4o", 1000, 500, 0, 0) == legacy
+
+    def test_anthropic_reads_price_at_a_tenth_of_input(self):
+        cost = self.calculator.calculate_cost("anthropic", "claude-3-5-sonnet", 1000, 100, 600, 0)
+        assert cost == round(0.0012 + 0.00018 + 0.0015, 6)
+
+    def test_anthropic_writes_price_at_the_premium(self):
+        cost = self.calculator.calculate_cost("anthropic", "claude-3-5-sonnet", 1000, 0, 0, 200)
+        assert cost == round(0.8 * 0.003 + 0.2 * 0.003 * 1.25, 6)
+
+    def test_bedrock_buckets_are_additive_to_raw_input(self, monkeypatch):
+        monkeypatch.setattr(llm_pricing, "get_db_pricing_nested", lambda tenant: MIRRORED_BEDROCK_RATES)
+        cost = self.calculator.calculate_cost("bedrock", "us.amazon.nova-2-lite-v1:0", 7, 20, 3697, 0)
+        assert cost == round((7 / 1000) * 0.0001 + (20 / 1000) * 0.0004 + (3697 / 1000) * 0.0001, 6)
+
+    def test_bedrock_without_a_resolved_cache_rate_keeps_the_legacy_display_estimate(self):
+        cost = self.calculator.calculate_cost("bedrock", "us.amazon.nova-2-lite-v1:0", 7, 20, 3697, 0)
+        assert cost == round((7 / 1000) * 0.0001 + (20 / 1000) * 0.0004 + (3697 / 1000) * 0.0001, 6)
+
+    def test_configured_cache_rates_win_over_the_provider_default(self, monkeypatch):
+        monkeypatch.setattr(
+            llm_pricing,
+            "get_db_pricing_nested",
+            lambda tenant: {
+                "bedrock": {
+                    "us.amazon.nova-2-lite-v1:0": {
+                        "input_per_1k": 0.0001,
+                        "output_per_1k": 0.0004,
+                        "cache_read_per_1k": 0.000025,
+                        "cache_creation_per_1k": 0.0,
+                    }
+                }
+            },
+        )
+        cost = self.calculator.calculate_cost("bedrock", "us.amazon.nova-2-lite-v1:0", 0, 0, 4000, 1000)
+        assert cost == round(4 * 0.000025, 6)
+
+    def test_unknown_model_prices_cache_buckets_at_the_fabricated_default(self):
+        cost = self.calculator.calculate_cost("openai", "unknown-model-xyz", 0, 0, 1000, 0)
+        assert cost == round(DEFAULT_PRICING["input_per_1k"], 6)
+
+    def test_negative_cache_counts_are_clamped(self):
+        legacy = self.calculator.calculate_cost("openai", "gpt-4o", 1000, 500)
+        assert self.calculator.calculate_cost("openai", "gpt-4o", 1000, 500, -5, -9) == legacy
+
+    def test_buckets_larger_than_input_never_price_negative_uncached(self):
+        cost = self.calculator.calculate_cost("anthropic", "claude-3-5-sonnet", 100, 0, 600, 0)
+        assert cost == round(0.6 * 0.003 * 0.1, 6)
 
 
 class TestResolvePricingBundledLayer:
-
     def test_exact_match_from_bundled_table_is_fallback(self):
         res = resolve_pricing("openai", "gpt-4o", {})
         assert res.status is PricingStatus.FALLBACK
@@ -102,7 +174,6 @@ class TestResolvePricingBundledLayer:
 
 
 class TestResolvePricingConfiguredLayer:
-
     def test_configured_exact_overrides_bundled(self):
         configured = {"openai": {"gpt-4o": {"input_per_1k": "0.005", "output_per_1k": "0.02"}}}
         res = resolve_pricing("openai", "gpt-4o", configured)
@@ -164,25 +235,48 @@ class TestResolvePricingConfiguredLayer:
 
 
 class TestResolvePricingBedrockRegions:
-    def test_bedrock_eu_region_matches_us_priced_variant(self):
-        res = resolve_pricing("bedrock", "eu.amazon.nova-2-lite-v1:0", {})
+    @pytest.mark.parametrize(
+        ("model", "input_rate", "output_rate"),
+        [
+            ("eu.amazon.nova-2-lite-v1:0", "0.0001", "0.0004"),
+            ("ca.amazon.nova-2-lite-v1:0", "0.0001", "0.0004"),
+            ("us.amazon.nova-2-lite-v1:0", "0.0001", "0.0004"),
+            ("us.amazon.nova-2-pro-v1:0", "0.0002", "0.0008"),
+            ("us.amazon.nova-2-flash-v1:0", "0.0004", "0.0016"),
+        ],
+    )
+    def test_known_profiles_price_from_the_bundled_table(self, model, input_rate, output_rate):
+        res = resolve_pricing("bedrock", model, {})
         assert res.status is PricingStatus.FALLBACK
-        assert res.matched_model_key == "us.amazon.nova-2-lite-v1:0"
-        assert res.input_per_1k == Decimal("0.0001")
-        assert res.output_per_1k == Decimal("0.0004")
+        assert res.input_per_1k == Decimal(input_rate)
+        assert res.output_per_1k == Decimal(output_rate)
 
-    def test_bedrock_apac_region_matches(self):
-        res = resolve_pricing("bedrock", "apac.amazon.nova-2-pro-v1:0", {})
-        assert res.status is PricingStatus.FALLBACK
-        assert res.input_per_1k == Decimal("0.0002")
-
-    def test_bedrock_region_less_id_matches(self):
-        res = resolve_pricing("bedrock", "amazon.nova-2-flash-v1:0", {})
-        assert res.status is PricingStatus.FALLBACK
-        assert res.input_per_1k == Decimal("0.0004")
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "apac.amazon.nova-2-lite-v1:0",
+            "amazon.nova-2-lite-v1:0",
+            "eu.amazon.nova-2-pro-v1:0",
+        ],
+    )
+    def test_another_geography_never_inherits_a_bundled_rate(self, model):
+        assert resolve_pricing("bedrock", model, {}).status is PricingStatus.UNPRICED
 
     def test_bedrock_unknown_model_still_unpriced(self):
         assert resolve_pricing("bedrock", "eu.amazon.titan-text-v1", {}).status is PricingStatus.UNPRICED
+
+    def test_configured_region_less_key_beats_bundled_exact_hit(self):
+        configured = {"bedrock": {"amazon.nova-2-lite-v1:0": {"input_per_1k": "0.009", "output_per_1k": "0.02"}}}
+        res = resolve_pricing("bedrock", "us.amazon.nova-2-lite-v1:0", configured)
+        assert res.status is PricingStatus.CONFIGURED
+        assert res.matched_model_key == "amazon.nova-2-lite-v1:0"
+        assert res.input_per_1k == Decimal("0.009")
+
+    def test_bundled_exact_hit_still_beats_a_configured_default(self):
+        configured = {"bedrock": {"_default": {"input_per_1k": "9", "output_per_1k": "9"}}}
+        res = resolve_pricing("bedrock", "us.amazon.nova-2-lite-v1:0", configured)
+        assert res.status is PricingStatus.FALLBACK
+        assert res.input_per_1k == Decimal("0.0001")
 
     def test_bedrock_region_retry_prefers_configured_over_bundled(self):
         configured = {"bedrock": {"us.amazon.nova-2-lite-v1:0": {"input_per_1k": "0.009", "output_per_1k": "0.02"}}}
@@ -190,11 +284,11 @@ class TestResolvePricingBedrockRegions:
         assert res.status is PricingStatus.CONFIGURED
         assert res.input_per_1k == Decimal("0.009")
 
-    def test_bedrock_region_retry_runs_before_tenant_default(self):
+    def test_a_tenant_default_answers_a_geography_the_bundled_table_cannot(self):
         configured = {"bedrock": {"_default": {"input_per_1k": "0.5", "output_per_1k": "0.9"}}}
-        res = resolve_pricing("bedrock", "eu.amazon.nova-2-pro-v1:0", configured)
-        assert res.status is PricingStatus.FALLBACK
-        assert res.matched_model_key == "us.amazon.nova-2-pro-v1:0"
+        res = resolve_pricing("bedrock", "apac.amazon.nova-2-lite-v1:0", configured)
+        assert res.status is PricingStatus.CONFIGURED
+        assert res.matched_model_key == "_default"
 
     def test_region_prefix_matching_is_deterministic(self):
         configured = {
@@ -209,8 +303,68 @@ class TestResolvePricingBedrockRegions:
         assert len(matches) == 1
 
 
-class TestFindPricingLegacyContract:
+class TestResolvePricingCacheRates:
+    def test_configured_cache_rates_are_carried(self):
+        configured = {
+            "openai": {
+                "gpt-4o": {
+                    "input_per_1k": "0.005",
+                    "output_per_1k": "0.02",
+                    "cache_read_per_1k": "0.0005",
+                    "cache_creation_per_1k": "0.00625",
+                }
+            }
+        }
+        res = resolve_pricing("openai", "gpt-4o", configured)
+        assert res.cache_read_per_1k == Decimal("0.0005")
+        assert res.cache_creation_per_1k == Decimal("0.00625")
 
+    def test_absent_cache_rates_resolve_to_none(self):
+        res = resolve_pricing("openai", "gpt-4o", {})
+        assert res.cache_read_per_1k is None
+        assert res.cache_creation_per_1k is None
+
+    def test_explicit_zero_stays_distinct_from_absent(self):
+        configured = {
+            "bedrock": {
+                "us.amazon.nova-2-lite-v1:0": {
+                    "input_per_1k": "0.0001",
+                    "output_per_1k": "0.0004",
+                    "cache_read_per_1k": "0.000025",
+                    "cache_creation_per_1k": "0",
+                }
+            }
+        }
+        res = resolve_pricing("bedrock", "us.amazon.nova-2-lite-v1:0", configured)
+        assert res.cache_creation_per_1k == Decimal("0")
+        assert res.cache_creation_per_1k is not None
+
+    @pytest.mark.parametrize("bad", ["abc", "-1", "NaN", "Infinity", None, [], True])
+    def test_unusable_cache_rate_becomes_none_without_touching_base_rates(self, bad):
+        configured = {
+            "openai": {"gpt-4o": {"input_per_1k": "0.005", "output_per_1k": "0.02", "cache_read_per_1k": bad}}
+        }
+        res = resolve_pricing("openai", "gpt-4o", configured)
+        assert res.cache_read_per_1k is None
+        assert res.status is PricingStatus.CONFIGURED
+        assert res.input_per_1k == Decimal("0.005")
+
+    def test_cache_rates_are_carried_from_a_tenant_default_row(self):
+        configured = {
+            "openai": {"_default": {"input_per_1k": "0.5", "output_per_1k": "0.9", "cache_read_per_1k": "0.05"}}
+        }
+        res = resolve_pricing("openai", "brand-new-model", configured)
+        assert res.matched_model_key == "_default"
+        assert res.cache_read_per_1k == Decimal("0.05")
+        assert res.cache_creation_per_1k is None
+
+    def test_unpriced_carries_no_cache_rates(self):
+        res = resolve_pricing("openai", "totally-unknown-model", {})
+        assert res.cache_read_per_1k is None
+        assert res.cache_creation_per_1k is None
+
+
+class TestFindPricingLegacyContract:
     @pytest.fixture(autouse=True)
     def _no_db_rates(self, no_db_rates):
         pass
@@ -228,8 +382,75 @@ class TestFindPricingLegacyContract:
     def test_bundled_default_row_still_applies_on_the_legacy_path(self):
         assert find_pricing("openrouter", "some/new-model") == {"input_per_1k": 0.001, "output_per_1k": 0.002}
 
-    def test_first_match_prefix_scan_is_preserved(self):
-        assert find_pricing("openai", "gpt-4o-mini-2024-07-18")["input_per_1k"] == 0.0025
+    def test_longest_prefix_wins_like_the_ledger(self):
+        assert find_pricing("openai", "gpt-4o-mini-2024-07-18")["input_per_1k"] == 0.00015
+
+    def test_bedrock_region_prefixed_model_matches_a_region_less_rate(self, monkeypatch):
+        monkeypatch.setattr(
+            llm_pricing,
+            "get_db_pricing_nested",
+            lambda tenant: {"bedrock": {"amazon.nova-2-lite-v1:0": {"input_per_1k": 0.009, "output_per_1k": 0.02}}},
+        )
+        assert find_pricing("bedrock", "us.amazon.nova-2-lite-v1:0")["input_per_1k"] == 0.009
+
+    def test_configured_prefix_beats_a_bundled_exact_hit(self, monkeypatch):
+        monkeypatch.setattr(
+            llm_pricing,
+            "get_db_pricing_nested",
+            lambda tenant: {"openai": {"gpt-4": {"input_per_1k": 0.111, "output_per_1k": 0.222}}},
+        )
+        assert find_pricing("openai", "gpt-4o")["input_per_1k"] == 0.111
+
+    def test_unusable_configured_row_falls_through_to_bundled(self, monkeypatch):
+        monkeypatch.setattr(
+            llm_pricing,
+            "get_db_pricing_nested",
+            lambda tenant: {"openai": {"gpt-4o": {"input_per_1k": "abc", "output_per_1k": "0.02"}}},
+        )
+        assert find_pricing("openai", "gpt-4o") == {"input_per_1k": 0.0025, "output_per_1k": 0.01}
+
+    def test_configured_cache_rates_reach_the_display_path(self, monkeypatch):
+        monkeypatch.setattr(
+            llm_pricing,
+            "get_db_pricing_nested",
+            lambda tenant: {
+                "openai": {"gpt-4o": {"input_per_1k": 0.005, "output_per_1k": 0.02, "cache_read_per_1k": 0.0005}}
+            },
+        )
+        pricing = find_pricing("openai", "gpt-4o")
+        assert pricing["cache_read_per_1k"] == 0.0005
+        assert "cache_creation_per_1k" not in pricing
+
+    def test_provider_whitespace_is_normalized(self):
+        assert find_pricing(" OpenAI ", "gpt-4o")["input_per_1k"] == 0.0025
+
+
+class TestDefaultRowPrecedenceMatchesTheLedger:
+    @pytest.fixture(autouse=True)
+    def _no_db_rates(self, no_db_rates):
+        pass
+
+    def test_ledger_bundled_exact_hit_beats_a_configured_default(self):
+        configured = {"openai": {"_default": {"input_per_1k": "9", "output_per_1k": "9"}}}
+        res = resolve_pricing("openai", "gpt-4o", configured)
+        assert res.status is PricingStatus.FALLBACK
+        assert res.input_per_1k == Decimal("0.0025")
+
+    def test_display_bundled_exact_hit_beats_a_configured_default(self, monkeypatch):
+        monkeypatch.setattr(
+            llm_pricing,
+            "get_db_pricing_nested",
+            lambda tenant: {"openai": {"_default": {"input_per_1k": 9.0, "output_per_1k": 9.0}}},
+        )
+        assert find_pricing("openai", "gpt-4o")["input_per_1k"] == 0.0025
+
+    def test_display_configured_default_wins_only_on_a_total_miss(self, monkeypatch):
+        monkeypatch.setattr(
+            llm_pricing,
+            "get_db_pricing_nested",
+            lambda tenant: {"openrouter": {"_default": {"input_per_1k": 0.5, "output_per_1k": 0.9}}},
+        )
+        assert find_pricing("openrouter", "some/new-model")["input_per_1k"] == 0.5
 
     def test_db_rate_overrides_static(self, monkeypatch):
         monkeypatch.setattr(
@@ -238,3 +459,239 @@ class TestFindPricingLegacyContract:
             lambda tenant: {"openai": {"gpt-4o": {"input_per_1k": 0.005, "output_per_1k": 0.02}}},
         )
         assert find_pricing("openai", "gpt-4o")["input_per_1k"] == 0.005
+
+_BUNDLED_WITH_CACHE = {
+    "us.amazon.nova-2-lite-v1:0": {
+        "input_per_1k": 0.001,
+        "output_per_1k": 0.002,
+        "cache_read_per_1k": 0.0004,
+        "cache_creation_per_1k": 0.0,
+    }
+}
+
+
+@pytest.fixture
+def bundled_cache_rates(monkeypatch):
+    monkeypatch.setitem(llm_pricing.STATIC_LLM_PRICING_FALLBACK, "bedrock", _BUNDLED_WITH_CACHE)
+
+
+class TestBundledCacheRateProvenance:
+    def test_the_bundled_bedrock_table_carries_base_rates_only(self):
+        bundled = llm_pricing.STATIC_LLM_PRICING_FALLBACK["bedrock"]
+        assert set(bundled) == {
+            "eu.amazon.nova-2-lite-v1:0",
+            "ca.amazon.nova-2-lite-v1:0",
+            "us.amazon.nova-2-lite-v1:0",
+            "us.amazon.nova-2-pro-v1:0",
+            "us.amazon.nova-2-flash-v1:0",
+        }
+        for row in bundled.values():
+            assert set(row) == {"input_per_1k", "output_per_1k"}, "no invented cache rates"
+
+    def test_an_exact_bundled_match_supplies_both_buckets(self, bundled_cache_rates):
+        res = resolve_pricing("bedrock", "us.amazon.nova-2-lite-v1:0", {})
+        assert res.cache_read_per_1k == Decimal("0.0004")
+        assert res.cache_creation_per_1k == Decimal("0")
+
+    @pytest.mark.parametrize(
+        "model",
+        ["eu.amazon.nova-2-lite-v1:0", "apac.amazon.nova-2-lite-v1:0", "amazon.nova-2-lite-v1:0"],
+    )
+    def test_a_bundled_row_prices_nothing_outside_its_own_geography(self, bundled_cache_rates, model):
+        res = resolve_pricing("bedrock", model, {})
+        assert res.status is PricingStatus.UNPRICED
+        assert (res.cache_read_per_1k, res.cache_creation_per_1k) == (None, None)
+
+    @pytest.mark.parametrize(
+        ("provider", "model", "expected_base"),
+        [
+            ("bedrock", "us.amazon.nova-2-lite-v1:0-future", Decimal("0.001")),
+            ("openai", "gpt-4o-mini-2024-07-18", Decimal("0.00015")),
+        ],
+    )
+    def test_a_longest_prefix_match_takes_the_base_rate_but_not_the_cache_rates(
+        self, bundled_cache_rates, monkeypatch, provider, model, expected_base
+    ):
+        monkeypatch.setitem(
+            llm_pricing.STATIC_LLM_PRICING_FALLBACK["openai"],
+            "gpt-4o-mini",
+            {"input_per_1k": 0.00015, "output_per_1k": 0.0006, "cache_read_per_1k": 0.001},
+        )
+        res = resolve_pricing(provider, model, {})
+        assert res.input_per_1k == expected_base, "version suffixes still price off the base model"
+        assert res.cache_read_per_1k is None
+
+    def test_a_configured_region_less_rate_is_always_allowed(self, bundled_cache_rates):
+        configured = {
+            "bedrock": {
+                "amazon.nova-2-lite-v1:0": {
+                    "input_per_1k": "0.001",
+                    "output_per_1k": "0.002",
+                    "cache_read_per_1k": "0.00009",
+                }
+            }
+        }
+        res = resolve_pricing("bedrock", "eu.amazon.nova-2-lite-v1:0", configured)
+        assert res.cache_read_per_1k == Decimal("0.00009")
+
+
+class TestCacheRateLadder:
+    def test_configured_beats_bundled_beats_family(self, bundled_cache_rates):
+        configured = {
+            "bedrock": {
+                "us.amazon.nova-2-lite-v1:0": {
+                    "input_per_1k": "0.001",
+                    "output_per_1k": "0.002",
+                    "cache_read_per_1k": "0.00001",
+                }
+            }
+        }
+        res = resolve_pricing("bedrock", "us.amazon.nova-2-lite-v1:0", configured)
+        assert res.cache_read_per_1k == Decimal("0.00001"), "the tenant's own rate wins"
+        assert res.cache_creation_per_1k == Decimal("0"), "the omitted bucket is inherited from the bundled row"
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "us.anthropic.claude-sonnet-4-v1:0",
+            "global.anthropic.claude-sonnet-5",
+            "us.anthropic.claude-fable-5",
+        ],
+    )
+    def test_claude_on_bedrock_falls_back_to_the_anthropic_multipliers(self, model):
+        configured = {"bedrock": {model: {"input_per_1k": "0.003", "output_per_1k": "0.015"}}}
+        res = resolve_pricing("bedrock", model, configured)
+        assert res.cache_read_per_1k == Decimal("0.0003")
+        assert res.cache_creation_per_1k == Decimal("0.00375")
+
+    @pytest.mark.parametrize("model", ["us.amazon.nova-2-lite-v1:0", "amazon.titan-text-express-v1"])
+    def test_no_other_bedrock_family_invents_a_multiplier(self, model):
+        configured = {"bedrock": {model: {"input_per_1k": "0.001", "output_per_1k": "0.002"}}}
+        res = resolve_pricing("bedrock", model, configured)
+        assert res.cache_read_per_1k is None
+        assert res.cache_creation_per_1k is None
+
+    def test_a_bundled_default_row_never_supplies_cache_rates(self, no_db_rates, monkeypatch):
+        monkeypatch.setitem(
+            llm_pricing.STATIC_LLM_PRICING_FALLBACK["openrouter"],
+            "_default",
+            {"input_per_1k": 0.001, "output_per_1k": 0.002, "cache_read_per_1k": 0.5},
+        )
+        live = llm_pricing.resolve_live_pricing("openrouter", "some/new-model")
+        assert live.display_rates["input_per_1k"] == 0.001, "the base rates still come off that row"
+        assert live.cache_read_per_1k is None
+
+    def test_an_explicit_zero_is_never_mistaken_for_unresolved(self):
+        configured = {
+            "bedrock": {
+                "us.amazon.nova-2-lite-v1:0": {
+                    "input_per_1k": "0.001",
+                    "output_per_1k": "0.002",
+                    "cache_read_per_1k": "0",
+                    "cache_creation_per_1k": "0",
+                }
+            }
+        }
+        res = resolve_pricing("bedrock", "us.amazon.nova-2-lite-v1:0", configured)
+        assert (res.cache_read_per_1k, res.cache_creation_per_1k) == (Decimal("0"), Decimal("0"))
+
+
+_READ_ONLY = {"input_per_1k": "0.001", "output_per_1k": "0.002", "cache_read_per_1k": "0.0001"}
+
+
+class TestBucketIndependence:
+
+    def test_read_activity_prices_from_a_read_rate_alone(self):
+        out = _resolve_cost("bedrock", "m", 10, 10, {"bedrock": {"m": _READ_ONLY}}, cache_read_tokens=1000)
+        assert out["pricing_status"] == "configured"
+        assert out["cost_usd"] == Decimal("0.00013")
+
+    def test_write_activity_without_a_write_rate_is_unpriced(self):
+        out = _resolve_cost("bedrock", "m", 10, 10, {"bedrock": {"m": _READ_ONLY}}, cache_creation_tokens=1000)
+        assert out["pricing_status"] == "unpriced"
+        assert out["cost_usd"] is None
+        assert out["cache_read_per_1k"] == Decimal("0.0001"), "the resolved bucket survives on the row"
+        assert out["cache_creation_per_1k"] is None
+
+    def test_no_cache_activity_prices_normally_whatever_the_buckets_resolved_to(self):
+        base = {"input_per_1k": "0.001", "output_per_1k": "0.002"}
+        out = _resolve_cost("bedrock", "m", 1000, 1000, {"bedrock": {"m": base}})
+        assert out["pricing_status"] == "configured"
+        assert out["cost_usd"] == Decimal("0.003")
+
+    def test_an_inclusive_provider_keeps_pricing_without_any_cache_rate(self):
+        out = _resolve_cost("openai", "gpt-4o", 1000, 500, {}, cache_read_tokens=400)
+        assert out["pricing_status"] == "fallback"
+        assert out["cost_usd"] == _resolve_cost("openai", "gpt-4o", 1000, 500, {})["cost_usd"]
+
+
+_PARITY_CASES = {
+    "bedrock_mirrored_fixture": (("bedrock", "us.amazon.nova-2-lite-v1:0", 7, 20, 3697, 0), MIRRORED_BEDROCK_RATES),
+    "anthropic_family_defaults": (("anthropic", "claude-3-5-sonnet", 1000, 200, 500, 100), {}),
+    "explicit_zero_rates": (
+        ("bedrock", "us.amazon.nova-2-lite-v1:0", 100, 10, 1000, 2000),
+        {
+            "bedrock": {
+                "us.amazon.nova-2-lite-v1:0": {
+                    "input_per_1k": "0.0001",
+                    "output_per_1k": "0.0004",
+                    "cache_read_per_1k": "0.000025",
+                    "cache_creation_per_1k": "0",
+                }
+            }
+        },
+    ),
+    "cache_exceeds_input": (("anthropic", "claude-3-5-sonnet", 100, 0, 600, 0), {}),
+    "bedrock_bundled_uncached": (("bedrock", "us.amazon.nova-2-lite-v1:0", 1000, 500, 0, 0), {}),
+    "inclusive_without_cache_rates": (("openai", "gpt-4o", 1000, 500, 400, 100), {}),
+    "no_cache_activity": (("openai", "gpt-4o", 1000, 500, 0, 0), {}),
+}
+
+
+class TestLiveLedgerParity:
+    @pytest.mark.parametrize("case", sorted(_PARITY_CASES))
+    def test_the_display_cost_matches_the_ledger_on_every_priced_case(self, case, monkeypatch):
+        args, configured = _PARITY_CASES[case]
+        monkeypatch.setattr(llm_pricing, "get_db_pricing_nested", lambda tenant: configured)
+        provider, model, input_tokens, output_tokens, cache_read, cache_creation = args
+
+        ledger = _resolve_cost(
+            provider,
+            model,
+            input_tokens,
+            output_tokens,
+            configured,
+            cache_read_tokens=cache_read,
+            cache_creation_tokens=cache_creation,
+        )
+        assert ledger["cost_usd"] is not None, "parity is only claimed where the ledger prices"
+        live = LlmCostCalculator().calculate_cost(
+            provider, model, input_tokens, output_tokens, cache_read, cache_creation
+        )
+        assert live == round(float(ledger["cost_usd"]), 6)
+
+    def test_an_unresolved_bedrock_bucket_splits_the_two_surfaces(self, no_db_rates):
+        args = ("bedrock", "us.amazon.nova-2-lite-v1:0", 7, 20, 3697, 0)
+
+        ledger = _resolve_cost(*args[:4], {}, cache_read_tokens=args[4], cache_creation_tokens=args[5])
+        assert ledger["cost_usd"] is None
+        assert ledger["pricing_status"] == PricingStatus.UNPRICED.value
+
+        live = LlmCostCalculator().calculate_cost(*args)
+        assert live == round((7 / 1000) * 0.0001 + (20 / 1000) * 0.0004 + (3697 / 1000) * 0.0001, 6)
+        assert live == LlmCostCalculator().calculate_cost("bedrock", args[1], 7 + 3697, 20)
+
+
+class TestFindPricingIgnoresTheResolutionLadder:
+
+    def test_inherited_bundled_cache_rates_stay_out_of_the_display_dict(self, monkeypatch, bundled_cache_rates):
+        configured = {"bedrock": {"us.amazon.nova-2-lite-v1:0": {"input_per_1k": 0.005, "output_per_1k": 0.02}}}
+        monkeypatch.setattr(llm_pricing, "get_db_pricing_nested", lambda tenant: configured)
+
+        assert find_pricing("bedrock", "us.amazon.nova-2-lite-v1:0") == {"input_per_1k": 0.005, "output_per_1k": 0.02}
+        live = llm_pricing.resolve_live_pricing("bedrock", "us.amazon.nova-2-lite-v1:0")
+        assert live.cache_read_per_1k == 0.0004, "the calculator still gets the inherited rate"
+        assert live.cache_creation_per_1k == 0.0
+
+    def test_family_derived_cache_rates_stay_out_of_the_display_dict(self, no_db_rates):
+        assert find_pricing("anthropic", "claude-3-5-sonnet") == {"input_per_1k": 0.003, "output_per_1k": 0.015}

--- a/backend/tests/unit/test_llm_cost_calculator.py
+++ b/backend/tests/unit/test_llm_cost_calculator.py
@@ -8,7 +8,6 @@ import app.core.config.llm_pricing as llm_pricing
 from app.core.config.llm_pricing import (
     DEFAULT_PRICING,
     PricingStatus,
-    find_pricing,
     resolve_pricing,
 )
 from app.services.llm_cost_calculator import LlmCostCalculator
@@ -18,6 +17,11 @@ from app.services.llm_usage_recorder import _resolve_cost
 @pytest.fixture
 def no_db_rates(monkeypatch):
     monkeypatch.setattr(llm_pricing, "get_db_pricing_nested", lambda tenant: {})
+
+
+def display_rates(provider: str, model: str) -> dict:
+    return llm_pricing.resolve_live_pricing(provider, model).display_rates
+
 
 MIRRORED_BEDROCK_RATES = {
     "bedrock": {
@@ -97,6 +101,11 @@ class TestCalculateCostWithCacheTokens:
     def test_bedrock_without_a_resolved_cache_rate_is_unpriced(self):
         model = "arn:aws:bedrock:eu-central-1:123456789012:provisioned-model/nova-tuned"
         assert self.calculator.calculate_cost("bedrock", model, 7, 20, 3697, 0) is None
+
+    def test_an_unrated_bedrock_family_derives_its_buckets_from_the_fabricated_default(self):
+        default_input = DEFAULT_PRICING["input_per_1k"]
+        cost = self.calculator.calculate_cost("bedrock", "eu.anthropic.claude-3-7-sonnet-20250219-v1:0", 0, 0, 1000, 0)
+        assert cost == round(default_input * 0.1, 6)
 
     def test_configured_cache_rates_win_over_the_provider_default(self, monkeypatch):
         monkeypatch.setattr(
@@ -371,26 +380,26 @@ class TestResolvePricingCacheRates:
         assert res.cache_creation_per_1k is None
 
 
-class TestFindPricingLegacyContract:
+class TestDisplayRatesContract:
     @pytest.fixture(autouse=True)
     def _no_db_rates(self, no_db_rates):
         pass
 
     def test_returns_floats_for_known_model(self):
-        pricing = find_pricing("openai", "gpt-4o")
+        pricing = display_rates("openai", "gpt-4o")
         assert pricing == {"input_per_1k": 0.0025, "output_per_1k": 0.01}
         assert isinstance(pricing["input_per_1k"], float)
 
     def test_unmatched_returns_default_pricing_copy(self):
-        pricing = find_pricing("openai", "unknown-model-xyz")
+        pricing = display_rates("openai", "unknown-model-xyz")
         assert pricing == DEFAULT_PRICING
         assert pricing is not DEFAULT_PRICING
 
-    def test_bundled_default_row_still_applies_on_the_legacy_path(self):
-        assert find_pricing("openrouter", "some/new-model") == {"input_per_1k": 0.001, "output_per_1k": 0.002}
+    def test_bundled_default_row_still_applies_on_the_display_path(self):
+        assert display_rates("openrouter", "some/new-model") == {"input_per_1k": 0.001, "output_per_1k": 0.002}
 
     def test_longest_prefix_wins_like_the_ledger(self):
-        assert find_pricing("openai", "gpt-4o-mini-2024-07-18")["input_per_1k"] == 0.00015
+        assert display_rates("openai", "gpt-4o-mini-2024-07-18")["input_per_1k"] == 0.00015
 
     def test_bedrock_region_prefixed_model_matches_a_region_less_rate(self, monkeypatch):
         monkeypatch.setattr(
@@ -398,7 +407,7 @@ class TestFindPricingLegacyContract:
             "get_db_pricing_nested",
             lambda tenant: {"bedrock": {"amazon.nova-2-lite-v1:0": {"input_per_1k": 0.009, "output_per_1k": 0.02}}},
         )
-        assert find_pricing("bedrock", "us.amazon.nova-2-lite-v1:0")["input_per_1k"] == 0.009
+        assert display_rates("bedrock", "us.amazon.nova-2-lite-v1:0")["input_per_1k"] == 0.009
 
     def test_configured_prefix_beats_a_bundled_exact_hit(self, monkeypatch):
         monkeypatch.setattr(
@@ -406,7 +415,7 @@ class TestFindPricingLegacyContract:
             "get_db_pricing_nested",
             lambda tenant: {"openai": {"gpt-4": {"input_per_1k": 0.111, "output_per_1k": 0.222}}},
         )
-        assert find_pricing("openai", "gpt-4o")["input_per_1k"] == 0.111
+        assert display_rates("openai", "gpt-4o")["input_per_1k"] == 0.111
 
     def test_unusable_configured_row_falls_through_to_bundled(self, monkeypatch):
         monkeypatch.setattr(
@@ -414,7 +423,7 @@ class TestFindPricingLegacyContract:
             "get_db_pricing_nested",
             lambda tenant: {"openai": {"gpt-4o": {"input_per_1k": "abc", "output_per_1k": "0.02"}}},
         )
-        assert find_pricing("openai", "gpt-4o") == {"input_per_1k": 0.0025, "output_per_1k": 0.01}
+        assert display_rates("openai", "gpt-4o") == {"input_per_1k": 0.0025, "output_per_1k": 0.01}
 
     def test_configured_cache_rates_reach_the_display_path(self, monkeypatch):
         monkeypatch.setattr(
@@ -424,12 +433,12 @@ class TestFindPricingLegacyContract:
                 "openai": {"gpt-4o": {"input_per_1k": 0.005, "output_per_1k": 0.02, "cache_read_per_1k": 0.0005}}
             },
         )
-        pricing = find_pricing("openai", "gpt-4o")
+        pricing = display_rates("openai", "gpt-4o")
         assert pricing["cache_read_per_1k"] == 0.0005
         assert "cache_creation_per_1k" not in pricing
 
     def test_provider_whitespace_is_normalized(self):
-        assert find_pricing(" OpenAI ", "gpt-4o")["input_per_1k"] == 0.0025
+        assert display_rates(" OpenAI ", "gpt-4o")["input_per_1k"] == 0.0025
 
 
 class TestDefaultRowPrecedenceMatchesTheLedger:
@@ -449,7 +458,7 @@ class TestDefaultRowPrecedenceMatchesTheLedger:
             "get_db_pricing_nested",
             lambda tenant: {"openai": {"_default": {"input_per_1k": 9.0, "output_per_1k": 9.0}}},
         )
-        assert find_pricing("openai", "gpt-4o")["input_per_1k"] == 0.0025
+        assert display_rates("openai", "gpt-4o")["input_per_1k"] == 0.0025
 
     def test_display_configured_default_wins_only_on_a_total_miss(self, monkeypatch):
         monkeypatch.setattr(
@@ -457,7 +466,7 @@ class TestDefaultRowPrecedenceMatchesTheLedger:
             "get_db_pricing_nested",
             lambda tenant: {"openrouter": {"_default": {"input_per_1k": 0.5, "output_per_1k": 0.9}}},
         )
-        assert find_pricing("openrouter", "some/new-model")["input_per_1k"] == 0.5
+        assert display_rates("openrouter", "some/new-model")["input_per_1k"] == 0.5
 
     def test_db_rate_overrides_static(self, monkeypatch):
         monkeypatch.setattr(
@@ -465,7 +474,7 @@ class TestDefaultRowPrecedenceMatchesTheLedger:
             "get_db_pricing_nested",
             lambda tenant: {"openai": {"gpt-4o": {"input_per_1k": 0.005, "output_per_1k": 0.02}}},
         )
-        assert find_pricing("openai", "gpt-4o")["input_per_1k"] == 0.005
+        assert display_rates("openai", "gpt-4o")["input_per_1k"] == 0.005
 
 _BUNDLED_WITH_CACHE = {
     "us.amazon.nova-2-lite-v1:0": {
@@ -721,16 +730,16 @@ class TestLiveLedgerParity:
         assert LlmCostCalculator().calculate_cost(*args) == 0.0
 
 
-class TestFindPricingIgnoresTheResolutionLadder:
+class TestDisplayDictOmitsInheritedCacheRates:
 
     def test_inherited_bundled_cache_rates_stay_out_of_the_display_dict(self, monkeypatch, bundled_cache_rates):
         configured = {"bedrock": {"us.amazon.nova-2-lite-v1:0": {"input_per_1k": 0.005, "output_per_1k": 0.02}}}
         monkeypatch.setattr(llm_pricing, "get_db_pricing_nested", lambda tenant: configured)
 
-        assert find_pricing("bedrock", "us.amazon.nova-2-lite-v1:0") == {"input_per_1k": 0.005, "output_per_1k": 0.02}
+        assert display_rates("bedrock", "us.amazon.nova-2-lite-v1:0") == {"input_per_1k": 0.005, "output_per_1k": 0.02}
         live = llm_pricing.resolve_live_pricing("bedrock", "us.amazon.nova-2-lite-v1:0")
         assert live.cache_read_per_1k == 0.0004, "the calculator still gets the inherited rate"
         assert live.cache_creation_per_1k == 0.0
 
     def test_family_derived_cache_rates_stay_out_of_the_display_dict(self, no_db_rates):
-        assert find_pricing("anthropic", "claude-3-5-sonnet") == {"input_per_1k": 0.003, "output_per_1k": 0.015}
+        assert display_rates("anthropic", "claude-3-5-sonnet") == {"input_per_1k": 0.003, "output_per_1k": 0.015}

--- a/backend/tests/unit/test_llm_cost_calculator.py
+++ b/backend/tests/unit/test_llm_cost_calculator.py
@@ -87,9 +87,16 @@ class TestCalculateCostWithCacheTokens:
         cost = self.calculator.calculate_cost("bedrock", "us.amazon.nova-2-lite-v1:0", 7, 20, 3697, 0)
         assert cost == round((7 / 1000) * 0.0001 + (20 / 1000) * 0.0004 + (3697 / 1000) * 0.0001, 6)
 
-    def test_bedrock_without_a_resolved_cache_rate_keeps_the_legacy_display_estimate(self):
-        cost = self.calculator.calculate_cost("bedrock", "us.amazon.nova-2-lite-v1:0", 7, 20, 3697, 0)
-        assert cost == round((7 / 1000) * 0.0001 + (20 / 1000) * 0.0004 + (3697 / 1000) * 0.0001, 6)
+    def test_bedrock_nova_derives_cache_rates_from_its_input_rate(self):
+        cost = self.calculator.calculate_cost("bedrock", "us.amazon.nova-2-lite-v1:0", 7, 20, 3697, 1000)
+        assert cost == round(
+            (7 / 1000) * 0.0001 + (20 / 1000) * 0.0004 + (3697 / 1000) * 0.0001 * 0.1 + (1000 / 1000) * 0.0001 * 1.25,
+            6,
+        )
+
+    def test_bedrock_without_a_resolved_cache_rate_is_unpriced(self):
+        model = "arn:aws:bedrock:eu-central-1:123456789012:provisioned-model/nova-tuned"
+        assert self.calculator.calculate_cost("bedrock", model, 7, 20, 3697, 0) is None
 
     def test_configured_cache_rates_win_over_the_provider_default(self, monkeypatch):
         monkeypatch.setattr(
@@ -503,14 +510,14 @@ class TestBundledCacheRateProvenance:
         assert (res.cache_read_per_1k, res.cache_creation_per_1k) == (None, None)
 
     @pytest.mark.parametrize(
-        ("provider", "model", "expected_base"),
+        ("provider", "model", "expected_base", "expected_cache"),
         [
-            ("bedrock", "us.amazon.nova-2-lite-v1:0-future", Decimal("0.001")),
-            ("openai", "gpt-4o-mini-2024-07-18", Decimal("0.00015")),
+            ("bedrock", "us.amazon.nova-2-lite-v1:0-future", Decimal("0.001"), Decimal("0.0001")),
+            ("openai", "gpt-4o-mini-2024-07-18", Decimal("0.00015"), None),
         ],
     )
     def test_a_longest_prefix_match_takes_the_base_rate_but_not_the_cache_rates(
-        self, bundled_cache_rates, monkeypatch, provider, model, expected_base
+        self, bundled_cache_rates, monkeypatch, provider, model, expected_base, expected_cache
     ):
         monkeypatch.setitem(
             llm_pricing.STATIC_LLM_PRICING_FALLBACK["openai"],
@@ -519,7 +526,7 @@ class TestBundledCacheRateProvenance:
         )
         res = resolve_pricing(provider, model, {})
         assert res.input_per_1k == expected_base, "version suffixes still price off the base model"
-        assert res.cache_read_per_1k is None
+        assert res.cache_read_per_1k == expected_cache, "the row's own cache rate is never inherited"
 
     def test_a_configured_region_less_rate_is_always_allowed(self, bundled_cache_rates):
         configured = {
@@ -556,15 +563,22 @@ class TestCacheRateLadder:
             "us.anthropic.claude-sonnet-4-v1:0",
             "global.anthropic.claude-sonnet-5",
             "us.anthropic.claude-fable-5",
+            "us.amazon.nova-2-lite-v1:0",
         ],
     )
-    def test_claude_on_bedrock_falls_back_to_the_anthropic_multipliers(self, model):
+    def test_cache_capable_bedrock_families_fall_back_to_the_multipliers(self, model):
         configured = {"bedrock": {model: {"input_per_1k": "0.003", "output_per_1k": "0.015"}}}
         res = resolve_pricing("bedrock", model, configured)
         assert res.cache_read_per_1k == Decimal("0.0003")
         assert res.cache_creation_per_1k == Decimal("0.00375")
 
-    @pytest.mark.parametrize("model", ["us.amazon.nova-2-lite-v1:0", "amazon.titan-text-express-v1"])
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "amazon.titan-text-express-v1",
+            "arn:aws:bedrock:eu-central-1:123456789012:provisioned-model/nova-tuned",
+        ],
+    )
     def test_no_other_bedrock_family_invents_a_multiplier(self, model):
         configured = {"bedrock": {model: {"input_per_1k": "0.001", "output_per_1k": "0.002"}}}
         res = resolve_pricing("bedrock", model, configured)
@@ -645,12 +659,26 @@ _PARITY_CASES = {
     "bedrock_bundled_uncached": (("bedrock", "us.amazon.nova-2-lite-v1:0", 1000, 500, 0, 0), {}),
     "inclusive_without_cache_rates": (("openai", "gpt-4o", 1000, 500, 400, 100), {}),
     "no_cache_activity": (("openai", "gpt-4o", 1000, 500, 0, 0), {}),
+    "bedrock_cache_without_any_cache_rate": (("bedrock", "us.amazon.nova-2-lite-v1:0", 7, 20, 3697, 0), {}),
+    "bedrock_write_without_a_write_rate": (
+        ("bedrock", "us.amazon.nova-2-lite-v1:0", 100, 10, 0, 2000),
+        {
+            "bedrock": {
+                "us.amazon.nova-2-lite-v1:0": {
+                    "input_per_1k": "0.0001",
+                    "output_per_1k": "0.0004",
+                    "cache_read_per_1k": "0.000025",
+                }
+            }
+        },
+    ),
 }
 
 
 class TestLiveLedgerParity:
+
     @pytest.mark.parametrize("case", sorted(_PARITY_CASES))
-    def test_the_display_cost_matches_the_ledger_on_every_priced_case(self, case, monkeypatch):
+    def test_the_display_cost_matches_the_ledger(self, case, monkeypatch):
         args, configured = _PARITY_CASES[case]
         monkeypatch.setattr(llm_pricing, "get_db_pricing_nested", lambda tenant: configured)
         provider, model, input_tokens, output_tokens, cache_read, cache_creation = args
@@ -664,22 +692,33 @@ class TestLiveLedgerParity:
             cache_read_tokens=cache_read,
             cache_creation_tokens=cache_creation,
         )
-        assert ledger["cost_usd"] is not None, "parity is only claimed where the ledger prices"
         live = LlmCostCalculator().calculate_cost(
             provider, model, input_tokens, output_tokens, cache_read, cache_creation
         )
-        assert live == round(float(ledger["cost_usd"]), 6)
 
-    def test_an_unresolved_bedrock_bucket_splits_the_two_surfaces(self, no_db_rates):
-        args = ("bedrock", "us.amazon.nova-2-lite-v1:0", 7, 20, 3697, 0)
+        if ledger["cost_usd"] is None:
+            assert ledger["pricing_status"] == PricingStatus.UNPRICED.value
+            assert live is None, "the display path must not substitute a rate the ledger refused"
+        else:
+            assert live == round(float(ledger["cost_usd"]), 6)
 
-        ledger = _resolve_cost(*args[:4], {}, cache_read_tokens=args[4], cache_creation_tokens=args[5])
-        assert ledger["cost_usd"] is None
-        assert ledger["pricing_status"] == PricingStatus.UNPRICED.value
+    def test_an_explicit_zero_cache_rate_prices_on_both_surfaces(self, monkeypatch):
+        configured = {
+            "bedrock": {
+                "us.amazon.nova-2-lite-v1:0": {
+                    "input_per_1k": "0.0001",
+                    "output_per_1k": "0.0004",
+                    "cache_read_per_1k": "0",
+                    "cache_creation_per_1k": "0",
+                }
+            }
+        }
+        monkeypatch.setattr(llm_pricing, "get_db_pricing_nested", lambda tenant: configured)
+        args = ("bedrock", "us.amazon.nova-2-lite-v1:0", 0, 0, 4000, 1000)
 
-        live = LlmCostCalculator().calculate_cost(*args)
-        assert live == round((7 / 1000) * 0.0001 + (20 / 1000) * 0.0004 + (3697 / 1000) * 0.0001, 6)
-        assert live == LlmCostCalculator().calculate_cost("bedrock", args[1], 7 + 3697, 20)
+        ledger = _resolve_cost(*args[:4], configured, cache_read_tokens=args[4], cache_creation_tokens=args[5])
+        assert ledger["cost_usd"] == Decimal("0"), "0 is a configured price, not an absent one"
+        assert LlmCostCalculator().calculate_cost(*args) == 0.0
 
 
 class TestFindPricingIgnoresTheResolutionLadder:

--- a/backend/tests/unit/test_llm_cost_rate_crud.py
+++ b/backend/tests/unit/test_llm_cost_rate_crud.py
@@ -17,6 +17,7 @@ from app.services.llm_cost_rates import LlmCostRateService
 
 class FakeRateRepo:
     def __init__(self, existing_by_pm=None, existing_by_id=None):
+        self.db = object()
         self._by_pm = existing_by_pm
         self._by_id = existing_by_id
 
@@ -42,6 +43,7 @@ def _configure_mappers(app_def):
 @pytest.fixture(autouse=True)
 def _no_cache_calls(monkeypatch):
     monkeypatch.setattr(rate_module, "invalidate_llm_cost_rates_cache", lambda tenant=None: None)
+    monkeypatch.setattr(rate_module, "invalidate_llm_cost_rates_cache_after_commit", lambda session, tenant=None: None)
     monkeypatch.setattr(rate_module, "get_tenant_context", lambda: "tenant-1")
 
 
@@ -284,3 +286,62 @@ def test_read_serializes_unset_cache_rates_as_null():
     dumped = read.model_dump(mode="json")
     assert dumped["cache_read_per_1k"] is None
     assert dumped["cache_creation_per_1k"] == "0"
+
+
+class TestInvalidationWaitsForTheCommit:
+
+    @pytest.fixture
+    def queued(self, monkeypatch):
+        seen: list = []
+        monkeypatch.setattr(
+            rate_module,
+            "invalidate_llm_cost_rates_cache_after_commit",
+            lambda session, tenant=None: seen.append((session, tenant)),
+        )
+        monkeypatch.setattr(
+            rate_module,
+            "invalidate_llm_cost_rates_cache",
+            lambda tenant=None: pytest.fail("a rate write must not clear the cache before its commit"),
+        )
+        return seen
+
+    @pytest.mark.asyncio
+    async def test_create_queues_on_the_writing_session(self, queued):
+        repo = FakeRateRepo(existing_by_pm=None)
+        await LlmCostRateService(repo).create_rate(
+            LlmCostRateCreate(provider="openai", model="gpt-4o", input_per_1k=0.0025, output_per_1k=0.01)
+        )
+        assert queued == [(repo.db, "tenant-1")]
+
+    @pytest.mark.asyncio
+    async def test_update_queues_on_the_writing_session(self, queued):
+        row = LlmCostRateModel(
+            id=uuid4(), provider_key="openai", model_key="gpt-4o", input_per_1k=0.001, output_per_1k=0.002
+        )
+        repo = FakeRateRepo(existing_by_id=row)
+        await LlmCostRateService(repo).update_rate(uuid4(), LlmCostRateUpdate(input_per_1k=0.003, output_per_1k=0.02))
+        assert queued == [(repo.db, "tenant-1")]
+
+    @pytest.mark.asyncio
+    async def test_a_missing_rate_queues_nothing(self, queued):
+        service = LlmCostRateService(FakeRateRepo(existing_by_id=None))
+        assert await service.update_rate(uuid4(), LlmCostRateUpdate(input_per_1k=1, output_per_1k=2)) is None
+        assert queued == []
+
+    @pytest.mark.asyncio
+    async def test_delete_queues_only_when_a_row_was_removed(self, queued):
+        repo = FakeRateRepo()
+        repo.soft_delete_by_id = _returns(False)
+        assert await LlmCostRateService(repo).delete_by_id(uuid4()) is False
+        assert queued == []
+
+        repo.soft_delete_by_id = _returns(True)
+        assert await LlmCostRateService(repo).delete_by_id(uuid4()) is True
+        assert queued == [(repo.db, "tenant-1")]
+
+
+def _returns(value):
+    async def _call(rate_id):
+        return value
+
+    return _call

--- a/backend/tests/unit/test_llm_cost_rate_crud.py
+++ b/backend/tests/unit/test_llm_cost_rate_crud.py
@@ -152,3 +152,135 @@ def test_create_schema_normalizes_keys():
     dto = LlmCostRateCreate(provider="  OpenAI ", model=" GPT-4o ", input_per_1k="0.001", output_per_1k="0.002")
     assert dto.provider == "openai"
     assert dto.model == "gpt-4o"
+
+
+@pytest.mark.asyncio
+async def test_create_carries_cache_rates_to_the_row():
+    service = LlmCostRateService(FakeRateRepo(existing_by_pm=None))
+
+    read = await service.create_rate(
+        LlmCostRateCreate(
+            provider="bedrock",
+            model="eu.amazon.nova-2-lite-v1:0",
+            input_per_1k="0.0001",
+            output_per_1k="0.0004",
+            cache_read_per_1k="0.000025",
+            cache_creation_per_1k="0",
+        )
+    )
+
+    assert read.cache_read_per_1k == Decimal("0.000025")
+    assert read.cache_creation_per_1k == Decimal("0"), "free writes are a configured rate, not an unset one"
+
+
+def _configured_row():
+    return LlmCostRateModel(
+        id=uuid4(),
+        provider_key="bedrock",
+        model_key="nova",
+        input_per_1k=Decimal("0.0001"),
+        output_per_1k=Decimal("0.0004"),
+        cache_read_per_1k=Decimal("0.000025"),
+        cache_creation_per_1k=Decimal("0"),
+    )
+
+async def _update(row, **cache_fields):
+    service = LlmCostRateService(FakeRateRepo(existing_by_id=row))
+    return await service.update_rate(
+        uuid4(),
+        LlmCostRateUpdate(input_per_1k="0.0001", output_per_1k="0.0004", **cache_fields),
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_clears_the_cache_rate_the_payload_sends_blank():
+    row = _configured_row()
+
+    read = await _update(row, cache_read_per_1k="  ")
+
+    assert row.cache_read_per_1k is None
+    assert read.cache_read_per_1k is None
+    assert row.cache_creation_per_1k == Decimal("0"), "the key the payload omitted is left alone"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["cache_read_per_1k", "cache_creation_per_1k"])
+async def test_update_clears_the_cache_rate_the_payload_sends_null(field):
+    row = _configured_row()
+
+    await _update(row, **{field: None})
+
+    assert getattr(row, field) is None
+
+
+@pytest.mark.asyncio
+async def test_update_omitting_both_cache_keys_preserves_them():
+    row = _configured_row()
+
+    read = await _update(row)
+
+    assert row.cache_read_per_1k == Decimal("0.000025")
+    assert row.cache_creation_per_1k == Decimal("0")
+    assert read.cache_read_per_1k == Decimal("0.000025")
+
+
+@pytest.mark.asyncio
+async def test_update_treats_zero_as_a_configured_rate():
+    row = _configured_row()
+
+    await _update(row, cache_read_per_1k="0")
+
+    assert row.cache_read_per_1k == Decimal("0"), "free reads are configured, not unset"
+
+
+@pytest.mark.asyncio
+async def test_update_replaces_both_cache_rates_when_both_are_sent():
+    row = _configured_row()
+
+    await _update(row, cache_read_per_1k="0.0003", cache_creation_per_1k="0.00375")
+
+    assert row.cache_read_per_1k == Decimal("0.0003")
+    assert row.cache_creation_per_1k == Decimal("0.00375")
+
+
+@pytest.mark.parametrize("field", ["cache_read_per_1k", "cache_creation_per_1k"])
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_blank_cache_rate_means_not_configured(field, blank):
+    dto = LlmCostRateCreate(
+        provider="openai", model="gpt-4o", input_per_1k="0.0025", output_per_1k="0.01", **{field: blank}
+    )
+
+    assert getattr(dto, field) is None
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("cache_read_per_1k", "-0.001"),
+        ("cache_creation_per_1k", "-0.001"),
+        ("cache_read_per_1k", "NaN"),
+        ("cache_creation_per_1k", "Infinity"),
+        ("cache_read_per_1k", "abc"),
+    ],
+)
+def test_create_rejects_unusable_cache_rates(field, value):
+    payload = {"provider": "openai", "model": "gpt-4o", "input_per_1k": "0.001", "output_per_1k": "0.002"}
+    payload[field] = value
+    with pytest.raises(ValidationError):
+        LlmCostRateCreate(**payload)
+
+
+def test_read_serializes_unset_cache_rates_as_null():
+    read = LlmCostRateRead(
+        id=uuid4(),
+        provider_key="bedrock",
+        model_key="nova",
+        input_per_1k=Decimal("0.0001"),
+        output_per_1k=Decimal("0.0004"),
+        cache_creation_per_1k=Decimal("0.0000000"),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+    dumped = read.model_dump(mode="json")
+    assert dumped["cache_read_per_1k"] is None
+    assert dumped["cache_creation_per_1k"] == "0"

--- a/backend/tests/unit/test_llm_cost_rate_csv.py
+++ b/backend/tests/unit/test_llm_cost_rate_csv.py
@@ -35,12 +35,16 @@ class FakeRateRepo:
     def __init__(self, existing: dict | None = None, fail_commit: bool = False):
         self._existing = existing or {}
         self.db = FakeDb(fail_commit=fail_commit)
-        self._listed: list = []
+        self._listed: list = list(self._existing.values())
+        self.list_active_calls = 0
+        self.lookup_calls = 0
 
     async def get_active_by_provider_model(self, provider, model):
+        self.lookup_calls += 1
         return self._existing.get((provider, model))
 
     async def list_active(self):
+        self.list_active_calls += 1
         return self._listed
 
 
@@ -50,23 +54,28 @@ def _configure_mappers(app_def):
 
 
 @pytest.fixture(autouse=True)
-def _no_cache_calls(monkeypatch):
-    monkeypatch.setattr(rate_module, "invalidate_llm_cost_rates_cache", lambda tenant=None: None)
+def cache_invalidations(monkeypatch):
+    calls: list = []
+    monkeypatch.setattr(rate_module, "invalidate_llm_cost_rates_cache", lambda tenant=None: calls.append(tenant))
     monkeypatch.setattr(rate_module, "get_tenant_context", lambda: "tenant-1")
+    return calls
 
 
-def _row(provider, model, inp, outp):
+def _row(provider, model, inp, outp, cache_read=None, cache_creation=None):
     return LlmCostRateModel(
         id=uuid4(),
         provider_key=provider,
         model_key=model,
         input_per_1k=inp,
         output_per_1k=outp,
+        cache_read_per_1k=cache_read,
+        cache_creation_per_1k=cache_creation,
         updated_at=datetime.now(timezone.utc),
     )
 
 
 HEADER = "provider,model,input_per_1k,output_per_1k\n"
+CACHE_HEADER = "provider,model,input_per_1k,output_per_1k,cache_read_per_1k,cache_creation_per_1k\n"
 
 
 @pytest.mark.asyncio
@@ -162,12 +171,266 @@ async def test_export_round_trips_small_rates_losslessly():
     repo._listed = [_row("openai", "gpt-4o-mini", Decimal("0.00015"), Decimal("0.0000001"))]
     service = LlmCostRateService(repo)
 
-    csv_text = await service.export_csv()
+    csv_text = await service.export_csv(True)
 
-    assert csv_text.splitlines()[1] == "openai,gpt-4o-mini,0.00015,0.0000001"
+    assert csv_text.splitlines()[1] == "openai,gpt-4o-mini,0.00015,0.0000001,,"
 
     reimport_repo = FakeRateRepo()
     result = await LlmCostRateService(reimport_repo).import_csv(csv_text)
     assert result.inserted == 1
     assert reimport_repo.db.added[0].input_per_1k == Decimal("0.00015")
     assert reimport_repo.db.added[0].output_per_1k == Decimal("0.0000001")
+    assert reimport_repo.db.added[0].cache_read_per_1k is None
+
+
+@pytest.mark.asyncio
+async def test_legacy_four_column_file_still_imports_without_cache_rates():
+    repo = FakeRateRepo()
+    service = LlmCostRateService(repo)
+
+    result = await service.import_csv(HEADER + "anthropic,claude-3-5-sonnet,0.003,0.015\n")
+
+    assert (result.inserted, result.errors) == (1, [])
+    added = repo.db.added[0]
+    assert added.cache_read_per_1k is None and added.cache_creation_per_1k is None
+
+
+@pytest.mark.asyncio
+async def test_legacy_four_column_file_leaves_configured_cache_rates_alone():
+    existing = _row("bedrock", "nova", Decimal("0.0001"), Decimal("0.0004"), Decimal("0.000025"), Decimal("0"))
+    service = LlmCostRateService(FakeRateRepo(existing={("bedrock", "nova"): existing}))
+
+    result = await service.import_csv(HEADER + "bedrock,nova,0.0002,0.0008\n")
+
+    assert (result.inserted, result.updated, result.errors) == (0, 1, [])
+    assert existing.input_per_1k == Decimal("0.0002")
+    assert existing.cache_read_per_1k == Decimal("0.000025")
+    assert existing.cache_creation_per_1k == Decimal("0"), "a file without the column cannot clear a rate"
+
+
+@pytest.mark.asyncio
+async def test_import_reads_cache_rates_and_keeps_zero_distinct_from_blank():
+    repo = FakeRateRepo()
+    service = LlmCostRateService(repo)
+
+    result = await service.import_csv(
+        CACHE_HEADER
+        + "bedrock,eu.amazon.nova-2-lite-v1:0,0.0001,0.0004,0.000025,0\n"
+        + "bedrock,eu.anthropic.claude-3-5-sonnet-20241022-v2:0,0.003,0.015,,\n"
+    )
+
+    assert (result.inserted, result.errors) == (2, [])
+    nova, claude = repo.db.added
+    assert nova.cache_read_per_1k == Decimal("0.000025")
+    assert nova.cache_creation_per_1k == Decimal("0"), "free writes are configured, not unset"
+    assert claude.cache_read_per_1k is None and claude.cache_creation_per_1k is None
+
+
+@pytest.mark.asyncio
+async def test_import_clears_cache_rates_a_row_no_longer_lists():
+    existing = _row("bedrock", "nova", Decimal("0.0001"), Decimal("0.0004"), Decimal("0.000025"), Decimal("0"))
+    service = LlmCostRateService(FakeRateRepo(existing={("bedrock", "nova"): existing}))
+
+    result = await service.import_csv(CACHE_HEADER + "bedrock,nova,0.0001,0.0004,,\n")
+
+    assert (result.inserted, result.updated) == (0, 1)
+    assert existing.cache_read_per_1k is None and existing.cache_creation_per_1k is None
+
+
+@pytest.mark.asyncio
+async def test_import_rejects_a_negative_cache_rate_row():
+    repo = FakeRateRepo()
+    service = LlmCostRateService(repo)
+
+    result = await service.import_csv(CACHE_HEADER + "openai,gpt-4o,0.0025,0.01,-0.001,0.001\n")
+
+    assert result.inserted == 0
+    assert result.errors == ["Row 2: invalid provider, model or rate value"]
+
+
+@pytest.mark.asyncio
+async def test_export_round_trips_cache_rates():
+    repo = FakeRateRepo()
+    repo._listed = [
+        _row("bedrock", "nova", Decimal("0.0001"), Decimal("0.0004"), Decimal("0.000025"), Decimal("0")),
+    ]
+
+    csv_text = await LlmCostRateService(repo).export_csv(True)
+
+    assert csv_text.splitlines()[0] == (
+        "provider,model,input_per_1k,output_per_1k,cache_read_per_1k,cache_creation_per_1k"
+    )
+    assert csv_text.splitlines()[1] == "bedrock,nova,0.0001,0.0004,0.000025,0"
+
+    reimport_repo = FakeRateRepo()
+    await LlmCostRateService(reimport_repo).import_csv(csv_text)
+    assert reimport_repo.db.added[0].cache_read_per_1k == Decimal("0.000025")
+    assert reimport_repo.db.added[0].cache_creation_per_1k == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_export_defaults_to_the_four_column_layout():
+    repo = FakeRateRepo()
+    repo._listed = [_row("bedrock", "nova", Decimal("0.0001"), Decimal("0.0004"), Decimal("0.000025"), Decimal("0"))]
+
+    csv_text = await LlmCostRateService(repo).export_csv(False)
+
+    assert csv_text.splitlines() == [
+        "provider,model,input_per_1k,output_per_1k",
+        "bedrock,nova,0.0001,0.0004",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_four_column_export_re_imports_without_touching_cache_rates():
+    configured = _row("bedrock", "nova", Decimal("0.0001"), Decimal("0.0004"), Decimal("0.000025"), Decimal("0"))
+    repo = FakeRateRepo(existing={("bedrock", "nova"): configured})
+
+    csv_text = await LlmCostRateService(repo).export_csv(False)
+    result = await LlmCostRateService(repo).import_csv(csv_text)
+
+    assert (result.inserted, result.updated, result.errors) == (0, 1, [])
+    assert configured.cache_read_per_1k == Decimal("0.000025")
+    assert configured.cache_creation_per_1k == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_six_column_export_round_trips_an_unset_cache_rate_as_unset():
+    unset = _row("openai", "gpt-4o", Decimal("0.0025"), Decimal("0.01"))
+    repo = FakeRateRepo(existing={("openai", "gpt-4o"): unset})
+
+    csv_text = await LlmCostRateService(repo).export_csv(True)
+    result = await LlmCostRateService(repo).import_csv(csv_text)
+
+    assert (result.inserted, result.updated, result.errors) == (0, 1, [])
+    assert unset.cache_read_per_1k is None and unset.cache_creation_per_1k is None
+
+
+@pytest.mark.asyncio
+async def test_import_rejects_a_file_over_the_row_cap_before_staging_anything():
+    repo = FakeRateRepo()
+    body = "".join(f"openai,model-{i},0.001,0.002\n" for i in range(rate_module.MAX_IMPORT_ROWS + 1))
+
+    result = await LlmCostRateService(repo).import_csv(HEADER + body)
+
+    assert (result.inserted, result.updated) == (0, 0)
+    assert result.errors == [f"CSV has more than {rate_module.MAX_IMPORT_ROWS} data rows"]
+    assert repo.db.added == [] and repo.db.committed is False
+    assert repo.list_active_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_import_accepts_a_file_exactly_at_the_row_cap():
+    repo = FakeRateRepo()
+    body = "".join(f"openai,model-{i},0.001,0.002\n" for i in range(rate_module.MAX_IMPORT_ROWS))
+
+    result = await LlmCostRateService(repo).import_csv(HEADER + body)
+
+    assert result.inserted == rate_module.MAX_IMPORT_ROWS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "header,expected",
+    [
+        ("provider,model,input_per_1k,output_per_1k,provider\n", "provider"),
+        ("provider,MODEL,input_per_1k,output_per_1k, model \n", "model"),
+    ],
+    ids=["identical", "case_and_whitespace_variant"],
+)
+async def test_import_rejects_duplicate_headers(header, expected):
+    repo = FakeRateRepo()
+
+    result = await LlmCostRateService(repo).import_csv(header + "openai,gpt-4o,0.001,0.002\n")
+
+    assert result.errors == [f"Duplicate columns: {expected}"]
+    assert repo.db.added == []
+
+
+@pytest.mark.asyncio
+async def test_import_caps_the_error_list_and_reports_the_omitted_count():
+    repo = FakeRateRepo()
+    body = "".join(f"openai,model-{i},abc,0.002\n" for i in range(rate_module.MAX_IMPORT_ERRORS + 25))
+
+    result = await LlmCostRateService(repo).import_csv(HEADER + body)
+
+    assert len(result.errors) == rate_module.MAX_IMPORT_ERRORS + 1
+    assert result.errors[-1] == "… 25 additional errors omitted"
+    assert result.errors[0].startswith("Row 2:")
+
+
+@pytest.mark.asyncio
+async def test_import_looks_up_existing_rates_once_for_the_whole_file():
+    existing = {
+        ("openai", "gpt-4o"): _row("openai", "gpt-4o", Decimal("0.001"), Decimal("0.002")),
+        ("openai", "gpt-4o-mini"): _row("openai", "gpt-4o-mini", Decimal("0.0001"), Decimal("0.0002")),
+    }
+    repo = FakeRateRepo(existing=existing)
+
+    result = await LlmCostRateService(repo).import_csv(
+        HEADER
+        + "openai,gpt-4o,0.009,0.02\n"
+        + "openai,gpt-4o-mini,0.0009,0.002\n"
+        + "anthropic,claude-3-opus,0.015,0.075\n"
+    )
+
+    assert (result.inserted, result.updated, result.errors) == (1, 2, [])
+    assert repo.list_active_calls == 1
+    assert repo.lookup_calls == 0, "one prefetch replaces the per-row query"
+
+
+@pytest.mark.asyncio
+async def test_import_that_changes_nothing_leaves_the_pricing_cache_alone(cache_invalidations):
+    repo = FakeRateRepo()
+
+    result = await LlmCostRateService(repo).import_csv(HEADER + "openai,gpt-4o,abc,0.002\n")
+
+    assert (result.inserted, result.updated) == (0, 0)
+    assert cache_invalidations == []
+
+
+@pytest.mark.asyncio
+async def test_import_that_writes_rows_invalidates_the_pricing_cache(cache_invalidations):
+    repo = FakeRateRepo()
+
+    await LlmCostRateService(repo).import_csv(HEADER + "openai,gpt-4o,0.001,0.002\n")
+
+    assert cache_invalidations == ["tenant-1"]
+
+
+def test_byte_cap_admits_a_file_exactly_at_the_limit():
+    assert rate_module.import_exceeds_byte_cap(b"x" * rate_module.MAX_IMPORT_BYTES) is False
+    assert rate_module.import_exceeds_byte_cap(b"x" * (rate_module.MAX_IMPORT_BYTES + 1)) is True
+@pytest.mark.asyncio
+async def test_import_matches_headers_ignoring_case_and_surrounding_space():
+    repo = FakeRateRepo()
+
+    result = await LlmCostRateService(repo).import_csv(
+        " Provider , MODEL ,Input_Per_1K,output_per_1k\nopenai,gpt-4o,0.001,0.002\n"
+    )
+
+    assert (result.inserted, result.errors) == (1, [])
+    assert repo.db.added[0].input_per_1k == Decimal("0.001")
+
+
+@pytest.mark.asyncio
+async def test_import_reads_a_short_row_as_blank_cells():
+    repo = FakeRateRepo()
+
+    result = await LlmCostRateService(repo).import_csv(CACHE_HEADER + "openai,gpt-4o,0.001,0.002\n")
+
+    assert (result.inserted, result.errors) == (1, [])
+    added = repo.db.added[0]
+    assert added.cache_read_per_1k is None and added.cache_creation_per_1k is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("padding", [",,", ",  ,\t", ", ,"], ids=["empty", "spaces_and_tab", "single_space"])
+async def test_padded_header_columns_are_not_read_as_duplicates(padding):
+    repo = FakeRateRepo()
+
+    result = await LlmCostRateService(repo).import_csv(
+        f"provider,model,input_per_1k,output_per_1k{padding}\nopenai,gpt-4o,0.001,0.002,,\n"
+    )
+
+    assert (result.inserted, result.errors) == (1, [])

--- a/backend/tests/unit/test_llm_pricing_cache.py
+++ b/backend/tests/unit/test_llm_pricing_cache.py
@@ -1,11 +1,14 @@
 import threading
 
 import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
 
 import app.services.llm_pricing_cache as pricing_cache
 from app.services.llm_pricing_cache import (
     get_db_pricing_nested,
     invalidate_llm_cost_rates_cache,
+    invalidate_llm_cost_rates_cache_after_commit,
 )
 
 TENANT = "acme"
@@ -270,3 +273,89 @@ def test_a_crashing_load_does_not_wedge_the_tenant(monkeypatch, clock):
     clock.advance(pricing_cache._FAILURE_COOLDOWN_SECONDS + 1)
     assert get_db_pricing_nested(TENANT) == RATES
     assert loader.calls == 1
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite://")
+    with Session(engine) as real_session:
+        real_session.execute(text("SELECT 1"))
+        yield real_session
+    engine.dispose()
+
+
+def test_a_pending_invalidation_leaves_the_cache_warm_until_the_commit(monkeypatch, clock, session):
+    loader = _install(monkeypatch, Loader(RATES, NEWER))
+    assert get_db_pricing_nested(TENANT) == RATES
+
+    invalidate_llm_cost_rates_cache_after_commit(session, TENANT)
+    assert get_db_pricing_nested(TENANT) == RATES, "uncommitted writes must not be published"
+
+    session.commit()
+    assert get_db_pricing_nested(TENANT) == NEWER
+    assert loader.calls == 2
+
+
+def test_a_rollback_keeps_the_committed_rates_cached(monkeypatch, clock, session):
+    loader = _install(monkeypatch, Loader(RATES, NEWER))
+    get_db_pricing_nested(TENANT)
+
+    invalidate_llm_cost_rates_cache_after_commit(session, TENANT)
+    session.rollback()
+    session.commit()
+
+    assert get_db_pricing_nested(TENANT) == RATES
+    assert loader.calls == 1
+
+
+def test_a_released_savepoint_does_not_publish_the_write_early(monkeypatch, clock, session):
+    _install(monkeypatch, Loader(RATES, NEWER))
+    get_db_pricing_nested(TENANT)
+
+    invalidate_llm_cost_rates_cache_after_commit(session, TENANT)
+    with session.begin_nested():
+        session.execute(text("SELECT 1"))
+
+    assert pricing_cache._cache.get(TENANT) is not None, "a savepoint is not the outer commit"
+    session.commit()
+    assert TENANT not in pricing_cache._cache
+
+
+def test_a_savepoint_rollback_keeps_the_invalidation_for_the_outer_commit(monkeypatch, clock, session):
+    _install(monkeypatch, Loader(RATES, NEWER))
+    get_db_pricing_nested(TENANT)
+
+    invalidate_llm_cost_rates_cache_after_commit(session, TENANT)
+    with pytest.raises(RuntimeError):
+        with session.begin_nested():
+            session.execute(text("SELECT 1"))
+            raise RuntimeError("the inner unit of work failed")
+
+    session.commit()
+    assert TENANT not in pricing_cache._cache, "the outer commit must still publish the write"
+
+
+def test_committing_one_tenant_leaves_the_others_cached(monkeypatch, clock, session):
+    other = "globex"
+    _install(monkeypatch, Loader(RATES, NEWER))
+    get_db_pricing_nested(TENANT)
+    get_db_pricing_nested(other)
+
+    invalidate_llm_cost_rates_cache_after_commit(session, TENANT)
+    session.commit()
+
+    assert pricing_cache._cache.get(other) is not None, "another tenant's entry survives"
+    assert TENANT not in pricing_cache._cache
+
+
+def test_a_commit_drains_the_queue_once(monkeypatch, clock, session):
+    _install(monkeypatch, Loader(RATES, NEWER))
+    get_db_pricing_nested(TENANT)
+
+    invalidate_llm_cost_rates_cache_after_commit(session, TENANT)
+    session.commit()
+    get_db_pricing_nested(TENANT)
+    session.commit()
+
+    assert pricing_cache._cache.get(TENANT) is not None, "a later commit must not re-clear"
+

--- a/backend/tests/unit/test_llm_pricing_cache.py
+++ b/backend/tests/unit/test_llm_pricing_cache.py
@@ -1,0 +1,272 @@
+import threading
+
+import pytest
+
+import app.services.llm_pricing_cache as pricing_cache
+from app.services.llm_pricing_cache import (
+    get_db_pricing_nested,
+    invalidate_llm_cost_rates_cache,
+)
+
+TENANT = "acme"
+RATES = {"openai": {"gpt-4o": {"input_per_1k": 0.005, "output_per_1k": 0.02}}}
+NEWER = {"openai": {"gpt-4o": {"input_per_1k": 0.009, "output_per_1k": 0.03}}}
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 1000.0
+
+    def advance(self, seconds):
+        self.now += seconds
+
+    def __call__(self):
+        return self.now
+
+
+class Loader:
+
+    def __init__(self, *results):
+        self.results = list(results)
+        self.calls = 0
+
+    def __call__(self, tenant):
+        self.calls += 1
+        return self.results[min(self.calls - 1, len(self.results) - 1)]
+
+
+class BlockingLoader(Loader):
+
+    def __init__(self, *results, block_on=1):
+        super().__init__(*results)
+        self.block_on = block_on
+        self.entered = threading.Event()
+        self.released = threading.Event()
+
+    def __call__(self, tenant):
+        result = super().__call__(tenant)
+        if self.calls == self.block_on:
+            self.entered.set()
+            assert self.released.wait(5), "the parked load was never released"
+        return result
+
+
+def _reset():
+    invalidate_llm_cost_rates_cache()
+    pricing_cache._refreshing.clear()
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    fake = FakeClock()
+    monkeypatch.setattr(pricing_cache.time, "monotonic", fake)
+    _reset()
+    yield fake
+    _reset()
+
+
+def _install(monkeypatch, loader):
+    monkeypatch.setattr(pricing_cache, "_load_db_nested", loader)
+    return loader
+
+
+def test_first_read_loads_and_caches(monkeypatch, clock):
+    loader = _install(monkeypatch, Loader(RATES))
+    assert get_db_pricing_nested(TENANT) == RATES
+    assert get_db_pricing_nested(TENANT) == RATES
+    assert loader.calls == 1
+
+
+def test_within_ttl_serves_the_cached_copy(monkeypatch, clock):
+    loader = _install(monkeypatch, Loader(RATES, NEWER))
+    get_db_pricing_nested(TENANT)
+    clock.advance(pricing_cache._TTL_SECONDS - 1)
+    assert get_db_pricing_nested(TENANT) == RATES
+    assert loader.calls == 1
+
+
+def _wait_for_background_refresh(timeout: float = 5.0):
+    import time as real_time
+
+    for _ in range(int(timeout / 0.01)):
+        with pricing_cache._condition:
+            if not pricing_cache._refreshing:
+                return
+        real_time.sleep(0.01)
+    raise AssertionError("the background refresh never finished")
+
+
+def test_expired_entry_serves_stale_and_refreshes_in_the_background(monkeypatch, clock):
+    loader = _install(monkeypatch, Loader(RATES, NEWER))
+    get_db_pricing_nested(TENANT)
+    clock.advance(pricing_cache._TTL_SECONDS + 1)
+
+    assert get_db_pricing_nested(TENANT) == RATES
+
+    _wait_for_background_refresh()
+    assert get_db_pricing_nested(TENANT) == NEWER
+    assert loader.calls == 2
+
+
+def test_invalidation_reloads_immediately(monkeypatch, clock):
+    loader = _install(monkeypatch, Loader(RATES, NEWER))
+    get_db_pricing_nested(TENANT)
+    invalidate_llm_cost_rates_cache(TENANT)
+    assert get_db_pricing_nested(TENANT) == NEWER
+    assert loader.calls == 2
+
+
+def test_tenants_are_cached_independently(monkeypatch, clock):
+    _install(monkeypatch, Loader(RATES, NEWER))
+    assert get_db_pricing_nested(TENANT) == RATES
+    assert get_db_pricing_nested("other") == NEWER
+    assert get_db_pricing_nested(TENANT) == RATES
+
+
+def test_db_failure_after_a_warm_load_serves_the_stale_copy(monkeypatch, clock):
+    _install(monkeypatch, Loader(RATES, None))
+    get_db_pricing_nested(TENANT)
+    clock.advance(pricing_cache._TTL_SECONDS + 1)
+    assert get_db_pricing_nested(TENANT) == RATES
+    _wait_for_background_refresh()
+    assert get_db_pricing_nested(TENANT) == RATES
+
+
+def test_db_failure_on_a_cold_cache_recovers_once_the_cooldown_elapses(monkeypatch, clock):
+    loader = _install(monkeypatch, Loader(None, RATES))
+    assert get_db_pricing_nested(TENANT) == {}
+    clock.advance(pricing_cache._FAILURE_COOLDOWN_SECONDS + 1)
+    assert get_db_pricing_nested(TENANT) == RATES
+    assert loader.calls == 2
+
+
+def test_repeated_calls_during_an_outage_attempt_the_db_once_per_cooldown(monkeypatch, clock):
+    loader = _install(monkeypatch, Loader(None))
+    get_db_pricing_nested(TENANT)
+    assert loader.calls == 1
+
+    for step in (0.1, 1, pricing_cache._FAILURE_COOLDOWN_SECONDS - 1.2):
+        clock.advance(step)
+        get_db_pricing_nested(TENANT)
+    assert loader.calls == 1
+
+    clock.advance(1)
+    get_db_pricing_nested(TENANT)
+    assert loader.calls == 2
+
+
+def test_invalidation_bypasses_the_failure_cooldown(monkeypatch, clock):
+    loader = _install(monkeypatch, Loader(None, RATES))
+    get_db_pricing_nested(TENANT)
+    assert loader.calls == 1
+
+    invalidate_llm_cost_rates_cache(TENANT)
+    assert get_db_pricing_nested(TENANT) == RATES
+    assert loader.calls == 2
+
+
+def _refresh_in_background():
+    loaded: list = []
+    thread = threading.Thread(target=lambda: loaded.append(get_db_pricing_nested(TENANT)))
+    thread.start()
+    return thread, loaded
+
+
+def test_a_cold_stampede_reaches_the_db_once_and_every_caller_waits_for_it(monkeypatch, clock):
+    loader = _install(monkeypatch, BlockingLoader(RATES))
+    thread, loaded = _refresh_in_background()
+    assert loader.entered.wait(5)
+
+    waiters = [_refresh_in_background() for _ in range(3)]
+    loader.released.set()
+    thread.join(5)
+    for waiter_thread, _ in waiters:
+        waiter_thread.join(5)
+
+    assert loaded == [RATES]
+    assert [result for _, results in waiters for result in results] == [RATES] * 3
+    assert loader.calls == 1
+
+
+def test_a_failed_thread_start_releases_the_refresh_slot(monkeypatch, clock):
+    loader = _install(monkeypatch, Loader(RATES, NEWER))
+    get_db_pricing_nested(TENANT)
+    clock.advance(pricing_cache._TTL_SECONDS + 1)
+
+    class _Unstartable:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            raise RuntimeError("can't start new thread")
+
+    real_thread = threading.Thread
+    monkeypatch.setattr(pricing_cache.threading, "Thread", _Unstartable)
+    assert get_db_pricing_nested(TENANT) == RATES
+    assert TENANT not in pricing_cache._refreshing
+
+    monkeypatch.setattr(pricing_cache.threading, "Thread", real_thread)
+    assert get_db_pricing_nested(TENANT) == RATES
+    _wait_for_background_refresh()
+    assert get_db_pricing_nested(TENANT) == NEWER
+    assert loader.calls == 2
+
+
+def test_a_ttl_expiry_stampede_serves_the_stale_copy_while_one_refresh_runs(monkeypatch, clock):
+    loader = _install(monkeypatch, BlockingLoader(RATES, NEWER, block_on=2))
+    get_db_pricing_nested(TENANT)
+    clock.advance(pricing_cache._TTL_SECONDS + 1)
+
+    assert get_db_pricing_nested(TENANT) == RATES
+    assert loader.entered.wait(5)
+
+    assert [get_db_pricing_nested(TENANT) for _ in range(5)] == [RATES] * 5
+    assert loader.calls == 2
+
+    loader.released.set()
+    _wait_for_background_refresh()
+    assert get_db_pricing_nested(TENANT) == NEWER
+
+
+@pytest.mark.parametrize("scope", ["tenant", "all"], ids=["one-tenant", "all-tenants"])
+def test_an_invalidation_during_a_load_discards_the_stale_snapshot(monkeypatch, clock, scope):
+    loader = _install(monkeypatch, BlockingLoader(RATES, NEWER))
+    thread, loaded = _refresh_in_background()
+    assert loader.entered.wait(5)
+
+    invalidate_llm_cost_rates_cache(TENANT if scope == "tenant" else None)
+    loader.released.set()
+    thread.join(5)
+
+    assert loaded == [NEWER]
+    assert loader.calls == 2
+    assert get_db_pricing_nested(TENANT) == NEWER
+
+
+def test_an_invalidation_during_a_failing_load_does_not_resurrect_the_cooldown(monkeypatch, clock):
+    loader = _install(monkeypatch, BlockingLoader(None, RATES))
+    thread, loaded = _refresh_in_background()
+    assert loader.entered.wait(5)
+
+    invalidate_llm_cost_rates_cache(TENANT)
+    loader.released.set()
+    thread.join(5)
+
+    assert loaded == [RATES]
+    assert loader.calls == 2
+
+
+def test_a_crashing_load_does_not_wedge_the_tenant(monkeypatch, clock):
+
+    def boom(tenant):
+        raise RuntimeError("connection reset")
+
+    _install(monkeypatch, boom)
+    with pytest.raises(RuntimeError):
+        get_db_pricing_nested(TENANT)
+    assert TENANT not in pricing_cache._refreshing
+
+    loader = _install(monkeypatch, Loader(RATES))
+    clock.advance(pricing_cache._FAILURE_COOLDOWN_SECONDS + 1)
+    assert get_db_pricing_nested(TENANT) == RATES
+    assert loader.calls == 1

--- a/backend/tests/unit/test_llm_usage_cache_pins.py
+++ b/backend/tests/unit/test_llm_usage_cache_pins.py
@@ -1,0 +1,48 @@
+"""Pins on how the installed provider SDKs report cached tokens"""
+
+from types import SimpleNamespace
+
+from langchain_anthropic.chat_models import _create_usage_metadata
+from langchain_aws.chat_models.bedrock_converse import _extract_usage_metadata
+
+from app.core.config.llm_pricing import CACHE_EXCLUSIVE_PROVIDERS
+
+
+class TestAnthropicReportsInclusiveInput:
+    def test_cache_buckets_are_summed_into_input_tokens(self):
+        usage = _create_usage_metadata(
+            SimpleNamespace(
+                input_tokens=100,
+                output_tokens=10,
+                cache_read_input_tokens=500,
+                cache_creation_input_tokens=60,
+                cache_creation=None,
+            )
+        )
+        assert usage["input_tokens"] == 660
+        assert usage["total_tokens"] == 670
+        assert usage["input_token_details"] == {"cache_read": 500, "cache_creation": 60}
+
+    def test_anthropic_is_not_treated_as_exclusive(self):
+        assert "anthropic" not in CACHE_EXCLUSIVE_PROVIDERS
+
+
+class TestBedrockReportsExclusiveInput:
+    def test_cache_buckets_are_left_out_of_input_tokens(self):
+        response = {
+            "usage": {
+                "inputTokens": 100,
+                "outputTokens": 10,
+                "totalTokens": 610,
+                "cacheReadInputTokens": 500,
+                "cacheWriteInputTokens": 0,
+            }
+        }
+        usage = _extract_usage_metadata(response)
+        assert usage["input_tokens"] == 100
+        assert usage["total_tokens"] == 610
+        assert usage["input_token_details"] == {"cache_read": 500, "cache_creation": 0}
+        assert "usage" not in response
+
+    def test_bedrock_is_treated_as_exclusive(self):
+        assert "bedrock" in CACHE_EXCLUSIVE_PROVIDERS

--- a/backend/tests/unit/test_llm_usage_cache_pins.py
+++ b/backend/tests/unit/test_llm_usage_cache_pins.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 from langchain_anthropic.chat_models import _create_usage_metadata
 from langchain_aws.chat_models.bedrock_converse import _extract_usage_metadata
+from langchain_openai.chat_models.base import _create_usage_metadata as _openai_usage_metadata
 
 from app.core.config.llm_pricing import CACHE_EXCLUSIVE_PROVIDERS
 
@@ -46,3 +47,23 @@ class TestBedrockReportsExclusiveInput:
 
     def test_bedrock_is_treated_as_exclusive(self):
         assert "bedrock" in CACHE_EXCLUSIVE_PROVIDERS
+
+
+class TestOpenAiReportsInclusiveInput:
+    def test_cached_tokens_are_a_subset_of_prompt_tokens(self):
+        usage = _openai_usage_metadata(
+            {
+                "prompt_tokens": 1000,
+                "completion_tokens": 50,
+                "total_tokens": 1050,
+                "prompt_tokens_details": {"cached_tokens": 400},
+            }
+        )
+        assert usage["input_tokens"] == 1000, "cached tokens are already counted in"
+        assert usage["input_token_details"]["cache_read"] == 400
+
+
+class TestGeminiReportsInclusiveInput:
+    def test_gemini_is_not_treated_as_exclusive(self):
+        assert "google_genai" not in CACHE_EXCLUSIVE_PROVIDERS
+        assert "google_vertexai" not in CACHE_EXCLUSIVE_PROVIDERS

--- a/backend/tests/unit/test_llm_usage_export.py
+++ b/backend/tests/unit/test_llm_usage_export.py
@@ -84,6 +84,18 @@ def test_csv_includes_rate_provenance_counts():
     assert "Unpriced calls,1" in text
 
 
+def test_csv_reports_the_cache_token_buckets():
+    text = _csv_text(summary=_summary(total_cache_read_tokens=3697, total_cache_creation_tokens=120))
+    assert "Cache read tokens,3697" in text
+    assert "Cache write tokens,120" in text
+
+
+def test_csv_reports_zero_cache_tokens_for_summaries_without_them():
+    text = _csv_text()
+    assert "Cache read tokens,0" in text
+    assert "Cache write tokens,0" in text
+
+
 def test_csv_labels_agent_studio_test_cost():
     assert "Agent Studio test cost (USD),0.5000" in _csv_text()
 

--- a/backend/tests/unit/test_llm_usage_read_repo_sql.py
+++ b/backend/tests/unit/test_llm_usage_read_repo_sql.py
@@ -11,7 +11,7 @@ import app.db.models.test_suite
 from app.repositories.dashboard import DashboardRepository, _ledger_window
 from app.repositories.llm_usage_read import LlmUsageReadRepository
 from app.schemas.llm_usage import LlmUsageQueryParams
-from app.services.llm_usage_read import _DIMENSION_COLUMNS, _EXTRA_BREAKDOWN_CONDITIONS
+from app.services.llm_usage_read import _DIMENSION_COLUMNS, _EXTRA_BREAKDOWN_CONDITIONS, LlmUsageReadService
 
 WINDOW_START = datetime(2026, 1, 1, tzinfo=timezone.utc)
 WINDOW_END = datetime(2026, 1, 31, tzinfo=timezone.utc)
@@ -26,8 +26,11 @@ class _Result:
     def all(self):
         return []
 
+    def mappings(self):
+        return self
+
     def one(self):
-        return ()
+        return {}
 
 
 class CapturingDb:
@@ -94,6 +97,33 @@ async def test_summary_counts_each_pricing_status():
         assert f"pricing_status = '{status}'" in sql
 
 
+@pytest.mark.asyncio
+async def test_summary_sums_the_cache_token_buckets():
+    db = CapturingDb()
+    await LlmUsageReadRepository(db).summary(LlmUsageQueryParams(), None)
+    sql = _sql(db.statements[0])
+    assert "sum(llm_usage_events.cache_read_tokens)" in sql
+    assert "sum(llm_usage_events.cache_creation_tokens)" in sql
+
+
+@pytest.mark.asyncio
+async def test_summary_adds_cache_buckets_back_for_providers_that_exclude_them():
+    db = CapturingDb()
+    await LlmUsageReadRepository(db).summary(LlmUsageQueryParams(), None)
+    sql = _sql(db.statements[0])
+    assert "CASE WHEN (llm_usage_events.provider_key IN ('bedrock'))" in sql
+    assert "llm_usage_events.cache_read_tokens + llm_usage_events.cache_creation_tokens ELSE 0" in sql
+@pytest.mark.asyncio
+@pytest.mark.parametrize("query", ["timeseries", "breakdown"])
+async def test_every_token_aggregate_shares_the_derived_total(query):
+    db = CapturingDb()
+    repo = LlmUsageReadRepository(db)
+    if query == "timeseries":
+        await repo.timeseries(LlmUsageQueryParams(), None)
+    else:
+        await repo.breakdown(LlmUsageQueryParams(), None, _DIMENSION_COLUMNS["provider"])
+    sql = _sql(db.statements[0])
+    assert "ELSE llm_usage_events.total_tokens END" in sql
 @pytest.mark.asyncio
 async def test_summary_scopes_agent_studio_cost_to_the_two_studio_test_sources():
     db = CapturingDb()
@@ -332,3 +362,20 @@ def test_ledger_window_includes_the_whole_upper_bound_day():
 def test_ledger_window_of_a_single_day_covers_that_day():
     day = datetime(2026, 1, 15, tzinfo=timezone.utc)
     assert _ledger_window(day, day) == (day, day + timedelta(days=1))
+
+
+@pytest.mark.asyncio
+async def test_the_service_reads_exactly_the_labels_the_summary_selects():
+    db = CapturingDb()
+    await LlmUsageReadRepository(db).summary(LlmUsageQueryParams(), None)
+    labels = {column.name: 0 for column in db.statements[0].selected_columns}
+
+    class _Repo:
+        async def summary(self, params, scope):
+            return labels
+
+        async def last_unpriced_at(self):
+            return None
+
+    summary = await LlmUsageReadService(_Repo(), None, None)._summary(LlmUsageQueryParams(), None)
+    assert summary.total_calls == 0

--- a/backend/tests/unit/test_llm_usage_read_repo_sql.py
+++ b/backend/tests/unit/test_llm_usage_read_repo_sql.py
@@ -107,12 +107,12 @@ async def test_summary_sums_the_cache_token_buckets():
 
 
 @pytest.mark.asyncio
-async def test_summary_adds_cache_buckets_back_for_providers_that_exclude_them():
+async def test_summary_reads_the_stored_prompt_total_instead_of_deriving_it():
     db = CapturingDb()
     await LlmUsageReadRepository(db).summary(LlmUsageQueryParams(), None)
     sql = _sql(db.statements[0])
-    assert "CASE WHEN (llm_usage_events.provider_key IN ('bedrock'))" in sql
-    assert "llm_usage_events.cache_read_tokens + llm_usage_events.cache_creation_tokens ELSE 0" in sql
+    assert "sum(llm_usage_events.prompt_tokens)" in sql
+    assert "provider_key IN" not in sql, "reads must not reapply provider reporting rules"
 @pytest.mark.asyncio
 @pytest.mark.parametrize("query", ["timeseries", "breakdown"])
 async def test_every_token_aggregate_shares_the_derived_total(query):
@@ -123,7 +123,7 @@ async def test_every_token_aggregate_shares_the_derived_total(query):
     else:
         await repo.breakdown(LlmUsageQueryParams(), None, _DIMENSION_COLUMNS["provider"])
     sql = _sql(db.statements[0])
-    assert "ELSE llm_usage_events.total_tokens END" in sql
+    assert "greatest(llm_usage_events.total_tokens, llm_usage_events.prompt_tokens" in sql
 @pytest.mark.asyncio
 async def test_summary_scopes_agent_studio_cost_to_the_two_studio_test_sources():
     db = CapturingDb()

--- a/backend/tests/unit/test_llm_usage_read_service.py
+++ b/backend/tests/unit/test_llm_usage_read_service.py
@@ -143,22 +143,26 @@ def _row(
     conv_cost="0.80",
     studio_cost="0.20",
     conversations=4,
+    cache_read=0,
+    cache_creation=0,
 ):
-    return (
-        Decimal(cost),
-        input_tokens,
-        output_tokens,
-        total_tokens,
-        calls,
-        unpriced,
-        configured,
-        fallback,
-        legacy,
-        priced_tokens,
-        Decimal(conv_cost),
-        Decimal(studio_cost),
-        conversations,
-    )
+    return {
+        "sum_cost": Decimal(cost),
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+        "total_calls": calls,
+        "unpriced_calls": unpriced,
+        "configured_calls": configured,
+        "fallback_calls": fallback,
+        "legacy_estimate_calls": legacy,
+        "priced_tokens": priced_tokens,
+        "conversation_cost": Decimal(conv_cost),
+        "agent_studio_test_cost": Decimal(studio_cost),
+        "distinct_conversations": conversations,
+        "cache_read_tokens": cache_read,
+        "cache_creation_tokens": cache_creation,
+    }
 
 
 @pytest.mark.asyncio
@@ -170,6 +174,20 @@ async def test_cost_per_conversation_divides_by_distinct():
     assert summ.agent_studio_test_cost_usd == 0.20
     assert summ.cost_is_partial is False
     assert summ.priced_token_coverage_pct == 100.0
+
+
+@pytest.mark.asyncio
+async def test_cache_token_totals_are_carried_from_the_summary_row():
+    service, *_ = _service(summary_row=_row(cache_read=3697, cache_creation=120))
+    summ = await service.get_summary(_params())
+    assert (summ.total_cache_read_tokens, summ.total_cache_creation_tokens) == (3697, 120)
+
+
+@pytest.mark.asyncio
+async def test_empty_scope_summary_reports_zero_cache_tokens():
+    service, *_ = _service(summary_row=_row(cache_read=3697, cache_creation=120), scope=[])
+    summ = await service.get_summary(_params(group_id=uuid4()))
+    assert (summ.total_cache_read_tokens, summ.total_cache_creation_tokens) == (0, 0)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_llm_usage_recorder_unit.py
+++ b/backend/tests/unit/test_llm_usage_recorder_unit.py
@@ -23,6 +23,7 @@ from app.services.llm_usage_recorder import (
     _clamp_run_status,
     _normalize,
     _resolve_cost,
+    _token_columns,
     _total_tokens,
 )
 
@@ -49,7 +50,6 @@ class FakeSession:
 
 
 class CapturingSession(FakeSession):
-
     def __init__(self, returned_ids=()):
         super().__init__()
         self.statements = []
@@ -152,6 +152,129 @@ class TestResolveCost:
         assert out["pricing_status"] == "unpriced"
         assert out["cost_usd"] is None
 
+
+class TestResolveCostCacheBuckets:
+    def test_zero_cache_is_identical_to_omitting_the_arguments(self):
+        omitted = _resolve_cost("openai", "gpt-4o", 1000, 500)
+        explicit = _resolve_cost("openai", "gpt-4o", 1000, 500, cache_read_tokens=0, cache_creation_tokens=0)
+        assert omitted == explicit
+        assert omitted["cost_usd"] == Decimal("0.0075")
+
+    def test_zero_cache_leaves_rate_snapshots_null(self):
+        out = _resolve_cost("openai", "gpt-4o", 1000, 500)
+        assert out["cache_read_per_1k"] is None
+        assert out["cache_creation_per_1k"] is None
+
+    def test_negative_counts_clamp_and_take_the_zero_cache_path(self):
+        out = _resolve_cost("openai", "gpt-4o", 1000, 500, cache_read_tokens=-5, cache_creation_tokens=-1)
+        assert out == _resolve_cost("openai", "gpt-4o", 1000, 500)
+
+    def test_anthropic_defaults_to_the_published_multipliers(self):
+        out = _resolve_cost(
+            "anthropic", "claude-3-5-sonnet", 1000, 200, cache_read_tokens=500, cache_creation_tokens=100
+        )
+        assert out["cache_read_per_1k"] == Decimal("0.0003")
+        assert out["cache_creation_per_1k"] == Decimal("0.00375")
+        assert out["cost_usd"] == Decimal("0.004725")
+
+    def test_inclusive_provider_clamps_when_buckets_exceed_input(self):
+        out = _resolve_cost("anthropic", "claude-3-5-sonnet", 100, 0, cache_read_tokens=500)
+        assert out["cost_usd"] == Decimal("0.00015")
+
+    def test_bedrock_buckets_are_additive_to_the_reported_input(self):
+        configured = {
+            "bedrock": {
+                "us.amazon.nova-2-lite-v1:0": {
+                    "input_per_1k": "0.0001",
+                    "output_per_1k": "0.0004",
+                    "cache_read_per_1k": "0.0001",
+                    "cache_creation_per_1k": "0.0001",
+                }
+            }
+        }
+        out = _resolve_cost("bedrock", "us.amazon.nova-2-lite-v1:0", 7, 20, configured, cache_read_tokens=3697)
+        assert out["cache_read_per_1k"] == Decimal("0.0001")
+        assert out["cache_creation_per_1k"] == Decimal("0.0001")
+        assert out["cost_usd"] == Decimal("0.0003784")
+
+    def test_bedrock_without_a_resolved_cache_rate_refuses_a_total(self):
+        configured = {"bedrock": {"m": {"input_per_1k": "0.00033", "output_per_1k": "0.00275"}}}
+        out = _resolve_cost("bedrock", "m", 7, 20, configured, cache_read_tokens=3697)
+        assert out["pricing_status"] == "unpriced"
+        assert out["cost_usd"] is None
+
+    def test_the_partial_snapshot_keeps_every_rate_that_was_known(self):
+        configured = {"bedrock": {"m": {"input_per_1k": "0.00033", "output_per_1k": "0.00275"}}}
+        out = _resolve_cost("bedrock", "m", 7, 20, configured, cache_read_tokens=3697)
+        assert out["input_per_1k"] == Decimal("0.00033"), "the base rates were resolved and stay on the row"
+        assert out["output_per_1k"] == Decimal("0.00275")
+        assert out["cache_read_per_1k"] is None, "only the bucket nobody could price is nulled"
+        assert out["cache_creation_per_1k"] is None
+
+    def test_a_bundled_profile_keeps_base_snapshots_but_refuses_a_cached_total(self):
+        out = _resolve_cost("bedrock", "eu.amazon.nova-2-lite-v1:0", 7, 20, cache_read_tokens=3697)
+        assert out["pricing_status"] == "unpriced"
+        assert out["input_per_1k"] == Decimal("0.0001"), "base rates come from the bundled EU profile"
+        assert out["output_per_1k"] == Decimal("0.0004")
+        assert all(out[key] is None for key in ("cache_read_per_1k", "cache_creation_per_1k", "cost_usd"))
+
+    def test_a_totally_unknown_model_still_snapshots_nothing(self):
+        out = _resolve_cost("bedrock", "amazon.titan-text-v1", 7, 20, cache_read_tokens=3697)
+        assert out["pricing_status"] == "unpriced"
+        assert all(out[key] is None for key in ("input_per_1k", "output_per_1k", "cost_usd"))
+
+    def test_configured_cache_rates_are_used_and_snapshotted(self):
+        configured = {
+            "bedrock": {
+                "us.amazon.nova-2-lite-v1:0": {
+                    "input_per_1k": "0.0001",
+                    "output_per_1k": "0.0004",
+                    "cache_read_per_1k": "0.000025",
+                    "cache_creation_per_1k": "0",
+                }
+            }
+        }
+        out = _resolve_cost(
+            "bedrock",
+            "us.amazon.nova-2-lite-v1:0",
+            100,
+            10,
+            configured,
+            cache_read_tokens=1000,
+            cache_creation_tokens=2000,
+        )
+        assert out["pricing_status"] == "configured"
+        assert out["cache_read_per_1k"] == Decimal("0.000025")
+        assert out["cache_creation_per_1k"] == Decimal("0")
+        assert out["cost_usd"] == Decimal("0.000039")
+
+    def test_configured_cache_rates_override_the_anthropic_multipliers(self):
+        configured = {
+            "anthropic": {
+                "claude-3-5-sonnet": {
+                    "input_per_1k": "0.003",
+                    "output_per_1k": "0.015",
+                    "cache_read_per_1k": "0.001",
+                    "cache_creation_per_1k": "0.002",
+                }
+            }
+        }
+        out = _resolve_cost("anthropic", "claude-3-5-sonnet", 1000, 0, configured, cache_read_tokens=500)
+        assert out["cache_read_per_1k"] == Decimal("0.001")
+        assert out["cache_creation_per_1k"] == Decimal("0.002")
+
+    def test_unpriced_shape_carries_the_snapshot_keys(self):
+        out = _resolve_cost("openai", "totally-unknown-model", 1000, 1000, cache_read_tokens=500)
+        assert out["pricing_status"] == "unpriced"
+        assert out["cache_read_per_1k"] is None
+        assert out["cache_creation_per_1k"] is None
+        assert out["cost_usd"] is None
+
+    def test_usage_missing_wins_over_cache_counts(self):
+        out = _resolve_cost("anthropic", "claude-3-5-sonnet", 1000, 10, usage_missing=True, cache_read_tokens=500)
+        assert out["pricing_status"] == "unpriced"
+        assert out["cost_usd"] is None
+
     def test_missing_usage_stays_unpriced_even_with_a_configured_rate(self):
         configured = {"openai": {"gpt-4o": {"input_per_1k": Decimal("0.01"), "output_per_1k": Decimal("0.02")}}}
         out = _resolve_cost("openai", "gpt-4o", 0, 0, configured, usage_missing=True)
@@ -172,10 +295,9 @@ class TestResolveCost:
 
 
 class TestConfiguredRatesLoad:
-
     @staticmethod
-    def _rate(provider, model, inp, outp):
-        return SimpleNamespace(provider_key=provider, model_key=model, input_per_1k=inp, output_per_1k=outp)
+    def _rate(provider, model, inp, outp, **cache):
+        return SimpleNamespace(provider_key=provider, model_key=model, input_per_1k=inp, output_per_1k=outp, **cache)
 
     @pytest.mark.asyncio
     async def test_builds_nested_map_and_normalizes_keys(self, monkeypatch):
@@ -191,12 +313,46 @@ class TestConfiguredRatesLoad:
         loaded = await LlmUsageRecorder()._configured_rates(session)
 
         assert loaded == {
-            "openai": {"gpt-4o": {"input_per_1k": Decimal("0.01"), "output_per_1k": Decimal("0.02")}},
+            "openai": {
+                "gpt-4o": {
+                    "input_per_1k": Decimal("0.01"),
+                    "output_per_1k": Decimal("0.02"),
+                    "cache_read_per_1k": None,
+                    "cache_creation_per_1k": None,
+                }
+            },
             "bedrock": {
-                "us.amazon.nova-2-lite-v1:0": {"input_per_1k": Decimal("0.1"), "output_per_1k": Decimal("0.2")}
+                "us.amazon.nova-2-lite-v1:0": {
+                    "input_per_1k": Decimal("0.1"),
+                    "output_per_1k": Decimal("0.2"),
+                    "cache_read_per_1k": None,
+                    "cache_creation_per_1k": None,
+                }
             },
         }
         assert session.rolled_back is False
+
+    @pytest.mark.asyncio
+    async def test_configured_cache_rates_reach_the_pricing_table(self, monkeypatch):
+        rows = [
+            self._rate(
+                "bedrock",
+                "amazon.nova-2-lite-v1:0",
+                Decimal("0.0001"),
+                Decimal("0.0004"),
+                cache_read_per_1k=Decimal("0.000025"),
+                cache_creation_per_1k=Decimal("0"),
+            )
+        ]
+        monkeypatch.setattr(recorder_module.injector, "get", lambda _cls: FakeRateRepo(rows))
+
+        loaded = await LlmUsageRecorder()._configured_rates(FakeSession())
+
+        assert loaded["bedrock"]["amazon.nova-2-lite-v1:0"]["cache_read_per_1k"] == Decimal("0.000025")
+        assert loaded["bedrock"]["amazon.nova-2-lite-v1:0"]["cache_creation_per_1k"] == Decimal("0")
+        priced = _resolve_cost("bedrock", "eu.amazon.nova-2-lite-v1:0", 100, 0, loaded, cache_read_tokens=1000)
+        assert priced["pricing_status"] == "configured"
+        assert priced["cost_usd"] == Decimal("0.000035"), "1000 cache reads at the configured rate plus 100 input"
 
     @pytest.mark.asyncio
     async def test_load_failure_degrades_to_bundled_and_rolls_back(self, monkeypatch):
@@ -283,7 +439,6 @@ class TestAgentForWorkflow:
 
 
 class RecordingSession(FakeSession):
-
     def __init__(self):
         super().__init__()
         self.statements = []
@@ -292,6 +447,9 @@ class RecordingSession(FakeSession):
     async def execute(self, stmt):
         self.statements.append(stmt)
         return SimpleNamespace(all=lambda: [], scalar=lambda: 0, scalar_one_or_none=lambda: True)
+
+    async def scalar(self, stmt):
+        return True
 
     async def commit(self):
         self.committed = True
@@ -302,7 +460,6 @@ class RecordingSession(FakeSession):
 
 @pytest.fixture
 def record_scope(monkeypatch):
-
     @asynccontextmanager
     async def _scope():
         yield
@@ -357,9 +514,7 @@ class TestOccurredAt:
         recorded = datetime(2026, 7, 21, 0, 0, 15, tzinfo=timezone.utc)
         monkeypatch.setattr(recorder_module, "utc_now", lambda: recorded)
 
-        await LlmUsageRecorder().record_workflow_state(
-            _state(), WorkflowUsageContext(source="schedule"), "returned"
-        )
+        await LlmUsageRecorder().record_workflow_state(_state(), WorkflowUsageContext(source="schedule"), "returned")
 
         assert recorded in _bound_values(record_scope.statements)
 
@@ -407,7 +562,6 @@ class TestCaptureBound:
 
 
 class EvaluationSession(FakeSession):
-
     def __init__(
         self, *, workflows=(), providers=(), agents=(), workflow_agents=None, persisted=0, capture_enabled=True
     ):
@@ -447,7 +601,6 @@ class EvaluationSession(FakeSession):
 
 @pytest.fixture
 def evaluation_scope(monkeypatch):
-
     @asynccontextmanager
     async def _scope():
         yield
@@ -496,7 +649,6 @@ def _entry(call_index=0, purpose="llm_judge", provider="openai", model="gpt-4o",
 
 
 class TestRecordEvaluationCalls:
-
     @pytest.mark.asyncio
     async def test_empty_entries_never_touch_the_database(self, evaluation_scope):
         session = evaluation_scope(EvaluationSession())
@@ -630,9 +782,7 @@ class TestRecordEvaluationCalls:
     async def test_unknown_workflow_and_provider_are_nulled_not_rejected(self, evaluation_scope):
         session = evaluation_scope(EvaluationSession())
 
-        await LlmUsageRecorder().record_evaluation_calls(
-            "eval:abc", [_entry(provider_id=uuid4())], workflow_id=uuid4()
-        )
+        await LlmUsageRecorder().record_evaluation_calls("eval:abc", [_entry(provider_id=uuid4())], workflow_id=uuid4())
 
         row = _rows_of(_insert_for(session.statements, "llm_usage_events"))[0]
         assert row["workflow_id"] is None and row["llm_provider_id"] is None and row["agent_id"] is None
@@ -675,3 +825,99 @@ class TestWorkflowUsageContext:
         ctx = WorkflowUsageContext(source="schedule", agent_id=aid)
         assert isinstance(ctx.agent_id, UUID)
         assert ctx.agent_id == aid
+
+
+class TestTokenColumns:
+    def test_cache_counts_are_read_from_the_token_details(self):
+        details = {"input_token_details": {"cache_read": 3697, "cache_creation": 60}}
+
+        assert _token_columns({"total_tokens": 3724}, 7, 20, details) == {
+            "input_tokens": 7,
+            "output_tokens": 20,
+            "total_tokens": 3724,
+            "token_details": details,
+            "cache_read_tokens": 3697,
+            "cache_creation_tokens": 60,
+        }
+
+    def test_stored_counts_stay_provider_raw(self):
+        columns = _token_columns({}, 7, 20, {"input_token_details": {"cache_read": 3697}})
+
+        assert columns["input_tokens"] == 7
+        assert columns["total_tokens"] == 27, "unchanged max(reported, in+out)"
+
+    @pytest.mark.parametrize("details", [None, {}, "junk", {"usage_metadata_missing": True}])
+    def test_entries_without_cache_details_count_zero(self, details):
+        columns = _token_columns({}, 10, 5, details)
+
+        assert (columns["cache_read_tokens"], columns["cache_creation_tokens"]) == (0, 0)
+
+
+_CACHED_DETAILS = {"input_token_details": {"cache_read": 500, "cache_creation": 60}}
+
+
+class TestCacheColumnWiring:
+
+    @pytest.mark.asyncio
+    async def test_workflow_rows_carry_counts_and_snapshots(self, record_scope):
+        state = SimpleNamespace(
+            execution_id=str(uuid4()),
+            llm_usage=[
+                {
+                    "provider": "bedrock",
+                    "model": "eu.amazon.nova-2-lite-v1:0",
+                    "input_tokens": 7,
+                    "output_tokens": 20,
+                    "total_tokens": 3724,
+                    "token_details": {"input_token_details": {"cache_read": 3697, "cache_creation": 0}},
+                }
+            ],
+            thread_id=None,
+            status="completed",
+        )
+
+        await LlmUsageRecorder().record_workflow_state(state, WorkflowUsageContext(source="chat"), "returned")
+
+        row = _rows_of(_insert_for(record_scope.statements, "llm_usage_events"))[0]
+        assert (row["cache_read_tokens"], row["cache_creation_tokens"]) == (3697, 0)
+        assert row["input_tokens"] == 7, "provider-raw, not inflated by the cached prefix"
+        assert row["cost_usd"] is None and row["pricing_status"] == "unpriced"
+        assert row["input_per_1k"] == Decimal("0.0001")
+        assert all(row[key] is None for key in ("cache_read_per_1k", "cache_creation_per_1k"))
+
+    @pytest.mark.asyncio
+    async def test_evaluation_rows_carry_counts_and_snapshots(self, evaluation_scope):
+        session = evaluation_scope(EvaluationSession())
+        usage = {"input_tokens": 660, "output_tokens": 10, "total_tokens": 670, "token_details": _CACHED_DETAILS}
+
+        await LlmUsageRecorder().record_evaluation_calls(
+            "eval:abc", [_entry(provider="anthropic", model="claude-3-5-sonnet", usage=usage)]
+        )
+
+        row = _rows_of(_insert_for(session.statements, "llm_usage_events"))[0]
+        assert (row["cache_read_tokens"], row["cache_creation_tokens"]) == (500, 60)
+        assert row["cache_read_per_1k"] == Decimal("0.0003"), "0.1x of the anthropic input rate"
+
+    @pytest.mark.asyncio
+    async def test_analyst_row_carries_counts_and_snapshots(self, record_scope):
+        await LlmUsageRecorder().record_analyst_call(
+            "analysis:1",
+            0,
+            "anthropic",
+            "claude-3-5-sonnet",
+            usage={"input_tokens": 660, "output_tokens": 10, "total_tokens": 670, "token_details": _CACHED_DETAILS},
+        )
+
+        row = _rows_of(_insert_for(record_scope.statements, "llm_usage_events"))[0]
+        assert (row["cache_read_tokens"], row["cache_creation_tokens"]) == (500, 60)
+        assert row["cache_creation_per_1k"] == Decimal("0.00375"), "1.25x of the anthropic input rate"
+
+    @pytest.mark.asyncio
+    async def test_uncached_rows_keep_zero_counts_and_null_snapshots(self, evaluation_scope):
+        session = evaluation_scope(EvaluationSession())
+
+        await LlmUsageRecorder().record_evaluation_calls("eval:abc", [_entry()])
+
+        row = _rows_of(_insert_for(session.statements, "llm_usage_events"))[0]
+        assert (row["cache_read_tokens"], row["cache_creation_tokens"]) == (0, 0)
+        assert (row["cache_read_per_1k"], row["cache_creation_per_1k"]) == (None, None)

--- a/backend/tests/unit/test_llm_usage_recorder_unit.py
+++ b/backend/tests/unit/test_llm_usage_recorder_unit.py
@@ -211,12 +211,13 @@ class TestResolveCostCacheBuckets:
         assert out["cache_read_per_1k"] is None, "only the bucket nobody could price is nulled"
         assert out["cache_creation_per_1k"] is None
 
-    def test_a_bundled_profile_keeps_base_snapshots_but_refuses_a_cached_total(self):
+    def test_a_bundled_profile_prices_a_cached_call_from_derived_rates(self):
         out = _resolve_cost("bedrock", "eu.amazon.nova-2-lite-v1:0", 7, 20, cache_read_tokens=3697)
-        assert out["pricing_status"] == "unpriced"
+        assert out["pricing_status"] == "fallback"
         assert out["input_per_1k"] == Decimal("0.0001"), "base rates come from the bundled EU profile"
         assert out["output_per_1k"] == Decimal("0.0004")
-        assert all(out[key] is None for key in ("cache_read_per_1k", "cache_creation_per_1k", "cost_usd"))
+        assert out["cache_read_per_1k"] == Decimal("0.00001")
+        assert out["cost_usd"] == Decimal("0.00004567")
 
     def test_a_totally_unknown_model_still_snapshots_nothing(self):
         out = _resolve_cost("bedrock", "amazon.titan-text-v1", 7, 20, cache_read_tokens=3697)
@@ -831,26 +832,39 @@ class TestTokenColumns:
     def test_cache_counts_are_read_from_the_token_details(self):
         details = {"input_token_details": {"cache_read": 3697, "cache_creation": 60}}
 
-        assert _token_columns({"total_tokens": 3724}, 7, 20, details) == {
+        assert _token_columns("bedrock", {"total_tokens": 3724}, 7, 20, details) == {
             "input_tokens": 7,
             "output_tokens": 20,
             "total_tokens": 3724,
             "token_details": details,
             "cache_read_tokens": 3697,
             "cache_creation_tokens": 60,
+            "prompt_tokens": 3764,
         }
 
     def test_stored_counts_stay_provider_raw(self):
-        columns = _token_columns({}, 7, 20, {"input_token_details": {"cache_read": 3697}})
+        columns = _token_columns("bedrock", {}, 7, 20, {"input_token_details": {"cache_read": 3697}})
 
         assert columns["input_tokens"] == 7
         assert columns["total_tokens"] == 27, "unchanged max(reported, in+out)"
 
+    def test_prompt_tokens_add_the_cache_buckets_only_for_exclusive_providers(self):
+        details = {"input_token_details": {"cache_read": 3697, "cache_creation": 60}}
+
+        assert _token_columns("bedrock", {}, 7, 20, details)["prompt_tokens"] == 3764
+        assert _token_columns("anthropic", {}, 3764, 20, details)["prompt_tokens"] == 3764
+
+    def test_prompt_tokens_are_normalized_before_the_provider_lookup(self):
+        details = {"input_token_details": {"cache_read": 100}}
+
+        assert _token_columns("  Bedrock ", {}, 7, 20, details)["prompt_tokens"] == 107
+
     @pytest.mark.parametrize("details", [None, {}, "junk", {"usage_metadata_missing": True}])
     def test_entries_without_cache_details_count_zero(self, details):
-        columns = _token_columns({}, 10, 5, details)
+        columns = _token_columns("bedrock", {}, 10, 5, details)
 
         assert (columns["cache_read_tokens"], columns["cache_creation_tokens"]) == (0, 0)
+        assert columns["prompt_tokens"] == 10, "an uncached call keeps the reported input count"
 
 
 _CACHED_DETAILS = {"input_token_details": {"cache_read": 500, "cache_creation": 60}}
@@ -881,9 +895,10 @@ class TestCacheColumnWiring:
         row = _rows_of(_insert_for(record_scope.statements, "llm_usage_events"))[0]
         assert (row["cache_read_tokens"], row["cache_creation_tokens"]) == (3697, 0)
         assert row["input_tokens"] == 7, "provider-raw, not inflated by the cached prefix"
-        assert row["cost_usd"] is None and row["pricing_status"] == "unpriced"
+        assert row["cost_usd"] == Decimal("0.00004567") and row["pricing_status"] == "fallback"
         assert row["input_per_1k"] == Decimal("0.0001")
-        assert all(row[key] is None for key in ("cache_read_per_1k", "cache_creation_per_1k"))
+        assert (row["cache_read_per_1k"], row["cache_creation_per_1k"]) == (Decimal("0.00001"), Decimal("0.000125"))
+        assert row["prompt_tokens"] == 3704, "bedrock reports input without the cache buckets"
 
     @pytest.mark.asyncio
     async def test_evaluation_rows_carry_counts_and_snapshots(self, evaluation_scope):
@@ -897,6 +912,7 @@ class TestCacheColumnWiring:
         row = _rows_of(_insert_for(session.statements, "llm_usage_events"))[0]
         assert (row["cache_read_tokens"], row["cache_creation_tokens"]) == (500, 60)
         assert row["cache_read_per_1k"] == Decimal("0.0003"), "0.1x of the anthropic input rate"
+        assert row["prompt_tokens"] == 660, "anthropic already counts the cache buckets in"
 
     @pytest.mark.asyncio
     async def test_analyst_row_carries_counts_and_snapshots(self, record_scope):
@@ -921,3 +937,4 @@ class TestCacheColumnWiring:
         row = _rows_of(_insert_for(session.statements, "llm_usage_events"))[0]
         assert (row["cache_read_tokens"], row["cache_creation_tokens"]) == (0, 0)
         assert (row["cache_read_per_1k"], row["cache_creation_per_1k"]) == (None, None)
+        assert row["prompt_tokens"] == row["input_tokens"], "an uncached call needs no adjustment"

--- a/backend/tests/unit/test_workflow_state_usage.py
+++ b/backend/tests/unit/test_workflow_state_usage.py
@@ -97,6 +97,17 @@ class TestTotalLlmUsageCacheTokens:
         assert usage["cache_read_tokens"] == 600
         assert usage["cache_creation_tokens"] == 40
 
+    def test_cache_reads_lower_the_run_cost(self, monkeypatch):
+        import app.core.config.llm_pricing as llm_pricing
+
+        monkeypatch.setattr(llm_pricing, "get_db_pricing_nested", lambda tenant: {})
+        details = {"input_token_details": {"cache_read": 900, "cache_creation": 0}}
+        cached = _state()
+        cached.add_llm_usage(1000, 0, provider="anthropic", model="claude-3-5-sonnet", token_details=details)
+        plain = _state()
+        plain.add_llm_usage(1000, 0, provider="anthropic", model="claude-3-5-sonnet")
+        assert cached.get_total_llm_usage()["cost_usd"] < plain.get_total_llm_usage()["cost_usd"]
+
 
 class TestTheNodeRequestDrivesTheTotals:
 

--- a/backend/tests/unit/test_workflow_state_usage.py
+++ b/backend/tests/unit/test_workflow_state_usage.py
@@ -171,6 +171,57 @@ class TestFormatIncludesExecutionId:
         assert isinstance(s.execution_id, str) and s.execution_id
 
 
+class TestTheRunCostNeverPassesOffASubtotal:
+
+    UNPRICED_MODEL = "arn:aws:bedrock:eu-central-1:123456789012:provisioned-model/nova-tuned"
+
+    @pytest.fixture(autouse=True)
+    def _no_db_rates(self, monkeypatch):
+        import app.core.config.llm_pricing as llm_pricing
+
+        monkeypatch.setattr(llm_pricing, "get_db_pricing_nested", lambda tenant: {})
+
+    def _unpriced_call(self, s: WorkflowState) -> None:
+        s.add_llm_usage(
+            7,
+            20,
+            provider="bedrock",
+            model=self.UNPRICED_MODEL,
+            token_details={"input_token_details": {"cache_read": 3697}},
+        )
+
+    def test_a_fully_priced_run_reports_its_total(self):
+        s = _state()
+        s.add_llm_usage(1000, 0, provider="anthropic", model="claude-3-5-sonnet")
+
+        response = s.format_state_as_response()
+        assert response["token_usage"]["cost_is_partial"] is False
+        assert response["cost_usd"] == round(1000 / 1000 * 0.003, 6)
+
+    def test_a_mixed_run_reports_no_total_but_keeps_the_subtotal(self):
+        s = _state()
+        s.add_llm_usage(1000, 0, provider="anthropic", model="claude-3-5-sonnet")
+        self._unpriced_call(s)
+
+        response = s.format_state_as_response()
+        assert response["cost_usd"] is None
+        assert response["token_usage"]["cost_is_partial"] is True
+        assert response["token_usage"]["cost_usd"] == round(1000 / 1000 * 0.003, 6)
+
+    def test_an_entirely_unpriced_run_is_not_reported_as_free(self):
+        s = _state()
+        self._unpriced_call(s)
+
+        response = s.format_state_as_response()
+        assert response["cost_usd"] is None
+        assert response["token_usage"]["cost_is_partial"] is True
+
+    def test_a_run_with_no_llm_calls_still_costs_zero(self):
+        response = _state().format_state_as_response()
+        assert response["cost_usd"] == 0.0
+        assert response["token_usage"]["cost_is_partial"] is False
+
+
 class TestUpdateNodesDoesNotMergeUsage:
     def test_child_usage_not_merged_by_update_nodes(self):
         parent = _state()

--- a/backend/tests/unit/test_workflow_state_usage.py
+++ b/backend/tests/unit/test_workflow_state_usage.py
@@ -108,6 +108,33 @@ class TestTotalLlmUsageCacheTokens:
         plain.add_llm_usage(1000, 0, provider="anthropic", model="claude-3-5-sonnet")
         assert cached.get_total_llm_usage()["cost_usd"] < plain.get_total_llm_usage()["cost_usd"]
 
+    def test_a_cache_bucket_with_no_rate_leaves_the_run_cost_partial(self, monkeypatch):
+        import app.core.config.llm_pricing as llm_pricing
+
+        monkeypatch.setattr(llm_pricing, "get_db_pricing_nested", lambda tenant: {})
+        s = _state()
+        s.add_llm_usage(
+            7,
+            20,
+            provider="bedrock",
+            model="arn:aws:bedrock:eu-central-1:123456789012:provisioned-model/nova-tuned",
+            token_details={"input_token_details": {"cache_read": 3697}},
+        )
+        s.add_llm_usage(1000, 0, provider="anthropic", model="claude-3-5-sonnet")
+
+        usage = s.get_total_llm_usage()
+        assert usage["cost_is_partial"] is True
+        assert usage["cost_usd"] == round(1000 / 1000 * 0.003, 6), "only the priced call is counted"
+
+    def test_a_fully_priced_run_is_not_partial(self, monkeypatch):
+        import app.core.config.llm_pricing as llm_pricing
+
+        monkeypatch.setattr(llm_pricing, "get_db_pricing_nested", lambda tenant: {})
+        s = _state()
+        s.add_llm_usage(1000, 0, provider="anthropic", model="claude-3-5-sonnet")
+
+        assert s.get_total_llm_usage()["cost_is_partial"] is False
+
 
 class TestTheNodeRequestDrivesTheTotals:
 

--- a/frontend/src/interfaces/llmCostRate.interface.ts
+++ b/frontend/src/interfaces/llmCostRate.interface.ts
@@ -7,6 +7,9 @@ export interface LlmCostRate {
   model_key: string;
   input_per_1k: string;
   output_per_1k: string;
+  /** null = not configured, the provider default applies. "0" = free */
+  cache_read_per_1k: string | null;
+  cache_creation_per_1k: string | null;
   updated_at: string;
 }
 
@@ -16,12 +19,16 @@ export interface LlmCostRateCreatePayload {
   model: string;
   input_per_1k: string;
   output_per_1k: string;
+  cache_read_per_1k?: string | null;
+  cache_creation_per_1k?: string | null;
 }
 
 /** Rate edit. Identity (provider/model) is fixed: delete and recreate to move a rate */
 export interface LlmCostRateUpdatePayload {
   input_per_1k: string;
   output_per_1k: string;
+  cache_read_per_1k?: string | null;
+  cache_creation_per_1k?: string | null;
 }
 
 export interface LlmCostRateImportResult {

--- a/frontend/src/interfaces/llmUsage.interface.ts
+++ b/frontend/src/interfaces/llmUsage.interface.ts
@@ -7,9 +7,12 @@ export interface LlmUsageSummaryResponse {
   cost_is_partial: boolean;
   cost_per_conversation_usd: number | null;
   agent_studio_test_cost_usd: number;
+  /** Prompt tokens sent, normalized across providers */
   total_input_tokens: number;
   total_output_tokens: number;
   total_tokens: number;
+  total_cache_read_tokens?: number;
+  total_cache_creation_tokens?: number;
   total_calls: number;
   configured_calls: number;
   fallback_calls: number;

--- a/frontend/src/services/llmCostRates.ts
+++ b/frontend/src/services/llmCostRates.ts
@@ -1,56 +1,49 @@
-import { getApiUrl, apiRequest } from "@/config/api";
+import { getApiUrl, apiRequest } from '@/config/api';
 import type {
   LlmCostRate,
   LlmCostRateCreatePayload,
   LlmCostRateImportResult,
   LlmCostRateUpdatePayload,
-} from "@/interfaces/llmCostRate.interface";
+} from '@/interfaces/llmCostRate.interface';
 
 export async function getLlmCostRates(): Promise<LlmCostRate[]> {
-  const data = await apiRequest<LlmCostRate[]>("GET", "llm-cost-rates/");
+  const data = await apiRequest<LlmCostRate[]>('GET', 'llm-cost-rates/');
   return data ?? [];
 }
 
-export async function createLlmCostRate(
-  payload: LlmCostRateCreatePayload
-): Promise<LlmCostRate | null> {
-  return await apiRequest<LlmCostRate>("POST", "llm-cost-rates/", {
+export async function createLlmCostRate(payload: LlmCostRateCreatePayload): Promise<LlmCostRate | null> {
+  return await apiRequest<LlmCostRate>('POST', 'llm-cost-rates/', {
     ...payload,
   });
 }
 
-export async function updateLlmCostRate(
-  id: string,
-  payload: LlmCostRateUpdatePayload
-): Promise<LlmCostRate | null> {
-  return await apiRequest<LlmCostRate>("PUT", `llm-cost-rates/${id}`, {
+export async function updateLlmCostRate(id: string, payload: LlmCostRateUpdatePayload): Promise<LlmCostRate | null> {
+  return await apiRequest<LlmCostRate>('PUT', `llm-cost-rates/${id}`, {
     ...payload,
   });
 }
 
-export async function importLlmCostRatesCsv(
-  file: File
-): Promise<LlmCostRateImportResult> {
-  const baseURL = (await getApiUrl()).replace(/\/$/, "");
+export async function importLlmCostRatesCsv(file: File): Promise<LlmCostRateImportResult> {
+  const baseURL = (await getApiUrl()).replace(/\/$/, '');
   const fullUrl = `${baseURL}/llm-cost-rates/import`;
 
-  const token = localStorage.getItem("access_token");
-  const tokenType = localStorage.getItem("token_type") || "Bearer";
-  const tenantId = localStorage.getItem("tenant_id");
+  const token = localStorage.getItem('access_token');
+  const tokenType = localStorage.getItem('token_type') || 'Bearer';
+  const tenantId = localStorage.getItem('tenant_id');
 
   const headers: Record<string, string> = {};
   if (token) {
     headers.Authorization = `${tokenType} ${token}`;
   }
   if (tenantId) {
-    headers["x-tenant-id"] = tenantId;
+    headers['x-tenant-id'] = tenantId;
   }
 
   const formData = new FormData();
-  formData.append("file", file);
+  formData.append('file', file);
 
   const response = await fetch(fullUrl, {
-    method: "POST",
+    method: 'POST',
     body: formData,
     headers,
   });
@@ -66,26 +59,27 @@ export async function importLlmCostRatesCsv(
 }
 
 export async function deleteLlmCostRate(id: string): Promise<void> {
-  await apiRequest("DELETE", `llm-cost-rates/${id}`);
+  await apiRequest('DELETE', `llm-cost-rates/${id}`);
 }
 
 export async function exportLlmCostRatesCsv(): Promise<Blob> {
-  const baseURL = (await getApiUrl()).replace(/\/$/, "");
-  const fullUrl = `${baseURL}/llm-cost-rates/export`;
+  const baseURL = (await getApiUrl()).replace(/\/$/, '');
+  // The endpoint defaults to the legacy 4-column layout; the dialog wants the cache columns
+  const fullUrl = `${baseURL}/llm-cost-rates/export?include_cache_rates=true`;
 
-  const token = localStorage.getItem("access_token");
-  const tokenType = localStorage.getItem("token_type") || "Bearer";
-  const tenantId = localStorage.getItem("tenant_id");
+  const token = localStorage.getItem('access_token');
+  const tokenType = localStorage.getItem('token_type') || 'Bearer';
+  const tenantId = localStorage.getItem('tenant_id');
 
   const headers: Record<string, string> = {};
   if (token) {
     headers.Authorization = `${tokenType} ${token}`;
   }
   if (tenantId) {
-    headers["x-tenant-id"] = tenantId;
+    headers['x-tenant-id'] = tenantId;
   }
 
-  const response = await fetch(fullUrl, { method: "GET", headers });
+  const response = await fetch(fullUrl, { method: 'GET', headers });
   if (!response.ok) {
     const errBody = (await response.json().catch(() => ({}))) as {
       detail?: string;

--- a/frontend/src/services/llmCostRates.ts
+++ b/frontend/src/services/llmCostRates.ts
@@ -1,49 +1,56 @@
-import { getApiUrl, apiRequest } from '@/config/api';
+import { getApiUrl, apiRequest } from "@/config/api";
 import type {
   LlmCostRate,
   LlmCostRateCreatePayload,
   LlmCostRateImportResult,
   LlmCostRateUpdatePayload,
-} from '@/interfaces/llmCostRate.interface';
+} from "@/interfaces/llmCostRate.interface";
 
 export async function getLlmCostRates(): Promise<LlmCostRate[]> {
-  const data = await apiRequest<LlmCostRate[]>('GET', 'llm-cost-rates/');
+  const data = await apiRequest<LlmCostRate[]>("GET", "llm-cost-rates/");
   return data ?? [];
 }
 
-export async function createLlmCostRate(payload: LlmCostRateCreatePayload): Promise<LlmCostRate | null> {
-  return await apiRequest<LlmCostRate>('POST', 'llm-cost-rates/', {
+export async function createLlmCostRate(
+  payload: LlmCostRateCreatePayload
+): Promise<LlmCostRate | null> {
+  return await apiRequest<LlmCostRate>("POST", "llm-cost-rates/", {
     ...payload,
   });
 }
 
-export async function updateLlmCostRate(id: string, payload: LlmCostRateUpdatePayload): Promise<LlmCostRate | null> {
-  return await apiRequest<LlmCostRate>('PUT', `llm-cost-rates/${id}`, {
+export async function updateLlmCostRate(
+  id: string,
+  payload: LlmCostRateUpdatePayload
+): Promise<LlmCostRate | null> {
+  return await apiRequest<LlmCostRate>("PUT", `llm-cost-rates/${id}`, {
     ...payload,
   });
 }
 
-export async function importLlmCostRatesCsv(file: File): Promise<LlmCostRateImportResult> {
-  const baseURL = (await getApiUrl()).replace(/\/$/, '');
+export async function importLlmCostRatesCsv(
+  file: File
+): Promise<LlmCostRateImportResult> {
+  const baseURL = (await getApiUrl()).replace(/\/$/, "");
   const fullUrl = `${baseURL}/llm-cost-rates/import`;
 
-  const token = localStorage.getItem('access_token');
-  const tokenType = localStorage.getItem('token_type') || 'Bearer';
-  const tenantId = localStorage.getItem('tenant_id');
+  const token = localStorage.getItem("access_token");
+  const tokenType = localStorage.getItem("token_type") || "Bearer";
+  const tenantId = localStorage.getItem("tenant_id");
 
   const headers: Record<string, string> = {};
   if (token) {
     headers.Authorization = `${tokenType} ${token}`;
   }
   if (tenantId) {
-    headers['x-tenant-id'] = tenantId;
+    headers["x-tenant-id"] = tenantId;
   }
 
   const formData = new FormData();
-  formData.append('file', file);
+  formData.append("file", file);
 
   const response = await fetch(fullUrl, {
-    method: 'POST',
+    method: "POST",
     body: formData,
     headers,
   });
@@ -59,27 +66,27 @@ export async function importLlmCostRatesCsv(file: File): Promise<LlmCostRateImpo
 }
 
 export async function deleteLlmCostRate(id: string): Promise<void> {
-  await apiRequest('DELETE', `llm-cost-rates/${id}`);
+  await apiRequest("DELETE", `llm-cost-rates/${id}`);
 }
 
 export async function exportLlmCostRatesCsv(): Promise<Blob> {
-  const baseURL = (await getApiUrl()).replace(/\/$/, '');
-  // The endpoint defaults to the legacy 4-column layout; the dialog wants the cache columns
+  const baseURL = (await getApiUrl()).replace(/\/$/, "");
+  // Export defaults to the legacy 4-column layout; the dialog needs cache columns
   const fullUrl = `${baseURL}/llm-cost-rates/export?include_cache_rates=true`;
 
-  const token = localStorage.getItem('access_token');
-  const tokenType = localStorage.getItem('token_type') || 'Bearer';
-  const tenantId = localStorage.getItem('tenant_id');
+  const token = localStorage.getItem("access_token");
+  const tokenType = localStorage.getItem("token_type") || "Bearer";
+  const tenantId = localStorage.getItem("tenant_id");
 
   const headers: Record<string, string> = {};
   if (token) {
     headers.Authorization = `${tokenType} ${token}`;
   }
   if (tenantId) {
-    headers['x-tenant-id'] = tenantId;
+    headers["x-tenant-id"] = tenantId;
   }
 
-  const response = await fetch(fullUrl, { method: 'GET', headers });
+  const response = await fetch(fullUrl, { method: "GET", headers });
   if (!response.ok) {
     const errBody = (await response.json().catch(() => ({}))) as {
       detail?: string;

--- a/frontend/src/services/workflows.ts
+++ b/frontend/src/services/workflows.ts
@@ -73,6 +73,8 @@ export interface WorkflowTokenUsage {
   cache_read_tokens?: number;
   cache_creation_tokens?: number;
   cost_usd?: number;
+  /** True when a call could not be priced, so cost_usd is the priced subtotal only. */
+  cost_is_partial?: boolean;
   calls?: number;
 }
 

--- a/frontend/src/views/Analytics/pages/LlmUsagePage.tsx
+++ b/frontend/src/views/Analytics/pages/LlmUsagePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { subDays } from "date-fns";
 import type { DateRange } from "react-day-picker";
@@ -14,6 +14,7 @@ import {
   TrendingDown,
   TrendingUp,
   X,
+  type LucideIcon,
 } from "lucide-react";
 
 import { Card, CardContent } from "@/components/card";
@@ -65,6 +66,15 @@ const PARTIAL_COST_HELP =
   "Some calls here ran on a model with no configured rate. " +
   "This figure is the priced subtotal, real spend may be higher. Add the missing rates under " +
   "LLM Settings › LLM Providers to price them.";
+
+interface LlmUsageKpi {
+  label: string;
+  value: string;
+  icon: LucideIcon;
+  sub?: string;
+  description?: string;
+  delta: ReactNode;
+}
 
 const compact = (n: number) =>
   n >= 1_000_000 ? `${(n / 1_000_000).toFixed(1)}M` : n >= 1_000 ? `${(n / 1_000).toFixed(1)}K` : `${n}`;
@@ -302,7 +312,10 @@ function LlmUsagePage() {
     },
   ];
 
-  const kpis = [
+  const cacheReadTokens = summary?.total_cache_read_tokens ?? 0;
+  const cacheWriteTokens = summary?.total_cache_creation_tokens ?? 0;
+
+  const kpis: LlmUsageKpi[] = [
     {
       label: "Total LLM Cost",
       value: formatUsd(summary?.total_cost_usd),
@@ -316,6 +329,10 @@ function LlmUsagePage() {
       value: compact(summary?.total_tokens ?? 0),
       icon: Coins,
       sub: `${compact(summary?.total_input_tokens ?? 0)} input · ${compact(summary?.total_output_tokens ?? 0)} output`,
+      description:
+        cacheReadTokens || cacheWriteTokens
+          ? `Input includes ${cacheReadTokens.toLocaleString()} cache-read and ${cacheWriteTokens.toLocaleString()} cache-write tokens reported by providers. Each cache bucket is priced at its own rate.`
+          : undefined,
       delta: summary && previous ? <KpiDelta delta={pctChange(summary.total_tokens, previous.total_tokens)} /> : null,
     },
     {
@@ -442,6 +459,7 @@ function LlmUsagePage() {
                 value={k.value}
                 icon={k.icon}
                 sub={k.sub}
+                description={k.description}
                 subClassName={KPI_SUB_CLASS}
                 delta={k.delta}
               />

--- a/frontend/src/views/Analytics/pages/LlmUsagePage.tsx
+++ b/frontend/src/views/Analytics/pages/LlmUsagePage.tsx
@@ -331,7 +331,7 @@ function LlmUsagePage() {
       sub: `${compact(summary?.total_input_tokens ?? 0)} input · ${compact(summary?.total_output_tokens ?? 0)} output`,
       description:
         cacheReadTokens || cacheWriteTokens
-          ? `Input includes ${cacheReadTokens.toLocaleString()} cache-read and ${cacheWriteTokens.toLocaleString()} cache-write tokens reported by providers. A cache bucket is priced at its configured rate where one is set, otherwise at a family estimate or at ordinary input pricing; buckets that resolve to neither leave the call unpriced.`
+          ? `Input includes ${cacheReadTokens.toLocaleString()} cache-read and ${cacheWriteTokens.toLocaleString()} cache-write tokens reported by providers.`
           : undefined,
       delta: summary && previous ? <KpiDelta delta={pctChange(summary.total_tokens, previous.total_tokens)} /> : null,
     },

--- a/frontend/src/views/Analytics/pages/LlmUsagePage.tsx
+++ b/frontend/src/views/Analytics/pages/LlmUsagePage.tsx
@@ -331,7 +331,7 @@ function LlmUsagePage() {
       sub: `${compact(summary?.total_input_tokens ?? 0)} input · ${compact(summary?.total_output_tokens ?? 0)} output`,
       description:
         cacheReadTokens || cacheWriteTokens
-          ? `Input includes ${cacheReadTokens.toLocaleString()} cache-read and ${cacheWriteTokens.toLocaleString()} cache-write tokens reported by providers. Each cache bucket is priced at its own rate.`
+          ? `Input includes ${cacheReadTokens.toLocaleString()} cache-read and ${cacheWriteTokens.toLocaleString()} cache-write tokens reported by providers. A cache bucket is priced at its configured rate where one is set, otherwise at a family estimate or at ordinary input pricing; buckets that resolve to neither leave the call unpriced.`
           : undefined,
       delta: summary && previous ? <KpiDelta delta={pctChange(summary.total_tokens, previous.total_tokens)} /> : null,
     },

--- a/frontend/src/views/LlmProviders/components/LlmCostRatesDialog.tsx
+++ b/frontend/src/views/LlmProviders/components/LlmCostRatesDialog.tsx
@@ -1,8 +1,21 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/dialog';
-import { Button } from '@/components/button';
-import { Input } from '@/components/ui/input';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/table';
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/dialog";
+import { Button } from "@/components/button";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/table";
 import {
   getLlmCostRates,
   importLlmCostRatesCsv,
@@ -10,23 +23,35 @@ import {
   exportLlmCostRatesCsv,
   createLlmCostRate,
   updateLlmCostRate,
-} from '@/services/llmCostRates';
-import type { LlmCostRate } from '@/interfaces/llmCostRate.interface';
-import toast from 'react-hot-toast';
-import { Coins, Copy, Download, FileText, Loader2, Pencil, Plus, RefreshCcw, Trash2, Upload } from 'lucide-react';
-import { formatTimeAgo } from '@/helpers/formatters';
-import { ConfirmDialog } from '@/components/ConfirmDialog';
-import { ListEmptyState } from '@/components/ListEmptyState';
+} from "@/services/llmCostRates";
+import type { LlmCostRate } from "@/interfaces/llmCostRate.interface";
+import toast from "react-hot-toast";
+import {
+  Coins,
+  Copy,
+  Download,
+  FileText,
+  Loader2,
+  Pencil,
+  Plus,
+  RefreshCcw,
+  Trash2,
+  Upload,
+} from "lucide-react";
+import { formatTimeAgo } from "@/helpers/formatters";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { ListEmptyState } from "@/components/ListEmptyState";
 import {
   changedCacheRates,
   serializeCacheRate,
   validateLlmCostRateForm,
   type LlmCostRateFieldErrors,
   type LlmCostRateFormValues,
-} from '@/views/LlmProviders/helpers/llmCostRateValidation';
+} from "@/views/LlmProviders/helpers/llmCostRateValidation";
 
 /** Header the import API requires (UTF-8). */
-const CSV_TEMPLATE = 'provider,model,input_per_1k,output_per_1k,cache_read_per_1k,cache_creation_per_1k';
+const CSV_TEMPLATE =
+  "provider,model,input_per_1k,output_per_1k,cache_read_per_1k,cache_creation_per_1k";
 
 /** Display-only placeholder keys prevent pasted data from overwriting rates. */
 const CSV_EXAMPLE = `${CSV_TEMPLATE}
@@ -42,31 +67,38 @@ interface LlmCostRatesDialogProps {
 type RateForm = LlmCostRateFormValues;
 
 const EMPTY_FORM: RateForm = {
-  provider: '',
-  model: '',
-  input_per_1k: '',
-  output_per_1k: '',
-  cache_read_per_1k: '',
-  cache_creation_per_1k: '',
+  provider: "",
+  model: "",
+  input_per_1k: "",
+  output_per_1k: "",
+  cache_read_per_1k: "",
+  cache_creation_per_1k: "",
 };
 
 function backendErrorMessage(err: unknown, fallback: string): string {
   const data = (err as { response?: { data?: unknown } })?.response?.data as
     | { error?: string; detail?: unknown }
     | undefined;
-  if (typeof data?.error === 'string' && data.error) return data.error;
+  if (typeof data?.error === "string" && data.error) return data.error;
   const detail = data?.detail;
-  if (typeof detail === 'string' && detail) return detail;
+  if (typeof detail === "string" && detail) return detail;
   if (Array.isArray(detail)) {
     const messages = detail
-      .map((d) => (typeof d === 'object' && d && 'msg' in d ? String((d as { msg: string }).msg) : ''))
+      .map((d) =>
+        typeof d === "object" && d && "msg" in d
+          ? String((d as { msg: string }).msg)
+          : ""
+      )
       .filter(Boolean);
-    if (messages.length) return messages.join('; ');
+    if (messages.length) return messages.join("; ");
   }
   return err instanceof Error ? err.message : fallback;
 }
 
-export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogProps) {
+export function LlmCostRatesDialog({
+  open,
+  onOpenChange,
+}: LlmCostRatesDialogProps) {
   const [rows, setRows] = useState<LlmCostRate[]>([]);
   const [loading, setLoading] = useState(false);
   const [uploading, setUploading] = useState(false);
@@ -89,7 +121,7 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
       const data = await getLlmCostRates();
       setRows(data);
     } catch {
-      toast.error('Could not load LLM cost rates.');
+      toast.error("Could not load LLM cost rates.");
     } finally {
       await new Promise((resolve) => setTimeout(resolve, 200));
       setLoading(false);
@@ -123,16 +155,18 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
 
   const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    e.target.value = '';
+    e.target.value = "";
     if (!file) return;
-    if (!file.name.toLowerCase().endsWith('.csv')) {
-      toast.error('Please choose a .csv file.');
+    if (!file.name.toLowerCase().endsWith(".csv")) {
+      toast.error("Please choose a .csv file.");
       return;
     }
     setUploading(true);
     try {
       const result = await importLlmCostRatesCsv(file);
-      toast.success(`Imported: ${result.inserted} new, ${result.updated} updated.`);
+      toast.success(
+        `Imported: ${result.inserted} new, ${result.updated} updated.`
+      );
       if (result.errors.length) {
         result.errors.slice(0, 5).forEach((msg) => toast.error(msg));
         if (result.errors.length > 5) {
@@ -141,7 +175,9 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
       }
       await load();
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Upload failed.');
+      toast.error(
+        err instanceof Error ? err.message : "Upload failed."
+      );
     } finally {
       setUploading(false);
     }
@@ -149,7 +185,7 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
 
   const copyCsvTemplate = () => {
     void navigator.clipboard.writeText(`${CSV_TEMPLATE}\n`);
-    toast.success('CSV header copied to clipboard.');
+    toast.success("CSV header copied to clipboard.");
   };
 
   const closeForm = () => {
@@ -169,13 +205,14 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
   };
 
   const openEditForm = (row: LlmCostRate) => {
+    // Frozen so changedCacheRates can omit cache fields the user never touched
     const prefill: RateForm = {
       provider: row.provider_key,
       model: row.model_key,
       input_per_1k: row.input_per_1k,
       output_per_1k: row.output_per_1k,
-      cache_read_per_1k: row.cache_read_per_1k ?? '',
-      cache_creation_per_1k: row.cache_creation_per_1k ?? '',
+      cache_read_per_1k: row.cache_read_per_1k ?? "",
+      cache_creation_per_1k: row.cache_creation_per_1k ?? "",
     };
     setEditingId(row.id);
     setFormError(null);
@@ -208,7 +245,7 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
           output_per_1k: form.output_per_1k.trim(),
           ...(editPrefill ? changedCacheRates(form, editPrefill) : {}),
         });
-        toast.success('Cost rate updated.');
+        toast.success("Cost rate updated.");
       } else {
         await createLlmCostRate({
           provider: form.provider.trim(),
@@ -216,14 +253,16 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
           input_per_1k: form.input_per_1k.trim(),
           output_per_1k: form.output_per_1k.trim(),
           cache_read_per_1k: serializeCacheRate(form.cache_read_per_1k),
-          cache_creation_per_1k: serializeCacheRate(form.cache_creation_per_1k),
+          cache_creation_per_1k: serializeCacheRate(
+            form.cache_creation_per_1k
+          ),
         });
-        toast.success('Cost rate added.');
+        toast.success("Cost rate added.");
       }
       closeForm();
       await load();
     } catch (err) {
-      setFormError(backendErrorMessage(err, 'Could not save this cost rate.'));
+      setFormError(backendErrorMessage(err, "Could not save this cost rate."));
     } finally {
       setSaving(false);
     }
@@ -239,12 +278,12 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
     setDeleting(true);
     try {
       await deleteLlmCostRate(rowToDelete.id);
-      toast.success('Cost rate removed.');
+      toast.success("Cost rate removed.");
       setDeleteDialogOpen(false);
       setRowToDelete(null);
       await load();
     } catch {
-      toast.error('Could not delete this cost rate.');
+      toast.error("Could not delete this cost rate.");
     } finally {
       setDeleting(false);
     }
@@ -252,329 +291,405 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
 
   const downloadCsvTemplate = () => {
     const blob = new Blob([`${CSV_TEMPLATE}\n`], {
-      type: 'text/csv;charset=utf-8',
+      type: "text/csv;charset=utf-8",
     });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
+    const a = document.createElement("a");
     a.href = url;
-    a.download = 'llm-cost-rates-template.csv';
+    a.download = "llm-cost-rates-template.csv";
     a.click();
     URL.revokeObjectURL(url);
-    toast.success('CSV header downloaded.');
+    toast.success("CSV header downloaded.");
   };
 
   const downloadCurrentRatesCsv = async () => {
     try {
       const blob = await exportLlmCostRatesCsv();
       const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
+      const a = document.createElement("a");
       a.href = url;
-      a.download = 'llm-cost-rates.csv';
+      a.download = "llm-cost-rates.csv";
       a.click();
       URL.revokeObjectURL(url);
-      toast.success('Current rates downloaded.');
+      toast.success("Current rates downloaded.");
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Export failed.');
+      toast.error(err instanceof Error ? err.message : "Export failed.");
     }
   };
 
   return (
     <>
-      <Dialog
-        open={open}
-        onOpenChange={(next) => {
-          if (!next) {
-            setCsvFormatOpen(false);
-            setDeleteDialogOpen(false);
-            setRowToDelete(null);
-            closeForm();
-          }
-          onOpenChange(next);
-        }}
-      >
-        <DialogContent className="max-w-5xl max-h-[85vh] flex flex-col gap-4 z-50">
-          <DialogHeader>
-            <DialogTitle>LLM cost rates</DialogTitle>
-            <DialogDescription>
-              USD per 1K tokens. Open <strong>CSV template</strong> for the exact column layout.
-            </DialogDescription>
-          </DialogHeader>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          setCsvFormatOpen(false);
+          setDeleteDialogOpen(false);
+          setRowToDelete(null);
+          closeForm();
+        }
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="max-w-5xl max-h-[85vh] flex flex-col gap-4 z-50">
+        <DialogHeader>
+          <DialogTitle>LLM cost rates</DialogTitle>
+          <DialogDescription>
+            USD per 1K tokens. Open{" "} <strong>CSV template</strong> for the exact column layout.
+          </DialogDescription>
+        </DialogHeader>
 
-          <div className="flex flex-wrap items-center gap-2">
-            <Button type="button" variant="default" size="sm" onClick={openCreateForm}>
-              <Plus className="w-4 h-4 mr-2" />
-              Add rate
-            </Button>
-            <Button type="button" variant="secondary" size="sm" onClick={() => setCsvFormatOpen(true)}>
-              <FileText className="w-4 h-4 mr-2" />
-              CSV template
-            </Button>
-            <Button type="button" variant="outline" size="sm" onClick={() => void downloadCurrentRatesCsv()}>
-              <Download className="w-4 h-4 mr-2" />
-              Download current CSV
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={uploading}
-              className="relative"
-              onClick={() => document.getElementById('csv-input')?.click()}
-            >
-              {uploading ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : <Upload className="w-4 h-4 mr-2" />}
-              Upload CSV
-              <Input
-                id="csv-input"
-                type="file"
-                accept=".csv,text/csv"
-                className="absolute inset-0 cursor-pointer opacity-0 w-full h-full"
-                disabled={uploading}
-                onChange={(ev) => void onFile(ev)}
-              />
-            </Button>
-            <Button
-              className="ml-auto"
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => void load()}
-              disabled={loading}
-            >
-              <RefreshCcw className={'w-2 h-2 ' + (loading ? 'animate-spin' : '')} />
-              {loading ? 'Refreshing...' : 'Refresh'}
-            </Button>
-          </div>
-
-          {form && (
-            <div className="rounded-md border p-3 space-y-3 shrink-0">
-              <div className="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-6 gap-3">
-                <label className="space-y-1">
-                  <span className="text-xs text-muted-foreground">Provider</span>
-                  <Input
-                    value={form.provider}
-                    disabled={!!editingId || saving}
-                    placeholder="openai"
-                    onChange={(e) => updateField('provider', e.target.value)}
-                  />
-                  {fieldErrors.provider && (
-                    <span className="block text-xs text-destructive">{fieldErrors.provider}</span>
-                  )}
-                </label>
-                <label className="space-y-1">
-                  <span className="text-xs text-muted-foreground">Model</span>
-                  <Input
-                    value={form.model}
-                    disabled={!!editingId || saving}
-                    placeholder="gpt-4o"
-                    onChange={(e) => updateField('model', e.target.value)}
-                  />
-                  {fieldErrors.model && <span className="block text-xs text-destructive">{fieldErrors.model}</span>}
-                </label>
-                <label className="space-y-1">
-                  <span className="text-xs text-muted-foreground">Input / 1K</span>
-                  <Input
-                    value={form.input_per_1k}
-                    disabled={saving}
-                    inputMode="decimal"
-                    placeholder="0.00015"
-                    onChange={(e) => updateField('input_per_1k', e.target.value)}
-                  />
-                  {fieldErrors.input_per_1k && (
-                    <span className="block text-xs text-destructive">{fieldErrors.input_per_1k}</span>
-                  )}
-                </label>
-                <label className="space-y-1">
-                  <span className="text-xs text-muted-foreground">Output / 1K</span>
-                  <Input
-                    value={form.output_per_1k}
-                    disabled={saving}
-                    inputMode="decimal"
-                    placeholder="0.0006"
-                    onChange={(e) => updateField('output_per_1k', e.target.value)}
-                  />
-                  {fieldErrors.output_per_1k && (
-                    <span className="block text-xs text-destructive">{fieldErrors.output_per_1k}</span>
-                  )}
-                </label>
-                <label className="space-y-1">
-                  <span className="text-xs text-muted-foreground">Cache read / 1K</span>
-                  <Input
-                    value={form.cache_read_per_1k}
-                    disabled={saving}
-                    inputMode="decimal"
-                    placeholder="optional"
-                    onChange={(e) => updateField('cache_read_per_1k', e.target.value)}
-                  />
-                  {fieldErrors.cache_read_per_1k && (
-                    <span className="block text-xs text-destructive">{fieldErrors.cache_read_per_1k}</span>
-                  )}
-                </label>
-                <label className="space-y-1">
-                  <span className="text-xs text-muted-foreground">Cache write / 1K</span>
-                  <Input
-                    value={form.cache_creation_per_1k}
-                    disabled={saving}
-                    inputMode="decimal"
-                    placeholder="optional"
-                    onChange={(e) => updateField('cache_creation_per_1k', e.target.value)}
-                  />
-                  {fieldErrors.cache_creation_per_1k && (
-                    <span className="block text-xs text-destructive">{fieldErrors.cache_creation_per_1k}</span>
-                  )}
-                </label>
-              </div>
-
-              <p className="text-xs text-muted-foreground">
-                Leave a cache rate blank to leave it unset; enter <code>0</code> to price that bucket as free.
-              </p>
-              {editingId && (
-                <p className="text-xs text-muted-foreground">
-                  Provider and model are fixed. Delete and re-add to move a rate.
-                </p>
-              )}
-              {formError && <p className="text-sm text-destructive">{formError}</p>}
-
-              <div className="flex items-center gap-2">
-                <Button type="button" size="sm" disabled={saving} onClick={() => void submitForm()}>
-                  {saving && <Loader2 className="w-4 h-4 animate-spin mr-2" />}
-                  {editingId ? 'Save changes' : 'Add rate'}
-                </Button>
-                <Button type="button" variant="outline" size="sm" disabled={saving} onClick={closeForm}>
-                  Cancel
-                </Button>
-              </div>
-            </div>
-          )}
-
-          <div className="flex-1 min-h-0 overflow-auto rounded-md border">
-            {loading ? (
-              <div className="flex items-center justify-center p-8 text-muted-foreground">
-                <Loader2 className="w-6 h-6 animate-spin mr-2" />
-                Loading…
-              </div>
-            ) : rows.length === 0 ? (
-              <ListEmptyState
-                icon={<Coins className="h-12 w-12 text-muted-foreground" />}
-                title="No cost rates yet"
-                description="Add a rate to price token usage per provider and model, or upload a CSV to set several at once."
-                action={
-                  !form ? (
-                    <Button onClick={openCreateForm} className="rounded-full flex items-center gap-2">
-                      <Plus className="h-4 w-4" />
-                      Add rate
-                    </Button>
-                  ) : undefined
-                }
-              />
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="default"
+            size="sm"
+            onClick={openCreateForm}
+          >
+            <Plus className="w-4 h-4 mr-2" />
+            Add rate
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={() => setCsvFormatOpen(true)}
+          >
+            <FileText className="w-4 h-4 mr-2" />
+            CSV template
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void downloadCurrentRatesCsv()}
+          >
+            <Download className="w-4 h-4 mr-2" />
+            Download current CSV
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={uploading}
+            className="relative"
+            onClick={() => document.getElementById("csv-input")?.click()}
+          >
+            {uploading ? (
+              <Loader2 className="w-4 h-4 animate-spin mr-2" />
             ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Provider</TableHead>
-                    <TableHead>Model</TableHead>
-                    <TableHead className="text-right">Input / 1K</TableHead>
-                    <TableHead className="text-right">Output / 1K</TableHead>
-                    <TableHead className="text-right whitespace-nowrap">Cache read / 1K</TableHead>
-                    <TableHead className="text-right whitespace-nowrap">Cache write / 1K</TableHead>
-                    <TableHead className="whitespace-nowrap">Updated</TableHead>
-                    <TableHead className="w-[104px] text-right">Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {pagedRows.map((r) => (
-                    <TableRow key={r.id}>
-                      <TableCell className="font-mono text-xs">{r.provider_key}</TableCell>
-                      <TableCell className="font-mono text-xs max-w-[200px] truncate" title={r.model_key}>
-                        {r.model_key}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums">{r.input_per_1k}</TableCell>
-                      <TableCell className="text-right tabular-nums">{r.output_per_1k}</TableCell>
-                      <TableCell className="text-right tabular-nums">{r.cache_read_per_1k ?? '—'}</TableCell>
-                      <TableCell className="text-right tabular-nums">{r.cache_creation_per_1k ?? '—'}</TableCell>
-                      <TableCell className="whitespace-nowrap text-sm text-muted-foreground" title={r.updated_at}>
-                        {formatTimeAgo(r.updated_at)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground"
-                          title="Edit rate"
-                          onClick={() => openEditForm(r)}
-                        >
-                          <Pencil className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
-                          title="Delete row"
-                          onClick={() => handleDeleteClick(r)}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+              <Upload className="w-4 h-4 mr-2" />
             )}
-          </div>
+            Upload CSV
+            <Input
+              id="csv-input"
+              type="file"
+              accept=".csv,text/csv"
+              className="absolute inset-0 cursor-pointer opacity-0 w-full h-full"
+              disabled={uploading}
+              onChange={(ev) => void onFile(ev)}
+            />
+          </Button>
+          <Button
+            className="ml-auto"
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void load()}
+            disabled={loading}
+          >
+            <RefreshCcw className={"w-2 h-2 " + (loading ? "animate-spin" : "")} />
+            {loading ? "Refreshing..." : "Refresh"}
+          </Button>
+        </div>
 
-          {!loading && rows.length > 0 && (
-            <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-              <span className="tabular-nums">
-                {fromRow}–{toRow} of {totalRows}
-              </span>
-
-              <div className="flex items-center gap-2 ml-auto">
-                <label className="flex items-center gap-2">
-                  <span className="text-xs">Rows</span>
-                  <select
-                    className="h-8 rounded-md border bg-background px-2 text-sm text-foreground"
-                    value={pageSize}
-                    onChange={(e) => {
-                      const next = Number(e.target.value);
-                      setPageSize(next);
-                      setPage(1);
-                    }}
-                  >
-                    {[10, 25, 50, 100].map((n) => (
-                      <option key={n} value={n}>
-                        {n}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  disabled={page <= 1}
-                  onClick={() => setPage((p) => Math.max(1, p - 1))}
-                >
-                  Prev
-                </Button>
-                <span className="tabular-nums">
-                  Page {page} / {totalPages}
+        {form && (
+          <div className="rounded-md border p-3 space-y-3 shrink-0">
+            <div className="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+              <label className="space-y-1">
+                <span className="text-xs text-muted-foreground">Provider</span>
+                <Input
+                  value={form.provider}
+                  disabled={!!editingId || saving}
+                  placeholder="openai"
+                  onChange={(e) => updateField("provider", e.target.value)}
+                />
+                {fieldErrors.provider && (
+                  <span className="block text-xs text-destructive">
+                    {fieldErrors.provider}
+                  </span>
+                )}
+              </label>
+              <label className="space-y-1">
+                <span className="text-xs text-muted-foreground">Model</span>
+                <Input
+                  value={form.model}
+                  disabled={!!editingId || saving}
+                  placeholder="gpt-4o"
+                  onChange={(e) => updateField("model", e.target.value)}
+                />
+                {fieldErrors.model && (
+                  <span className="block text-xs text-destructive">
+                    {fieldErrors.model}
+                  </span>
+                )}
+              </label>
+              <label className="space-y-1">
+                <span className="text-xs text-muted-foreground">Input / 1K</span>
+                <Input
+                  value={form.input_per_1k}
+                  disabled={saving}
+                  inputMode="decimal"
+                  placeholder="0.00015"
+                  onChange={(e) => updateField("input_per_1k", e.target.value)}
+                />
+                {fieldErrors.input_per_1k && (
+                  <span className="block text-xs text-destructive">
+                    {fieldErrors.input_per_1k}
+                  </span>
+                )}
+              </label>
+              <label className="space-y-1">
+                <span className="text-xs text-muted-foreground">
+                  Output / 1K
                 </span>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  disabled={page >= totalPages}
-                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-                >
-                  Next
-                </Button>
-              </div>
+                <Input
+                  value={form.output_per_1k}
+                  disabled={saving}
+                  inputMode="decimal"
+                  placeholder="0.0006"
+                  onChange={(e) => updateField("output_per_1k", e.target.value)}
+                />
+                {fieldErrors.output_per_1k && (
+                  <span className="block text-xs text-destructive">
+                    {fieldErrors.output_per_1k}
+                  </span>
+                )}
+              </label>
+              <label className="space-y-1">
+                <span className="text-xs text-muted-foreground">
+                  Cache read / 1K
+                </span>
+                <Input
+                  value={form.cache_read_per_1k}
+                  disabled={saving}
+                  inputMode="decimal"
+                  placeholder="optional"
+                  onChange={(e) =>
+                    updateField("cache_read_per_1k", e.target.value)
+                  }
+                />
+                {fieldErrors.cache_read_per_1k && (
+                  <span className="block text-xs text-destructive">
+                    {fieldErrors.cache_read_per_1k}
+                  </span>
+                )}
+              </label>
+              <label className="space-y-1">
+                <span className="text-xs text-muted-foreground">
+                  Cache write / 1K
+                </span>
+                <Input
+                  value={form.cache_creation_per_1k}
+                  disabled={saving}
+                  inputMode="decimal"
+                  placeholder="optional"
+                  onChange={(e) =>
+                    updateField("cache_creation_per_1k", e.target.value)
+                  }
+                />
+                {fieldErrors.cache_creation_per_1k && (
+                  <span className="block text-xs text-destructive">
+                    {fieldErrors.cache_creation_per_1k}
+                  </span>
+                )}
+              </label>
             </div>
+
+            <p className="text-xs text-muted-foreground">
+              Leave a cache rate blank to leave it unset; enter <code>0</code> to
+              price that bucket as free.
+            </p>
+            {editingId && (
+              <p className="text-xs text-muted-foreground">
+                Provider and model are fixed. Delete and re-add to move a rate.
+              </p>
+            )}
+            {formError && (
+              <p className="text-sm text-destructive">{formError}</p>
+            )}
+
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                size="sm"
+                disabled={saving}
+                onClick={() => void submitForm()}
+              >
+                {saving && <Loader2 className="w-4 h-4 animate-spin mr-2" />}
+                {editingId ? "Save changes" : "Add rate"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={saving}
+                onClick={closeForm}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+
+        <div className="flex-1 min-h-0 overflow-auto rounded-md border">
+          {loading ? (
+            <div className="flex items-center justify-center p-8 text-muted-foreground">
+              <Loader2 className="w-6 h-6 animate-spin mr-2" />
+              Loading…
+            </div>
+          ) : rows.length === 0 ? (
+            <ListEmptyState
+              icon={<Coins className="h-12 w-12 text-muted-foreground" />}
+              title="No cost rates yet"
+              description="Add a rate to price token usage per provider and model, or upload a CSV to set several at once."
+              action={
+                !form ? (
+                  <Button
+                    onClick={openCreateForm}
+                    className="rounded-full flex items-center gap-2"
+                  >
+                    <Plus className="h-4 w-4" />
+                    Add rate
+                  </Button>
+                ) : undefined
+              }
+            />
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Provider</TableHead>
+                  <TableHead>Model</TableHead>
+                  <TableHead className="text-right">Input / 1K</TableHead>
+                  <TableHead className="text-right">Output / 1K</TableHead>
+                  <TableHead className="text-right whitespace-nowrap">
+                    Cache read / 1K
+                  </TableHead>
+                  <TableHead className="text-right whitespace-nowrap">
+                    Cache write / 1K
+                  </TableHead>
+                  <TableHead className="whitespace-nowrap">Updated</TableHead>
+                  <TableHead className="w-[104px] text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {pagedRows.map((r) => (
+                  <TableRow key={r.id}>
+                    <TableCell className="font-mono text-xs">
+                      {r.provider_key}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs max-w-[200px] truncate" title={r.model_key}>
+                      {r.model_key}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {r.input_per_1k}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {r.output_per_1k}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {r.cache_read_per_1k ?? "—"}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {r.cache_creation_per_1k ?? "—"}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap text-sm text-muted-foreground"
+                      title={r.updated_at}
+                    >
+                      {formatTimeAgo(r.updated_at)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground"
+                        title="Edit rate"
+                        onClick={() => openEditForm(r)}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                        title="Delete row"
+                        onClick={() => handleDeleteClick(r)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
           )}
-        </DialogContent>
-      </Dialog>
+        </div>
+
+        {!loading && rows.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+            <span className="tabular-nums">
+              {fromRow}–{toRow} of {totalRows}
+            </span>
+
+            <div className="flex items-center gap-2 ml-auto">
+              <label className="flex items-center gap-2">
+                <span className="text-xs">Rows</span>
+                <select
+                  className="h-8 rounded-md border bg-background px-2 text-sm text-foreground"
+                  value={pageSize}
+                  onChange={(e) => {
+                    const next = Number(e.target.value);
+                    setPageSize(next);
+                    setPage(1);
+                  }}
+                >
+                  {[10, 25, 50, 100].map((n) => (
+                    <option key={n} value={n}>
+                      {n}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+              >
+                Prev
+              </Button>
+              <span className="tabular-nums">
+                Page {page} / {totalPages}
+              </span>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages}
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
 
       <ConfirmDialog
         isOpen={deleteDialogOpen}
@@ -599,29 +714,50 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
             <DialogDescription asChild>
               <div className="space-y-2 text-sm text-muted-foreground">
                 <p>
-                  Required header (column names are case-insensitive):{' '}
-                  <code className="text-xs bg-muted px-1.5 py-0.5 rounded">provider</code>,{' '}
-                  <code className="text-xs bg-muted px-1.5 py-0.5 rounded">model</code>,{' '}
-                  <code className="text-xs bg-muted px-1.5 py-0.5 rounded">input_per_1k</code>,{' '}
-                  <code className="text-xs bg-muted px-1.5 py-0.5 rounded">output_per_1k</code>. Values are USD per 1K
-                  tokens.
+                  Required header (column names are case-insensitive):{" "}
+                  <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                    provider
+                  </code>
+                  ,{" "}
+                  <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                    model
+                  </code>
+                  ,{" "}
+                  <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                    input_per_1k
+                  </code>
+                  ,{" "}
+                  <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                    output_per_1k
+                  </code>
+                  . Values are USD per 1K tokens.
                 </p>
                 <p>
-                  Optional: <code className="text-xs bg-muted px-1 rounded">cache_read_per_1k</code> and{' '}
-                  <code className="text-xs bg-muted px-1 rounded">cache_creation_per_1k</code>. Files without them still
-                  import. Enter <code className="text-xs bg-muted px-1 rounded">0</code> where the model charges
-                  nothing. Left blank the bucket is unset, and the cost falls back to a family estimate where one
-                  exists, otherwise to ordinary input pricing, or stays unpriced on providers that report cache tokens
-                  outside their input count.
+                  Optional:{" "}
+                  <code className="text-xs bg-muted px-1 rounded">
+                    cache_read_per_1k
+                  </code>{" "}
+                  and{" "}
+                  <code className="text-xs bg-muted px-1 rounded">
+                    cache_creation_per_1k
+                  </code>
+                  . Files without them still import. Enter{" "}
+                  <code className="text-xs bg-muted px-1 rounded">0</code> where
+                  the model charges nothing. Left blank the bucket is unset, and
+                  the cost falls back to a family estimate where one exists,
+                  otherwise to ordinary input pricing, or stays unpriced on
+                  providers that report cache tokens outside their input count.
                 </p>
                 <p>
-                  The rows below only illustrate the layout, the keys and rates are placeholders. Copy the real per-1K figures from your provider's
-                  price list.
+                  The rows below only illustrate the layout, the keys and rates
+                  are placeholders. Copy the real per-1K figures from your
+                  provider's price list.
                 </p>
                 <p>
-                  Use <code className="text-xs bg-muted px-1 rounded">_default</code> as{' '}
-                  <code className="text-xs bg-muted px-1 rounded">model</code> for a provider-wide default when no
-                  specific model matches.
+                  Use{" "}
+                  <code className="text-xs bg-muted px-1 rounded">_default</code>{" "}
+                  as <code className="text-xs bg-muted px-1 rounded">model</code>{" "}
+                  for a provider-wide default when no specific model matches.
                 </p>
               </div>
             </DialogDescription>
@@ -632,7 +768,12 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
               <Copy className="w-4 h-4 mr-2" />
               Copy header
             </Button>
-            <Button type="button" variant="outline" size="sm" onClick={downloadCsvTemplate}>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={downloadCsvTemplate}
+            >
               <Download className="w-4 h-4 mr-2" />
               Download header .csv
             </Button>

--- a/frontend/src/views/LlmProviders/components/LlmCostRatesDialog.tsx
+++ b/frontend/src/views/LlmProviders/components/LlmCostRatesDialog.tsx
@@ -18,6 +18,7 @@ import { formatTimeAgo } from '@/helpers/formatters';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { ListEmptyState } from '@/components/ListEmptyState';
 import {
+  serializeCacheRate,
   validateLlmCostRateForm,
   type LlmCostRateFieldErrors,
   type LlmCostRateFormValues,
@@ -25,11 +26,11 @@ import {
 
 /** Example CSV matching the import API (UTF-8, header row required). */
 const CSV_MODEL = `provider,model,input_per_1k,output_per_1k,cache_read_per_1k,cache_creation_per_1k
-openai,gpt-4o,0.0025,0.01,,
-openai,gpt-4o-mini,0.00015,0.0006,,
-anthropic,claude-3-5-sonnet,0.003,0.015,0.0003,0.00375
-bedrock,eu.amazon.nova-2-lite-v1:0,0.0001,0.0004,0.000025,0
-bedrock,eu.anthropic.claude-3-5-sonnet-20241022-v2:0,0.003,0.015,0.0003,0.00375
+openai,gpt-4o,0.001,0.002,,
+openai,gpt-4o-mini,0.001,0.002,,
+anthropic,claude-3-5-sonnet,0.001,0.002,,
+bedrock,eu.amazon.nova-2-lite-v1:0,0.001,0.002,0.0001,0
+bedrock,eu.anthropic.claude-3-5-sonnet-20241022-v2:0,0.001,0.002,0.0001,0.00125
 openrouter,_default,0.001,0.002,,
 vllm,_default,0,0,,`;
 
@@ -200,8 +201,8 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
         await updateLlmCostRate(editingId, {
           input_per_1k: form.input_per_1k.trim(),
           output_per_1k: form.output_per_1k.trim(),
-          cache_read_per_1k: form.cache_read_per_1k.trim() || null,
-          cache_creation_per_1k: form.cache_creation_per_1k.trim() || null,
+          cache_read_per_1k: serializeCacheRate(form.cache_read_per_1k),
+          cache_creation_per_1k: serializeCacheRate(form.cache_creation_per_1k),
         });
         toast.success('Cost rate updated.');
       } else {
@@ -210,8 +211,8 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
           model: form.model.trim(),
           input_per_1k: form.input_per_1k.trim(),
           output_per_1k: form.output_per_1k.trim(),
-          cache_read_per_1k: form.cache_read_per_1k.trim() || null,
-          cache_creation_per_1k: form.cache_creation_per_1k.trim() || null,
+          cache_read_per_1k: serializeCacheRate(form.cache_read_per_1k),
+          cache_creation_per_1k: serializeCacheRate(form.cache_creation_per_1k),
         });
         toast.success('Cost rate added.');
       }
@@ -420,6 +421,9 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
                 </label>
               </div>
 
+              <p className="text-xs text-muted-foreground">
+                Leave a cache rate blank to leave it unset; enter <code>0</code> to price that bucket as free.
+              </p>
               {editingId && (
                 <p className="text-xs text-muted-foreground">
                   Provider and model are fixed. Delete and re-add to move a rate.
@@ -602,8 +606,14 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
                 <p>
                   Optional: <code className="text-xs bg-muted px-1 rounded">cache_read_per_1k</code> and{' '}
                   <code className="text-xs bg-muted px-1 rounded">cache_creation_per_1k</code>. Files without them still
-                  import. Leave a value blank for the provider default, or enter{' '}
-                  <code className="text-xs bg-muted px-1 rounded">0</code> where the model charges nothing.
+                  import. Enter <code className="text-xs bg-muted px-1 rounded">0</code> where the model charges
+                  nothing. Left blank the bucket is unset, and the cost falls back to a family estimate where one
+                  exists, otherwise to ordinary input pricing, or stays unpriced on providers that report cache tokens
+                  outside their input count.
+                </p>
+                <p>
+                  The rates in the example below are placeholders. Copy the real per-1K figures from your provider's
+                  price list.
                 </p>
                 <p>
                   Use <code className="text-xs bg-muted px-1 rounded">_default</code> as{' '}

--- a/frontend/src/views/LlmProviders/components/LlmCostRatesDialog.tsx
+++ b/frontend/src/views/LlmProviders/components/LlmCostRatesDialog.tsx
@@ -1,21 +1,8 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/dialog";
-import { Button } from "@/components/button";
-import { Input } from "@/components/ui/input";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/table";
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/dialog';
+import { Button } from '@/components/button';
+import { Input } from '@/components/ui/input';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/table';
 import {
   getLlmCostRates,
   importLlmCostRatesCsv,
@@ -23,77 +10,62 @@ import {
   exportLlmCostRatesCsv,
   createLlmCostRate,
   updateLlmCostRate,
-} from "@/services/llmCostRates";
-import type { LlmCostRate } from "@/interfaces/llmCostRate.interface";
-import toast from "react-hot-toast";
+} from '@/services/llmCostRates';
+import type { LlmCostRate } from '@/interfaces/llmCostRate.interface';
+import toast from 'react-hot-toast';
+import { Coins, Copy, Download, FileText, Loader2, Pencil, Plus, RefreshCcw, Trash2, Upload } from 'lucide-react';
+import { formatTimeAgo } from '@/helpers/formatters';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { ListEmptyState } from '@/components/ListEmptyState';
 import {
-  Coins,
-  Copy,
-  Download,
-  FileText,
-  Loader2,
-  Pencil,
-  Plus,
-  RefreshCcw,
-  Trash2,
-  Upload,
-} from "lucide-react";
-import { formatTimeAgo } from "@/helpers/formatters";
-import { ConfirmDialog } from "@/components/ConfirmDialog";
-import { ListEmptyState } from "@/components/ListEmptyState";
+  validateLlmCostRateForm,
+  type LlmCostRateFieldErrors,
+  type LlmCostRateFormValues,
+} from '@/views/LlmProviders/helpers/llmCostRateValidation';
 
 /** Example CSV matching the import API (UTF-8, header row required). */
-const CSV_MODEL = `provider,model,input_per_1k,output_per_1k
-openai,gpt-4o,0.0025,0.01
-openai,gpt-4o-mini,0.00015,0.0006
-anthropic,claude-3-5-sonnet,0.003,0.015
-bedrock,eu.amazon.nova-2-lite-v1:0,0.0001,0.0004
-openrouter,_default,0.001,0.002
-vllm,_default,0,0`;
+const CSV_MODEL = `provider,model,input_per_1k,output_per_1k,cache_read_per_1k,cache_creation_per_1k
+openai,gpt-4o,0.0025,0.01,,
+openai,gpt-4o-mini,0.00015,0.0006,,
+anthropic,claude-3-5-sonnet,0.003,0.015,0.0003,0.00375
+bedrock,eu.amazon.nova-2-lite-v1:0,0.0001,0.0004,0.000025,0
+bedrock,eu.anthropic.claude-3-5-sonnet-20241022-v2:0,0.003,0.015,0.0003,0.00375
+openrouter,_default,0.001,0.002,,
+vllm,_default,0,0,,`;
 
 interface LlmCostRatesDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-interface RateForm {
-  provider: string;
-  model: string;
-  input_per_1k: string;
-  output_per_1k: string;
-}
+type RateForm = LlmCostRateFormValues;
 
 const EMPTY_FORM: RateForm = {
-  provider: "",
-  model: "",
-  input_per_1k: "",
-  output_per_1k: "",
+  provider: '',
+  model: '',
+  input_per_1k: '',
+  output_per_1k: '',
+  cache_read_per_1k: '',
+  cache_creation_per_1k: '',
 };
 
 function backendErrorMessage(err: unknown, fallback: string): string {
   const data = (err as { response?: { data?: unknown } })?.response?.data as
     | { error?: string; detail?: unknown }
     | undefined;
-  if (typeof data?.error === "string" && data.error) return data.error;
+  if (typeof data?.error === 'string' && data.error) return data.error;
   const detail = data?.detail;
-  if (typeof detail === "string" && detail) return detail;
+  if (typeof detail === 'string' && detail) return detail;
   if (Array.isArray(detail)) {
     const messages = detail
-      .map((d) =>
-        typeof d === "object" && d && "msg" in d
-          ? String((d as { msg: string }).msg)
-          : ""
-      )
+      .map((d) => (typeof d === 'object' && d && 'msg' in d ? String((d as { msg: string }).msg) : ''))
       .filter(Boolean);
-    if (messages.length) return messages.join("; ");
+    if (messages.length) return messages.join('; ');
   }
   return err instanceof Error ? err.message : fallback;
 }
 
-export function LlmCostRatesDialog({
-  open,
-  onOpenChange,
-}: LlmCostRatesDialogProps) {
+export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogProps) {
   const [rows, setRows] = useState<LlmCostRate[]>([]);
   const [loading, setLoading] = useState(false);
   const [uploading, setUploading] = useState(false);
@@ -107,6 +79,7 @@ export function LlmCostRatesDialog({
   const [editingId, setEditingId] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<LlmCostRateFieldErrors>({});
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -114,7 +87,7 @@ export function LlmCostRatesDialog({
       const data = await getLlmCostRates();
       setRows(data);
     } catch {
-      toast.error("Could not load LLM cost rates.");
+      toast.error('Could not load LLM cost rates.');
     } finally {
       await new Promise((resolve) => setTimeout(resolve, 200));
       setLoading(false);
@@ -148,18 +121,16 @@ export function LlmCostRatesDialog({
 
   const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    e.target.value = "";
+    e.target.value = '';
     if (!file) return;
-    if (!file.name.toLowerCase().endsWith(".csv")) {
-      toast.error("Please choose a .csv file.");
+    if (!file.name.toLowerCase().endsWith('.csv')) {
+      toast.error('Please choose a .csv file.');
       return;
     }
     setUploading(true);
     try {
       const result = await importLlmCostRatesCsv(file);
-      toast.success(
-        `Imported: ${result.inserted} new, ${result.updated} updated.`
-      );
+      toast.success(`Imported: ${result.inserted} new, ${result.updated} updated.`);
       if (result.errors.length) {
         result.errors.slice(0, 5).forEach((msg) => toast.error(msg));
         if (result.errors.length > 5) {
@@ -168,9 +139,7 @@ export function LlmCostRatesDialog({
       }
       await load();
     } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : "Upload failed."
-      );
+      toast.error(err instanceof Error ? err.message : 'Upload failed.');
     } finally {
       setUploading(false);
     }
@@ -178,56 +147,78 @@ export function LlmCostRatesDialog({
 
   const copyCsvModel = () => {
     void navigator.clipboard.writeText(`${CSV_MODEL.trim()}\n`);
-    toast.success("Example CSV copied to clipboard.");
+    toast.success('Example CSV copied to clipboard.');
   };
 
   const closeForm = () => {
     setForm(null);
     setEditingId(null);
     setFormError(null);
+    setFieldErrors({});
   };
 
   const openCreateForm = () => {
     setEditingId(null);
     setFormError(null);
+    setFieldErrors({});
     setForm({ ...EMPTY_FORM });
   };
 
   const openEditForm = (row: LlmCostRate) => {
     setEditingId(row.id);
     setFormError(null);
+    setFieldErrors({});
     setForm({
       provider: row.provider_key,
       model: row.model_key,
       input_per_1k: row.input_per_1k,
       output_per_1k: row.output_per_1k,
+      cache_read_per_1k: row.cache_read_per_1k ?? '',
+      cache_creation_per_1k: row.cache_creation_per_1k ?? '',
+    });
+  };
+
+  const updateField = (field: keyof RateForm, value: string) => {
+    setForm((prev) => (prev ? { ...prev, [field]: value } : prev));
+    setFieldErrors((prev) => {
+      if (!prev[field]) return prev;
+      const next = { ...prev };
+      delete next[field];
+      return next;
     });
   };
 
   const submitForm = async () => {
     if (!form) return;
-    setSaving(true);
+    const errors = validateLlmCostRateForm(form);
+    setFieldErrors(errors);
     setFormError(null);
+    if (Object.keys(errors).length > 0) return;
+    setSaving(true);
     try {
       if (editingId) {
         await updateLlmCostRate(editingId, {
           input_per_1k: form.input_per_1k.trim(),
           output_per_1k: form.output_per_1k.trim(),
+          cache_read_per_1k: form.cache_read_per_1k.trim() || null,
+          cache_creation_per_1k: form.cache_creation_per_1k.trim() || null,
         });
-        toast.success("Cost rate updated.");
+        toast.success('Cost rate updated.');
       } else {
         await createLlmCostRate({
           provider: form.provider.trim(),
           model: form.model.trim(),
           input_per_1k: form.input_per_1k.trim(),
           output_per_1k: form.output_per_1k.trim(),
+          cache_read_per_1k: form.cache_read_per_1k.trim() || null,
+          cache_creation_per_1k: form.cache_creation_per_1k.trim() || null,
         });
-        toast.success("Cost rate added.");
+        toast.success('Cost rate added.');
       }
       closeForm();
       await load();
     } catch (err) {
-      setFormError(backendErrorMessage(err, "Could not save this cost rate."));
+      setFormError(backendErrorMessage(err, 'Could not save this cost rate.'));
     } finally {
       setSaving(false);
     }
@@ -243,12 +234,12 @@ export function LlmCostRatesDialog({
     setDeleting(true);
     try {
       await deleteLlmCostRate(rowToDelete.id);
-      toast.success("Cost rate removed.");
+      toast.success('Cost rate removed.');
       setDeleteDialogOpen(false);
       setRowToDelete(null);
       await load();
     } catch {
-      toast.error("Could not delete this cost rate.");
+      toast.error('Could not delete this cost rate.');
     } finally {
       setDeleting(false);
     }
@@ -256,337 +247,327 @@ export function LlmCostRatesDialog({
 
   const downloadCsvModel = () => {
     const blob = new Blob([`${CSV_MODEL.trim()}\n`], {
-      type: "text/csv;charset=utf-8",
+      type: 'text/csv;charset=utf-8',
     });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
+    const a = document.createElement('a');
     a.href = url;
-    a.download = "llm-cost-rates-template.csv";
+    a.download = 'llm-cost-rates-template.csv';
     a.click();
     URL.revokeObjectURL(url);
-    toast.success("Template downloaded.");
+    toast.success('Template downloaded.');
   };
 
   const downloadCurrentRatesCsv = async () => {
     try {
       const blob = await exportLlmCostRatesCsv();
       const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
+      const a = document.createElement('a');
       a.href = url;
-      a.download = "llm-cost-rates.csv";
+      a.download = 'llm-cost-rates.csv';
       a.click();
       URL.revokeObjectURL(url);
-      toast.success("Current rates downloaded.");
+      toast.success('Current rates downloaded.');
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Export failed.");
+      toast.error(err instanceof Error ? err.message : 'Export failed.');
     }
   };
 
   return (
     <>
-    <Dialog
-      open={open}
-      onOpenChange={(next) => {
-        if (!next) {
-          setCsvFormatOpen(false);
-          setDeleteDialogOpen(false);
-          setRowToDelete(null);
-          closeForm();
-        }
-        onOpenChange(next);
-      }}
-    >
-      <DialogContent className="max-w-4xl max-h-[85vh] flex flex-col gap-4 z-50">
-        <DialogHeader>
-          <DialogTitle>LLM cost rates</DialogTitle>
-          <DialogDescription>
-            USD per 1K tokens. Open{" "} <strong>CSV template</strong> for the exact column layout and a ready-to-edit example.
-          </DialogDescription>
-        </DialogHeader>
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          if (!next) {
+            setCsvFormatOpen(false);
+            setDeleteDialogOpen(false);
+            setRowToDelete(null);
+            closeForm();
+          }
+          onOpenChange(next);
+        }}
+      >
+        <DialogContent className="max-w-5xl max-h-[85vh] flex flex-col gap-4 z-50">
+          <DialogHeader>
+            <DialogTitle>LLM cost rates</DialogTitle>
+            <DialogDescription>
+              USD per 1K tokens. Open <strong>CSV template</strong> for the exact column layout and a ready-to-edit
+              example.
+            </DialogDescription>
+          </DialogHeader>
 
-        <div className="flex flex-wrap items-center gap-2">
-          <Button
-            type="button"
-            variant="default"
-            size="sm"
-            onClick={openCreateForm}
-          >
-            <Plus className="w-4 h-4 mr-2" />
-            Add rate
-          </Button>
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={() => setCsvFormatOpen(true)}
-          >
-            <FileText className="w-4 h-4 mr-2" />
-            CSV template
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => void downloadCurrentRatesCsv()}
-          >
-            <Download className="w-4 h-4 mr-2" />
-            Download current CSV
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={uploading}
-            className="relative"
-            onClick={() => document.getElementById("csv-input")?.click()}
-          >
-            {uploading ? (
-              <Loader2 className="w-4 h-4 animate-spin mr-2" />
-            ) : (
-              <Upload className="w-4 h-4 mr-2" />
-            )}
-            Upload CSV
-            <Input
-              id="csv-input"
-              type="file"
-              accept=".csv,text/csv"
-              className="absolute inset-0 cursor-pointer opacity-0 w-full h-full"
+          <div className="flex flex-wrap items-center gap-2">
+            <Button type="button" variant="default" size="sm" onClick={openCreateForm}>
+              <Plus className="w-4 h-4 mr-2" />
+              Add rate
+            </Button>
+            <Button type="button" variant="secondary" size="sm" onClick={() => setCsvFormatOpen(true)}>
+              <FileText className="w-4 h-4 mr-2" />
+              CSV template
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={() => void downloadCurrentRatesCsv()}>
+              <Download className="w-4 h-4 mr-2" />
+              Download current CSV
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
               disabled={uploading}
-              onChange={(ev) => void onFile(ev)}
-            />
-          </Button>
-          <Button
-            className="ml-auto"
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => void load()}
-            disabled={loading}
-          >
-            <RefreshCcw className={"w-2 h-2 " + (loading ? "animate-spin" : "")} />
-            {loading ? "Refreshing..." : "Refresh"}
-          </Button>
-        </div>
-
-        {form && (
-          <div className="rounded-md border p-3 space-y-3 shrink-0">
-            <div className="grid grid-cols-1 sm:grid-cols-4 gap-3">
-              <label className="space-y-1">
-                <span className="text-xs text-muted-foreground">Provider</span>
-                <Input
-                  value={form.provider}
-                  disabled={!!editingId || saving}
-                  placeholder="openai"
-                  onChange={(e) =>
-                    setForm({ ...form, provider: e.target.value })
-                  }
-                />
-              </label>
-              <label className="space-y-1">
-                <span className="text-xs text-muted-foreground">Model</span>
-                <Input
-                  value={form.model}
-                  disabled={!!editingId || saving}
-                  placeholder="gpt-4o"
-                  onChange={(e) => setForm({ ...form, model: e.target.value })}
-                />
-              </label>
-              <label className="space-y-1">
-                <span className="text-xs text-muted-foreground">Input / 1K</span>
-                <Input
-                  value={form.input_per_1k}
-                  disabled={saving}
-                  inputMode="decimal"
-                  placeholder="0.00015"
-                  onChange={(e) =>
-                    setForm({ ...form, input_per_1k: e.target.value })
-                  }
-                />
-              </label>
-              <label className="space-y-1">
-                <span className="text-xs text-muted-foreground">
-                  Output / 1K
-                </span>
-                <Input
-                  value={form.output_per_1k}
-                  disabled={saving}
-                  inputMode="decimal"
-                  placeholder="0.0006"
-                  onChange={(e) =>
-                    setForm({ ...form, output_per_1k: e.target.value })
-                  }
-                />
-              </label>
-            </div>
-
-            {editingId && (
-              <p className="text-xs text-muted-foreground">
-                Provider and model are fixed. Delete and re-add to move a rate.
-              </p>
-            )}
-            {formError && (
-              <p className="text-sm text-destructive">{formError}</p>
-            )}
-
-            <div className="flex items-center gap-2">
-              <Button
-                type="button"
-                size="sm"
-                disabled={saving}
-                onClick={() => void submitForm()}
-              >
-                {saving && <Loader2 className="w-4 h-4 animate-spin mr-2" />}
-                {editingId ? "Save changes" : "Add rate"}
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={saving}
-                onClick={closeForm}
-              >
-                Cancel
-              </Button>
-            </div>
+              className="relative"
+              onClick={() => document.getElementById('csv-input')?.click()}
+            >
+              {uploading ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : <Upload className="w-4 h-4 mr-2" />}
+              Upload CSV
+              <Input
+                id="csv-input"
+                type="file"
+                accept=".csv,text/csv"
+                className="absolute inset-0 cursor-pointer opacity-0 w-full h-full"
+                disabled={uploading}
+                onChange={(ev) => void onFile(ev)}
+              />
+            </Button>
+            <Button
+              className="ml-auto"
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void load()}
+              disabled={loading}
+            >
+              <RefreshCcw className={'w-2 h-2 ' + (loading ? 'animate-spin' : '')} />
+              {loading ? 'Refreshing...' : 'Refresh'}
+            </Button>
           </div>
-        )}
 
-        <div className="flex-1 min-h-0 overflow-auto rounded-md border">
-          {loading ? (
-            <div className="flex items-center justify-center p-8 text-muted-foreground">
-              <Loader2 className="w-6 h-6 animate-spin mr-2" />
-              Loading…
+          {form && (
+            <div className="rounded-md border p-3 space-y-3 shrink-0">
+              <div className="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+                <label className="space-y-1">
+                  <span className="text-xs text-muted-foreground">Provider</span>
+                  <Input
+                    value={form.provider}
+                    disabled={!!editingId || saving}
+                    placeholder="openai"
+                    onChange={(e) => updateField('provider', e.target.value)}
+                  />
+                  {fieldErrors.provider && (
+                    <span className="block text-xs text-destructive">{fieldErrors.provider}</span>
+                  )}
+                </label>
+                <label className="space-y-1">
+                  <span className="text-xs text-muted-foreground">Model</span>
+                  <Input
+                    value={form.model}
+                    disabled={!!editingId || saving}
+                    placeholder="gpt-4o"
+                    onChange={(e) => updateField('model', e.target.value)}
+                  />
+                  {fieldErrors.model && <span className="block text-xs text-destructive">{fieldErrors.model}</span>}
+                </label>
+                <label className="space-y-1">
+                  <span className="text-xs text-muted-foreground">Input / 1K</span>
+                  <Input
+                    value={form.input_per_1k}
+                    disabled={saving}
+                    inputMode="decimal"
+                    placeholder="0.00015"
+                    onChange={(e) => updateField('input_per_1k', e.target.value)}
+                  />
+                  {fieldErrors.input_per_1k && (
+                    <span className="block text-xs text-destructive">{fieldErrors.input_per_1k}</span>
+                  )}
+                </label>
+                <label className="space-y-1">
+                  <span className="text-xs text-muted-foreground">Output / 1K</span>
+                  <Input
+                    value={form.output_per_1k}
+                    disabled={saving}
+                    inputMode="decimal"
+                    placeholder="0.0006"
+                    onChange={(e) => updateField('output_per_1k', e.target.value)}
+                  />
+                  {fieldErrors.output_per_1k && (
+                    <span className="block text-xs text-destructive">{fieldErrors.output_per_1k}</span>
+                  )}
+                </label>
+                <label className="space-y-1">
+                  <span className="text-xs text-muted-foreground">Cache read / 1K</span>
+                  <Input
+                    value={form.cache_read_per_1k}
+                    disabled={saving}
+                    inputMode="decimal"
+                    placeholder="optional"
+                    onChange={(e) => updateField('cache_read_per_1k', e.target.value)}
+                  />
+                  {fieldErrors.cache_read_per_1k && (
+                    <span className="block text-xs text-destructive">{fieldErrors.cache_read_per_1k}</span>
+                  )}
+                </label>
+                <label className="space-y-1">
+                  <span className="text-xs text-muted-foreground">Cache write / 1K</span>
+                  <Input
+                    value={form.cache_creation_per_1k}
+                    disabled={saving}
+                    inputMode="decimal"
+                    placeholder="optional"
+                    onChange={(e) => updateField('cache_creation_per_1k', e.target.value)}
+                  />
+                  {fieldErrors.cache_creation_per_1k && (
+                    <span className="block text-xs text-destructive">{fieldErrors.cache_creation_per_1k}</span>
+                  )}
+                </label>
+              </div>
+
+              {editingId && (
+                <p className="text-xs text-muted-foreground">
+                  Provider and model are fixed. Delete and re-add to move a rate.
+                </p>
+              )}
+              {formError && <p className="text-sm text-destructive">{formError}</p>}
+
+              <div className="flex items-center gap-2">
+                <Button type="button" size="sm" disabled={saving} onClick={() => void submitForm()}>
+                  {saving && <Loader2 className="w-4 h-4 animate-spin mr-2" />}
+                  {editingId ? 'Save changes' : 'Add rate'}
+                </Button>
+                <Button type="button" variant="outline" size="sm" disabled={saving} onClick={closeForm}>
+                  Cancel
+                </Button>
+              </div>
             </div>
-          ) : rows.length === 0 ? (
-            <ListEmptyState
-              icon={<Coins className="h-12 w-12 text-muted-foreground" />}
-              title="No cost rates yet"
-              description="Add a rate to price token usage per provider and model, or upload a CSV to set several at once."
-              action={
-                !form ? (
-                  <Button
-                    onClick={openCreateForm}
-                    className="rounded-full flex items-center gap-2"
-                  >
-                    <Plus className="h-4 w-4" />
-                    Add rate
-                  </Button>
-                ) : undefined
-              }
-            />
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Provider</TableHead>
-                  <TableHead>Model</TableHead>
-                  <TableHead className="text-right">Input / 1K</TableHead>
-                  <TableHead className="text-right">Output / 1K</TableHead>
-                  <TableHead className="whitespace-nowrap">Updated</TableHead>
-                  <TableHead className="w-[104px] text-right">Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {pagedRows.map((r) => (
-                  <TableRow key={r.id}>
-                    <TableCell className="font-mono text-xs">
-                      {r.provider_key}
-                    </TableCell>
-                    <TableCell className="font-mono text-xs max-w-[240px] truncate" title={r.model_key}>
-                      {r.model_key}
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums">
-                      {r.input_per_1k}
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums">
-                      {r.output_per_1k}
-                    </TableCell>
-                    <TableCell className="whitespace-nowrap text-sm text-muted-foreground"
-                      title={r.updated_at}
-                    >
-                      {formatTimeAgo(r.updated_at)}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground"
-                        title="Edit rate"
-                        onClick={() => openEditForm(r)}
-                      >
-                        <Pencil className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
-                        title="Delete row"
-                        onClick={() => handleDeleteClick(r)}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
           )}
-        </div>
 
-        {!loading && rows.length > 0 && (
-          <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-            <span className="tabular-nums">
-              {fromRow}–{toRow} of {totalRows}
-            </span>
-
-            <div className="flex items-center gap-2 ml-auto">
-              <label className="flex items-center gap-2">
-                <span className="text-xs">Rows</span>
-                <select
-                  className="h-8 rounded-md border bg-background px-2 text-sm text-foreground"
-                  value={pageSize}
-                  onChange={(e) => {
-                    const next = Number(e.target.value);
-                    setPageSize(next);
-                    setPage(1);
-                  }}
-                >
-                  {[10, 25, 50, 100].map((n) => (
-                    <option key={n} value={n}>
-                      {n}
-                    </option>
+          <div className="flex-1 min-h-0 overflow-auto rounded-md border">
+            {loading ? (
+              <div className="flex items-center justify-center p-8 text-muted-foreground">
+                <Loader2 className="w-6 h-6 animate-spin mr-2" />
+                Loading…
+              </div>
+            ) : rows.length === 0 ? (
+              <ListEmptyState
+                icon={<Coins className="h-12 w-12 text-muted-foreground" />}
+                title="No cost rates yet"
+                description="Add a rate to price token usage per provider and model, or upload a CSV to set several at once."
+                action={
+                  !form ? (
+                    <Button onClick={openCreateForm} className="rounded-full flex items-center gap-2">
+                      <Plus className="h-4 w-4" />
+                      Add rate
+                    </Button>
+                  ) : undefined
+                }
+              />
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Provider</TableHead>
+                    <TableHead>Model</TableHead>
+                    <TableHead className="text-right">Input / 1K</TableHead>
+                    <TableHead className="text-right">Output / 1K</TableHead>
+                    <TableHead className="text-right whitespace-nowrap">Cache read / 1K</TableHead>
+                    <TableHead className="text-right whitespace-nowrap">Cache write / 1K</TableHead>
+                    <TableHead className="whitespace-nowrap">Updated</TableHead>
+                    <TableHead className="w-[104px] text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {pagedRows.map((r) => (
+                    <TableRow key={r.id}>
+                      <TableCell className="font-mono text-xs">{r.provider_key}</TableCell>
+                      <TableCell className="font-mono text-xs max-w-[200px] truncate" title={r.model_key}>
+                        {r.model_key}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">{r.input_per_1k}</TableCell>
+                      <TableCell className="text-right tabular-nums">{r.output_per_1k}</TableCell>
+                      <TableCell className="text-right tabular-nums">{r.cache_read_per_1k ?? '—'}</TableCell>
+                      <TableCell className="text-right tabular-nums">{r.cache_creation_per_1k ?? '—'}</TableCell>
+                      <TableCell className="whitespace-nowrap text-sm text-muted-foreground" title={r.updated_at}>
+                        {formatTimeAgo(r.updated_at)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground"
+                          title="Edit rate"
+                          onClick={() => openEditForm(r)}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                          title="Delete row"
+                          onClick={() => handleDeleteClick(r)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
                   ))}
-                </select>
-              </label>
-
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={page <= 1}
-                onClick={() => setPage((p) => Math.max(1, p - 1))}
-              >
-                Prev
-              </Button>
-              <span className="tabular-nums">
-                Page {page} / {totalPages}
-              </span>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={page >= totalPages}
-                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-              >
-                Next
-              </Button>
-            </div>
+                </TableBody>
+              </Table>
+            )}
           </div>
-        )}
-      </DialogContent>
-    </Dialog>
+
+          {!loading && rows.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+              <span className="tabular-nums">
+                {fromRow}–{toRow} of {totalRows}
+              </span>
+
+              <div className="flex items-center gap-2 ml-auto">
+                <label className="flex items-center gap-2">
+                  <span className="text-xs">Rows</span>
+                  <select
+                    className="h-8 rounded-md border bg-background px-2 text-sm text-foreground"
+                    value={pageSize}
+                    onChange={(e) => {
+                      const next = Number(e.target.value);
+                      setPageSize(next);
+                      setPage(1);
+                    }}
+                  >
+                    {[10, 25, 50, 100].map((n) => (
+                      <option key={n} value={n}>
+                        {n}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                >
+                  Prev
+                </Button>
+                <span className="tabular-nums">
+                  Page {page} / {totalPages}
+                </span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={page >= totalPages}
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
 
       <ConfirmDialog
         isOpen={deleteDialogOpen}
@@ -611,29 +592,23 @@ export function LlmCostRatesDialog({
             <DialogDescription asChild>
               <div className="space-y-2 text-sm text-muted-foreground">
                 <p>
-                  Required header (column names are case-insensitive):{" "}
-                  <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
-                    provider
-                  </code>
-                  ,{" "}
-                  <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
-                    model
-                  </code>
-                  ,{" "}
-                  <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
-                    input_per_1k
-                  </code>
-                  ,{" "}
-                  <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
-                    output_per_1k
-                  </code>
-                  . Values are USD per 1K tokens.
+                  Required header (column names are case-insensitive):{' '}
+                  <code className="text-xs bg-muted px-1.5 py-0.5 rounded">provider</code>,{' '}
+                  <code className="text-xs bg-muted px-1.5 py-0.5 rounded">model</code>,{' '}
+                  <code className="text-xs bg-muted px-1.5 py-0.5 rounded">input_per_1k</code>,{' '}
+                  <code className="text-xs bg-muted px-1.5 py-0.5 rounded">output_per_1k</code>. Values are USD per 1K
+                  tokens.
                 </p>
                 <p>
-                  Use{" "}
-                  <code className="text-xs bg-muted px-1 rounded">_default</code>{" "}
-                  as <code className="text-xs bg-muted px-1 rounded">model</code>{" "}
-                  for a provider-wide default when no specific model matches.
+                  Optional: <code className="text-xs bg-muted px-1 rounded">cache_read_per_1k</code> and{' '}
+                  <code className="text-xs bg-muted px-1 rounded">cache_creation_per_1k</code>. Files without them still
+                  import. Leave a value blank for the provider default, or enter{' '}
+                  <code className="text-xs bg-muted px-1 rounded">0</code> where the model charges nothing.
+                </p>
+                <p>
+                  Use <code className="text-xs bg-muted px-1 rounded">_default</code> as{' '}
+                  <code className="text-xs bg-muted px-1 rounded">model</code> for a provider-wide default when no
+                  specific model matches.
                 </p>
               </div>
             </DialogDescription>
@@ -644,12 +619,7 @@ export function LlmCostRatesDialog({
               <Copy className="w-4 h-4 mr-2" />
               Copy example
             </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={downloadCsvModel}
-            >
+            <Button type="button" variant="outline" size="sm" onClick={downloadCsvModel}>
               <Download className="w-4 h-4 mr-2" />
               Download .csv
             </Button>

--- a/frontend/src/views/LlmProviders/components/LlmCostRatesDialog.tsx
+++ b/frontend/src/views/LlmProviders/components/LlmCostRatesDialog.tsx
@@ -18,21 +18,21 @@ import { formatTimeAgo } from '@/helpers/formatters';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { ListEmptyState } from '@/components/ListEmptyState';
 import {
+  changedCacheRates,
   serializeCacheRate,
   validateLlmCostRateForm,
   type LlmCostRateFieldErrors,
   type LlmCostRateFormValues,
 } from '@/views/LlmProviders/helpers/llmCostRateValidation';
 
-/** Example CSV matching the import API (UTF-8, header row required). */
-const CSV_MODEL = `provider,model,input_per_1k,output_per_1k,cache_read_per_1k,cache_creation_per_1k
-openai,gpt-4o,0.001,0.002,,
-openai,gpt-4o-mini,0.001,0.002,,
-anthropic,claude-3-5-sonnet,0.001,0.002,,
-bedrock,eu.amazon.nova-2-lite-v1:0,0.001,0.002,0.0001,0
-bedrock,eu.anthropic.claude-3-5-sonnet-20241022-v2:0,0.001,0.002,0.0001,0.00125
-openrouter,_default,0.001,0.002,,
-vllm,_default,0,0,,`;
+/** Header the import API requires (UTF-8). */
+const CSV_TEMPLATE = 'provider,model,input_per_1k,output_per_1k,cache_read_per_1k,cache_creation_per_1k';
+
+/** Display-only placeholder keys prevent pasted data from overwriting rates. */
+const CSV_EXAMPLE = `${CSV_TEMPLATE}
+example-provider,example-model,0.00025,0.001,,
+example-provider,example-model-cached,0.00025,0.001,0.000025,0
+example-provider,_default,0.00025,0.001,,`;
 
 interface LlmCostRatesDialogProps {
   open: boolean;
@@ -77,6 +77,7 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(25);
   const [form, setForm] = useState<RateForm | null>(null);
+  const [editPrefill, setEditPrefill] = useState<RateForm | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
@@ -146,13 +147,14 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
     }
   };
 
-  const copyCsvModel = () => {
-    void navigator.clipboard.writeText(`${CSV_MODEL.trim()}\n`);
-    toast.success('Example CSV copied to clipboard.');
+  const copyCsvTemplate = () => {
+    void navigator.clipboard.writeText(`${CSV_TEMPLATE}\n`);
+    toast.success('CSV header copied to clipboard.');
   };
 
   const closeForm = () => {
     setForm(null);
+    setEditPrefill(null);
     setEditingId(null);
     setFormError(null);
     setFieldErrors({});
@@ -162,21 +164,24 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
     setEditingId(null);
     setFormError(null);
     setFieldErrors({});
+    setEditPrefill(null);
     setForm({ ...EMPTY_FORM });
   };
 
   const openEditForm = (row: LlmCostRate) => {
-    setEditingId(row.id);
-    setFormError(null);
-    setFieldErrors({});
-    setForm({
+    const prefill: RateForm = {
       provider: row.provider_key,
       model: row.model_key,
       input_per_1k: row.input_per_1k,
       output_per_1k: row.output_per_1k,
       cache_read_per_1k: row.cache_read_per_1k ?? '',
       cache_creation_per_1k: row.cache_creation_per_1k ?? '',
-    });
+    };
+    setEditingId(row.id);
+    setFormError(null);
+    setFieldErrors({});
+    setEditPrefill(prefill);
+    setForm({ ...prefill });
   };
 
   const updateField = (field: keyof RateForm, value: string) => {
@@ -201,8 +206,7 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
         await updateLlmCostRate(editingId, {
           input_per_1k: form.input_per_1k.trim(),
           output_per_1k: form.output_per_1k.trim(),
-          cache_read_per_1k: serializeCacheRate(form.cache_read_per_1k),
-          cache_creation_per_1k: serializeCacheRate(form.cache_creation_per_1k),
+          ...(editPrefill ? changedCacheRates(form, editPrefill) : {}),
         });
         toast.success('Cost rate updated.');
       } else {
@@ -246,8 +250,8 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
     }
   };
 
-  const downloadCsvModel = () => {
-    const blob = new Blob([`${CSV_MODEL.trim()}\n`], {
+  const downloadCsvTemplate = () => {
+    const blob = new Blob([`${CSV_TEMPLATE}\n`], {
       type: 'text/csv;charset=utf-8',
     });
     const url = URL.createObjectURL(blob);
@@ -256,7 +260,7 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
     a.download = 'llm-cost-rates-template.csv';
     a.click();
     URL.revokeObjectURL(url);
-    toast.success('Template downloaded.');
+    toast.success('CSV header downloaded.');
   };
 
   const downloadCurrentRatesCsv = async () => {
@@ -292,8 +296,7 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
           <DialogHeader>
             <DialogTitle>LLM cost rates</DialogTitle>
             <DialogDescription>
-              USD per 1K tokens. Open <strong>CSV template</strong> for the exact column layout and a ready-to-edit
-              example.
+              USD per 1K tokens. Open <strong>CSV template</strong> for the exact column layout.
             </DialogDescription>
           </DialogHeader>
 
@@ -612,7 +615,7 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
                   outside their input count.
                 </p>
                 <p>
-                  The rates in the example below are placeholders. Copy the real per-1K figures from your provider's
+                  The rows below only illustrate the layout, the keys and rates are placeholders. Copy the real per-1K figures from your provider's
                   price list.
                 </p>
                 <p>
@@ -625,18 +628,18 @@ export function LlmCostRatesDialog({ open, onOpenChange }: LlmCostRatesDialogPro
           </DialogHeader>
 
           <div className="flex flex-wrap gap-2 shrink-0">
-            <Button type="button" variant="outline" size="sm" onClick={copyCsvModel}>
+            <Button type="button" variant="outline" size="sm" onClick={copyCsvTemplate}>
               <Copy className="w-4 h-4 mr-2" />
-              Copy example
+              Copy header
             </Button>
-            <Button type="button" variant="outline" size="sm" onClick={downloadCsvModel}>
+            <Button type="button" variant="outline" size="sm" onClick={downloadCsvTemplate}>
               <Download className="w-4 h-4 mr-2" />
-              Download .csv
+              Download header .csv
             </Button>
           </div>
 
           <pre className="text-xs font-mono bg-muted/80 rounded-md p-3 overflow-auto flex-1 min-h-[140px] border">
-            {CSV_MODEL.trim()}
+            {CSV_EXAMPLE}
           </pre>
         </DialogContent>
       </Dialog>

--- a/frontend/src/views/LlmProviders/helpers/llmCostRateValidation.ts
+++ b/frontend/src/views/LlmProviders/helpers/llmCostRateValidation.ts
@@ -38,3 +38,9 @@ export function validateLlmCostRateForm(values: LlmCostRateFormValues): LlmCostR
   // Cache rates may stay blank: "not configured" is not the same as 0.
   return errors;
 }
+
+/** Trimmed rate for the API. Blank clears the rate to unset; "0" is kept as a real price. */
+export function serializeCacheRate(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed === '' ? null : trimmed;
+}

--- a/frontend/src/views/LlmProviders/helpers/llmCostRateValidation.ts
+++ b/frontend/src/views/LlmProviders/helpers/llmCostRateValidation.ts
@@ -1,0 +1,40 @@
+/**
+ * Validates presence and length only. Backend RateDecimal validates syntax,
+ * precision, and range; 422 errors surface as formError.
+ */
+
+export interface LlmCostRateFormValues {
+  provider: string;
+  model: string;
+  input_per_1k: string;
+  output_per_1k: string;
+  cache_read_per_1k: string;
+  cache_creation_per_1k: string;
+}
+
+export type LlmCostRateFieldErrors = Partial<Record<keyof LlmCostRateFormValues, string>>;
+
+const PROVIDER_MAX = 64;
+const MODEL_MAX = 512;
+
+function keyError(value: string, label: string, max: number): string | undefined {
+  if (!value) return `${label} is required.`;
+  if (value.length > max) return `${label} must be ${max} characters or fewer.`;
+  return undefined;
+}
+
+export function validateLlmCostRateForm(values: LlmCostRateFormValues): LlmCostRateFieldErrors {
+  const errors: LlmCostRateFieldErrors = {};
+
+  const provider = keyError(values.provider.trim(), 'Provider', PROVIDER_MAX);
+  if (provider) errors.provider = provider;
+  const model = keyError(values.model.trim(), 'Model', MODEL_MAX);
+  if (model) errors.model = model;
+
+  for (const field of ['input_per_1k', 'output_per_1k'] as const) {
+    if (!values[field].trim()) errors[field] = 'A rate is required.';
+  }
+
+  // Cache rates may stay blank: "not configured" is not the same as 0.
+  return errors;
+}

--- a/frontend/src/views/LlmProviders/helpers/llmCostRateValidation.ts
+++ b/frontend/src/views/LlmProviders/helpers/llmCostRateValidation.ts
@@ -3,6 +3,8 @@
  * precision, and range; 422 errors surface as formError.
  */
 
+import type { LlmCostRateUpdatePayload } from '@/interfaces/llmCostRate.interface';
+
 export interface LlmCostRateFormValues {
   provider: string;
   model: string;
@@ -43,4 +45,21 @@ export function validateLlmCostRateForm(values: LlmCostRateFormValues): LlmCostR
 export function serializeCacheRate(value: string): string | null {
   const trimmed = value.trim();
   return trimmed === '' ? null : trimmed;
+}
+
+type CacheRatePatch = Pick<LlmCostRateUpdatePayload, 'cache_read_per_1k' | 'cache_creation_per_1k'>;
+
+const CACHE_FIELDS = ['cache_read_per_1k', 'cache_creation_per_1k'] as const;
+
+/**
+ * Only send changed cache-rate fields: skip unchanged ones, send null for fields the user cleared.
+ */
+export function changedCacheRates(values: LlmCostRateFormValues, prefill: LlmCostRateFormValues): CacheRatePatch {
+  const patch: CacheRatePatch = {};
+  for (const field of CACHE_FIELDS) {
+    if (values[field].trim() !== prefill[field].trim()) {
+      patch[field] = serializeCacheRate(values[field]);
+    }
+  }
+  return patch;
 }

--- a/frontend/src/views/Transcripts/components/TranscriptDialog.tsx
+++ b/frontend/src/views/Transcripts/components/TranscriptDialog.tsx
@@ -143,6 +143,7 @@ export function TranscriptDialog({ transcript, isOpen, onOpenChange, agentName: 
     input_tokens: 0,
     output_tokens: 0,
   });
+  const [costIncomplete, setCostIncomplete] = useState(false);
 
   useEffect(() => {
     setLocalTranscript(transcript);
@@ -269,6 +270,7 @@ export function TranscriptDialog({ transcript, isOpen, onOpenChange, agentName: 
 
       setCostsByMessageId(map);
       setTotalCost(totalCost);
+      setCostIncomplete(logs.some((log) => log.cost_usd == null));
     });
   }, [isOpen, localTranscript?.id]);
 
@@ -626,7 +628,19 @@ export function TranscriptDialog({ transcript, isOpen, onOpenChange, agentName: 
                 <h4 className="text-sm font-medium mb-2">Conversation Costs</h4>
                 <p className="text-sm text-muted-foreground flex justify-between"><span>Input Tokens:</span> <b>{totalCost.input_tokens}</b></p>
                 <p className="text-sm text-muted-foreground flex justify-between"><span>Output Tokens:</span> <b>{totalCost.output_tokens}</b></p>
-                <p className="text-sm text-muted-foreground flex justify-between"><span>Total Cost:</span> <b>${totalCost.total.toFixed(6)}</b></p>
+                <p
+                  className="text-sm text-muted-foreground flex justify-between"
+                  title={
+                    costIncomplete
+                      ? 'Some messages have no cost recorded. The real total is higher than this.'
+                      : undefined
+                  }
+                >
+                  <span>Total Cost:</span>{' '}
+                  <b>
+                    {costIncomplete ? '≥ ' : ''}${totalCost.total.toFixed(6)}
+                  </b>
+                </p>
               </div>
               </>
             )}

--- a/frontend/src/views/Transcripts/components/TranscriptThread.tsx
+++ b/frontend/src/views/Transcripts/components/TranscriptThread.tsx
@@ -326,7 +326,9 @@ export function TranscriptThread({
                           <span className="font-bold">{costs[messageId].input_tokens ?? '—'}</span>/
                           <span className="font-bold">{costs[messageId].output_tokens ?? '—'}</span>,
                           <Coins className="w-2 h-2 inline-block" /> Cost:{' '}
-                          <span className="font-bold">${(costs[messageId].cost_usd ?? 0).toFixed(6)}</span>
+                          <span className="font-bold">
+                            {costs[messageId].cost_usd == null ? '—' : `$${costs[messageId].cost_usd.toFixed(6)}`}
+                          </span>
                         </div>
                       )}
                     </div>

--- a/frontend/tests/views/LlmProviders/helpers/llmCostRateValidation.test.ts
+++ b/frontend/tests/views/LlmProviders/helpers/llmCostRateValidation.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { LlmCostRateFormValues, validateLlmCostRateForm } from '@/views/LlmProviders/helpers/llmCostRateValidation';
+
+const VALID: LlmCostRateFormValues = {
+  provider: 'openai',
+  model: 'gpt-4o',
+  input_per_1k: '0.0025',
+  output_per_1k: '0.01',
+  cache_read_per_1k: '',
+  cache_creation_per_1k: '',
+};
+
+const form = (over: Partial<LlmCostRateFormValues> = {}): LlmCostRateFormValues => ({
+  ...VALID,
+  ...over,
+});
+
+const rateErrors = (value: string) => validateLlmCostRateForm(form({ input_per_1k: value })).input_per_1k;
+
+describe('validateLlmCostRateForm', () => {
+  it('accepts a complete, well-formed row', () => {
+    expect(validateLlmCostRateForm(form())).toEqual({});
+  });
+
+  it('accepts configured cache rates, zero included', () => {
+    expect(validateLlmCostRateForm(form({ cache_read_per_1k: '0.000025', cache_creation_per_1k: '0' }))).toEqual({});
+  });
+
+  it('treats blank cache rates as not configured', () => {
+    expect(validateLlmCostRateForm(form({ cache_read_per_1k: '  ', cache_creation_per_1k: '' }))).toEqual({});
+  });
+
+  it('reports one message per field', () => {
+    const errors = validateLlmCostRateForm(form({ provider: '', input_per_1k: '  ' }));
+
+    expect(Object.keys(errors).sort()).toEqual(['input_per_1k', 'provider']);
+    expect(errors.model).toBeUndefined();
+  });
+});
+
+describe('identity fields', () => {
+  it.each([
+    ['provider', ''],
+    ['provider', '   '],
+    ['model', ''],
+    ['model', '\t'],
+  ] as const)('requires a non-blank %s', (field, value) => {
+    expect(validateLlmCostRateForm(form({ [field]: value }))[field]).toBeDefined();
+  });
+
+  it("enforces the backend's length caps", () => {
+    expect(validateLlmCostRateForm(form({ provider: 'p'.repeat(64) })).provider).toBeUndefined();
+    expect(validateLlmCostRateForm(form({ provider: 'p'.repeat(65) })).provider).toBeDefined();
+    expect(validateLlmCostRateForm(form({ model: 'm'.repeat(512) })).model).toBeUndefined();
+    expect(validateLlmCostRateForm(form({ model: 'm'.repeat(513) })).model).toBeDefined();
+  });
+});
+
+describe('rate values', () => {
+  it.each(['0', '0.5', '0.00015', '12345678', '99999999.9999999999'])('accepts %s', (value) => {
+    expect(rateErrors(value)).toBeUndefined();
+  });
+
+  it.each(['.5', '+1', '1.', '1e-7', '1E+3', '1_000'])('leaves backend-valid %s to the backend', (value) => {
+    expect(rateErrors(value)).toBeUndefined();
+  });
+
+  it.each(['abc', '-0.001', '0.00000000001'])('does not pre-judge %s client-side', (value) => {
+    expect(rateErrors(value)).toBeUndefined();
+  });
+
+  it.each(['', '   '])('requires a value (%s)', (value) => {
+    expect(rateErrors(value)).toBe('A rate is required.');
+  });
+
+  it('trims surrounding whitespace, matching what the dialog submits', () => {
+    expect(rateErrors('  0.5  ')).toBeUndefined();
+  });
+});

--- a/frontend/tests/views/LlmProviders/helpers/llmCostRateValidation.test.ts
+++ b/frontend/tests/views/LlmProviders/helpers/llmCostRateValidation.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { LlmCostRateFormValues, validateLlmCostRateForm } from '@/views/LlmProviders/helpers/llmCostRateValidation';
+import {
+  LlmCostRateFormValues,
+  serializeCacheRate,
+  validateLlmCostRateForm,
+} from '@/views/LlmProviders/helpers/llmCostRateValidation';
 
 const VALID: LlmCostRateFormValues = {
   provider: 'openai',
@@ -75,5 +79,19 @@ describe('rate values', () => {
 
   it('trims surrounding whitespace, matching what the dialog submits', () => {
     expect(rateErrors('  0.5  ')).toBeUndefined();
+  });
+});
+
+describe('serializeCacheRate', () => {
+  it.each(['', '   '])('sends a blank rate as null so the bucket stays unset (%j)', (value) => {
+    expect(serializeCacheRate(value)).toBeNull();
+  });
+
+  it.each(['0', '0.0', ' 0 '])('keeps an explicit zero as a configured free rate (%j)', (value) => {
+    expect(serializeCacheRate(value)).toBe(value.trim());
+  });
+
+  it('trims a configured rate without reformatting it', () => {
+    expect(serializeCacheRate(' 0.000025 ')).toBe('0.000025');
   });
 });

--- a/frontend/tests/views/LlmProviders/helpers/llmCostRateValidation.test.ts
+++ b/frontend/tests/views/LlmProviders/helpers/llmCostRateValidation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  changedCacheRates,
   LlmCostRateFormValues,
   serializeCacheRate,
   validateLlmCostRateForm,
@@ -93,5 +94,29 @@ describe('serializeCacheRate', () => {
 
   it('trims a configured rate without reformatting it', () => {
     expect(serializeCacheRate(' 0.000025 ')).toBe('0.000025');
+  });
+});
+
+describe('changedCacheRates', () => {
+  const prefill = form({ cache_read_per_1k: '0.0001', cache_creation_per_1k: '' });
+
+  it('omits both fields when neither was touched, so the backend keeps what it has', () => {
+    expect(changedCacheRates(form({ ...prefill }), prefill)).toEqual({});
+  });
+
+  it('sends null only for the field the user cleared', () => {
+    const edited = form({ ...prefill, cache_read_per_1k: '' });
+
+    expect(changedCacheRates(edited, prefill)).toEqual({ cache_read_per_1k: null });
+  });
+
+  it('sends a newly configured rate, zero included', () => {
+    const edited = form({ ...prefill, cache_creation_per_1k: '0' });
+
+    expect(changedCacheRates(edited, prefill)).toEqual({ cache_creation_per_1k: '0' });
+  });
+
+  it('treats a whitespace-only edit of a blank field as untouched', () => {
+    expect(changedCacheRates(form({ ...prefill, cache_creation_per_1k: '  ' }), prefill)).toEqual({});
   });
 });


### PR DESCRIPTION
## Description

Adds cache-aware LLM cost accounting for the existing prompt-caching support. Records provider-reported cache reads and writes, snapshots their resolved rates in the usage ledger, exposes cache activity in analytics, and keeps unpriced or partial costs from being presented as complete totals.
It also extends tenant-managed cost rates with optional cache pricing, strengthens CSV import/export behavior, and keeps live workflow estimates aligned with the existing best-effort.

## Type of Change


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [x] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

- Added persisted cache-read, cache-write, and canonical prompt-token fields to LLM usage events.
- Added optional cache-read and cache-creation rates to tenant-managed LLM cost rates.
- Centralized cache-aware cost calculation across live workflow estimates and ledger recording.
- Normalized inclusive and exclusive provider token-reporting formats before storing analytics data.
- Snapshotted resolved cache rates and left genuinely unpriced ledger events with a null cost.
- Added cache-token totals, unpriced-call indicators, exports, and UI feedback to LLM Usage analytics.
- Extended cost-rate CRUD and CSV import/export with cache columns, validation, size limits, and safe header-only templates.
- Preserved concurrently updated cache rates when an edit form leaves those fields unchanged.
- Prevented partial workflow costs from being stored or displayed as complete totals.
- Removed the unused `find_pricing` wrapper while preserving coverage of the live pricing path.
- Hardened tenant pricing-cache refresh and post-commit invalidation behavior.
- Added unit and integration coverage for pricing resolution, cache tokens, rate management, analytics, and partial costs.

## Testing


- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] Multi-tenant considerations addressed (if applicable)

## Related Issues


Closes #

## Screenshots (if applicable)


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
