### PR TITLE
fix: 66904-constrain message feedback popover to transcript panel

### DIFF
--- a/frontend/src/views/Transcripts/components/MessageFeedbackPopover.tsx
+++ b/frontend/src/views/Transcripts/components/MessageFeedbackPopover.tsx
@@ -7,6 +7,7 @@ type MessageFeedbackPopoverProps = {
   isOpen: boolean;
   hasFeedbackMessage: boolean;
   text: string;
+  collisionBoundary: Element | null;
   onOpenChange: (open: boolean) => void;
   onTextChange: (value: string) => void;
   onSave: () => void;
@@ -17,6 +18,7 @@ export function MessageFeedbackPopover({
   isOpen,
   hasFeedbackMessage,
   text,
+  collisionBoundary,
   onOpenChange,
   onTextChange,
   onSave,
@@ -44,6 +46,9 @@ export function MessageFeedbackPopover({
         className="w-80 z-[1401]"
         side="bottom"
         align="start"
+        // Collision detection defaults to the viewport, not the transcript pane.
+        collisionBoundary={collisionBoundary}
+        hideWhenDetached
         // The popover is portaled to <body>, so the host Dialog's scroll lock
         // (react-remove-scroll) treats wheel/touch here as "outside" and cancels it,
         // which kills scrolling inside the textarea. Keep the events local.

--- a/frontend/src/views/Transcripts/components/TranscriptThread.tsx
+++ b/frontend/src/views/Transcripts/components/TranscriptThread.tsx
@@ -21,11 +21,13 @@ function MessageFeedbackButton({
   messageId,
   localTranscript,
   setLocalTranscript,
+  collisionBoundary,
   onOpenChange,
 }: {
   messageId: string;
   localTranscript: Transcript | null;
   setLocalTranscript: Dispatch<SetStateAction<Transcript | null>>;
+  collisionBoundary: Element | null;
   onOpenChange?: (open: boolean) => void;
 }) {
   const [isOpen, setIsOpen] = useState(false);
@@ -98,6 +100,7 @@ function MessageFeedbackButton({
       isOpen={isOpen}
       hasFeedbackMessage={hasFeedbackMessage}
       text={text}
+      collisionBoundary={collisionBoundary}
       onOpenChange={handleOpenChange}
       onTextChange={setText}
       onSave={handleSave}
@@ -149,7 +152,7 @@ export function TranscriptThread({
   style,
 }: TranscriptThreadProps) {
   const [openPopoverMessageId, setOpenPopoverMessageId] = useState<string | null>(null);
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
   const messageRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
   const isInteractive = variant === 'full';
@@ -159,23 +162,22 @@ export function TranscriptThread({
   // Centre the flagged message inside this pane only — scrollIntoView() would walk up the
   // ancestor chain and drag the surrounding dialog along with it.
   useEffect(() => {
-    if (!highlightMessageId) return;
+    if (!highlightMessageId || !scrollEl) return;
 
     const raf = requestAnimationFrame(() => {
-      const container = scrollRef.current;
       const node = messageRefs.current.get(highlightMessageId);
-      if (!container || !node) return;
+      if (!node) return;
 
-      const top = node.offsetTop - container.clientHeight / 2 + node.offsetHeight / 2;
-      container.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+      const top = node.offsetTop - scrollEl.clientHeight / 2 + node.offsetHeight / 2;
+      scrollEl.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
     });
 
     return () => cancelAnimationFrame(raf);
-  }, [highlightMessageId, transcript.id, messages.length]);
+  }, [highlightMessageId, transcript.id, messages.length, scrollEl]);
 
   return (
     <div
-      ref={scrollRef}
+      ref={setScrollEl}
       className={cn('relative overflow-y-auto p-3 text-[13px] sm:text-[12px]', className)}
       style={style}
     >
@@ -282,6 +284,7 @@ export function TranscriptThread({
                         messageId={messageId}
                         localTranscript={transcript}
                         setLocalTranscript={onTranscriptChange}
+                        collisionBoundary={scrollEl}
                         onOpenChange={(open) => setOpenPopoverMessageId(open ? messageId : null)}
                       />
                     )}


### PR DESCRIPTION
## Description

Fixes the message feedback popover remaining visible and interactive after its associated message is scrolled outside the transcript pane. The popover now uses the transcript scroll container as its collision boundary and hides when its trigger becomes detached, while preserving existing positioning, draft state, and feedback behavior.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

- Pass the mounted transcript scroll container to the message feedback popover as its collision boundary.
- Hide the popover when its associated message is fully detached from the transcript pane.
- Preserve the existing highlighted-message scrolling behavior using the mounted scroll element.

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] E2E tests (if applicable)


## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (not applicable; frontend-only UI behavior)

## Related Issues

Closes #66904

## Screenshots (if applicable)


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.