### PR TITLE
feat: enhance duration formatting and operator statistics handling

### DIFF
--- a/frontend/src/helpers/formatters.ts
+++ b/frontend/src/helpers/formatters.ts
@@ -27,16 +27,65 @@ export const formatCallDuration = (time: string | number | null | undefined): st
   return totalMinutes >= 60 ? `${Math.floor(totalMinutes / 60)}h ${totalMinutes % 60}m` : `${totalMinutes}m`;
 };
 
+// Matches the backend's `str(timedelta(...))` output, which grows a day prefix
+// past 24h: "0:08:34", "23:59:59", "1 day, 0:00:00", "2 days, 7:33:20".
+const DURATION_STRING_RE = /^(?:(\d+)\s+days?,\s*)?(\d+):([0-5]?\d):([0-5]?\d)$/;
+
+export const parseDurationToSeconds = (time: string | number | null | undefined): number | null => {
+  if (typeof time === "number") {
+    return Number.isFinite(time) && time >= 0 ? Math.floor(time) : null;
+  }
+
+  if (!time || typeof time !== "string") return null;
+
+  const match = DURATION_STRING_RE.exec(time.trim());
+  if (!match) return null;
+
+  const [, days, hours, minutes, seconds] = match;
+  return Number(days ?? 0) * 86400 + Number(hours) * 3600 + Number(minutes) * 60 + Number(seconds);
+};
+
+// Exact duration — no rounding to the nearest minute, seconds always shown.
+export const formatExactDuration = (time: string | number | null | undefined): string => {
+  const totalSeconds = parseDurationToSeconds(time);
+  if (totalSeconds === null) return "0s";
+
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) return `${hours}h ${minutes}m ${seconds}s`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+};
+
 export const formatTimeAgo = (timestamp: string): string => {
   const now = new Date();
   const callTime = new Date(timestamp);
   const differenceInSeconds = Math.floor((now.getTime() - callTime.getTime()) / 1000);
 
+  const ago = (count: number, unit: string) =>
+    `${count} ${count === 1 ? unit : `${unit}s`} ago`;
+
   if (differenceInSeconds < 60) return "Just now";
   if (differenceInSeconds < 3600) return `${Math.floor(differenceInSeconds / 60)} min ago`;
-  if (differenceInSeconds < 86400) return `${Math.floor(differenceInSeconds / 3600)} hours ago`;
-  if (differenceInSeconds < 604800) return `${Math.floor(differenceInSeconds / 86400)} days ago`;
-  return `${Math.floor(differenceInSeconds / 604800)} weeks ago`;
+  if (differenceInSeconds < 86400) return ago(Math.floor(differenceInSeconds / 3600), "hour");
+  if (differenceInSeconds < 604800) return ago(Math.floor(differenceInSeconds / 86400), "day");
+  return ago(Math.floor(differenceInSeconds / 604800), "week");
+};
+
+// Operator KPI averages arrive from the backend as pre-formatted percent strings
+// ("86.0%"), so any arithmetic on them has to strip the suffix first — otherwise
+// Number("86.0%") is NaN and the NaN propagates into the rendered value.
+export const parsePercentValue = (value: string | number | null | undefined): number | null => {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value !== "string") return null;
+
+  const stripped = value.trim().replace(/%$/, "").trim();
+  if (stripped === "") return null; // Number("") is 0, which would read as a real 0%
+
+  const parsed = Number(stripped);
+  return Number.isFinite(parsed) ? parsed : null;
 };
 
 export const formatPercentage = (value: number | string | undefined | null): string => {

--- a/frontend/src/interfaces/operator.interface.ts
+++ b/frontend/src/interfaces/operator.interface.ts
@@ -9,12 +9,13 @@ export type Operator = {
     neutral?: number;
     negative?: number;
     totalCallDuration?: string;
-    score?: number;
+    score?: number | string;
     callCount?: number;
-    avg_customer_satisfaction?: number;
-    avg_resolution_rate?: number;
-    avg_response_time?: number;
-    avg_quality_of_service?: number;
+    // Serialized by the backend as percent strings ("86.0%"), not numbers.
+    avg_customer_satisfaction?: number | string;
+    avg_resolution_rate?: number | string;
+    avg_response_time?: number | string;
+    avg_quality_of_service?: number | string;
   };
   latest_conversation_analysis?: {
     conversation_id?: number;

--- a/frontend/src/services/transcripts.ts
+++ b/frontend/src/services/transcripts.ts
@@ -41,6 +41,7 @@ export interface FetchTranscriptsParams {
   order_by?: string;
   sort_direction?: string;
   agent_id?: string;
+  operator_id?: string;
   workflow_id?: string;
   customer_satisfaction_min?: number;
   customer_satisfaction_max?: number;
@@ -67,7 +68,7 @@ export const fetchTranscripts = async (
     const {
       limit, skip, sentiment, hostility_neutral_max, hostility_positive_max,
       include_feedback, conversation_status, order_by, sort_direction,
-      agent_id, workflow_id, scoreFilters, from_date, to_date, exclude_empty, id_suffix,
+      agent_id, operator_id, workflow_id, scoreFilters, from_date, to_date, exclude_empty, id_suffix,
       custom_attributes, search,
     } = params;
 
@@ -97,6 +98,7 @@ export const fetchTranscripts = async (
     if (order_by) queryParams.append("order_by", order_by);
     if (sort_direction) queryParams.append("sort_direction", sort_direction);
     if (agent_id) queryParams.append("agent_id", agent_id);
+    if (operator_id) queryParams.append("operator_id", operator_id);
     if (workflow_id) queryParams.append("workflow_id", workflow_id);
     if (from_date) queryParams.append("from_date", from_date);
     if (to_date) queryParams.append("to_date", to_date);

--- a/frontend/src/views/Operators/components/LatestCallDetails.tsx
+++ b/frontend/src/views/Operators/components/LatestCallDetails.tsx
@@ -1,5 +1,5 @@
-import { Phone } from "lucide-react";
-import { formatCallDuration, formatTimeAgo } from "@/helpers/formatters";
+import { MessageSquare } from "lucide-react";
+import { formatCallDuration, formatTimeAgo, parsePercentValue } from "@/helpers/formatters";
 import { Operator } from "@/interfaces/operator.interface";
 
 interface LatestCallDetailsProps {
@@ -11,18 +11,40 @@ export function LatestCallDetails({ operator }: LatestCallDetailsProps) {
 
   const callDuration = formatCallDuration(operator.latest_conversation_analysis.duration);
 
-  const agentRatio = operator.latest_conversation_analysis.agent_ratio ?? 0;
-  const customerRatio = operator.latest_conversation_analysis.customer_ratio ?? 100 - agentRatio;
+  const { agent_ratio: agentRatioRaw, customer_ratio: customerRatioRaw } =
+    operator.latest_conversation_analysis;
 
-  const customerSatisfaction = operator.latest_conversation_analysis.analysis?.customer_satisfaction !== undefined
-    ? `${operator.latest_conversation_analysis.analysis.customer_satisfaction * 10}%`
-    : operator.operator_statistics?.avg_customer_satisfaction || "N/A";
+  // Conversations are created with 0/0 placeholders and only get real ratios once
+  // the transcript is scored, so 0/0 means "not computed yet", not "nobody spoke".
+  const hasSpeakingRatio =
+    (typeof agentRatioRaw === "number" && agentRatioRaw > 0) ||
+    (typeof customerRatioRaw === "number" && customerRatioRaw > 0);
+
+  const agentRatio =
+    typeof agentRatioRaw === "number" ? agentRatioRaw : 100 - (customerRatioRaw ?? 0);
+  const customerRatio =
+    typeof customerRatioRaw === "number" ? customerRatioRaw : 100 - (agentRatioRaw ?? 0);
+
+  // Conversation-level satisfaction is 0-10; the operator average is already a percent.
+  const conversationSatisfaction = parsePercentValue(
+    operator.latest_conversation_analysis.analysis?.customer_satisfaction
+  );
+  const averageSatisfaction = parsePercentValue(
+    operator.operator_statistics?.avg_customer_satisfaction
+  );
+
+  const customerSatisfaction =
+    conversationSatisfaction !== null
+      ? `${Math.round(conversationSatisfaction * 10 * 10) / 10}%`
+      : averageSatisfaction !== null
+        ? `${averageSatisfaction}%`
+        : "N/A";
 
   return (
     <div className="bg-primary/5 p-4 rounded-lg">
       <h3 className="text-sm font-semibold mb-3 flex items-center gap-2">
-        <Phone className="w-4 h-4" />
-        Latest Call Details
+        <MessageSquare className="w-4 h-4" />
+        Latest Conversation Details
       </h3>
       <div className="space-y-2">
         <div className="flex justify-between text-sm">
@@ -42,7 +64,9 @@ export function LatestCallDetails({ operator }: LatestCallDetailsProps) {
         <div className="flex justify-between text-sm">
           <span className="text-muted-foreground">Speaking Ratio:</span>
           <span>
-            Operator {agentRatio}% / Customer {customerRatio}%
+            {hasSpeakingRatio
+              ? `Operator ${agentRatio}% / Customer ${customerRatio}%`
+              : "N/A"}
           </span>
         </div>
       </div>

--- a/frontend/src/views/Operators/components/OperatorCard.tsx
+++ b/frontend/src/views/Operators/components/OperatorCard.tsx
@@ -5,7 +5,7 @@ import { OperatorDetailsDialog } from "./OperatorDetailsDialog";
 import { useSearchParams } from "react-router-dom";
 import { fetchOperatorById, fetchOperatorsPaginated } from "@/services/operators";
 import { Operator, OperatorListItem } from "@/interfaces/operator.interface";
-import { formatCallDuration } from "@/helpers/formatters";
+import { formatExactDuration } from "@/helpers/formatters";
 import { Button } from "@/components/button";
 import { PageListSkeleton } from "@/components/skeletons";
 import { ListEmptyState } from "@/components/ListEmptyState";
@@ -15,6 +15,9 @@ import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 
 const PAGE_SIZE = 20;
 const SEARCH_DEBOUNCE_MS = 300;
+
+const formatConversationCount = (count: number) =>
+  `${count} ${count === 1 ? "conversation" : "conversations"}`;
 
 interface OperatorsCardProps {
   searchQuery: string;
@@ -204,7 +207,7 @@ export function OperatorsCard({
                     <div className="flex items-center gap-1">
                       <Clock className="w-3.5 h-3.5 text-muted-foreground" />
                       <span className="text-xs text-muted-foreground">
-                        {formatCallDuration(
+                        {formatExactDuration(
                           agent.operator_statistics?.totalCallDuration
                         )}
                       </span>
@@ -218,7 +221,7 @@ export function OperatorsCard({
                   </div>
                 </div>
                 <div className="text-xs font-medium text-muted-foreground shrink-0">
-                  {agent.operator_statistics?.callCount ?? 0} calls
+                  {formatConversationCount(agent.operator_statistics?.callCount ?? 0)}
                 </div>
               </div>
             ))

--- a/frontend/src/views/Operators/components/OperatorDetailsDialog.tsx
+++ b/frontend/src/views/Operators/components/OperatorDetailsDialog.tsx
@@ -23,8 +23,20 @@ export function OperatorDetailsDialog({ operator, isOpen, onOpenChange }: Operat
         return;
       }
       
+      // Without an id we cannot scope the lookup, and an unfiltered fetch would
+      // surface some other operator's conversation as this operator's latest.
+      if (!operator.id) {
+        setOperatorWithLatestCall({...operator});
+        return;
+      }
+
       try {
-        const { items: transcripts } = await fetchTranscripts();
+        const { items: transcripts } = await fetchTranscripts({
+          operator_id: operator.id,
+          limit: 1,
+          order_by: "created_at",
+          sort_direction: "desc",
+        });
         const latestTranscript = getLatestTranscript(transcripts);
         
         if (!latestTranscript) {
@@ -52,7 +64,7 @@ export function OperatorDetailsDialog({ operator, isOpen, onOpenChange }: Operat
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-w-4xl 2xl:max-w-[960px] min-[1920px]:max-w-[1120px]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-4">
             <OperatorAvatar 

--- a/frontend/src/views/Operators/components/PerformanceMetrics.tsx
+++ b/frontend/src/views/Operators/components/PerformanceMetrics.tsx
@@ -1,6 +1,6 @@
-import { Clock, Star, Phone } from "lucide-react";
+import { Clock, Star, MessageSquare } from "lucide-react";
 import { MetricCard } from "@/components/metrics/MetricCard";
-import { formatCallDuration } from "@/helpers/formatters";
+import { formatExactDuration } from "@/helpers/formatters";
 import { Operator } from "@/interfaces/operator.interface";
 
 interface PerformanceMetricsProps {
@@ -9,26 +9,26 @@ interface PerformanceMetricsProps {
 
 export function PerformanceMetrics({ operator }: PerformanceMetricsProps) {
   const callCount = operator.operator_statistics?.callCount ?? 0;
-  const callDuration = formatCallDuration(operator.operator_statistics?.totalCallDuration);
+  const callDuration = formatExactDuration(operator.operator_statistics?.totalCallDuration);
   const rating = operator.operator_statistics?.score ?? 0;
   
   return (
     <div className="grid grid-cols-3 gap-4">
       <MetricCard
-        icon={<Phone className="w-5 h-5" />}
+        icon={<MessageSquare className="w-5 h-5" />}
         value={callCount}
-        label="Total Calls"
+        label="Total Conversations"
       />
       
       <MetricCard
         icon={<Clock className="w-5 h-5" />}
         value={callDuration}
-        label="Total Calls"
+        label="Total Conversation Duration"
       />
       
       <MetricCard
         icon={<Star className="w-5 h-5" />}
-        value={rating}
+        value={`${rating} / 5`}
         label="Average Rating"
         iconColor="text-yellow-400"
       />

--- a/frontend/src/views/Operators/utils/operatorAnalysis.ts
+++ b/frontend/src/views/Operators/utils/operatorAnalysis.ts
@@ -1,5 +1,6 @@
 import { Operator } from "@/interfaces/operator.interface";
 import { BackendTranscript } from "@/interfaces/transcript.interface";
+import { parsePercentValue } from "@/helpers/formatters";
 
 type LatestConversationAnalysis = NonNullable<Operator["latest_conversation_analysis"]>;
 
@@ -17,10 +18,12 @@ export function createConversationAnalysis(
   transcript: BackendTranscript,
   operator: Operator
 ): LatestConversationAnalysis {
-  const fallbackSatisfaction =
-    operator.operator_statistics?.avg_customer_satisfaction != null
-      ? operator.operator_statistics.avg_customer_satisfaction / 10
-      : 8.6;
+  // avg_customer_satisfaction is a percent ("86.0%" / 86) on a 0-100 scale;
+  // conversation-level satisfaction is on a 0-10 scale, hence the divide.
+  const averagePercent = parsePercentValue(
+    operator.operator_statistics?.avg_customer_satisfaction
+  );
+  const fallbackSatisfaction = averagePercent !== null ? averagePercent / 10 : 8.6;
 
   const customerSatisfaction =
     transcript.analysis?.customer_satisfaction ?? fallbackSatisfaction;

--- a/frontend/tests/helpers/formatters.test.ts
+++ b/frontend/tests/helpers/formatters.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   formatCallDuration,
+  parsePercentValue,
+  formatExactDuration,
+  parseDurationToSeconds,
   formatTimeAgo,
   formatPercentage,
   getInitials,
@@ -56,6 +59,91 @@ describe("formatCallDuration", () => {
   });
 });
 
+describe("formatExactDuration", () => {
+  describe("numeric seconds input", () => {
+    it("formats seconds only", () => {
+      expect(formatExactDuration(0)).toBe("0s");
+      expect(formatExactDuration(45)).toBe("45s");
+    });
+
+    it("formats minutes and seconds", () => {
+      expect(formatExactDuration(514)).toBe("8m 34s");
+      expect(formatExactDuration(600)).toBe("10m 0s");
+    });
+
+    it("formats hours, minutes and seconds", () => {
+      expect(formatExactDuration(3600)).toBe("1h 0m 0s");
+      expect(formatExactDuration(3725)).toBe("1h 2m 5s");
+    });
+  });
+
+  describe("HH:MM:SS string input", () => {
+    it("does not round leftover seconds up to the next minute", () => {
+      expect(formatExactDuration("0:08:34")).toBe("8m 34s");
+      expect(formatExactDuration("00:00:30")).toBe("30s");
+      expect(formatExactDuration("00:45:01")).toBe("45m 1s");
+    });
+
+    it("keeps seconds past the hour mark", () => {
+      expect(formatExactDuration("01:30:12")).toBe("1h 30m 12s");
+      expect(formatExactDuration("23:59:59")).toBe("23h 59m 59s");
+    });
+  });
+
+  describe("day-prefixed string input from the backend", () => {
+    it("parses totals of 24h and beyond", () => {
+      expect(formatExactDuration("1 day, 0:00:00")).toBe("24h 0m 0s");
+      expect(formatExactDuration("2 days, 7:33:20")).toBe("55h 33m 20s");
+    });
+  });
+
+  describe("invalid input", () => {
+    it("falls back to 0s", () => {
+      expect(formatExactDuration(null)).toBe("0s");
+      expect(formatExactDuration(undefined)).toBe("0s");
+      expect(formatExactDuration("")).toBe("0s");
+      expect(formatExactDuration("abc")).toBe("0s");
+      expect(formatExactDuration("1:2")).toBe("0s");
+      expect(formatExactDuration(-5)).toBe("0s");
+    });
+  });
+});
+
+describe("parseDurationToSeconds", () => {
+  it("converts supported shapes to seconds", () => {
+    expect(parseDurationToSeconds(514)).toBe(514);
+    expect(parseDurationToSeconds("0:08:34")).toBe(514);
+    expect(parseDurationToSeconds("1 day, 0:00:00")).toBe(86400);
+    expect(parseDurationToSeconds("2 days, 7:33:20")).toBe(200000);
+  });
+
+  it("returns null for unparseable input", () => {
+    expect(parseDurationToSeconds("aa:bb:cc")).toBeNull();
+    expect(parseDurationToSeconds(null)).toBeNull();
+  });
+});
+
+describe("parsePercentValue", () => {
+  it("strips the percent suffix the backend adds", () => {
+    expect(parsePercentValue("86.0%")).toBe(86);
+    expect(parsePercentValue("0.00%")).toBe(0);
+    expect(parsePercentValue(" 42.5% ")).toBe(42.5);
+  });
+
+  it("passes finite numbers through", () => {
+    expect(parsePercentValue(90)).toBe(90);
+    expect(parsePercentValue(0)).toBe(0);
+  });
+
+  it("returns null rather than NaN for unusable input", () => {
+    expect(parsePercentValue("N/A")).toBeNull();
+    expect(parsePercentValue("")).toBeNull();
+    expect(parsePercentValue(null)).toBeNull();
+    expect(parsePercentValue(undefined)).toBeNull();
+    expect(parsePercentValue(NaN)).toBeNull();
+  });
+});
+
 describe("formatTimeAgo", () => {
   const secondsAgoIso = (s: number) =>
     new Date(Date.now() - s * 1000).toISOString();
@@ -78,6 +166,12 @@ describe("formatTimeAgo", () => {
 
   it("returns weeks beyond a week", () => {
     expect(formatTimeAgo(secondsAgoIso(2 * 604800))).toBe("2 weeks ago");
+  });
+
+  it("drops the plural 's' for a single unit", () => {
+    expect(formatTimeAgo(secondsAgoIso(3600))).toBe("1 hour ago");
+    expect(formatTimeAgo(secondsAgoIso(86400))).toBe("1 day ago");
+    expect(formatTimeAgo(secondsAgoIso(604800))).toBe("1 week ago");
   });
 });
 

--- a/frontend/tests/services/transcripts.test.ts
+++ b/frontend/tests/services/transcripts.test.ts
@@ -52,6 +52,7 @@ describe("fetchTranscripts", () => {
       order_by: "created_at",
       sort_direction: "desc",
       agent_id: "a1",
+      operator_id: "op1",
       workflow_id: "w1",
       from_date: "2024-01-01",
       to_date: "2024-02-01",
@@ -67,7 +68,7 @@ describe("fetchTranscripts", () => {
       "conversations/?skip=10&limit=100&sentiment=positive&hostility_neutral_max=5" +
         "&hostility_positive_max=3&include_feedback=true&conversation_status=open" +
         "&conversation_status=closed&order_by=created_at&sort_direction=desc&agent_id=a1" +
-        "&workflow_id=w1&from_date=2024-01-01&to_date=2024-02-01&exclude_empty=true" +
+        "&operator_id=op1&workflow_id=w1&from_date=2024-01-01&to_date=2024-02-01&exclude_empty=true" +
         "&id_suffix=abcd&search=hello&customer_satisfaction_min=2" +
         "&custom_attributes=%7B%22plan%22%3A%22gold%22%7D",
       undefined,
@@ -79,6 +80,18 @@ describe("fetchTranscripts", () => {
       page_size: 100,
       has_more: true,
     });
+  });
+
+  it("scopes the query to a single operator when operator_id is given", async () => {
+    mockApiRequest.mockResolvedValue({ items: [] } as never);
+
+    await fetchTranscripts({ operator_id: "op-42", limit: 1 });
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      "GET",
+      "conversations/?limit=1&operator_id=op-42",
+      undefined,
+    );
   });
 
   it("defaults limit to 20 and applies field fallbacks for a sparse response", async () => {

--- a/frontend/tests/views/Operators/utils/operatorAnalysis.test.ts
+++ b/frontend/tests/views/Operators/utils/operatorAnalysis.test.ts
@@ -104,6 +104,28 @@ describe("createConversationAnalysis", () => {
     ).toBe(0);
   });
 
+  it("parses the backend's percent-string average instead of producing NaN", () => {
+    const transcript = makeTranscript({});
+    const operator = makeOperator({
+      operator_statistics: { avg_customer_satisfaction: "86.0%" },
+    });
+    expect(
+      createConversationAnalysis(transcript, operator).analysis
+        .customer_satisfaction,
+    ).toBe(8.6);
+  });
+
+  it("falls back to the 8.6 default when the average is an unparseable string", () => {
+    const transcript = makeTranscript({});
+    const operator = makeOperator({
+      operator_statistics: { avg_customer_satisfaction: "N/A" },
+    });
+    expect(
+      createConversationAnalysis(transcript, operator).analysis
+        .customer_satisfaction,
+    ).toBe(8.6);
+  });
+
   it("preserves a transcript satisfaction of 0 rather than falling back", () => {
     const transcript = makeTranscript({
       analysis: { customer_satisfaction: 0 } as BackendTranscript["analysis"],


### PR DESCRIPTION
## Description

enhance duration formatting and operator statistics handling

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [x] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- Added `parseDurationToSeconds` and `formatExactDuration` functions for improved duration parsing and formatting.
- Updated `Operator` interface to support string values for average statistics.
- Modified `fetchTranscripts` to include `operator_id` for scoped queries.
- Enhanced `LatestCallDetails` and `PerformanceMetrics` components to utilize new formatting functions.
- Added unit tests for new formatting functions and updated existing tests for operator statistics.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
