### PR TITLE
fix: allow .pkl upload and validation on non-local storage

### DIFF
--- a/backend/app/api/v1/routes/ml_models.py
+++ b/backend/app/api/v1/routes/ml_models.py
@@ -227,7 +227,7 @@ async def validate_model_file(
     # Get model from database
     ml_model = await service.get_by_id(ml_model_id)
 
-    if not ml_model.pkl_file or not ml_model.pkl_file_id:
+    if not ml_model.pkl_file and not ml_model.pkl_file_id:
         raise HTTPException(
             status_code=400,
             detail="Model has no PKL file configured"

--- a/backend/app/services/file_manager.py
+++ b/backend/app/services/file_manager.py
@@ -67,7 +67,7 @@ class FileManagerService:
             return self.storage_provider
         except Exception as e:
             logger.error(f"Failed to initialize file manager service: {e}")
-            raise AppException(error_key=ErrorKey.FILE_MANAGER_INITIALIZATION_FAILED, detail=str(e))
+            raise AppException(error_key=ErrorKey.FILE_MANAGER_INITIALIZATION_FAILED, error_detail=str(e))
 
 
     async def set_storage_provider(self, provider: BaseStorageProvider):
@@ -382,7 +382,7 @@ class FileManagerService:
                 f.write(content)
         except Exception as e:
             logger.error(f"Failed to download file to path {path}: {e}")
-            raise AppException(error_key=ErrorKey.INTERNAL_ERROR, detail=str(e))
+            raise AppException(error_key=ErrorKey.INTERNAL_ERROR, error_detail=str(e))
 
     async def download_file_from_url_to_path(self, file_url: str, path: str) -> bool:
         """Download file from URL to path."""

--- a/frontend/src/services/mlModels.ts
+++ b/frontend/src/services/mlModels.ts
@@ -59,7 +59,7 @@ export const deleteMLModel = async (id: string): Promise<void> => {
 
 export const uploadModelFile = async (
   file: File,
-): Promise<{ file_path: string; original_filename: string; file_id?: string; file_url?: string }> => {
+): Promise<{ file_path: string | null; original_filename: string; file_id?: string; file_url?: string }> => {
   try {
   const formData = new FormData();
   formData.append("file", file);

--- a/frontend/src/views/MLModels/components/MLModelsManager.tsx
+++ b/frontend/src/views/MLModels/components/MLModelsManager.tsx
@@ -194,8 +194,8 @@ const MLModelsManager: React.FC = () => {
       let pklFileId = values.pkl_file_id;
       if (values.pendingFile) {
         const uploaded = await uploadModelFile(values.pendingFile);
-        if (!uploaded?.file_path) throw new Error("File upload failed.");
-        pklFile = uploaded.file_path;
+        if (!uploaded?.file_id && !uploaded?.file_path) throw new Error("File upload failed.");
+        pklFile = uploaded.file_path ?? null;
         pklFileId = uploaded.file_id ?? null;
       }
 


### PR DESCRIPTION
## Description

## Summary

`.pkl` upload when creating a new ML model failed on any **non-local storage
provider** (S3). It worked in dev but not in test — the only difference is the
configured storage provider.

### Root cause

The upload endpoint (`/ml-models/upload`) only populates `file_path` for
`local` storage; for S3 it intentionally returns `file_path: null` and links
the model via `file_id`:

```python
file_path = None
if created_file.storage_provider == "local":
    file_path = f"{storage_provider.get_base_path()}/{created_file.path}"
file_id = str(created_file.id)

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
