### PR TITLE
enhancement: make variables atomic for the cursor

### DIFF
--- a/frontend/src/helpers/variable-input/templateVariableCaret.ts
+++ b/frontend/src/helpers/variable-input/templateVariableCaret.ts
@@ -12,6 +12,24 @@ export function snapCaretOutOfVariable(value: string, pos: number): number {
   return r ? r.end : pos
 }
 
+// Caret target for one horizontal step that treats a variable as one character.
+// null means no variable is crossed, so the browser default should run.
+export function getVariableStepTarget(
+  value: string,
+  pos: number,
+  direction: "backward" | "forward"
+): number | null {
+  const ranges = getVariableRanges(value)
+  if (direction === "backward") {
+    // At the trailing edge or stranded inside: jump to before the first "{".
+    const r = ranges.find((r) => pos > r.start && pos <= r.end)
+    return r ? r.start : null
+  }
+  // At the leading edge or stranded inside: jump to after the final "}".
+  const r = ranges.find((r) => pos >= r.start && pos < r.end)
+  return r ? r.end : null
+}
+
 export function snapToVariableBoundary(value: string, pos: number, toEnd: boolean): number {
   const ranges = getVariableRanges(value)
   const r = ranges.find((r) => pos > r.start && pos < r.end)

--- a/frontend/src/helpers/variable-input/templateVariableHandlers.ts
+++ b/frontend/src/helpers/variable-input/templateVariableHandlers.ts
@@ -3,6 +3,7 @@ import * as React from "react"
 import {
   deleteSelectionWithVariables,
   findVariableAtPosition,
+  getVariableStepTarget,
   removeVariableAtCursor,
   snapCaretOutOfVariable,
   snapToVariableBoundary,
@@ -42,6 +43,19 @@ export function createVariableKeyDownHandler<TEl extends HTMLInputElement | HTML
     const el = e.currentTarget
     const start = el.selectionStart ?? 0
     const end = el.selectionEnd ?? 0
+
+    // A variable is one atomic character: step over the whole block, never into it.
+    const stepDirection =
+      e.key === "ArrowLeft" ? "backward" : e.key === "ArrowRight" ? "forward" : null
+    const isPlainStep = !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey
+    if (stepDirection && start === end && isPlainStep) {
+      const target = getVariableStepTarget(opts.value, start, stepDirection)
+      if (target !== null) {
+        e.preventDefault()
+        el.setSelectionRange(target, target)
+      }
+      return
+    }
 
     if (e.key === "Backspace" || e.key === "Delete") {
       if (start !== end) {
@@ -102,24 +116,31 @@ export function createVariableMouseUpHandler<TEl extends HTMLInputElement | HTML
 ): React.MouseEventHandler<TEl> {
   return (e) => {
     const el = e.currentTarget
-    if (!opts.useOverlay || typeof opts.value !== "string") return
-    const start = el.selectionStart ?? 0
-    const end = el.selectionEnd ?? 0
-    if (start === end) {
-      const inside = findVariableAtPosition(opts.value, start)
-      if (inside) {
-        el.setSelectionRange(inside.start, inside.end)
+    // Captured as a const: TS drops the narrowing inside the deferred callback.
+    const value = opts.value
+    if (!opts.useOverlay || typeof value !== "string") return
+    // Clicking inside an existing selection defers the native collapse to mouseup's
+    // default action, which runs after this handler — so snap on the next frame.
+    requestAnimationFrame(() => {
+      if (el.value !== value) return
+      const start = el.selectionStart ?? 0
+      const end = el.selectionEnd ?? 0
+      if (start === end) {
+        const inside = findVariableAtPosition(value, start)
+        if (inside) {
+          el.setSelectionRange(inside.start, inside.end)
+        } else {
+          const snapped = snapCaretOutOfVariable(value, start)
+          if (snapped !== start) el.setSelectionRange(snapped, snapped)
+        }
       } else {
-        const snapped = snapCaretOutOfVariable(opts.value, start)
-        if (snapped !== start) el.setSelectionRange(snapped, snapped)
+        const snappedStart = snapToVariableBoundary(value, start, false)
+        const snappedEnd = snapToVariableBoundary(value, end, true)
+        if (snappedStart !== start || snappedEnd !== end) {
+          el.setSelectionRange(snappedStart, snappedEnd)
+        }
       }
-    } else {
-      const snappedStart = snapToVariableBoundary(opts.value, start, false)
-      const snappedEnd = snapToVariableBoundary(opts.value, end, true)
-      if (snappedStart !== start || snappedEnd !== end) {
-        el.setSelectionRange(snappedStart, snappedEnd)
-      }
-    }
+    })
     opts.onMouseUp?.(e)
   }
 }

--- a/frontend/tests/helpers/variable-input/templateVariableCaret.test.ts
+++ b/frontend/tests/helpers/variable-input/templateVariableCaret.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   snapCaretOutOfVariable,
   snapToVariableBoundary,
+  getVariableStepTarget,
   removeVariableAtCursor,
   deleteSelectionWithVariables,
   findVariableAtPosition,
@@ -53,6 +54,53 @@ describe("snapToVariableBoundary", () => {
   it("leaves a position outside any variable unchanged", () => {
     expect(snapToVariableBoundary(VALUE, 0, true)).toBe(0);
     expect(snapToVariableBoundary(VALUE, 8, false)).toBe(8);
+  });
+});
+
+describe("getVariableStepTarget", () => {
+  it("jumps to the front of the variable when stepping left off its trailing edge", () => {
+    expect(getVariableStepTarget(VALUE, 7, "backward")).toBe(2);
+  });
+
+  it("jumps past the variable when stepping right off its leading edge", () => {
+    expect(getVariableStepTarget(VALUE, 2, "forward")).toBe(7);
+  });
+
+  it("frees a caret stranded inside a variable in either direction", () => {
+    expect(getVariableStepTarget(VALUE, 4, "backward")).toBe(2);
+    expect(getVariableStepTarget(VALUE, 4, "forward")).toBe(7);
+  });
+
+  it("returns null when no variable is crossed, so the browser steps natively", () => {
+    expect(getVariableStepTarget(VALUE, 2, "backward")).toBeNull();
+    expect(getVariableStepTarget(VALUE, 7, "forward")).toBeNull();
+    expect(getVariableStepTarget(VALUE, 0, "backward")).toBeNull();
+    expect(getVariableStepTarget(VALUE, 1, "forward")).toBeNull();
+    expect(getVariableStepTarget(VALUE, 8, "backward")).toBeNull();
+    expect(getVariableStepTarget("plain", 2, "backward")).toBeNull();
+    expect(getVariableStepTarget("plain", 2, "forward")).toBeNull();
+  });
+
+  it("keeps the shared boundary between adjacent variables reachable", () => {
+    // "{{a}}{{b}}": ranges [0,5] and [5,10].
+    const value = "{{a}}{{b}}";
+    expect(getVariableStepTarget(value, 5, "backward")).toBe(0);
+    expect(getVariableStepTarget(value, 5, "forward")).toBe(10);
+    expect(getVariableStepTarget(value, 10, "backward")).toBe(5);
+  });
+
+  it("walks out of the field one block at a time without ever landing inside", () => {
+    const stops = [];
+    let pos = VALUE.length;
+    while (pos > 0) {
+      const target = getVariableStepTarget(VALUE, pos, "backward");
+      pos = target !== null ? target : pos - 1;
+      stops.push(pos);
+    }
+    expect(stops).toEqual([8, 7, 2, 1, 0]);
+    for (const stop of stops) {
+      expect(findVariableAtPosition(VALUE, stop)).toBeUndefined();
+    }
   });
 });
 


### PR DESCRIPTION
## Description

Makes "{{variable_name}}" behave as a single unit rather than as individual characters:
- ArrowLeft at a variable's right edge now jumps the cursor to the front of the variable, instead of bouncing back and trapping it.
- ArrowRight at the left edge jumps past the variable.
- Clicking an already-selected variable keeps the whole variable selected, instead of dropping a cursor mid-variable.
The cursor can no longer end up inside a variable.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [X] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
