### PR TITLE
hotfix: release DB connection before LLM call to prevent pool exhaustion

### DIFF
--- a/backend/app/use_cases/chat_as_client_use_case.py
+++ b/backend/app/use_cases/chat_as_client_use_case.py
@@ -9,6 +9,7 @@ from uuid import UUID
 from app.api.v1.routes.agents import run_query_agent_logic
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
+from app.core.utils.db_connection_utils import release_db_connection
 from app.core.utils.enums.conversation_status_enum import ConversationStatus
 from app.db.base import generate_sequential_uuid
 from app.db.models.conversation import ConversationModel
@@ -385,6 +386,10 @@ async def process_conversation_update_with_agent(
             )
         else:
             session_message = model.messages[-1].text
+
+        # Release the pooled connection before the LLM/tool run so it isn't held
+        # idle-in-transaction for the duration of the call (see incident-queuepool-exhaustion.md).
+        await release_db_connection(context=f"conversation {conversation_id}")
 
         agent_response = await run_query_agent_logic(
             agent_service,


### PR DESCRIPTION

## Description
The chat update flow (process_conversation_update_with_agent) held its pooled DB connection idle-in-transaction for the full duration of the LLM/tool call (5-30s), so under concurrent traffic connections piled up and exhausted the pool (QueuePool limit reached, "too many clients").

Add a release_db_connection() call right after the last pre-LLM read and before run_query_agent_logic, so the connection returns to the pool during the LLM call instead of being held through it. expire_on_commit=False means already-loaded objects (conversation, agent) keep their values after the release, so no lazy-load issues follow.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
