### PR TITLE
fix: allow updating inactive LLM analysts

### DIFF
--- a/backend/app/core/exceptions/error_messages.py
+++ b/backend/app/core/exceptions/error_messages.py
@@ -74,6 +74,7 @@ class ErrorKey(Enum):
     WEBHOOK_NOT_FOUND = "WEBHOOK_NOT_FOUND"
     LLM_PROVIDER_NOT_FOUND = "LLM_PROVIDER_NOT_FOUND"
     LLM_ANALYST_NOT_FOUND = "LLM_ANALYST_NOT_FOUND"
+    LLM_ANALYST_INACTIVE = "LLM_ANALYST_INACTIVE"
     FALLBACK_CHAIN_NOT_FOUND = "FALLBACK_CHAIN_NOT_FOUND"
     FALLBACK_CHAIN_INVALID_PROVIDER = "FALLBACK_CHAIN_INVALID_PROVIDER"
     LLM_PROVIDER_IN_USE_BY_CHAIN = "LLM_PROVIDER_IN_USE_BY_CHAIN"
@@ -251,6 +252,7 @@ ERROR_MESSAGES = {
         ErrorKey.DATASOURCE_NOT_FOUND: "Datasource not found.",
         ErrorKey.LLM_PROVIDER_NOT_FOUND: "LLM Provider not found.",
         ErrorKey.LLM_ANALYST_NOT_FOUND: "LLM Analyst not found.",
+        ErrorKey.LLM_ANALYST_INACTIVE: "LLM Analyst is inactive.",
         ErrorKey.FALLBACK_CHAIN_NOT_FOUND: "Fallback chain not found.",
         ErrorKey.FALLBACK_CHAIN_INVALID_PROVIDER: "Fallback chain references an LLM provider that does not exist.",
         ErrorKey.LLM_PROVIDER_IN_USE_BY_CHAIN: "This LLM provider is used by one or more fallback chains. Remove it from those chains before deleting.",

--- a/backend/app/repositories/llm_analysts.py
+++ b/backend/app/repositories/llm_analysts.py
@@ -21,14 +21,16 @@ class LlmAnalystRepository(DbRepository[LlmAnalystModel]):
         return obj
 
 
-    async def get_by_id(self, llm_analyst_id: UUID):
+    async def get_by_id(self, llm_analyst_id: UUID, include_inactive: bool = False):
         query = (
             select(LlmAnalystModel)
             .options(
                     joinedload(LlmAnalystModel.llm_provider)
                     )
-            .where(LlmAnalystModel.id == llm_analyst_id, LlmAnalystModel.is_active == 1)
+            .where(LlmAnalystModel.id == llm_analyst_id)
         )
+        if not include_inactive:
+            query = query.where(LlmAnalystModel.is_active == 1)
         result = await self.db.execute(query)
         return result.scalars().first()
 

--- a/backend/app/services/llm_analysts.py
+++ b/backend/app/services/llm_analysts.py
@@ -22,16 +22,22 @@ class LlmAnalystService:
             raise AppException(error_key=ErrorKey.LLM_PROVIDER_NOT_FOUND, status_code=404)
         
         llm_analyst =  await self.repository.create(data)
-        model = await self.repository.get_by_id(llm_analyst.id)
+        model = await self.repository.get_by_id(llm_analyst.id, include_inactive=True)
         return model
 
-    async def get_by_id(self, llm_analyst_id: UUID, throw_not_found: bool = True) -> LlmAnalyst:
-        obj = await self._read_by_id(llm_analyst_id, throw_not_found=throw_not_found)
+    async def get_by_id(self, llm_analyst_id: UUID, include_inactive: bool = False,
+                        throw_not_found: bool = True) -> LlmAnalyst:
+        obj = await self._read_by_id(llm_analyst_id, include_inactive=include_inactive,
+                                     throw_not_found=throw_not_found)
         return obj
 
-    async def _read_by_id(self, llm_analyst_id: UUID, throw_not_found: bool = True) -> LlmAnalyst:
-        obj = await self.repository.get_by_id(llm_analyst_id)
+    async def _read_by_id(self, llm_analyst_id: UUID, include_inactive: bool = False,
+                          throw_not_found: bool = True) -> LlmAnalyst:
+        obj = await self.repository.get_by_id(llm_analyst_id, include_inactive=include_inactive)
         if not obj and throw_not_found:
+            if not include_inactive and await self.repository.get_by_id(llm_analyst_id,
+                                                                        include_inactive=True):
+                raise AppException(error_key=ErrorKey.LLM_ANALYST_INACTIVE, status_code=409)
             raise AppException(error_key=ErrorKey.LLM_ANALYST_NOT_FOUND, status_code=404)
         return obj
 
@@ -40,13 +46,13 @@ class LlmAnalystService:
         return models
 
     async def update(self, llm_analyst_id: UUID, data: LlmAnalystUpdate):
-        obj = await self._read_by_id(llm_analyst_id)
+        obj = await self._read_by_id(llm_analyst_id, include_inactive=True)
         for field, value in data.model_dump(exclude_unset=True).items():
             setattr(obj, field, value)
         model = await self.repository.update(obj)
         return model
 
     async def delete(self, llm_analyst_id: UUID):
-        obj = await self._read_by_id(llm_analyst_id)
+        obj = await self._read_by_id(llm_analyst_id, include_inactive=True)
         await self.repository.delete(obj)
         return {"message": f"LlmAnalyst with ID {llm_analyst_id} has been deleted."}

--- a/backend/tests/unit/test_llm_analysts_service.py
+++ b/backend/tests/unit/test_llm_analysts_service.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 from uuid import UUID, uuid4
 from app.services.llm_analysts import LlmAnalystService
 from app.repositories.llm_analysts import LlmAnalystRepository
@@ -60,7 +60,7 @@ async def test_get_by_id_success(llm_analyst_service, mock_repository, sample_ll
     result = await llm_analyst_service.get_by_id(analyst_id)
 
     # Assert
-    mock_repository.get_by_id.assert_called_once_with(analyst_id)
+    mock_repository.get_by_id.assert_called_once_with(analyst_id, include_inactive=False)
     assert result.id == analyst_id
     assert result.name == sample_llm_analyst_data["name"]
 
@@ -75,7 +75,24 @@ async def test_get_by_id_not_found(llm_analyst_service, mock_repository):
         await llm_analyst_service.get_by_id(analyst_id)
     
     assert exc_info.value.error_key == ErrorKey.LLM_ANALYST_NOT_FOUND
-    mock_repository.get_by_id.assert_called_once_with(analyst_id)
+    assert mock_repository.get_by_id.await_args_list == [
+        call(analyst_id, include_inactive=False),
+        call(analyst_id, include_inactive=True),
+    ]
+
+@pytest.mark.asyncio
+async def test_get_by_id_inactive(llm_analyst_service, mock_repository, sample_llm_analyst_data):
+    # Setup
+    analyst_id = uuid4()
+    inactive_analyst = LlmAnalystModel(id=analyst_id, **{**sample_llm_analyst_data, "is_active": 0})
+    mock_repository.get_by_id.side_effect = [None, inactive_analyst]
+
+    # Execute and Assert
+    with pytest.raises(AppException) as exc_info:
+        await llm_analyst_service.get_by_id(analyst_id)
+
+    assert exc_info.value.error_key == ErrorKey.LLM_ANALYST_INACTIVE
+    assert exc_info.value.status_code == 409
 
 @pytest.mark.asyncio
 async def test_get_all_success(llm_analyst_service, mock_repository, sample_llm_analyst_data):
@@ -116,7 +133,7 @@ async def test_update_success(llm_analyst_service, mock_repository, sample_llm_a
     result = await llm_analyst_service.update(analyst_id, update_data)
 
     # Assert
-    mock_repository.get_by_id.assert_called_once_with(analyst_id)
+    mock_repository.get_by_id.assert_called_once_with(analyst_id, include_inactive=True)
     mock_repository.update.assert_called_once()
     assert result.id == analyst_id
     assert result.name == update_data.name
@@ -133,6 +150,6 @@ async def test_delete_success(llm_analyst_service, mock_repository, sample_llm_a
     result = await llm_analyst_service.delete(analyst_id)
 
     # Assert
-    mock_repository.get_by_id.assert_called_once_with(analyst_id)
+    mock_repository.get_by_id.assert_called_once_with(analyst_id, include_inactive=True)
     mock_repository.delete.assert_called_once_with(mock_analyst)
     assert result["message"] == f"LlmAnalyst with ID {analyst_id} has been deleted." 

--- a/frontend/src/views/ActiveConversations/components/ActiveConversationDialog.tsx
+++ b/frontend/src/views/ActiveConversations/components/ActiveConversationDialog.tsx
@@ -25,6 +25,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/button";
 import { Badge } from "@/components/badge";
 import { conversationService } from "@/services/liveConversations";
+import { extractErrorMessage } from "@/helpers/apiError";
 import { getCurrentUserId } from "@/services/auth";
 import { useWebSocketTranscript } from "../hooks/useWebsocket";
 import { DEFAULT_LLM_ANALYST_ID } from "@/constants/llmAnalyst";
@@ -633,7 +634,7 @@ function TranscriptDialogContent({
       if (refetchConversations) refetchConversations();
     } catch (err) {
       toast.dismiss(processingToast);
-      toast.error("Failed to finalize conversation.");
+      toast.error(extractErrorMessage(err, "Failed to finalize conversation."));
     } finally {
       setIsFinalizing(false);
     }


### PR DESCRIPTION
## Description

The by-id lookup filtered on is_active = 1, so a deactivated analyst was unreachable by PATCH/DELETE and could never be toggled back on.
Adds an include_inactive flag (default off) that create, update and delete opt into.
In addition: A distinct LLM_ANALYST_INACTIVE error so an existing-but-inactive analyst stops reporting itself as missing. The finalize toast now surfaces the API message instead of a generic string.

## Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [X] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
