### PR TITLE
fix: fixes evaluation runs showing "queued" while executing

### DIFF
--- a/backend/app/services/test_suite.py
+++ b/backend/app/services/test_suite.py
@@ -1948,6 +1948,8 @@ class TestSuiteService:
         )
 
         created = await self.run_repo.create(run)
+        # Commit so the row exists before the caller dispatches the Celery task
+        await self.run_repo.db.commit()
         return TestRunInDB.model_validate(created, from_attributes=True)
 
     async def _fail_run(self, run: TestRunModel, error: str) -> None:
@@ -2065,6 +2067,8 @@ class TestSuiteService:
         # Mark running
         run.status = "running"
         await self.run_repo.update(run)
+        # Commit the RUNNING marker so it is visible during the long execution
+        await self.run_repo.db.commit()
 
         # Load cases
         cases = await self.list_cases_for_suite(suite.id)


### PR DESCRIPTION
## Description

- Commit the RUNNING marker when set so the UI and reconcilers see it mid-run; also releases the row lock that blocked the stuck-run reconciler
- Commit the run row before Celery dispatch so a fast worker can't miss it

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
