### PR TITLE
fix: 66928 paginate api keys and enable editing

### DIFF
--- a/backend/app/api/v1/routes/api_keys.py
+++ b/backend/app/api/v1/routes/api_keys.py
@@ -4,8 +4,9 @@ from fastapi_injector import Injected
 
 from app.auth.dependencies import auth, permissions
 from app.core.permissions.constants import Permissions as P
-from app.schemas.api_key import ApiKeyCreateRead, ApiKeySafeRead, ApiKeyCreate, ApiKeyRotate, ApiKeyUpdate
-from app.schemas.filter import ApiKeysFilter
+from app.schemas.api_key import ApiKeyCreate, ApiKeyCreateRead, ApiKeyRotate, ApiKeySafeRead, ApiKeyUpdate
+from app.schemas.common import PaginatedResponse
+from app.schemas.filter import ApiKeyListFilter, ApiKeysFilter
 from app.services.api_keys import ApiKeysService
 
 router = APIRouter()
@@ -27,6 +28,15 @@ async def create(api_key: ApiKeyCreate, service: ApiKeysService = Injected(ApiKe
 ])
 async def get_all(api_keys_filter: ApiKeysFilter = Depends(), service: ApiKeysService = Injected(ApiKeysService)):
     return await service.get_all(api_keys_filter)
+
+# Declared before /{api_key_id} so "list" is not matched as a UUID path param.
+@router.get("/list", response_model=PaginatedResponse[ApiKeySafeRead], dependencies=[
+    Depends(auth),
+    Depends(permissions(P.ApiKey.READ))
+])
+async def get_list(filter_obj: ApiKeyListFilter = Depends(), service: ApiKeysService = Injected(ApiKeysService)):
+    """Paginated API key list, newest first, with optional name search"""
+    return await service.get_list_paginated(filter_obj)
 
 @router.get("/{api_key_id}", response_model=ApiKeySafeRead, dependencies=[
     Depends(auth),

--- a/backend/app/repositories/api_keys.py
+++ b/backend/app/repositories/api_keys.py
@@ -3,7 +3,7 @@ from typing import Optional
 from uuid import UUID
 
 from injector import inject
-from sqlalchemy import and_, delete, or_, select, update
+from sqlalchemy import and_, delete, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -18,7 +18,7 @@ from app.db.models.role import RoleModel
 from app.db.models.role_permission import RolePermissionModel
 from app.repositories.db_repository import DbRepository
 from app.schemas.api_key import ApiKeyCreate, ApiKeyUpdate
-from app.schemas.filter import ApiKeysFilter
+from app.schemas.filter import ApiKeyListFilter, ApiKeysFilter
 
 api_key_key_builder  = make_key_builder("api_key")
 
@@ -119,6 +119,40 @@ class ApiKeysRepository(DbRepository[ApiKeyModel]):
         result = await self.db.execute(query)
 
         return result.scalars().all()
+
+
+    def _search_condition(self, search: Optional[str]):
+        """Case-insensitive substring match on the key name"""
+        if not search or not search.strip():
+            return None
+
+        term = search.strip()
+        escaped = term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        return ApiKeyModel.name.ilike(f"%{escaped}%", escape="\\")
+
+
+    async def get_list_paginated(self, filter_obj: ApiKeyListFilter) -> tuple[list[ApiKeyModel], int]:
+        """Return one page of API keys, newest first, plus the unpaginated total"""
+        search_condition = self._search_condition(filter_obj.search)
+
+        count_stmt = select(func.count(ApiKeyModel.id)).where(ApiKeyModel.is_deleted == 0)
+        if search_condition is not None:
+            count_stmt = count_stmt.where(search_condition)
+        total = (await self.db.execute(count_stmt)).scalar() or 0
+
+        data_stmt = (
+            select(ApiKeyModel)
+            .options(selectinload(ApiKeyModel.api_key_roles).selectinload(ApiKeyRoleModel.role))
+            .where(ApiKeyModel.is_deleted == 0)
+        )
+        if search_condition is not None:
+            data_stmt = data_stmt.where(search_condition)
+
+        data_stmt = data_stmt.order_by(ApiKeyModel.created_at.desc(), ApiKeyModel.id.desc())
+        data_stmt = self._apply_pagination(data_stmt, filter_obj)
+
+        result = await self.db.execute(data_stmt)
+        return result.scalars().all(), total
 
 
     async def delete(self, api_key: ApiKeyModel):

--- a/backend/app/schemas/filter.py
+++ b/backend/app/schemas/filter.py
@@ -115,6 +115,13 @@ class OperatorListFilter(BaseModel):
     search: Optional[str] = Field(None, description="Case-insensitive substring match on operator first or last name")
 
 
+class ApiKeyListFilter(BaseModel):
+    """Query params for the paginated API key list"""
+    skip: int = Field(0, ge=0, description="The number of rows to skip before returning results")
+    limit: int = Field(20, ge=1, le=100, description="The number of rows to return per page")
+    search: Optional[str] = Field(None, description="Case-insensitive substring match on API key name")
+
+
 class AgentResponseLogFilter(BaseModel):
     conversation_id: UUID
     node_type: Optional[str] = Field(None, description="Filter by node type found in state.nodeExecutionStatus[*].type")

--- a/backend/app/services/api_keys.py
+++ b/backend/app/services/api_keys.py
@@ -2,27 +2,26 @@ import json
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Optional
+from uuid import UUID
+from cryptography.fernet import InvalidToken
 from fastapi_cache.coder import PickleCoder
 from fastapi_cache.decorator import cache
 from injector import inject
 from starlette_context import context
-from uuid import UUID
-from app.auth.utils import current_user_is_admin, generate_api_key, hash_api_key
-from app.auth.utils import get_current_user_id
+from app.auth.utils import current_user_is_admin, generate_api_key, get_current_user_id, hash_api_key
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.core.utils.date_time_utils import utc_now
 from app.core.utils.encryption_utils import decrypt_key, encrypt_key
 from app.db.models import ApiKeyModel
 from app.db.models.audit_log import AuditLogModel
+from app.repositories.api_keys import ApiKeysRepository, api_key_key_builder
 from app.repositories.audit_logs import AuditLogRepository
 from app.repositories.roles import RolesRepository
-from app.schemas.api_key import ApiKeyCreate, ApiKeyInternal, ApiKeyRotate, ApiKeyUpdate
-from app.repositories.api_keys import ApiKeysRepository, api_key_key_builder
-from app.schemas.filter import ApiKeysFilter
+from app.schemas.api_key import ApiKeyCreate, ApiKeyInternal, ApiKeyRotate, ApiKeySafeRead, ApiKeyUpdate
+from app.schemas.common import PaginatedResponse
+from app.schemas.filter import ApiKeyListFilter, ApiKeysFilter
 from app.schemas.role import RoleRead
-from cryptography.fernet import InvalidToken
-
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +97,11 @@ class ApiKeysService:
 
     async def get_all(self, api_key_filter: ApiKeysFilter):
         return await self.repository.get_all(api_key_filter)
+
+    async def get_list_paginated(self, filter_obj: ApiKeyListFilter) -> PaginatedResponse[ApiKeySafeRead]:
+        rows, total = await self.repository.get_list_paginated(filter_obj)
+        items = [ApiKeySafeRead.model_validate(api_key) for api_key in rows]
+        return PaginatedResponse.from_filter(items, total, filter_obj)
 
     async def reveal(self, api_key_id: UUID):
         api_key = await self.repository.get_by_id(api_key_id)

--- a/backend/tests/integration/security/test_api_keys.py
+++ b/backend/tests/integration/security/test_api_keys.py
@@ -1,5 +1,6 @@
 import pytest
 import logging
+from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 
@@ -67,3 +68,33 @@ async def test_delete_api_key(authorized_client, new_api_key_data):
     # Confirm deletion
     get_response = authorized_client.get(f"/api/api-keys/{id}")
     assert get_response.status_code == 404 
+
+
+@pytest.fixture
+def listed_api_key(authorized_client):
+    name = f"zz_list_{uuid4().hex[:8]}"
+    created = authorized_client.post("/api/api-keys", json={"name": name, "role_ids": []}).json()
+    yield created
+    authorized_client.delete(f"/api/api-keys/{created['id']}")
+
+
+@pytest.mark.asyncio
+async def test_get_api_keys_paginated(authorized_client, listed_api_key):
+    response = authorized_client.get("/api/api-keys/list", params={"limit": 5, "search": listed_api_key["name"]})
+    assert response.status_code == 200
+
+    body = response.json()
+    assert set(body) >= {"items", "total", "page", "page_size", "total_pages"}
+    assert body["page"] == 1 and body["page_size"] == 5 and body["total"] == 1
+    assert [item["id"] for item in body["items"]] == [listed_api_key["id"]]
+
+    item = body["items"][0]
+    assert "roles" in item and "key_val" not in item and "hashed_value" not in item
+
+
+@pytest.mark.asyncio
+async def test_get_api_keys_paginated_excludes_deleted(authorized_client, listed_api_key):
+    authorized_client.delete(f"/api/api-keys/{listed_api_key['id']}")
+
+    body = authorized_client.get("/api/api-keys/list", params={"search": listed_api_key["name"]}).json()
+    assert body["total"] == 0 and body["items"] == []

--- a/backend/tests/integration/security/test_api_keys.py
+++ b/backend/tests/integration/security/test_api_keys.py
@@ -73,7 +73,9 @@ async def test_delete_api_key(authorized_client, new_api_key_data):
 @pytest.fixture
 def listed_api_key(authorized_client):
     name = f"zz_list_{uuid4().hex[:8]}"
-    created = authorized_client.post("/api/api-keys", json={"name": name, "role_ids": []}).json()
+    response = authorized_client.post("/api/api-keys", json={"name": name, "role_ids": []})
+    assert response.status_code == 200, response.text
+    created = response.json()
     yield created
     authorized_client.delete(f"/api/api-keys/{created['id']}")
 

--- a/backend/tests/integration/security/test_api_keys_pagination_db.py
+++ b/backend/tests/integration/security/test_api_keys_pagination_db.py
@@ -1,0 +1,255 @@
+"""DB-backed proof that the API key list paginates, orders and searches in SQL"""
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config.settings import settings
+from app.db.models import (
+    ApiKeyModel,
+    ApiKeyRoleModel,
+    RoleModel,
+    UserModel,
+    UserTypeModel,
+    test_suite,  # noqa: F401
+)
+from app.repositories.api_keys import ApiKeysRepository
+from app.schemas.api_key import ApiKeySafeRead
+from app.schemas.filter import ApiKeyListFilter, ApiKeysFilter
+
+ORDERED_COUNT = 22
+TIE_COUNT = 3
+PROBE_NAMES = ("be%ta", "back\\slash", "İlkay")
+MATCHING_COUNT = ORDERED_COUNT + TIE_COUNT + len(PROBE_NAMES)
+TURKISH_NAME = PROBE_NAMES[2]
+BASE_CREATED_AT = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(settings.DATABASE_URL)
+    maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_api_keys(db_session):
+    session = db_session
+    prefix = f"zz_{uuid4().hex[:8]}_"
+
+    user_type_id = (await session.execute(select(UserTypeModel.id).limit(1))).scalar_one()
+    user = UserModel(
+        username=f"{prefix}user",
+        email=f"{prefix}user@example.test",
+        hashed_password="not-a-real-hash",
+        is_active=1,
+        user_type_id=user_type_id,
+    )
+    session.add(user)
+    await session.flush()
+
+    role_id = (await session.execute(select(RoleModel.id).limit(1))).scalar_one()
+
+    def add_key(name, created_at, is_deleted=0):
+        key = ApiKeyModel(
+            name=name,
+            is_active=1,
+            user_id=user.id,
+            key_val="enc",
+            hashed_value=f"{prefix}h_{name}",
+            created_at=created_at,
+            is_deleted=is_deleted,
+        )
+        session.add(key)
+        return key
+
+    key_ids = []
+    try:
+        ordered = [add_key(f"{prefix}key{i:02d}", BASE_CREATED_AT - timedelta(minutes=i)) for i in range(ORDERED_COUNT)]
+        tied = [add_key(f"{prefix}tie{j}", BASE_CREATED_AT - timedelta(minutes=100)) for j in range(TIE_COUNT)]
+        probes = [add_key(f"{prefix}{n}", BASE_CREATED_AT - timedelta(minutes=200 + j)) for j, n in enumerate(PROBE_NAMES)]
+        deleted = add_key(f"{prefix}gone", BASE_CREATED_AT - timedelta(minutes=300), is_deleted=1)
+
+        await session.flush()
+        key_ids = [key.id for key in [*ordered, *tied, *probes, deleted]]
+        with_role_id = ordered[0].id
+
+        session.add(ApiKeyRoleModel(api_key_id=with_role_id, role_id=role_id))
+        await session.commit()
+        session.expunge_all()
+
+        yield {
+            "prefix": prefix,
+            "user_id": user.id,
+            "role_id": role_id,
+            "with_role_id": with_role_id,
+            "keyless_id": ordered[1].id,
+            "deleted_id": deleted.id,
+            "tied_ids": [key.id for key in tied],
+            "visible_ids": set(key_ids) - {deleted.id},
+        }
+    finally:
+        await session.execute(delete(ApiKeyRoleModel).where(ApiKeyRoleModel.api_key_id.in_(key_ids)))
+        await session.execute(delete(ApiKeyModel).where(ApiKeyModel.id.in_(key_ids)))
+        await session.execute(delete(UserModel).where(UserModel.id == user.id))
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_total_counts_matching_rows_and_excludes_soft_deleted(db_session, seeded_api_keys):
+    repo = ApiKeysRepository(db_session)
+    prefix = seeded_api_keys["prefix"]
+
+    rows, total = await repo.get_list_paginated(ApiKeyListFilter(skip=0, limit=100, search=prefix))
+
+    assert total == MATCHING_COUNT
+    assert len(rows) == MATCHING_COUNT
+    assert {key.id for key in rows} == seeded_api_keys["visible_ids"]
+    assert seeded_api_keys["deleted_id"] not in {key.id for key in rows}
+
+
+@pytest.mark.asyncio
+async def test_database_returns_only_the_requested_page(db_session, seeded_api_keys):
+    repo = ApiKeysRepository(db_session)
+    prefix = seeded_api_keys["prefix"]
+
+    page1, total1 = await repo.get_list_paginated(ApiKeyListFilter(skip=0, limit=10, search=prefix))
+    page2, total2 = await repo.get_list_paginated(ApiKeyListFilter(skip=10, limit=10, search=prefix))
+    page3, total3 = await repo.get_list_paginated(ApiKeyListFilter(skip=20, limit=10, search=prefix))
+
+    assert [len(page1), len(page2), len(page3)] == [10, 10, MATCHING_COUNT - 20]
+    assert total1 == total2 == total3 == MATCHING_COUNT
+
+    ids1, ids2, ids3 = ({key.id for key in page} for page in (page1, page2, page3))
+    assert ids1.isdisjoint(ids2) and ids1.isdisjoint(ids3) and ids2.isdisjoint(ids3)
+    assert ids1 | ids2 | ids3 == seeded_api_keys["visible_ids"]
+
+
+@pytest.mark.asyncio
+async def test_ordering_is_newest_first_and_stable_on_ties(db_session, seeded_api_keys):
+    repo = ApiKeysRepository(db_session)
+    prefix = seeded_api_keys["prefix"]
+
+    rows, _ = await repo.get_list_paginated(ApiKeyListFilter(skip=0, limit=100, search=prefix))
+
+    assert [key.name for key in rows[:ORDERED_COUNT]] == [f"{prefix}key{i:02d}" for i in range(ORDERED_COUNT)]
+
+    timestamps = [key.created_at for key in rows]
+    assert timestamps == sorted(timestamps, reverse=True)
+
+    tie_ids = [key.id for key in rows[ORDERED_COUNT:ORDERED_COUNT + TIE_COUNT]]
+    assert set(tie_ids) == set(seeded_api_keys["tied_ids"])
+    assert tie_ids == sorted(seeded_api_keys["tied_ids"], reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_roles_are_eagerly_loaded_for_serialisation(db_session, seeded_api_keys):
+    repo = ApiKeysRepository(db_session)
+    prefix = seeded_api_keys["prefix"]
+
+    rows, _ = await repo.get_list_paginated(ApiKeyListFilter(skip=0, limit=100, search=prefix))
+    by_id = {key.id: key for key in rows}
+
+    with_role = ApiKeySafeRead.model_validate(by_id[seeded_api_keys["with_role_id"]])
+    assert [role.id for role in with_role.roles] == [seeded_api_keys["role_id"]]
+    assert "key_val" not in with_role.model_dump()
+
+    keyless = ApiKeySafeRead.model_validate(by_id[seeded_api_keys["keyless_id"]])
+    assert keyless.roles == []
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_eagerly_loads_roles(db_session, seeded_api_keys):
+    # Sole query in this test, so the role cannot already be in the identity map.
+    repo = ApiKeysRepository(db_session)
+
+    row = await repo.get_by_id(seeded_api_keys["with_role_id"])
+
+    read = ApiKeySafeRead.model_validate(row)
+    assert [role.id for role in read.roles] == [seeded_api_keys["role_id"]]
+
+
+@pytest.mark.asyncio
+async def test_legacy_get_all_eagerly_loads_roles(db_session, seeded_api_keys):
+    repo = ApiKeysRepository(db_session)
+
+    rows = await repo.get_all(ApiKeysFilter(skip=0, limit=100, user_id=seeded_api_keys["user_id"]))
+    with_role = next(key for key in rows if key.id == seeded_api_keys["with_role_id"])
+
+    read = ApiKeySafeRead.model_validate(with_role)
+    assert [role.id for role in read.roles] == [seeded_api_keys["role_id"]]
+
+
+@pytest.mark.asyncio
+async def test_search_narrows_on_name_and_ignores_case(db_session, seeded_api_keys):
+    repo = ApiKeysRepository(db_session)
+    prefix = seeded_api_keys["prefix"]
+
+    exact, total_exact = await repo.get_list_paginated(ApiKeyListFilter(skip=0, limit=100, search=f"{prefix}key07"))
+    assert total_exact == 1 and exact[0].name == f"{prefix}key07"
+
+    _, total_upper = await repo.get_list_paginated(
+        ApiKeyListFilter(skip=0, limit=100, search=f"{prefix}key07".upper())
+    )
+    assert total_upper == 1
+
+    _, total_none = await repo.get_list_paginated(ApiKeyListFilter(skip=0, limit=100, search=f"{prefix}nope"))
+    assert total_none == 0
+
+
+@pytest.mark.asyncio
+async def test_like_wildcards_in_the_search_term_stay_literal(db_session, seeded_api_keys):
+    repo = ApiKeysRepository(db_session)
+    prefix = seeded_api_keys["prefix"]
+
+    literal, total_literal = await repo.get_list_paginated(ApiKeyListFilter(skip=0, limit=100, search=f"{prefix}be%t"))
+    assert total_literal == 1 and literal[0].name == f"{prefix}be%ta"
+
+    _, total_wildcard = await repo.get_list_paginated(ApiKeyListFilter(skip=0, limit=100, search=f"{prefix}key%7"))
+    assert total_wildcard == 0
+
+    _, total_underscore = await repo.get_list_paginated(ApiKeyListFilter(skip=0, limit=100, search=f"{prefix}key_7"))
+    assert total_underscore == 0
+
+    backslash, total_backslash = await repo.get_list_paginated(
+        ApiKeyListFilter(skip=0, limit=100, search=f"{prefix}back\\slash")
+    )
+    assert total_backslash == 1 and backslash[0].name == f"{prefix}back\\slash"
+
+    _, total_escape_eaten = await repo.get_list_paginated(
+        ApiKeyListFilter(skip=0, limit=100, search=f"{prefix}backslash")
+    )
+    assert total_escape_eaten == 0
+
+
+@pytest.mark.asyncio
+async def test_search_casefolds_the_way_the_database_does(db_session, seeded_api_keys):
+    repo = ApiKeysRepository(db_session)
+    prefix = seeded_api_keys["prefix"]
+    stored = f"{prefix}{TURKISH_NAME}"
+
+    pasted, total_pasted = await repo.get_list_paginated(ApiKeyListFilter(skip=0, limit=100, search=stored))
+    assert total_pasted == 1 and pasted[0].name == stored
+
+    _, total_lower = await repo.get_list_paginated(ApiKeyListFilter(skip=0, limit=100, search=f"{prefix}ilkay"))
+    assert total_lower == 1
+
+    _, total_upper = await repo.get_list_paginated(ApiKeyListFilter(skip=0, limit=100, search=f"{prefix}ILKAY"))
+    assert total_upper == 1
+
+
+@pytest.mark.asyncio
+async def test_blank_search_is_treated_as_no_search(db_session, seeded_api_keys):
+    repo = ApiKeysRepository(db_session)
+
+    _, total_blank = await repo.get_list_paginated(ApiKeyListFilter(skip=0, limit=1, search="   "))
+    _, total_unset = await repo.get_list_paginated(ApiKeyListFilter(skip=0, limit=1))
+
+    assert total_blank == total_unset >= MATCHING_COUNT

--- a/backend/tests/integration/security/test_api_keys_pagination_db.py
+++ b/backend/tests/integration/security/test_api_keys_pagination_db.py
@@ -96,6 +96,7 @@ async def seeded_api_keys(db_session):
             "visible_ids": set(key_ids) - {deleted.id},
         }
     finally:
+        await session.rollback()
         await session.execute(delete(ApiKeyRoleModel).where(ApiKeyRoleModel.api_key_id.in_(key_ids)))
         await session.execute(delete(ApiKeyModel).where(ApiKeyModel.id.in_(key_ids)))
         await session.execute(delete(UserModel).where(UserModel.id == user.id))

--- a/backend/tests/unit/test_group_scope.py
+++ b/backend/tests/unit/test_group_scope.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.dialects import postgresql
 from starlette_context import context, request_cycle_context
 
@@ -13,6 +13,7 @@ import app.db.models  # noqa: F401 — registers mappers for ORM compilation
 import app.db.models.test_suite  # noqa: F401
 from app.db.events.group_scope import _group_scope_filter, get_group_scope_clause
 from app.db.models.agent import AgentModel
+from app.db.models.api_key import ApiKeyModel
 from app.db.models.conversation import ConversationModel
 
 
@@ -21,18 +22,23 @@ def _sql(stmt) -> str:
 
 
 @contextmanager
-def caller(*, user_id=None, group_id=None, supervised=()):
+def caller(*, user_id=None, group_id=None, supervised=(), roles=("operator",)):
     with request_cycle_context():
         context["user_id"] = user_id
         context["group_id"] = group_id
         context["supervised_group_ids"] = list(supervised)
-        context["user_roles"] = [SimpleNamespace(name="operator")]
+        context["user_roles"] = [SimpleNamespace(name=role) for role in roles]
         yield
 
 
 def _listener_sql(model_cls):
     """Run the do_orm_execute listener over a bare ORM select and compile the result."""
-    state = SimpleNamespace(is_select=True, execution_options={}, statement=select(model_cls))
+    return _listener_sql_for(select(model_cls))
+
+
+def _listener_sql_for(stmt):
+    """Run the do_orm_execute listener over an arbitrary ORM select and compile the result."""
+    state = SimpleNamespace(is_select=True, execution_options={}, statement=stmt)
     _group_scope_filter(state)
     return _sql(state.statement)
 
@@ -79,3 +85,43 @@ def test_non_supervisors_keep_the_group_equality_form(model_cls):
     group_id = uuid4()
     with caller(user_id=uuid4(), group_id=group_id):
         assert f"users.group_id = '{group_id}'" in _listener_sql(model_cls)
+
+
+def _api_key_statements():
+    return {"page": select(ApiKeyModel), "count": select(func.count(ApiKeyModel.id))}
+
+
+@pytest.mark.parametrize("kind", ["page", "count"])
+def test_api_key_page_and_count_receive_the_ungrouped_criteria(kind):
+    user_id = uuid4()
+    with caller(user_id=user_id):
+        sql = _listener_sql_for(_api_key_statements()[kind])
+
+    assert f"api_keys.created_by = '{user_id}'" in sql
+
+
+@pytest.mark.parametrize("kind", ["page", "count"])
+def test_api_key_page_and_count_receive_the_group_criteria(kind):
+    group_id = uuid4()
+    with caller(user_id=uuid4(), group_id=group_id):
+        sql = _listener_sql_for(_api_key_statements()[kind])
+
+    assert "api_keys.created_by IN (SELECT users.id" in sql
+    assert f"users.group_id = '{group_id}'" in sql
+
+
+@pytest.mark.parametrize("kind", ["page", "count"])
+def test_api_key_page_and_count_receive_the_supervised_criteria(kind):
+    own_group, supervised = uuid4(), uuid4()
+    with caller(user_id=uuid4(), group_id=own_group, supervised=[supervised]):
+        sql = _listener_sql_for(_api_key_statements()[kind])
+
+    assert "api_keys.created_by IN (SELECT users.id" in sql
+    for group_id in (own_group, supervised):
+        assert f"'{group_id}'" in sql
+
+
+@pytest.mark.parametrize("kind", ["page", "count"])
+def test_admins_leave_both_api_key_statements_untouched(kind):
+    with caller(user_id=uuid4(), group_id=uuid4(), roles=("admin",)):
+        assert _listener_sql_for(_api_key_statements()[kind]) == _sql(_api_key_statements()[kind])

--- a/frontend/src/services/apiKeys.ts
+++ b/frontend/src/services/apiKeys.ts
@@ -1,5 +1,6 @@
 import { apiRequest } from "@/config/api";
 import { ApiKey } from "@/interfaces/api-key.interface";
+import { PaginatedResponse } from "@/interfaces/common.interface";
 
 export const getAllApiKeys = async (): Promise<ApiKey[]> => {
   const data = await apiRequest<ApiKey[]>("GET", "api-keys/");
@@ -12,6 +13,27 @@ export const getAllApiKeys = async (): Promise<ApiKey[]> => {
   }
 
   return data;
+};
+
+export const getApiKeysPaginated = async (
+  page: number = 1,
+  pageSize: number = 20,
+  search?: string
+): Promise<PaginatedResponse<ApiKey>> => {
+  const limit = Math.min(Math.max(1, pageSize), 100);
+  const skip = (Math.max(1, page) - 1) * limit;
+  const params = new URLSearchParams({ skip: String(skip), limit: String(limit) });
+  const trimmed = search?.trim();
+  if (trimmed) params.set("search", trimmed);
+
+  const response = await apiRequest<PaginatedResponse<ApiKey>>(
+    "GET",
+    `api-keys/list?${params.toString()}`
+  );
+  // apiRequest returns null on 403; other failures still throw.
+  return (
+    response ?? { items: [], total: 0, page: 1, page_size: limit, total_pages: 0 }
+  );
 };
 
 export const getApiKey = async (id: string): Promise<ApiKey | null> => {

--- a/frontend/src/services/apiKeys.ts
+++ b/frontend/src/services/apiKeys.ts
@@ -2,19 +2,6 @@ import { apiRequest } from "@/config/api";
 import { ApiKey } from "@/interfaces/api-key.interface";
 import { PaginatedResponse } from "@/interfaces/common.interface";
 
-export const getAllApiKeys = async (): Promise<ApiKey[]> => {
-  const data = await apiRequest<ApiKey[]>("GET", "api-keys/");
-  if (!data) {
-    return [];
-  }
-
-  if (!Array.isArray(data)) {
-    return [];
-  }
-
-  return data;
-};
-
 export const getApiKeysPaginated = async (
   page: number = 1,
   pageSize: number = 20,

--- a/frontend/src/views/ApiKeys/components/ApiKeyDialog.tsx
+++ b/frontend/src/views/ApiKeys/components/ApiKeyDialog.tsx
@@ -7,7 +7,8 @@ import { Eye, EyeOff, Copy } from "lucide-react";
 import { useApiKeyDialogState } from "./ApiKeyDialogLogic";
 import {
   ApiKeyDialogFormValues,
-  KEEP_EXPIRY_VALUE,
+  apiKeyExpiryPreset,
+  apiKeyRoleIds,
   buildApiKeyUpdatePayload,
 } from "../helpers/apiKeyUpdatePayload";
 import { ApiKey } from "@/interfaces/api-key.interface";
@@ -106,11 +107,8 @@ export function ApiKeyDialog({
           ? {
               name: apiKeyToEdit.name || "",
               is_active: apiKeyToEdit.is_active === 1,
-              role_ids:
-                apiKeyToEdit.roles?.map((r) => r.id) ||
-                apiKeyToEdit.role_ids ||
-                [],
-              expiry_preset: KEEP_EXPIRY_VALUE,
+              role_ids: apiKeyRoleIds(apiKeyToEdit),
+              expiry_preset: apiKeyExpiryPreset(apiKeyToEdit),
             }
           : null
       }
@@ -157,12 +155,12 @@ export function ApiKeyDialog({
           setHasGeneratedKey(true);
           onApiKeyCreated?.();
         } else {
-          if (!apiKeyToEdit || !userId) {
-            throw new Error("User information is not available.");
+          if (!apiKeyToEdit) {
+            throw new Error("No API key selected.");
           }
           const updatedFromApi = await updateApiKey(
             apiKeyToEdit.id,
-            buildApiKeyUpdatePayload(values)
+            buildApiKeyUpdatePayload(values, apiKeyToEdit)
           );
           onApiKeyUpdated?.(updatedFromApi);
         }
@@ -241,9 +239,6 @@ export function ApiKeyDialog({
                     <SelectValue placeholder="Expiry" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value={KEEP_EXPIRY_VALUE}>
-                      Keep current expiry
-                    </SelectItem>
                     {API_KEY_EXPIRY_PRESET_VALUES.map((opt) => (
                       <SelectItem key={opt.value} value={opt.value}>
                         {opt.label}
@@ -276,9 +271,8 @@ export function ApiKeyDialog({
                 )}
 
                 <p className="text-xs text-muted-foreground">
-                  Keep current expiry leaves it unchanged. A duration restarts it
-                  from now; Never removes it. Rotation restarts the saved
-                  duration.
+                  Changing this restarts the expiry from now; Never removes it.
+                  Rotation restarts the saved duration.
                 </p>
               </div>
             ) : null}

--- a/frontend/src/views/ApiKeys/components/ApiKeyDialog.tsx
+++ b/frontend/src/views/ApiKeys/components/ApiKeyDialog.tsx
@@ -4,10 +4,12 @@ import { Label } from "@/components/label";
 import { FormField } from "@/components/ui/form-field";
 import { CRUDDialog } from "@/components/ui/crud-dialog";
 import { Eye, EyeOff, Copy } from "lucide-react";
+import { useApiKeyDialogState } from "./ApiKeyDialogLogic";
 import {
-  useApiKeyDialogState,
-  inferPresetFromApiKey,
-} from "./ApiKeyDialogLogic";
+  ApiKeyDialogFormValues,
+  KEEP_EXPIRY_VALUE,
+  buildApiKeyUpdatePayload,
+} from "../helpers/apiKeyUpdatePayload";
 import { ApiKey } from "@/interfaces/api-key.interface";
 import { ApiRoleSelection } from "./ApiRoleSelection";
 import { Switch } from "@/components/switch";
@@ -33,13 +35,6 @@ interface ApiKeyDialogProps {
   mode?: "create" | "edit";
   apiKeyToEdit?: ApiKey | null;
 }
-
-type ApiKeyFormValues = {
-  name: string;
-  is_active: boolean;
-  role_ids: string[];
-  expiry_preset: string;
-};
 
 export function ApiKeyDialog({
   isOpen,
@@ -94,7 +89,7 @@ export function ApiKeyDialog({
       : null;
 
   return (
-    <CRUDDialog<ApiKeyFormValues>
+    <CRUDDialog<ApiKeyDialogFormValues>
       open={isOpen}
       onOpenChange={onOpenChange}
       mode={dialogMode}
@@ -115,7 +110,7 @@ export function ApiKeyDialog({
                 apiKeyToEdit.roles?.map((r) => r.id) ||
                 apiKeyToEdit.role_ids ||
                 [],
-              expiry_preset: inferPresetFromApiKey(apiKeyToEdit),
+              expiry_preset: KEEP_EXPIRY_VALUE,
             }
           : null
       }
@@ -165,16 +160,10 @@ export function ApiKeyDialog({
           if (!apiKeyToEdit || !userId) {
             throw new Error("User information is not available.");
           }
-          const expiresInDays = presetToExpiresInDays(values.expiry_preset);
-          const updateData: Partial<ApiKey> & { role_ids?: string[] } = {
-            name: values.name,
-            user_id: userId,
-            is_active: values.is_active ? 1 : 0,
-            role_ids: values.role_ids,
-            // undefined ("never") => backend expects 0 to clear/store Never.
-            expires_in_days: expiresInDays ?? 0,
-          };
-          const updatedFromApi = await updateApiKey(apiKeyToEdit.id, updateData);
+          const updatedFromApi = await updateApiKey(
+            apiKeyToEdit.id,
+            buildApiKeyUpdatePayload(values)
+          );
           onApiKeyUpdated?.(updatedFromApi);
         }
       }}
@@ -195,7 +184,7 @@ export function ApiKeyDialog({
               </Button>
             )}
             {dialogMode === "edit" && (
-              <Button type="submit" disabled={busy || !hasGeneratedKey}>
+              <Button type="submit" disabled={busy}>
                 {busy ? "Updating..." : "Update Key"}
               </Button>
             )}
@@ -243,7 +232,7 @@ export function ApiKeyDialog({
 
             {dialogMode === "edit" ? (
               <div className="space-y-2">
-                <Label>Credential expires</Label>
+                <Label htmlFor="credential-expiry-edit">Credential expires</Label>
                 <Select
                   value={values.expiry_preset}
                   onValueChange={(v) => setField("expiry_preset", v)}
@@ -252,6 +241,9 @@ export function ApiKeyDialog({
                     <SelectValue placeholder="Expiry" />
                   </SelectTrigger>
                   <SelectContent>
+                    <SelectItem value={KEEP_EXPIRY_VALUE}>
+                      Keep current expiry
+                    </SelectItem>
                     {API_KEY_EXPIRY_PRESET_VALUES.map((opt) => (
                       <SelectItem key={opt.value} value={opt.value}>
                         {opt.label}
@@ -270,6 +262,12 @@ export function ApiKeyDialog({
                     ) : (
                       <span>Expiration is set.</span>
                     )}
+                    {apiKeyToEdit.credential_expiry_days ? (
+                      <span className="text-muted-foreground">
+                        {" "}
+                        ({apiKeyToEdit.credential_expiry_days}-day policy)
+                      </span>
+                    ) : null}
                   </div>
                 ) : (
                   <p className="text-xs text-muted-foreground">
@@ -278,8 +276,9 @@ export function ApiKeyDialog({
                 )}
 
                 <p className="text-xs text-muted-foreground">
-                  On rotate, expiration will be recalculated from now based on
-                  this setting (unless set to Never).
+                  Keep current expiry leaves it unchanged. A duration restarts it
+                  from now; Never removes it. Rotation restarts the saved
+                  duration.
                 </p>
               </div>
             ) : null}

--- a/frontend/src/views/ApiKeys/components/ApiKeyDialogLogic.tsx
+++ b/frontend/src/views/ApiKeys/components/ApiKeyDialogLogic.tsx
@@ -5,27 +5,6 @@ import { toast } from "react-hot-toast";
 import { Role } from "@/interfaces/role.interface";
 import { ApiKey } from "@/interfaces/api-key.interface";
 
-const PRESET_DAY_VALUES = new Set([30, 90, 180, 365]);
-
-export function inferPresetFromApiKey(apiKey: ApiKey): string {
-  if (typeof apiKey.credential_expiry_days === "number") {
-    if (apiKey.credential_expiry_days <= 0) return "never";
-    return String(apiKey.credential_expiry_days);
-  }
-
-  // Legacy fallback: try to infer from created_at -> credential_expires_at (if present).
-  if (apiKey.created_at && apiKey.credential_expires_at) {
-    const createdMs = new Date(apiKey.created_at).getTime();
-    const expMs = new Date(apiKey.credential_expires_at).getTime();
-    if (!Number.isNaN(createdMs) && !Number.isNaN(expMs) && expMs > createdMs) {
-      const days = Math.round((expMs - createdMs) / (24 * 60 * 60 * 1000));
-      if (PRESET_DAY_VALUES.has(days)) return String(days);
-    }
-  }
-
-  return "never";
-}
-
 /**
  * Non-form state for the API key dialog: the authenticated user, the roles
  * available to assign, and the one-time "generated key" reveal state. The form

--- a/frontend/src/views/ApiKeys/components/ApiKeysCard.tsx
+++ b/frontend/src/views/ApiKeys/components/ApiKeysCard.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { DataTable, Column } from '@/components/ui/data-table';
+import { PaginationBar } from '@/components/PaginationBar';
 import { LIST_PAGE_SIZE } from '@/constants/pagination';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { Button } from '@/components/button';
 import { Badge } from '@/components/badge';
 import { KeyRound, Pencil, RefreshCw, Trash } from 'lucide-react';
@@ -8,13 +10,13 @@ import { ListEmptyState } from '@/components/ListEmptyState';
 import { ApiKeyExpiryLines } from '@/components/api-keys/ApiKeyExpiryLines';
 import { RotateApiKeyDialog, type RotateApiKeyTarget } from '@/components/api-keys/RotateApiKeyDialog';
 import { ApiKey } from '@/interfaces/api-key.interface';
-import { getAllApiKeys } from '@/services/apiKeys';
-import { getAllUsers } from '@/services/users';
+import { getApiKeysPaginated } from '@/services/apiKeys';
 import { toast } from 'react-hot-toast';
 import { formatDate } from '@/helpers/utils';
-import { User } from '@/interfaces/user.interface';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/RadixTooltip';
 import { TooltipButton } from '@/components/tooltip-button';
+
+const SEARCH_DEBOUNCE_MS = 300;
 
 interface ApiKeysCardProps {
   searchQuery: string;
@@ -36,37 +38,65 @@ export function ApiKeysCard({
   onDeleteApiKey,
 }: ApiKeysCardProps) {
   const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
-  const [users, setUsers] = useState<User[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [rotateTarget, setRotateTarget] = useState<RotateApiKeyTarget | null>(null);
 
+  const debouncedSearch = useDebouncedValue(searchQuery, SEARCH_DEBOUNCE_MS).trim();
+  const requestSeqRef = useRef(0);
+  const lastResetSigRef = useRef(`${debouncedSearch}|${refreshKey}`);
+
+  const fetchData = useCallback(async () => {
+    const seq = ++requestSeqRef.current;
+
+    const resetSig = `${debouncedSearch}|${refreshKey}`;
+    if (resetSig !== lastResetSigRef.current) {
+      lastResetSigRef.current = resetSig;
+      // A new search or a create/edit/delete refresh belongs on page 1
+      if (page !== 1) {
+        setPage(1);
+        return;
+      }
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getApiKeysPaginated(page, LIST_PAGE_SIZE, debouncedSearch);
+      if (seq !== requestSeqRef.current) return;
+
+      // Rows removed elsewhere can leave the page past the end: fall back to the last valid page
+      const lastPage = Math.max(1, data.total_pages);
+      if (data.items.length === 0 && page > lastPage) {
+        setPage(lastPage);
+        return;
+      }
+
+      setApiKeys(data.items);
+      setTotal(data.total);
+    } catch (err) {
+      if (seq !== requestSeqRef.current) return;
+      setError(err instanceof Error ? err.message : 'Failed to fetch data');
+      toast.error('Failed to fetch data.');
+    } finally {
+      if (seq === requestSeqRef.current) setLoading(false);
+    }
+  }, [page, debouncedSearch, refreshKey]);
+
   useEffect(() => {
     fetchData();
-  }, [refreshKey]);
+    return () => {
+      requestSeqRef.current += 1;
+    };
+  }, [fetchData]);
 
   useEffect(() => {
     if (updatedApiKey) {
       setApiKeys((prevKeys) => prevKeys.map((key) => (key.id === updatedApiKey.id ? updatedApiKey : key)));
     }
   }, [updatedApiKey]);
-
-  const fetchData = async () => {
-    try {
-      setLoading(true);
-      const [keysData, usersData] = await Promise.all([getAllApiKeys(), getAllUsers()]);
-      setApiKeys(keysData);
-      setUsers(usersData);
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch data');
-      toast.error('Failed to fetch data.');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const filteredApiKeys = apiKeys.filter((apiKey) => apiKey.name.toLowerCase().includes(searchQuery.toLowerCase()));
 
   const columns: Column<ApiKey>[] = [
     {
@@ -149,24 +179,23 @@ export function ApiKeysCard({
   return (
     <>
       <DataTable
-        data={filteredApiKeys}
+        data={apiKeys}
         columns={columns}
         loading={loading}
         error={error}
         onRetry={fetchData}
-        searchQuery={searchQuery}
-        pageSize={LIST_PAGE_SIZE}
+        searchQuery={debouncedSearch}
         emptyState={
           <ListEmptyState
             icon={<KeyRound className="h-12 w-12 text-muted-foreground" />}
-            title={searchQuery ? "No matching API keys" : "No API keys yet"}
+            title={debouncedSearch ? "No matching API keys" : "No API keys yet"}
             description={
-              searchQuery
+              debouncedSearch
                 ? "No API keys match your search. Try a different name."
                 : "API keys let external services authenticate with the platform. Create one to grant programmatic access."
             }
             action={
-              !searchQuery && onCreateApiKey ? (
+              !debouncedSearch && onCreateApiKey ? (
                 <Button className="rounded-full" onClick={onCreateApiKey}>
                   Generate your first API key
                 </Button>
@@ -175,6 +204,15 @@ export function ApiKeysCard({
           />
         }
       />
+      {!loading && !error && (
+        <PaginationBar
+          total={total}
+          currentPage={page}
+          pageSize={LIST_PAGE_SIZE}
+          pageItemCount={apiKeys.length}
+          onPageChange={setPage}
+        />
+      )}
       <RotateApiKeyDialog
         open={rotateTarget !== null}
         target={rotateTarget}

--- a/frontend/src/views/ApiKeys/helpers/apiKeyUpdatePayload.ts
+++ b/frontend/src/views/ApiKeys/helpers/apiKeyUpdatePayload.ts
@@ -1,9 +1,6 @@
 import type { ApiKey } from "@/interfaces/api-key.interface";
 import { presetToExpiresInDays } from "@/components/api-keys/apiKeyExpiryPresets";
 
-/** Edit-only expiry choice */
-export const KEEP_EXPIRY_VALUE = "__keep__";
-
 export type ApiKeyDialogFormValues = {
   name: string;
   is_active: boolean;
@@ -11,24 +8,53 @@ export type ApiKeyDialogFormValues = {
   expiry_preset: string;
 };
 
-/** Builds the PATCH body for an edit; expiry is only sent when the user changed it. */
+/** Role ids already on a key, from whichever shape the API returned. */
+export function apiKeyRoleIds(apiKey: ApiKey): string[] {
+  return apiKey.roles?.map((role) => role.id) || apiKey.role_ids || [];
+}
+
+/** Expiry preset a key currently stores; no stored expiry reads as "never". */
+export function apiKeyExpiryPreset(apiKey: ApiKey): string {
+  const days = apiKey.credential_expiry_days;
+  return typeof days === "number" && days > 0 ? String(days) : "never";
+}
+
+const sameRoleSelection = (selected: string[], current: string[]) => {
+  const currentIds = new Set(current);
+  return (
+    selected.length === current.length &&
+    selected.every((id) => currentIds.has(id))
+  );
+};
+
+/** Builds the PATCH body for an edit; expiry and roles are only sent when the user changed them. */
 export function buildApiKeyUpdatePayload(
-  values: ApiKeyDialogFormValues
+  values: ApiKeyDialogFormValues,
+  apiKeyToEdit: ApiKey
 ): Partial<ApiKey> {
   const payload: Partial<ApiKey> = {
     name: values.name,
     is_active: values.is_active ? 1 : 0,
-    role_ids: values.role_ids,
   };
-  if (values.expiry_preset === "never") {
-    // 0 clears the stored expiry; a duration restarts it from now.
-    payload.expires_in_days = 0;
-  } else if (values.expiry_preset !== KEEP_EXPIRY_VALUE) {
-    const days = presetToExpiresInDays(values.expiry_preset);
-    if (days === undefined) {
-      throw new Error("Invalid expiry selection.");
+
+  // The picker only lists the caller's own roles, and the backend rejects role ids the caller
+  // does not hold: resend the selection only when it changed.
+  if (!sameRoleSelection(values.role_ids, apiKeyRoleIds(apiKeyToEdit))) {
+    payload.role_ids = values.role_ids;
+  }
+
+  // Sending expires_in_days restarts the deadline from now, so an untouched preset is omitted.
+  if (values.expiry_preset !== apiKeyExpiryPreset(apiKeyToEdit)) {
+    if (values.expiry_preset === "never") {
+      // 0 clears the stored expiry.
+      payload.expires_in_days = 0;
+    } else {
+      const days = presetToExpiresInDays(values.expiry_preset);
+      if (days === undefined) {
+        throw new Error("Invalid expiry selection.");
+      }
+      payload.expires_in_days = days;
     }
-    payload.expires_in_days = days;
   }
   return payload;
 }

--- a/frontend/src/views/ApiKeys/helpers/apiKeyUpdatePayload.ts
+++ b/frontend/src/views/ApiKeys/helpers/apiKeyUpdatePayload.ts
@@ -1,0 +1,34 @@
+import type { ApiKey } from "@/interfaces/api-key.interface";
+import { presetToExpiresInDays } from "@/components/api-keys/apiKeyExpiryPresets";
+
+/** Edit-only expiry choice */
+export const KEEP_EXPIRY_VALUE = "__keep__";
+
+export type ApiKeyDialogFormValues = {
+  name: string;
+  is_active: boolean;
+  role_ids: string[];
+  expiry_preset: string;
+};
+
+/** Builds the PATCH body for an edit; expiry is only sent when the user changed it. */
+export function buildApiKeyUpdatePayload(
+  values: ApiKeyDialogFormValues
+): Partial<ApiKey> {
+  const payload: Partial<ApiKey> = {
+    name: values.name,
+    is_active: values.is_active ? 1 : 0,
+    role_ids: values.role_ids,
+  };
+  if (values.expiry_preset === "never") {
+    // 0 clears the stored expiry; a duration restarts it from now.
+    payload.expires_in_days = 0;
+  } else if (values.expiry_preset !== KEEP_EXPIRY_VALUE) {
+    const days = presetToExpiresInDays(values.expiry_preset);
+    if (days === undefined) {
+      throw new Error("Invalid expiry selection.");
+    }
+    payload.expires_in_days = days;
+  }
+  return payload;
+}

--- a/frontend/src/views/ApiKeys/pages/ApiKeys.tsx
+++ b/frontend/src/views/ApiKeys/pages/ApiKeys.tsx
@@ -87,7 +87,7 @@ export default function ApiKeys() {
         isOpen={isDialogOpen}
         onOpenChange={setIsDialogOpen}
         onApiKeyCreated={handleApiKeySaved}
-        onApiKeyUpdated={handleApiKeyUpdated}
+        onApiKeyUpdated={handleApiKeySaved}
         apiKeyToEdit={apiKeyToEdit}
         mode={dialogMode}
       />

--- a/frontend/tests/services/apiKeys.test.ts
+++ b/frontend/tests/services/apiKeys.test.ts
@@ -12,7 +12,6 @@ vi.mock("@/config/api", () => ({
 
 import { apiRequest } from "@/config/api";
 import {
-  getAllApiKeys,
   getApiKeysPaginated,
   getApiKey,
   createApiKey,
@@ -25,30 +24,6 @@ import {
 
 const mockApiRequest = vi.mocked(apiRequest);
 beforeEach(() => vi.clearAllMocks());
-
-describe("getAllApiKeys", () => {
-  it("requests the api-keys list and returns the array", async () => {
-    const keys = [{ id: "k1" }];
-    mockApiRequest.mockResolvedValue(keys as never);
-
-    const result = await getAllApiKeys();
-
-    expect(mockApiRequest).toHaveBeenCalledWith("GET", "api-keys/");
-    expect(result).toBe(keys);
-  });
-
-  it("returns an empty array when the response is null", async () => {
-    mockApiRequest.mockResolvedValue(null as never);
-
-    await expect(getAllApiKeys()).resolves.toEqual([]);
-  });
-
-  it("returns an empty array when the response is not an array", async () => {
-    mockApiRequest.mockResolvedValue({ not: "array" } as never);
-
-    await expect(getAllApiKeys()).resolves.toEqual([]);
-  });
-});
 
 describe("getApiKeysPaginated", () => {
   const page = <T,>(items: T[]) => ({

--- a/frontend/tests/services/apiKeys.test.ts
+++ b/frontend/tests/services/apiKeys.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/config/api", () => ({
 import { apiRequest } from "@/config/api";
 import {
   getAllApiKeys,
+  getApiKeysPaginated,
   getApiKey,
   createApiKey,
   updateApiKey,
@@ -46,6 +47,95 @@ describe("getAllApiKeys", () => {
     mockApiRequest.mockResolvedValue({ not: "array" } as never);
 
     await expect(getAllApiKeys()).resolves.toEqual([]);
+  });
+});
+
+describe("getApiKeysPaginated", () => {
+  const page = <T,>(items: T[]) => ({
+    items,
+    total: items.length,
+    page: 1,
+    page_size: 20,
+    total_pages: 1,
+  });
+
+  const requestedUrl = () => String(mockApiRequest.mock.calls[0][1]);
+
+  it("defaults to the first page of 20", async () => {
+    mockApiRequest.mockResolvedValue(page([{ id: "k1" }]) as never);
+
+    await getApiKeysPaginated();
+
+    expect(mockApiRequest).toHaveBeenCalledWith("GET", "api-keys/list?skip=0&limit=20");
+  });
+
+  it("converts page and pageSize into skip and limit", async () => {
+    mockApiRequest.mockResolvedValue(page([]) as never);
+
+    await getApiKeysPaginated(3, 10);
+
+    expect(requestedUrl()).toBe("api-keys/list?skip=20&limit=10");
+  });
+
+  it("clamps pageSize to the backend maximum of 100", async () => {
+    mockApiRequest.mockResolvedValue(page([]) as never);
+
+    await getApiKeysPaginated(1, 500);
+
+    expect(requestedUrl()).toContain("limit=100");
+  });
+
+  it("clamps page and pageSize to their minimums", async () => {
+    mockApiRequest.mockResolvedValue(page([]) as never);
+
+    await getApiKeysPaginated(0, 0);
+
+    expect(requestedUrl()).toBe("api-keys/list?skip=0&limit=1");
+  });
+
+  it("passes a trimmed search term", async () => {
+    mockApiRequest.mockResolvedValue(page([]) as never);
+
+    await getApiKeysPaginated(1, 20, "  ana  ");
+
+    expect(requestedUrl()).toBe("api-keys/list?skip=0&limit=20&search=ana");
+  });
+
+  it("omits the search param when it is absent or blank", async () => {
+    mockApiRequest.mockResolvedValue(page([]) as never);
+
+    await getApiKeysPaginated(1, 20, "   ");
+    expect(requestedUrl()).not.toContain("search");
+
+    vi.clearAllMocks();
+    mockApiRequest.mockResolvedValue(page([]) as never);
+    await getApiKeysPaginated(1, 20, undefined);
+    expect(requestedUrl()).not.toContain("search");
+  });
+
+  it("returns the paginated body unchanged", async () => {
+    const body = page([{ id: "k1" }, { id: "k2" }]);
+    mockApiRequest.mockResolvedValue(body as never);
+
+    await expect(getApiKeysPaginated()).resolves.toEqual(body);
+  });
+
+  it("returns an empty page when the response is null (403)", async () => {
+    mockApiRequest.mockResolvedValue(null as never);
+
+    await expect(getApiKeysPaginated(2, 50)).resolves.toEqual({
+      items: [],
+      total: 0,
+      page: 1,
+      page_size: 50,
+      total_pages: 0,
+    });
+  });
+
+  it("propagates non-403 errors", async () => {
+    mockApiRequest.mockRejectedValue(new Error("boom"));
+
+    await expect(getApiKeysPaginated()).rejects.toThrow("boom");
   });
 });
 

--- a/frontend/tests/views/ApiKeys/helpers/apiKeyUpdatePayload.test.ts
+++ b/frontend/tests/views/ApiKeys/helpers/apiKeyUpdatePayload.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  KEEP_EXPIRY_VALUE,
+  buildApiKeyUpdatePayload,
+} from "@/views/ApiKeys/helpers/apiKeyUpdatePayload";
+
+const base = { name: "renamed", is_active: true, role_ids: ["r1"] };
+
+describe("buildApiKeyUpdatePayload", () => {
+  it("omits expires_in_days when the expiry is kept", () => {
+    const payload = buildApiKeyUpdatePayload({
+      ...base,
+      expiry_preset: KEEP_EXPIRY_VALUE,
+    });
+    expect(payload).toEqual({ name: "renamed", is_active: 1, role_ids: ["r1"] });
+    expect(payload).not.toHaveProperty("expires_in_days");
+    expect(payload).not.toHaveProperty("user_id");
+  });
+
+  it("sends 0 for Never and the day count for a duration", () => {
+    expect(
+      buildApiKeyUpdatePayload({ ...base, expiry_preset: "never" })
+        .expires_in_days
+    ).toBe(0);
+    expect(
+      buildApiKeyUpdatePayload({ ...base, expiry_preset: "90" }).expires_in_days
+    ).toBe(90);
+  });
+
+  it("maps the active switch to 0/1 and passes roles through", () => {
+    const payload = buildApiKeyUpdatePayload({
+      ...base,
+      is_active: false,
+      role_ids: [],
+      expiry_preset: KEEP_EXPIRY_VALUE,
+    });
+    expect(payload.is_active).toBe(0);
+    expect(payload.role_ids).toEqual([]);
+  });
+
+  it.each(["", "unknown", "abc-30"])(
+    "rejects an unrecognised expiry %j instead of clearing it",
+    (preset) => {
+      expect(() =>
+        buildApiKeyUpdatePayload({ ...base, expiry_preset: preset })
+      ).toThrow("Invalid expiry selection.");
+    }
+  );
+});

--- a/frontend/tests/views/ApiKeys/helpers/apiKeyUpdatePayload.test.ts
+++ b/frontend/tests/views/ApiKeys/helpers/apiKeyUpdatePayload.test.ts
@@ -1,48 +1,71 @@
 import { describe, expect, it } from "vitest";
-import {
-  KEEP_EXPIRY_VALUE,
-  buildApiKeyUpdatePayload,
-} from "@/views/ApiKeys/helpers/apiKeyUpdatePayload";
+import type { ApiKey } from "@/interfaces/api-key.interface";
+import { buildApiKeyUpdatePayload } from "@/views/ApiKeys/helpers/apiKeyUpdatePayload";
 
 const base = { name: "renamed", is_active: true, role_ids: ["r1"] };
+const edited = {
+  id: "k1",
+  role_ids: ["r1"],
+  credential_expiry_days: 90,
+} as unknown as ApiKey;
+const neverExpires = { id: "k1", role_ids: ["r1"] } as unknown as ApiKey;
 
 describe("buildApiKeyUpdatePayload", () => {
-  it("omits expires_in_days when the expiry is kept", () => {
-    const payload = buildApiKeyUpdatePayload({
-      ...base,
-      expiry_preset: KEEP_EXPIRY_VALUE,
-    });
-    expect(payload).toEqual({ name: "renamed", is_active: 1, role_ids: ["r1"] });
-    expect(payload).not.toHaveProperty("expires_in_days");
+  it("omits expires_in_days when the preset still matches the stored expiry", () => {
+    const payload = buildApiKeyUpdatePayload(
+      { ...base, expiry_preset: "90" },
+      edited
+    );
+    expect(payload).toEqual({ name: "renamed", is_active: 1 });
     expect(payload).not.toHaveProperty("user_id");
+
+    expect(
+      buildApiKeyUpdatePayload({ ...base, expiry_preset: "never" }, neverExpires)
+    ).not.toHaveProperty("expires_in_days");
   });
 
   it("sends 0 for Never and the day count for a duration", () => {
     expect(
-      buildApiKeyUpdatePayload({ ...base, expiry_preset: "never" })
+      buildApiKeyUpdatePayload({ ...base, expiry_preset: "never" }, edited)
         .expires_in_days
     ).toBe(0);
     expect(
-      buildApiKeyUpdatePayload({ ...base, expiry_preset: "90" }).expires_in_days
+      buildApiKeyUpdatePayload({ ...base, expiry_preset: "30" }, edited)
+        .expires_in_days
+    ).toBe(30);
+    expect(
+      buildApiKeyUpdatePayload({ ...base, expiry_preset: "90" }, neverExpires)
+        .expires_in_days
     ).toBe(90);
   });
 
-  it("maps the active switch to 0/1 and passes roles through", () => {
-    const payload = buildApiKeyUpdatePayload({
-      ...base,
-      is_active: false,
-      role_ids: [],
-      expiry_preset: KEEP_EXPIRY_VALUE,
-    });
+  it("maps the active switch to 0/1 and sends a changed role selection", () => {
+    const payload = buildApiKeyUpdatePayload(
+      {
+        ...base,
+        is_active: false,
+        role_ids: [],
+        expiry_preset: "90",
+      },
+      edited
+    );
     expect(payload.is_active).toBe(0);
     expect(payload.role_ids).toEqual([]);
+  });
+
+  it("omits role_ids when the selection is unchanged, whatever its order", () => {
+    const payload = buildApiKeyUpdatePayload(
+      { ...base, role_ids: ["r2", "r1"], expiry_preset: "never" },
+      { id: "k1", roles: [{ id: "r1" }, { id: "r2" }] } as unknown as ApiKey
+    );
+    expect(payload).not.toHaveProperty("role_ids");
   });
 
   it.each(["", "unknown", "abc-30"])(
     "rejects an unrecognised expiry %j instead of clearing it",
     (preset) => {
       expect(() =>
-        buildApiKeyUpdatePayload({ ...base, expiry_preset: preset })
+        buildApiKeyUpdatePayload({ ...base, expiry_preset: preset }, edited)
       ).toThrow("Invalid expiry selection.");
     }
   );

--- a/ui_tests/tests/apiKeys.spec.ts
+++ b/ui_tests/tests/apiKeys.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from './fixtures';
+import type { Page, Route } from '@playwright/test';
 
 test('API Keys › create, edit, and revoke', async ({ page }) => {
   const randomSuffix = Math.floor(Math.random() * 100000);
@@ -73,4 +74,214 @@ await page.waitForTimeout(1000);
   await expect(updatedRow).toBeVisible();
   await page.waitForTimeout(1000);
 
+});
+
+// The tests below serve the list from an in-memory store so a tenant with more
+// keys than one page fits can be set up deterministically
+
+type StoredKey = {
+  id: string;
+  name: string;
+  is_active: number;
+  user_id: string;
+  roles: [];
+  created_at: string;
+};
+
+const BASE_MS = Date.UTC(2026, 0, 1, 12, 0);
+
+const makeKey = (id: string, name: string, ageMinutes: number): StoredKey => ({
+  id,
+  name,
+  is_active: 1,
+  user_id: 'mock-user',
+  roles: [],
+  created_at: new Date(BASE_MS - ageMinutes * 60_000).toISOString(),
+});
+
+const seedStore = (count: number): StoredKey[] =>
+  Array.from({ length: count }, (_, i) => makeKey(`mock-${i}`, `zz_mock_${String(i).padStart(2, '0')}`, i));
+
+type ListHook = (url: URL, route: Route) => Promise<boolean> | boolean;
+
+
+async function mockApiKeys(page: Page, store: StoredKey[], onList?: ListHook): Promise<URL[]> {
+  const listUrls: URL[] = [];
+
+  await page.route('**/api-keys**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const method = request.method();
+
+    if (method === 'GET' && url.pathname.endsWith('/api-keys/list')) {
+      listUrls.push(url);
+      if (onList && (await onList(url, route))) return;
+
+      const skip = Number(url.searchParams.get('skip') ?? '0');
+      const limit = Number(url.searchParams.get('limit') ?? '20');
+      const search = (url.searchParams.get('search') ?? '').toLowerCase();
+      const matched = search ? store.filter((key) => key.name.toLowerCase().includes(search)) : store;
+
+      return route.fulfill({
+        json: {
+          items: matched.slice(skip, skip + limit),
+          total: matched.length,
+          page: Math.floor(skip / limit) + 1,
+          page_size: limit,
+          total_pages: Math.ceil(matched.length / limit),
+        },
+      });
+    }
+
+    if (method === 'POST' && url.pathname.endsWith('/api-keys')) {
+      const body = request.postDataJSON() as { name: string };
+      const created = makeKey(`mock-new-${store.length}`, body.name, -1);
+      store.unshift(created);
+      return route.fulfill({ json: { ...created, key_val: 'mock-secret-value' } });
+    }
+
+    if (method === 'PATCH' && /\/api-keys\/[^/]+$/.test(url.pathname)) {
+      const id = url.pathname.split('/').pop();
+      const body = request.postDataJSON() as { name?: string };
+      const row = store.find((key) => key.id === id);
+      if (!row) return route.fulfill({ status: 404, json: { detail: 'not found' } });
+      if (typeof body.name === 'string') row.name = body.name;
+      return route.fulfill({ json: row });
+    }
+
+    return route.fallback();
+  });
+
+  return listUrls;
+}
+
+async function openApiKeys(page: Page) {
+  await page.getByRole('button', { name: 'Admin Tools' }).click();
+  await page.getByRole('link', { name: /api keys/i }).click();
+  await page.waitForURL('**/api-keys');
+}
+
+const pageLink = (page: Page, number: string) => page.getByRole('link', { name: number, exact: true });
+
+test('API Keys › every key is reachable when there are more than one page of them', async ({ page }) => {
+  const store = seedStore(21);
+  const listUrls = await mockApiKeys(page, store);
+
+  await openApiKeys(page);
+
+  await expect(page.getByText('Showing 1 to 10 of 21 results')).toBeVisible();
+  expect(listUrls[0].searchParams.get('skip')).toBe('0');
+  expect(listUrls[0].searchParams.get('limit')).toBe('10');
+
+  await pageLink(page, '2').click();
+  await expect(page.getByText('Showing 11 to 20 of 21 results')).toBeVisible();
+  expect(listUrls[listUrls.length - 1].searchParams.get('skip')).toBe('10');
+
+  await pageLink(page, '3').click();
+  await expect(page.getByText('Showing 21 to 21 of 21 results')).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'zz_mock_20' })).toBeVisible();
+});
+
+test('API Keys › a key created from a later page lands on top of page 1', async ({ page }) => {
+  const store = seedStore(21);
+  const listUrls = await mockApiKeys(page, store);
+  const createdName = 'zz_mock_created';
+
+  await openApiKeys(page);
+  await pageLink(page, '2').click();
+  await expect(page.getByText('Showing 11 to 20 of 21 results')).toBeVisible();
+
+  await page.getByRole('button', { name: /generate new api key/i }).click();
+  await page.getByRole('textbox', { name: /name/i }).fill(createdName);
+  await Promise.all([
+    page.waitForResponse(
+      (response) => response.request().method() === 'POST' && response.url().includes('/api-keys')
+    ),
+    page.getByRole('button', { name: /^Generate Key$/i }).click(),
+  ]);
+  await page.getByRole('button', { name: 'Cancel' }).click();
+
+  await expect(page.getByText('Showing 1 to 10 of 22 results')).toBeVisible();
+  await expect(page.getByRole('cell', { name: createdName })).toBeVisible();
+  expect(listUrls[listUrls.length - 1].searchParams.get('skip')).toBe('0');
+});
+
+test('API Keys › a page past the end falls back to the last page that has rows', async ({ page }) => {
+  const store = seedStore(21);
+  const listUrls = await mockApiKeys(page, store);
+
+  await openApiKeys(page);
+  await pageLink(page, '2').click();
+  await expect(page.getByText('Showing 11 to 20 of 21 results')).toBeVisible();
+
+  store.splice(15);
+
+  await pageLink(page, '3').click();
+  await expect(page.getByText('Showing 11 to 15 of 15 results')).toBeVisible();
+
+  const skips = listUrls.map((url) => url.searchParams.get('skip'));
+  expect(skips.slice(-2)).toEqual(['20', '10']);
+});
+
+test('API Keys › a failed list offers a retry that recovers', async ({ page }) => {
+  const store = seedStore(12);
+  let failNext = true;
+  await mockApiKeys(page, store, async (_url, route) => {
+    if (!failNext) return false;
+    failNext = false;
+    await route.fulfill({ status: 500, json: { detail: 'boom' } });
+    return true;
+  });
+
+  await openApiKeys(page);
+
+  const retry = page.getByRole('button', { name: 'Try again' });
+  await expect(retry).toBeVisible();
+  await retry.click();
+
+  await expect(page.getByText('Showing 1 to 10 of 12 results')).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'zz_mock_00' })).toBeVisible();
+});
+
+test('API Keys › a slow search response cannot overwrite a newer one', async ({ page }) => {
+  const store = [
+    ...Array.from({ length: 4 }, (_, i) => makeKey(`ab-${i}`, `zz_ab_${i}`, i)),
+    ...Array.from({ length: 6 }, (_, i) => makeKey(`alpha-${i}`, `zz_alpha_${i}`, 10 + i)),
+  ];
+
+  let release = () => {};
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await mockApiKeys(page, store, async (url) => {
+    if (url.searchParams.get('search') === 'a') await held;
+    return false;
+  });
+
+  await openApiKeys(page);
+  await expect(page.getByText('Showing 1 to 10 of 10 results')).toBeVisible();
+
+  const search = page.getByPlaceholder('Search API keys...');
+  const searchTerm = (url: string) => new URL(url).searchParams.get('search');
+
+  const requestA = page.waitForRequest((request) => searchTerm(request.url()) === 'a');
+  await search.fill('a');
+  await requestA;
+
+  const responseB = page.waitForResponse((response) => searchTerm(response.url()) === 'ab');
+  await search.fill('ab');
+  await responseB;
+
+  await expect(page.getByText('Showing 1 to 4 of 4 results')).toBeVisible();
+
+  const responseA = page.waitForResponse((response) => searchTerm(response.url()) === 'a');
+  release();
+  await responseA;
+
+  await page.evaluate(
+    () => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+  );
+
+  await expect(page.getByText('Showing 1 to 4 of 4 results')).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'zz_alpha_0' })).toHaveCount(0);
 });

--- a/ui_tests/tests/apiKeys.spec.ts
+++ b/ui_tests/tests/apiKeys.spec.ts
@@ -140,15 +140,6 @@ async function mockApiKeys(page: Page, store: StoredKey[], onList?: ListHook): P
       return route.fulfill({ json: { ...created, key_val: 'mock-secret-value' } });
     }
 
-    if (method === 'PATCH' && /\/api-keys\/[^/]+$/.test(url.pathname)) {
-      const id = url.pathname.split('/').pop();
-      const body = request.postDataJSON() as { name?: string };
-      const row = store.find((key) => key.id === id);
-      if (!row) return route.fulfill({ status: 404, json: { detail: 'not found' } });
-      if (typeof body.name === 'string') row.name = body.name;
-      return route.fulfill({ json: row });
-    }
-
     return route.fallback();
   });
 


### PR DESCRIPTION
## Description

The API Keys page only ever showed the 20 oldest keys. The backend list endpoint (`GET /api-keys/`) defaults to `limit=20` and ordered by `created_at ASC`, and the frontend called it without any `skip`/`limit`, so any key beyond the first twenty was invisible, including newly created ones. Search filtered the already-fetched array in the browser, so it could never find a key that wasn't in that truncated set. The "Update Key" button stayed disabled, and the edit form guessed the key's current expiry from `created_at` / `credential_expires_at`. A wrong guess silently rewrote the expiry (usually to "Never") on an unrelated save, so renaming a key could wipe its expiration date.
A server-side paginated list is added (newest first, DB-side name search) and fixes the edit dialog so expiry is only changed when the user deliberately changes it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [x] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

- New `GET /api-keys/list` endpoint returning `PaginatedResponse[ApiKeySafeRead]`, declared before `/{api_key_id}` so `list` is not matched as a UUID path param
-`ApiKeysRepository.get_list_paginated()` — orders by `created_at DESC, id DESC`, filters `is_deleted == 0`, and returns the unpaginated total alongside the page
- Case-insensitive `ILIKE` name search with `%`, `_` and `\` escaped, applied to both the count and the data query
- New `ApiKeyListFilter` schema (`skip` >= 0, `limit` 1–100 default 20, optional `search`)
- `getApiKeysPaginated()` service calling the new endpoint, clamping page size and trimming the search term
- `ApiKeysCard` now fetches one page at a time with a `PaginationBar`, a 300ms debounced search, request-sequence guards against out-of-order responses, and a fallback to the last valid page when rows are deleted elsewhere
- Dropped the `getAllUsers()` call
- Re-enabled the "Update Key" button in edit mode (it was gated on `hasGeneratedKey`)
- Expiry on edit now seeds from the key's stored credential_expiry_days (apiKeyExpiryPreset()), dropping inferPresetFromApiKey()'s created_at/credential_expires_at guesswork; the new buildApiKeyUpdatePayload() helper omits expires_in_days unless the user picks a different option, since sending it restarts the credential deadline from now.
- Edit dialog shows the key's current expiry policy and clearer help text

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [x] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues


Closes #

## Screenshots (if applicable)


---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
