### PR TITLE
fix: celery worker reliability, stuck jobs, silent freezes, and lost jobs on restart

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -382,9 +382,11 @@ def create_celery():
         timezone="UTC",
         enable_utc=True,
         task_track_started=True,
-        # Ack after completion so a job survives a worker killed or moved mid-task
+        # Ack after completion so a job survives a worker killed or moved mid-task.
+        # A job whose child process dies is not requeued: that death is usually
+        # deterministic for the job, and requeueing it would loop forever
         task_acks_late=True,
-        task_reject_on_worker_lost=True,
+        task_reject_on_worker_lost=False,
         # Backstop for hangs the per-task asyncio timeouts cannot see. Enforced by the
         # prefork pool only; the global pair covers every task without its own entry.
         task_time_limit=480,

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -266,6 +266,41 @@ async def output_open_api(app):
     Path("openapi.json").write_text(json.dumps(schema, indent=2))
 
 
+# Internal asyncio timeout of each long task. Celery's soft and hard limits sit 5 and
+# 10 minutes above it, so a task is always stopped by its own timeout first.
+LONG_TASK_TIMEOUTS = {
+    "execute_test_suite_run": 2 * 60 * 60,
+    "execute_workflow_run": 2 * 60 * 60,
+    "execute_pipeline_run": 2 * 60 * 60,
+    "app.tasks.analytics_aggregation_tasks.aggregate_agent_analytics": 110 * 60,
+    "app.tasks.analytics_aggregation_tasks.backfill_agent_analytics": 110 * 60,
+    "app.tasks.backfill_llm_usage_tasks.backfill_llm_usage_ledger": 110 * 60,
+    "app.tasks.zendesk_tasks.analyze_zendesk_tickets_task": 50 * 60,
+    "app.tasks.audio_tasks.transcribe_audio_files_from_s3": 45 * 60,
+    "app.tasks.s3_tasks.import_s3_files_to_kb": 45 * 60,
+    "app.tasks.share_folder_tasks.transcribe_audio_files_from_smb": 45 * 60,
+    "app.tasks.sharepoint_tasks.import_sharepoint_files_to_kb": 45 * 60,
+    "app.tasks.salesforce_article_sync_tasks.import_salesforce_articles_to_kb": 15 * 60,
+    "app.tasks.zendesk_article_sync_tasks.import_zendesk_articles_to_kb": 15 * 60,
+    "app.tasks.fine_tune_job_sync_tasks.sync_all_fine_tuning_jobs": 10 * 60,
+    "app.tasks.conversations_tasks.backfill_missing_conversation_analyses": 9 * 60,
+    "app.tasks.conversations_tasks.cleanup_stale_conversations": 9 * 60,
+}
+TIME_LIMIT_SOFT_MARGIN_SECONDS = 5 * 60
+TIME_LIMIT_HARD_MARGIN_SECONDS = 10 * 60
+
+
+def _long_task_time_limits() -> dict:
+    """Per-task Celery time limits derived from each long task's internal timeout."""
+    return {
+        name: {
+            "soft_time_limit": timeout + TIME_LIMIT_SOFT_MARGIN_SECONDS,
+            "time_limit": timeout + TIME_LIMIT_HARD_MARGIN_SECONDS,
+        }
+        for name, timeout in LONG_TASK_TIMEOUTS.items()
+    }
+
+
 def create_celery():
     """
     Create and configure the Celery application.
@@ -273,10 +308,9 @@ def create_celery():
     logger.debug("Creating new Celery app instance")
     logger.debug(f"Redis URL: {settings.REDIS_URL}")
 
-    # Task modules that top-level import the workflow engine (-> sklearn at boot).
-    # They run only on the dedicated "ml" (solo) worker and are routed to the "ml"
-    # queue. The prefork "default" worker excludes them (CELERY_INCLUDE_ML_TASKS=False)
-    # so its master process never loads ML libs and is safe to fork.
+    # Task modules for the dedicated "ml" worker. They import the workflow engine
+    # lazily, so including them keeps the worker master free of ML libs and fork-safe.
+    # The "default" worker excludes them (CELERY_INCLUDE_ML_TASKS=False).
     ML_TASK_MODULES = [
         "app.tasks.ml_model_pipeline_tasks",
         "app.tasks.test_suite_tasks",
@@ -351,19 +385,18 @@ def create_celery():
         # Ack after completion so a job survives a worker killed or moved mid-task
         task_acks_late=True,
         task_reject_on_worker_lost=True,
-        task_time_limit=300,  # 5 minutes
-        task_soft_time_limit=240,  # 4 minutes (soft limit)
-        # Hard time limits above don't apply to the solo pool we run with;
-        # enforcement happens via asyncio.wait_for inside each task body
-        # (see app/tasks/base.py::run_async_in_celery). Bound result-backend
-        # growth so a slow/wedged worker doesn't pile up Redis keys.
+        # Backstop for hangs the per-task asyncio timeouts cannot see. Enforced by the
+        # prefork pool only; the global pair covers every task without its own entry.
+        task_time_limit=480,
+        task_soft_time_limit=420,
+        task_annotations=_long_task_time_limits(),
+        # Bound result-backend growth so a slow/wedged worker doesn't pile up Redis keys
         result_expires=3600,
         worker_max_tasks_per_child=1000,
         worker_prefetch_multiplier=1,
         worker_pool=settings.CELERY_WORKER_POOL,
-        # Queue routing for the two-worker split. Everything defaults to "default"
-        # (consumed by the prefork worker); the ML/evaluation tasks are pinned to the
-        # "ml" queue, consumed only by the solo worker that can safely import ML libs.
+        # Queue routing for the two-worker split. Everything defaults to "default";
+        # the ML/evaluation tasks are pinned to the "ml" queue and its dedicated worker.
         task_default_queue="default",
         task_routes={
             "execute_pipeline_run": {"queue": "ml"},

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -317,7 +317,7 @@ def create_celery():
         result_backend=settings.REDIS_URL,  # Explicitly set result backend
         broker_connection_retry_on_startup=True,  # Retain pre-Celery 6.0 startup retry behavior
         broker_transport_options={
-            "visibility_timeout": 3600,  # 1 hour
+            "visibility_timeout": settings.CELERY_BROKER_VISIBILITY_TIMEOUT,
             "fanout_prefix": True,
             "fanout_patterns": True,
             "max_connections": settings.CELERY_REDIS_MAX_CONNECTIONS,  # Limit broker connection pool
@@ -347,6 +347,9 @@ def create_celery():
         timezone="UTC",
         enable_utc=True,
         task_track_started=True,
+        # Ack after completion so a job survives a worker killed or moved mid-task
+        task_acks_late=True,
+        task_reject_on_worker_lost=True,
         task_time_limit=300,  # 5 minutes
         task_soft_time_limit=240,  # 4 minutes (soft limit)
         # Hard time limits above don't apply to the solo pool we run with;

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -533,6 +533,8 @@ def create_celery():
         beat_schedule["check-scheduled-pipeline-runs"] = {
             "task": "app.tasks.ml_model_pipeline_tasks.check_scheduled_pipeline_runs",
             "schedule": 60.0,  # Every minute (60 seconds)
+            # Expire before the next tick so ticks never pile up behind a long ml job
+            "options": {"expires": 55},
         }
 
     # Check for scheduled workflow runs every minute
@@ -540,6 +542,7 @@ def create_celery():
         beat_schedule["check-scheduled-workflow-runs"] = {
             "task": "app.tasks.workflow_schedule_tasks.check_scheduled_workflow_runs",
             "schedule": 60.0,  # Every minute (60 seconds)
+            "options": {"expires": 55},
         }
 
     # Reconcile runs orphaned by a lost worker every 5 minutes. These run on the
@@ -548,12 +551,14 @@ def create_celery():
         beat_schedule["reconcile-stuck-workflow-runs"] = {
             "task": "app.tasks.run_reconciliation_tasks.reconcile_stuck_workflow_runs",
             "schedule": 300.0,  # Every 5 minutes (300 seconds)
+            "options": {"expires": 290},
         }
 
     if settings.CELERY_ENABLE_RECONCILE_STUCK_TEST_RUNS_TASK:
         beat_schedule["reconcile-stuck-test-runs"] = {
             "task": "app.tasks.run_reconciliation_tasks.reconcile_stuck_test_runs",
             "schedule": 300.0,  # Every 5 minutes (300 seconds)
+            "options": {"expires": 290},
         }
 
     # Sync active KB's jobs every 5 minutes

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -322,10 +322,23 @@ def create_celery():
             "fanout_patterns": True,
             "max_connections": settings.CELERY_REDIS_MAX_CONNECTIONS,  # Limit broker connection pool
             "global_keyprefix": "{celery}",  # Force all keys to same Redis Cluster hash slot
+            # Bound socket operations so a dead connection raises and retries
+            # instead of blocking the process indefinitely
+            "socket_timeout": settings.CELERY_REDIS_SOCKET_TIMEOUT,
+            "socket_connect_timeout": settings.CELERY_REDIS_SOCKET_CONNECT_TIMEOUT,
+            "socket_keepalive": True,
+            "retry_on_timeout": True,
+            "health_check_interval": 30,
         },
         result_backend_transport_options={
             "global_keyprefix": "{celery}",  # Force all keys to same Redis Cluster hash slot
         },
+        # Same socket bounds for the result-backend client
+        redis_socket_timeout=settings.CELERY_REDIS_SOCKET_TIMEOUT,
+        redis_socket_connect_timeout=settings.CELERY_REDIS_SOCKET_CONNECT_TIMEOUT,
+        redis_socket_keepalive=True,
+        redis_retry_on_timeout=True,
+        redis_backend_health_check_interval=25,
         redis_max_connections=settings.CELERY_REDIS_MAX_CONNECTIONS,  # Limit result backend connection pool
         worker_enable_mingle=False,  # Disable mingle to avoid cross-slot errors on startup
         task_serializer="json",

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -300,6 +300,7 @@ def create_celery():
         "app.tasks.file_upload_session_tasks",
         "app.tasks.email_tasks",
         "app.tasks.support_ticket_tasks",
+        "app.tasks.run_reconciliation_tasks",
     ]
     if settings.CELERY_INCLUDE_ML_TASKS:
         include += ML_TASK_MODULES
@@ -370,8 +371,6 @@ def create_celery():
             "app.tasks.ml_model_pipeline_tasks.check_scheduled_pipeline_runs": {"queue": "ml"},
             "execute_workflow_run": {"queue": "ml"},
             "app.tasks.workflow_schedule_tasks.check_scheduled_workflow_runs": {"queue": "ml"},
-            "app.tasks.workflow_schedule_tasks.reconcile_stuck_workflow_runs": {"queue": "ml"},
-            "app.tasks.test_suite_tasks.reconcile_stuck_test_runs": {"queue": "ml"},
         },
         worker_log_format="[%(asctime)s: %(levelname)s/%(processName)s] %(message)s",
         worker_task_log_format="[%(asctime)s: %(levelname)s/%(processName)s][%(task_name)s(%(task_id)s)] %(message)s",
@@ -510,16 +509,17 @@ def create_celery():
             "schedule": 60.0,  # Every minute (60 seconds)
         }
 
-    # Reconcile workflow runs orphaned by a worker/pod crash every 5 minutes
+    # Reconcile runs orphaned by a lost worker every 5 minutes. These run on the
+    # default queue so they are never trapped behind the ml queue they clean up.
     if settings.CELERY_ENABLE_RECONCILE_STUCK_WORKFLOW_RUNS_TASK:
         beat_schedule["reconcile-stuck-workflow-runs"] = {
-            "task": "app.tasks.workflow_schedule_tasks.reconcile_stuck_workflow_runs",
+            "task": "app.tasks.run_reconciliation_tasks.reconcile_stuck_workflow_runs",
             "schedule": 300.0,  # Every 5 minutes (300 seconds)
         }
 
     if settings.CELERY_ENABLE_RECONCILE_STUCK_TEST_RUNS_TASK:
         beat_schedule["reconcile-stuck-test-runs"] = {
-            "task": "app.tasks.test_suite_tasks.reconcile_stuck_test_runs",
+            "task": "app.tasks.run_reconciliation_tasks.reconcile_stuck_test_runs",
             "schedule": 300.0,  # Every 5 minutes (300 seconds)
         }
 

--- a/backend/app/core/config/settings.py
+++ b/backend/app/core/config/settings.py
@@ -79,21 +79,15 @@ class ProjectSettings(BaseSettings):
     # flag is off: with no direct-S3 rows the task simply finds nothing to do.
     CELERY_ENABLE_CLEANUP_STALE_DIRECT_UPLOADS_TASK: bool = True
 
-    # Worker pool. "solo" is required for the ML worker: ML libs (torch/sklearn/
-    # transformers) spawn native OpenMP/MKL threads at import, and fork() copies
-    # only the calling thread, leaving the child with locked mutexes -> SIGSEGV.
-    # The "default" worker can run "prefork" for true concurrency *because* its boot
-    # import graph is ML-free (see CELERY_INCLUDE_ML_TASKS and the lean worker
-    # bootstrap in run_celery.py): prefork children may lazily import ML libs after
-    # fork safely; only the parent (master) must stay clean.
+    # Worker pool. Only "prefork" enforces task time limits and answers health pings
+    # during a task. It is fork-safe for both workers because every task module loads
+    # the ML libs (torch/sklearn/transformers) lazily, inside the task, so the master
+    # process stays clean; test_celery_worker_boot_clean.py guards this.
     CELERY_WORKER_POOL: str = "solo"
 
-    # Role selector for the two-worker split. When True (default — preserves the
-    # legacy single-worker behavior), the Celery app includes the ML/evaluation task
-    # modules (ml_model_pipeline_tasks, test_suite_tasks), which top-level import the
-    # workflow engine and therefore pull sklearn into the process at boot. The
-    # prefork "default" worker MUST set this False so its master process never imports
-    # those modules; ML/eval tasks are routed to the dedicated "ml" queue instead.
+    # Role selector for the two-worker split. When True (default), the app includes
+    # the ML/evaluation task modules; the "default" worker sets it False and those
+    # tasks are routed to the dedicated "ml" queue instead.
     CELERY_INCLUDE_ML_TASKS: bool = True
 
     # Explicit prefork concurrency (number of child worker processes). Leave None to

--- a/backend/app/core/config/settings.py
+++ b/backend/app/core/config/settings.py
@@ -83,9 +83,10 @@ class ProjectSettings(BaseSettings):
     CELERY_ENABLE_CLEANUP_STALE_DIRECT_UPLOADS_TASK: bool = True
 
     # Worker pool. Only "prefork" enforces task time limits and answers health pings
-    # during a task. It is fork-safe for both workers because every task module loads
-    # the ML libs (torch/sklearn/transformers) lazily, inside the task, so the master
-    # process stays clean; test_celery_worker_boot_clean.py guards this.
+    # during a task; the default worker runs it. The ml worker stays "solo": workflow
+    # Python code nodes run user code in a subprocess, which a prefork child (daemonic)
+    # is not allowed to start. Task modules load ML libs lazily so the master stays
+    # fork-safe either way; test_celery_worker_boot_clean.py guards this.
     CELERY_WORKER_POOL: str = "solo"
 
     # Role selector for the two-worker split. When True (default), the app includes

--- a/backend/app/core/config/settings.py
+++ b/backend/app/core/config/settings.py
@@ -41,6 +41,8 @@ class ProjectSettings(BaseSettings):
     # them a silently dead connection blocks the worker or beat indefinitely.
     CELERY_REDIS_SOCKET_TIMEOUT: int = 30
     CELERY_REDIS_SOCKET_CONNECT_TIMEOUT: int = 15
+    # Redelivery delay for unacknowledged messages; above the 2h task timeout
+    CELERY_BROKER_VISIBILITY_TIMEOUT: int = 8400
 
     # Celery Beat task toggles (enable/disable periodic jobs)
     CELERY_ENABLE_RUN_EXAMPLE_TASK: bool = True
@@ -62,13 +64,13 @@ class ProjectSettings(BaseSettings):
     # (its worker never picked it up / crashed before starting) and marked FAILED.
     WORKFLOW_SCHEDULE_PENDING_MAX_AGE_SECONDS: int = 900  # 15 minutes
     # A scheduled run still RUNNING after this many seconds is presumed orphaned
-    # (worker died mid-run). Kept above the 2h execution timeout + buffer so a
-    # genuinely long run is never failed prematurely.
-    WORKFLOW_SCHEDULE_RUNNING_MAX_AGE_SECONDS: int = 7800  # 2h10m
+    # (worker died mid-run). Kept above the 2h execution timeout and the broker
+    # redelivery delay so a lost run is re-run before it is declared dead.
+    WORKFLOW_SCHEDULE_RUNNING_MAX_AGE_SECONDS: int = 9000  # 2h30m
     # Evaluation (test) runs use the same orphaned-run reconciliation.
     CELERY_ENABLE_RECONCILE_STUCK_TEST_RUNS_TASK: bool = True
     TEST_RUN_QUEUED_MAX_AGE_SECONDS: int = 900  # 15 minutes
-    TEST_RUN_RUNNING_MAX_AGE_SECONDS: int = 7800  # 2h10m, above the 2h task timeout
+    TEST_RUN_RUNNING_MAX_AGE_SECONDS: int = 9000  # 2h30m, above the broker redelivery delay
     CELERY_ENABLE_SUMMARIZE_FILES_FROM_AZURE_TASK: bool = True
     CELERY_ENABLE_AGGREGATE_AGENT_ANALYTICS_TASK: bool = True
     CELERY_ENABLE_BACKFILL_CUSTOM_ATTRIBUTES_TASK: bool = True

--- a/backend/app/core/config/settings.py
+++ b/backend/app/core/config/settings.py
@@ -43,6 +43,9 @@ class ProjectSettings(BaseSettings):
     CELERY_REDIS_SOCKET_CONNECT_TIMEOUT: int = 15
     # Redelivery delay for unacknowledged messages; above the 2h task timeout
     CELERY_BROKER_VISIBILITY_TIMEOUT: int = 8400
+    # Only one beat replica dispatches; the others stand by and take over within the TTL
+    CELERY_BEAT_LEADER_LOCK_ENABLED: bool = True
+    CELERY_BEAT_LEADER_LOCK_TTL_SECONDS: int = 60
 
     # Celery Beat task toggles (enable/disable periodic jobs)
     CELERY_ENABLE_RUN_EXAMPLE_TASK: bool = True

--- a/backend/app/core/config/settings.py
+++ b/backend/app/core/config/settings.py
@@ -37,6 +37,10 @@ class ProjectSettings(BaseSettings):
 
     # Celery Redis connection pool settings
     CELERY_REDIS_MAX_CONNECTIONS: int = 50  # Max connections for Celery broker & backend
+    # Socket bounds for Celery's broker/result-backend Redis connections; without
+    # them a silently dead connection blocks the worker or beat indefinitely.
+    CELERY_REDIS_SOCKET_TIMEOUT: int = 30
+    CELERY_REDIS_SOCKET_CONNECT_TIMEOUT: int = 15
 
     # Celery Beat task toggles (enable/disable periodic jobs)
     CELERY_ENABLE_RUN_EXAMPLE_TASK: bool = True

--- a/backend/app/repositories/test_suite.py
+++ b/backend/app/repositories/test_suite.py
@@ -113,31 +113,36 @@ class TestRunRepository(DbRepository[TestRunModel]):
         )
         await self.db.flush()
 
-    async def mark_stuck_as_failed(
+    async def get_waiting_ids_older_than(self, before: datetime) -> List[str]:
+        """Ids of queued runs last updated before ``before``."""
+        stmt = select(TestRunModel.id).where(
+            TestRunModel.is_deleted == 0,
+            TestRunModel.status == "queued",
+            TestRunModel.updated_at < before,
+        )
+        result = await self.db.execute(stmt)
+        return [str(run_id) for run_id in result.scalars().all()]
+
+    async def mark_orphaned_as_failed(
         self,
-        queued_before: datetime,
+        waiting_ids: List[str],
         running_before: datetime,
         error_message: str,
     ) -> int:
-        """Fail runs orphaned by a worker/pod crash in one atomic UPDATE:
-        queued runs never picked up, and running runs past the max execution age.
-        Returns the number of rows transitioned to failed.
-        """
+        """Fail queued runs whose job left the broker and runs past the max run age."""
+        conditions = [
+            and_(
+                TestRunModel.status == "running",
+                TestRunModel.updated_at < running_before,
+            )
+        ]
+        if waiting_ids:
+            conditions.append(
+                and_(TestRunModel.status == "queued", TestRunModel.id.in_(waiting_ids))
+            )
         stmt = (
             update(TestRunModel)
-            .where(
-                TestRunModel.is_deleted == 0,
-                or_(
-                    and_(
-                        TestRunModel.status == "queued",
-                        TestRunModel.updated_at < queued_before,
-                    ),
-                    and_(
-                        TestRunModel.status == "running",
-                        TestRunModel.updated_at < running_before,
-                    ),
-                ),
-            )
+            .where(TestRunModel.is_deleted == 0, or_(*conditions))
             .values(status="failed", summary_metrics={"error": error_message})
             .execution_options(synchronize_session=False)
         )

--- a/backend/app/repositories/workflow_schedule_run.py
+++ b/backend/app/repositories/workflow_schedule_run.py
@@ -127,45 +127,46 @@ class WorkflowScheduleRunRepository(DbRepository[WorkflowScheduleRunModel]):
 
         return await super().update(run)
 
-    async def mark_stuck_as_failed(
+    async def get_waiting_ids_older_than(self, before: datetime) -> List[str]:
+        """Ids of pending runs created before ``before``."""
+        stmt = select(WorkflowScheduleRunModel.id).where(
+            WorkflowScheduleRunModel.is_deleted == 0,
+            WorkflowScheduleRunModel.status == WorkflowScheduleRunStatus.PENDING,
+            WorkflowScheduleRunModel.created_at < before,
+        )
+        result = await self.db.execute(stmt)
+        return [str(run_id) for run_id in result.scalars().all()]
+
+    async def mark_orphaned_as_failed(
         self,
-        pending_before: datetime,
+        waiting_ids: List[str],
         running_before: datetime,
         error_message: str,
     ) -> int:
-        """Atomically fail runs left stuck by a worker/pod crash:
-        - PENDING created before `pending_before` (never picked up), and
-        - RUNNING whose start (or creation) precedes `running_before` (the
-          worker died mid-execution; past the max execution time).
-
-        A single UPDATE avoids races with a run that completes concurrently.
-        Returns the number of rows transitioned to FAILED.
-        """
-        now = datetime.now(timezone.utc)
+        """Fail pending runs whose job left the broker and runs past the max run age."""
+        conditions = [
+            and_(
+                WorkflowScheduleRunModel.status == WorkflowScheduleRunStatus.RUNNING,
+                func.coalesce(
+                    WorkflowScheduleRunModel.started_at,
+                    WorkflowScheduleRunModel.created_at,
+                )
+                < running_before,
+            )
+        ]
+        if waiting_ids:
+            conditions.append(
+                and_(
+                    WorkflowScheduleRunModel.status == WorkflowScheduleRunStatus.PENDING,
+                    WorkflowScheduleRunModel.id.in_(waiting_ids),
+                )
+            )
         stmt = (
             update(WorkflowScheduleRunModel)
-            .where(
-                WorkflowScheduleRunModel.is_deleted == 0,
-                or_(
-                    and_(
-                        WorkflowScheduleRunModel.status
-                        == WorkflowScheduleRunStatus.PENDING,
-                        WorkflowScheduleRunModel.created_at < pending_before,
-                    ),
-                    and_(
-                        WorkflowScheduleRunModel.status
-                        == WorkflowScheduleRunStatus.RUNNING,
-                        func.coalesce(
-                            WorkflowScheduleRunModel.started_at,
-                            WorkflowScheduleRunModel.created_at,
-                        )
-                        < running_before,
-                    ),
-                ),
-            )
+            .where(WorkflowScheduleRunModel.is_deleted == 0, or_(*conditions))
             .values(
                 status=WorkflowScheduleRunStatus.FAILED,
-                completed_at=now,
+                completed_at=datetime.now(timezone.utc),
                 error_message=error_message,
             )
             .execution_options(synchronize_session=False)
@@ -173,3 +174,4 @@ class WorkflowScheduleRunRepository(DbRepository[WorkflowScheduleRunModel]):
         result = await self.db.execute(stmt)
         await self.db.flush()
         return result.rowcount or 0
+

--- a/backend/app/tasks/base.py
+++ b/backend/app/tasks/base.py
@@ -49,9 +49,9 @@ def run_async_in_celery(
     unreliable with the solo pool — this is the actual enforcement point.
     """
     async def _runner() -> Any:
-        if timeout is None:
-            return await coro
         try:
+            if timeout is None:
+                return await coro
             return await asyncio.wait_for(coro, timeout=timeout)
         except asyncio.TimeoutError:
             logger.error(
@@ -61,8 +61,34 @@ def run_async_in_celery(
                 timeout,
             )
             raise
+        finally:
+            await disconnect_async_redis_pools()
 
     return asyncio.run(_runner())
+
+
+def _async_redis_clients() -> List[Any]:
+    """Process-wide async Redis clients whose pooled connections outlive a task's loop."""
+    from app.dependencies.dependency_injection import RedisBinary, RedisString
+    from app.dependencies.injector import injector
+
+    clients = [injector.get(RedisString), injector.get(RedisBinary)]
+    try:
+        from fastapi_cache import FastAPICache
+
+        clients.append(FastAPICache.get_backend().redis)
+    except Exception:  # cache backend not initialized in this process
+        pass
+    return clients
+
+
+async def disconnect_async_redis_pools() -> None:
+    """Drop pooled Redis connections so the next task's event loop opens fresh ones."""
+    for client in _async_redis_clients():
+        try:
+            await client.connection_pool.disconnect(inuse_connections=True)
+        except Exception as exc:  # cleanup must never fail the task
+            logger.debug("Async Redis pool disconnect skipped: %s", exc)
 
 
 class BaseTaskWithLogging(Task):

--- a/backend/app/tasks/base.py
+++ b/backend/app/tasks/base.py
@@ -13,6 +13,23 @@ from app.core.tenant_scope import (
 
 logger = logging.getLogger(__name__)
 
+TERMINAL_RUN_STATUSES = ("completed", "failed", "cancelled")
+
+
+def should_execute_run(kind: str, run_id, status) -> bool:
+    """Skip terminal runs; re-run one left "running" by a lost worker."""
+    status_value = getattr(status, "value", status)
+    if status_value in TERMINAL_RUN_STATUSES:
+        logger.info("%s %s is already %s; skipping", kind, run_id, status_value)
+        return False
+    if status_value == "running":
+        logger.warning(
+            "%s %s was left running by a lost worker; re-running it from scratch",
+            kind,
+            run_id,
+        )
+    return True
+
 
 def run_async_in_celery(
     coro: Coroutine[Any, Any, Any],

--- a/backend/app/tasks/beat_leader.py
+++ b/backend/app/tasks/beat_leader.py
@@ -13,7 +13,7 @@ import signal
 import socket
 import threading
 import time
-from typing import Callable
+from typing import Callable, Optional
 
 import redis
 from celery.signals import beat_init
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 
 LEADER_KEY = "{celery}beat-leader"
 HEARTBEAT_FILE = os.environ.get("CELERY_BEAT_HEARTBEAT_FILE", "/tmp/celery_beat_heartbeat")
+# A loop that has not ticked for this long is frozen; its lock must be allowed to expire
+STALE_SCHEDULER_SECONDS = 600
 
 _RENEW_IF_OWNER = """
 if redis.call('get', KEYS[1]) == ARGV[1] then
@@ -37,6 +39,20 @@ def _terminate_self() -> None:
     os.kill(os.getpid(), signal.SIGTERM)
 
 
+class TickMonitor:
+    """Remembers when the scheduler loop last ticked."""
+
+    def __init__(self, clock: Callable[[], float] = time.monotonic):
+        self._clock = clock
+        self.last_tick_at = clock()
+
+    def record_tick(self) -> None:
+        self.last_tick_at = self._clock()
+
+    def is_alive(self, max_stale_seconds: int = STALE_SCHEDULER_SECONDS) -> bool:
+        return self._clock() - self.last_tick_at < max_stale_seconds
+
+
 class BeatLeaderLock:
     """Hold a Redis lock while this beat dispatches; other replicas wait as standbys."""
 
@@ -47,18 +63,23 @@ class BeatLeaderLock:
         ttl_seconds: int,
         sleep: Callable[[float], None] = time.sleep,
         step_down: Callable[[], None] = _terminate_self,
+        loop_is_alive: Callable[[], bool] = lambda: True,
     ):
         self._client = client
         self._token = token
         self._ttl = ttl_seconds
         self._sleep = sleep
         self._step_down = step_down
+        self._loop_is_alive = loop_is_alive
 
     def try_acquire(self) -> bool:
         return bool(self._client.set(LEADER_KEY, self._token, nx=True, ex=self._ttl))
 
     def renew(self) -> bool:
         return bool(self._client.eval(_RENEW_IF_OWNER, 1, LEADER_KEY, self._token, self._ttl))
+
+    def still_owner(self) -> bool:
+        return self._client.get(LEADER_KEY) == self._token
 
     def wait_until_leader(self) -> None:
         while True:
@@ -69,6 +90,7 @@ class BeatLeaderLock:
                 logger.info("Another beat holds the leader lock; standing by")
             except redis.RedisError as exc:
                 logger.warning("Beat leader lock check failed: %s", exc)
+            heartbeat_while_standing_by()
             self._sleep(self._ttl / 6)
 
     def start_renewal_thread(self) -> None:
@@ -82,13 +104,17 @@ class BeatLeaderLock:
                 return
 
     def renew_once(self) -> bool:
-        """Renew the lock; a lock now owned by someone else stops this scheduler."""
+        """Renew while the loop is alive; a frozen loop lets the lock expire instead."""
         try:
-            renewed = self.renew()
+            if self._loop_is_alive():
+                owned = self.renew()
+            else:
+                logger.warning("Scheduler loop is stale; not renewing the beat leader lock")
+                owned = self.still_owner()
         except redis.RedisError as exc:
             logger.warning("Beat leader lock renewal failed: %s", exc)
             return True
-        if renewed:
+        if owned:
             return True
         logger.critical("Beat leader lock was lost; stopping this scheduler")
         self._step_down()
@@ -103,11 +129,23 @@ def write_heartbeat(path: str = HEARTBEAT_FILE) -> None:
     os.replace(temporary, path)
 
 
-def install_tick_heartbeat(scheduler, path: str = HEARTBEAT_FILE) -> None:
-    """Touch the heartbeat on every scheduler tick, from the loop that can freeze."""
+def heartbeat_while_standing_by() -> None:
+    """A healthy standby never ticks, so it must satisfy the liveness probe itself."""
+    try:
+        write_heartbeat()
+    except OSError as exc:
+        logger.warning("Beat heartbeat write failed: %s", exc)
+
+
+def install_tick_heartbeat(
+    scheduler, path: str = HEARTBEAT_FILE, monitor: Optional[TickMonitor] = None
+) -> TickMonitor:
+    """Record and publish every scheduler tick, from the loop that can freeze."""
+    monitor = monitor or TickMonitor()
     original_tick = scheduler.tick
 
     def tick(*args, **kwargs):
+        monitor.record_tick()
         try:
             write_heartbeat(path)
         except OSError as exc:
@@ -115,11 +153,13 @@ def install_tick_heartbeat(scheduler, path: str = HEARTBEAT_FILE) -> None:
         return original_tick(*args, **kwargs)
 
     scheduler.tick = tick
+    return monitor
 
 
 def _redis_client():
     return redis.Redis.from_url(
         settings.REDIS_URL,
+        decode_responses=True,
         socket_timeout=settings.CELERY_REDIS_SOCKET_TIMEOUT,
         socket_connect_timeout=settings.CELERY_REDIS_SOCKET_CONNECT_TIMEOUT,
         socket_keepalive=True,
@@ -133,9 +173,15 @@ def _token() -> str:
 
 @beat_init.connect
 def on_beat_init(sender=None, **kwargs):
-    install_tick_heartbeat(sender.scheduler)
+    monitor = install_tick_heartbeat(sender.scheduler)
     if not settings.CELERY_BEAT_LEADER_LOCK_ENABLED:
         return
-    lock = BeatLeaderLock(_redis_client(), _token(), settings.CELERY_BEAT_LEADER_LOCK_TTL_SECONDS)
+    lock = BeatLeaderLock(
+        _redis_client(),
+        _token(),
+        settings.CELERY_BEAT_LEADER_LOCK_TTL_SECONDS,
+        loop_is_alive=monitor.is_alive,
+    )
     lock.wait_until_leader()
+    monitor.record_tick()
     lock.start_renewal_thread()

--- a/backend/app/tasks/beat_leader.py
+++ b/backend/app/tasks/beat_leader.py
@@ -1,0 +1,141 @@
+"""
+Guards for the Celery beat scheduler.
+
+Beat has no leader election, so several replicas dispatch every scheduled task
+several times. A Redis lock lets one replica dispatch while the others stand by
+and take over if it disappears. A heartbeat written from the scheduler loop
+itself lets a liveness probe tell a frozen scheduler from a healthy one.
+"""
+
+import logging
+import os
+import signal
+import socket
+import threading
+import time
+from typing import Callable
+
+import redis
+from celery.signals import beat_init
+
+from app.core.config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+LEADER_KEY = "{celery}beat-leader"
+HEARTBEAT_FILE = os.environ.get("CELERY_BEAT_HEARTBEAT_FILE", "/tmp/celery_beat_heartbeat")
+
+_RENEW_IF_OWNER = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+  return redis.call('expire', KEYS[1], ARGV[2])
+end
+return 0
+"""
+
+
+def _terminate_self() -> None:
+    os.kill(os.getpid(), signal.SIGTERM)
+
+
+class BeatLeaderLock:
+    """Hold a Redis lock while this beat dispatches; other replicas wait as standbys."""
+
+    def __init__(
+        self,
+        client,
+        token: str,
+        ttl_seconds: int,
+        sleep: Callable[[float], None] = time.sleep,
+        step_down: Callable[[], None] = _terminate_self,
+    ):
+        self._client = client
+        self._token = token
+        self._ttl = ttl_seconds
+        self._sleep = sleep
+        self._step_down = step_down
+
+    def try_acquire(self) -> bool:
+        return bool(self._client.set(LEADER_KEY, self._token, nx=True, ex=self._ttl))
+
+    def renew(self) -> bool:
+        return bool(self._client.eval(_RENEW_IF_OWNER, 1, LEADER_KEY, self._token, self._ttl))
+
+    def wait_until_leader(self) -> None:
+        while True:
+            try:
+                if self.try_acquire():
+                    logger.info("This beat holds the leader lock and will dispatch")
+                    return
+                logger.info("Another beat holds the leader lock; standing by")
+            except redis.RedisError as exc:
+                logger.warning("Beat leader lock check failed: %s", exc)
+            self._sleep(self._ttl / 6)
+
+    def start_renewal_thread(self) -> None:
+        thread = threading.Thread(target=self.renew_forever, name="beat-leader", daemon=True)
+        thread.start()
+
+    def renew_forever(self) -> None:
+        while True:
+            self._sleep(self._ttl / 3)
+            if not self.renew_once():
+                return
+
+    def renew_once(self) -> bool:
+        """Renew the lock; a lock now owned by someone else stops this scheduler."""
+        try:
+            renewed = self.renew()
+        except redis.RedisError as exc:
+            logger.warning("Beat leader lock renewal failed: %s", exc)
+            return True
+        if renewed:
+            return True
+        logger.critical("Beat leader lock was lost; stopping this scheduler")
+        self._step_down()
+        return False
+
+
+def write_heartbeat(path: str = HEARTBEAT_FILE) -> None:
+    """Write the current time atomically so a probe never reads a half-written file."""
+    temporary = f"{path}.tmp"
+    with open(temporary, "w") as handle:
+        handle.write(str(int(time.time())))
+    os.replace(temporary, path)
+
+
+def install_tick_heartbeat(scheduler, path: str = HEARTBEAT_FILE) -> None:
+    """Touch the heartbeat on every scheduler tick, from the loop that can freeze."""
+    original_tick = scheduler.tick
+
+    def tick(*args, **kwargs):
+        try:
+            write_heartbeat(path)
+        except OSError as exc:
+            logger.warning("Beat heartbeat write failed: %s", exc)
+        return original_tick(*args, **kwargs)
+
+    scheduler.tick = tick
+
+
+def _redis_client():
+    return redis.Redis.from_url(
+        settings.REDIS_URL,
+        socket_timeout=settings.CELERY_REDIS_SOCKET_TIMEOUT,
+        socket_connect_timeout=settings.CELERY_REDIS_SOCKET_CONNECT_TIMEOUT,
+        socket_keepalive=True,
+        health_check_interval=30,
+    )
+
+
+def _token() -> str:
+    return f"{socket.gethostname()}:{os.getpid()}"
+
+
+@beat_init.connect
+def on_beat_init(sender=None, **kwargs):
+    install_tick_heartbeat(sender.scheduler)
+    if not settings.CELERY_BEAT_LEADER_LOCK_ENABLED:
+        return
+    lock = BeatLeaderLock(_redis_client(), _token(), settings.CELERY_BEAT_LEADER_LOCK_TTL_SECONDS)
+    lock.wait_until_leader()
+    lock.start_renewal_thread()

--- a/backend/app/tasks/ml_model_pipeline_tasks.py
+++ b/backend/app/tasks/ml_model_pipeline_tasks.py
@@ -18,7 +18,6 @@ from app.repositories.ml_model_pipeline import (
 )
 from app.core.utils.uuid_utils import coerce_uuid
 from app.db.models.ml_model_pipeline import PipelineRunStatus, ArtifactType
-from app.modules.workflow.engine.workflow_engine import WorkflowEngine
 from app.modules.workflow.usage_context import WorkflowUsageContext
 from app.repositories.workflow import WorkflowRepository
 from app.repositories.ml_models import MLModelsRepository
@@ -139,7 +138,9 @@ async def execute_pipeline_run_async(run_id: UUID):
                     "edges": workflow.edges or [],
                 }
 
-                # Build workflow engine with configuration
+                # Imported lazily so the worker master never loads ML libs before forking
+                from app.modules.workflow.engine.workflow_engine import WorkflowEngine
+
                 workflow_engine = WorkflowEngine(workflow_config)
 
                 # Prepare input data with model context

--- a/backend/app/tasks/ml_model_pipeline_tasks.py
+++ b/backend/app/tasks/ml_model_pipeline_tasks.py
@@ -24,7 +24,7 @@ from app.repositories.workflow import WorkflowRepository
 from app.repositories.ml_models import MLModelsRepository
 from app.core.project_path import DATA_VOLUME
 from app.schemas.ml_model_pipeline import MLModelPipelineArtifactCreate
-from app.tasks.base import run_task_for_all_tenants, run_async_in_celery
+from app.tasks.base import run_task_for_all_tenants, run_async_in_celery, should_execute_run
 from app.core.exceptions.exception_classes import AppException
 from app.core.exceptions.error_messages import ErrorKey
 from app.dependencies.injector import injector
@@ -115,6 +115,8 @@ async def execute_pipeline_run_async(run_id: UUID):
                         )
                         return None  # Skip this tenant - run doesn't belong to it
                     raise
+                if not should_execute_run("Pipeline run", run_id, run.status):
+                    return None
 
                 # Update status to running
                 await run_repository.update_status(run_id, PipelineRunStatus.RUNNING)

--- a/backend/app/tasks/run_reconciliation_tasks.py
+++ b/backend/app/tasks/run_reconciliation_tasks.py
@@ -1,0 +1,172 @@
+"""
+Beat tasks that fail runs orphaned by a lost worker.
+
+Kept free of ML imports so they run on the default worker, outside the ml queue
+they watch. A waiting run counts as orphaned only when its job is no longer in
+the broker; a running run when it exceeds the maximum run age.
+"""
+
+import base64
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Callable, List, Optional, Set
+
+from celery import current_app, shared_task
+
+from app.core.config.settings import settings
+from app.core.tenant_scope import get_tenant_context
+from app.db.multi_tenant_session import multi_tenant_manager
+from app.repositories.test_suite import TestRunRepository
+from app.repositories.workflow_schedule_run import WorkflowScheduleRunRepository
+from app.tasks.base import run_async_in_celery, run_task_with_tenant_support
+
+logger = logging.getLogger(__name__)
+
+RUN_QUEUE = "ml"
+EVALUATION_RUN_TASK = "execute_test_suite_run"
+WORKFLOW_RUN_TASK = "execute_workflow_run"
+RECONCILER_TIMEOUT_SECONDS = 240
+
+STUCK_TEST_RUN_ERROR = (
+    "Run stopped unexpectedly (its worker crashed or was restarted) and was "
+    "marked failed by the reconciliation job."
+)
+STUCK_WORKFLOW_RUN_ERROR = (
+    "Run did not complete — the worker/pod was lost or restarted "
+    "mid-execution and the task was not resumed."
+)
+
+
+@dataclass(frozen=True)
+class RunReconciliation:
+    kind: str
+    repository: Callable
+    task_name: str
+    waiting_max_age_seconds: int
+    running_max_age_seconds: int
+    error_message: str
+
+
+def run_id_from_message(raw, task_name: str) -> Optional[str]:
+    """Run id carried by a broker message of ``task_name``, else None."""
+    try:
+        message = json.loads(raw)
+        # Reserved (unacked) entries are stored as [message, exchange, routing_key]
+        if isinstance(message, list):
+            message = message[0]
+        if message["headers"].get("task") != task_name:
+            return None
+        args = json.loads(base64.b64decode(message["body"]))[0]
+        return str(args[0])
+    except (ValueError, KeyError, IndexError, TypeError):
+        return None
+
+
+def _read_broker_messages(queue: str) -> list:
+    """Raw messages waiting in ``queue`` plus those reserved by a worker."""
+    with current_app.connection_for_read() as connection:
+        channel = connection.default_channel
+        prefix = channel.global_keyprefix or ""
+        client = channel.client
+        waiting = client.lrange(f"{prefix}{queue}", 0, -1)
+        reserved = client.hvals(f"{prefix}{channel.unacked_key}")
+        return waiting + reserved
+
+
+async def run_ids_in_broker(task_name: str, queue: str = RUN_QUEUE) -> Set[str]:
+    """Ids of runs whose job still exists in the broker, waiting or executing."""
+    # Read inline: the Celery current app is thread-local, and the lists are small
+    raw_messages = _read_broker_messages(queue)
+    ids = {run_id_from_message(raw, task_name) for raw in raw_messages}
+    ids.discard(None)
+    return ids
+
+
+def _orphaned(candidates: List[str], present: Set[str]) -> List[str]:
+    return [run_id for run_id in candidates if run_id not in present]
+
+
+async def _reconcile_runs(spec: RunReconciliation) -> None:
+    """Fail the current tenant's orphaned runs of one kind."""
+    tenant_id = get_tenant_context()
+    session_factory = multi_tenant_manager.get_tenant_session_factory(tenant_id)
+    now = datetime.now(timezone.utc)
+    waiting_before = now - timedelta(seconds=spec.waiting_max_age_seconds)
+    running_before = now - timedelta(seconds=spec.running_max_age_seconds)
+
+    async with session_factory() as session:
+        try:
+            repository = spec.repository(session)
+            candidates = await repository.get_waiting_ids_older_than(waiting_before)
+            present = await run_ids_in_broker(spec.task_name) if candidates else set()
+            failed = await repository.mark_orphaned_as_failed(
+                waiting_ids=_orphaned(candidates, present),
+                running_before=running_before,
+                error_message=spec.error_message,
+            )
+            # Repos only flush; this out-of-band session owns its commit
+            await session.commit()
+            if failed:
+                logger.warning(
+                    "Reconciled %s stuck %s(s) as failed for tenant %s",
+                    failed,
+                    spec.kind,
+                    tenant_id,
+                )
+        except Exception as exc:
+            await session.rollback()
+            logger.error("Error reconciling stuck %ss: %s", spec.kind, exc, exc_info=True)
+        finally:
+            await session.close()
+
+
+async def reconcile_stuck_test_runs_async() -> None:
+    await _reconcile_runs(
+        RunReconciliation(
+            kind="evaluation run",
+            repository=TestRunRepository,
+            task_name=EVALUATION_RUN_TASK,
+            waiting_max_age_seconds=settings.TEST_RUN_QUEUED_MAX_AGE_SECONDS,
+            running_max_age_seconds=settings.TEST_RUN_RUNNING_MAX_AGE_SECONDS,
+            error_message=STUCK_TEST_RUN_ERROR,
+        )
+    )
+
+
+async def reconcile_stuck_workflow_runs_async() -> None:
+    await _reconcile_runs(
+        RunReconciliation(
+            kind="workflow schedule run",
+            repository=WorkflowScheduleRunRepository,
+            task_name=WORKFLOW_RUN_TASK,
+            waiting_max_age_seconds=settings.WORKFLOW_SCHEDULE_PENDING_MAX_AGE_SECONDS,
+            running_max_age_seconds=settings.WORKFLOW_SCHEDULE_RUNNING_MAX_AGE_SECONDS,
+            error_message=STUCK_WORKFLOW_RUN_ERROR,
+        )
+    )
+
+
+@shared_task
+def reconcile_stuck_test_runs():
+    """Celery beat task to fail evaluation runs orphaned by a worker/pod loss."""
+    run_async_in_celery(
+        run_task_with_tenant_support(
+            reconcile_stuck_test_runs_async, "reconcile stuck evaluation runs"
+        ),
+        timeout=RECONCILER_TIMEOUT_SECONDS,
+        task_name="reconcile_stuck_test_runs",
+    )
+
+
+@shared_task
+def reconcile_stuck_workflow_runs():
+    """Celery beat task to fail scheduled workflow runs orphaned by a worker/pod loss."""
+    run_async_in_celery(
+        run_task_with_tenant_support(
+            reconcile_stuck_workflow_runs_async, "reconcile stuck workflow runs"
+        ),
+        timeout=RECONCILER_TIMEOUT_SECONDS,
+        task_name="reconcile_stuck_workflow_runs",
+    )

--- a/backend/app/tasks/run_reconciliation_tasks.py
+++ b/backend/app/tasks/run_reconciliation_tasks.py
@@ -39,6 +39,10 @@ STUCK_WORKFLOW_RUN_ERROR = (
 )
 
 
+class BrokerScanError(RuntimeError):
+    """The queue holds messages the scan could not read; nothing may be reaped from it."""
+
+
 @dataclass(frozen=True)
 class RunReconciliation:
     kind: str
@@ -72,6 +76,9 @@ def _read_broker_messages(queue: str) -> list:
         client = channel.client
         waiting = client.lrange(f"{prefix}{queue}", 0, -1)
         reserved = client.hvals(f"{prefix}{channel.unacked_key}")
+        # kombu prefixes LLEN itself, so a mismatch means the raw keys above are wrong
+        if not waiting and not reserved and client.llen(queue) > 0:
+            raise BrokerScanError(f"queue '{queue}' holds messages the scan cannot read")
         return waiting + reserved
 
 
@@ -84,7 +91,15 @@ async def run_ids_in_broker(task_name: str, queue: str = RUN_QUEUE) -> Set[str]:
     return ids
 
 
-def _orphaned(candidates: List[str], present: Set[str]) -> List[str]:
+async def orphaned_waiting_runs(candidates: List[str], task_name: str) -> List[str]:
+    """Waiting runs whose job is gone; none when the broker cannot be read safely."""
+    if not candidates:
+        return []
+    try:
+        present = await run_ids_in_broker(task_name)
+    except BrokerScanError as exc:
+        logger.warning("%s; leaving waiting runs untouched this round", exc)
+        return []
     return [run_id for run_id in candidates if run_id not in present]
 
 
@@ -100,9 +115,8 @@ async def _reconcile_runs(spec: RunReconciliation) -> None:
         try:
             repository = spec.repository(session)
             candidates = await repository.get_waiting_ids_older_than(waiting_before)
-            present = await run_ids_in_broker(spec.task_name) if candidates else set()
             failed = await repository.mark_orphaned_as_failed(
-                waiting_ids=_orphaned(candidates, present),
+                waiting_ids=await orphaned_waiting_runs(candidates, spec.task_name),
                 running_before=running_before,
                 error_message=spec.error_message,
             )

--- a/backend/app/tasks/test_suite_tasks.py
+++ b/backend/app/tasks/test_suite_tasks.py
@@ -29,11 +29,20 @@ logger = logging.getLogger(__name__)
 async def _persist_failure(service, run, exc: Exception) -> None:
     """Commit the failed status on its own; the task wrapper rolls back on raise."""
     session = service.run_repo.db
+    # The service may already have failed the run in memory and notified the user
+    already_notified = run.status in TERMINAL_RUN_STATUSES
+    error = (run.summary_metrics or {}).get("error") or f"Run failed unexpectedly: {exc}"
     try:
         await session.rollback()
         await session.refresh(run)
-        if run.status not in TERMINAL_RUN_STATUSES:
-            await service._fail_run(run, f"Run failed unexpectedly: {exc}")
+        if run.status in TERMINAL_RUN_STATUSES:
+            return
+        if already_notified:
+            run.status = "failed"
+            run.summary_metrics = {"error": error}
+            await service.run_repo.update(run)
+        else:
+            await service._fail_run(run, error)
         await session.commit()
     except Exception:
         logger.error("Could not persist the failed status of TestRun %s", run.id, exc_info=True)

--- a/backend/app/tasks/test_suite_tasks.py
+++ b/backend/app/tasks/test_suite_tasks.py
@@ -15,7 +15,7 @@ from app.core.tenant_scope import (
     clear_tenant_context,
     background_task_context,
 )
-from app.tasks.base import create_task_wrapper, run_async_in_celery
+from app.tasks.base import create_task_wrapper, run_async_in_celery, should_execute_run
 from app.core.tenant_scope import get_tenant_context
 from app.db.multi_tenant_session import multi_tenant_manager
 from app.dependencies.injector import injector
@@ -49,6 +49,8 @@ async def _execute_test_suite_run_async(
     run = await service.run_repo.get_by_id(run_id)
     if not run:
         logger.warning("TestRun %s not found — skipping", run_id)
+        return
+    if not should_execute_run("TestRun", run_id, run.status):
         return
 
     suite = await service.suite_repo.get_by_id(run.suite_id)

--- a/backend/app/tasks/test_suite_tasks.py
+++ b/backend/app/tasks/test_suite_tasks.py
@@ -3,32 +3,40 @@ Celery tasks for test suite run execution.
 """
 
 import logging
-from datetime import datetime, timedelta, timezone
 from typing import Any, Dict
 from uuid import UUID
 
 from celery import shared_task
 
-from app.core.config.settings import settings
 from app.core.tenant_scope import (
     set_tenant_context,
     clear_tenant_context,
     background_task_context,
 )
-from app.tasks.base import create_task_wrapper, run_async_in_celery, should_execute_run
+from app.tasks.base import (
+    TERMINAL_RUN_STATUSES,
+    create_task_wrapper,
+    run_async_in_celery,
+    should_execute_run,
+)
 from app.core.tenant_scope import get_tenant_context
-from app.db.multi_tenant_session import multi_tenant_manager
 from app.dependencies.injector import injector
 from app.modules.websockets.socket_connection_manager import SocketConnectionManager
-from app.repositories.test_suite import TestRunRepository
 from app.services.realtime_notifications import emit_notification, notification_payload
 
 logger = logging.getLogger(__name__)
 
-_STUCK_TEST_RUN_ERROR = (
-    "Run stopped unexpectedly (its worker crashed or was restarted) and was "
-    "marked failed by the reconciliation job."
-)
+async def _persist_failure(service, run, exc: Exception) -> None:
+    """Commit the failed status on its own; the task wrapper rolls back on raise."""
+    session = service.run_repo.db
+    try:
+        await session.rollback()
+        await session.refresh(run)
+        if run.status not in TERMINAL_RUN_STATUSES:
+            await service._fail_run(run, f"Run failed unexpectedly: {exc}")
+        await session.commit()
+    except Exception:
+        logger.error("Could not persist the failed status of TestRun %s", run.id, exc_info=True)
 
 
 async def _execute_test_suite_run_async(
@@ -86,8 +94,7 @@ async def _execute_test_suite_run_async(
         )
     except Exception as exc:
         logger.error("Test run %s failed: %s", run_id, exc, exc_info=True)
-        if run.status not in ("completed", "failed"):
-            await service._fail_run(run, f"Run failed unexpectedly: {exc}")
+        await _persist_failure(service, run, exc)
         raise
 
 
@@ -142,62 +149,3 @@ def execute_test_suite_run_task(
             raise
         finally:
             clear_tenant_context()
-
-
-async def reconcile_stuck_test_runs_async() -> None:
-    """Fail evaluation runs left stuck by a crashed worker for the current tenant."""
-    tenant_id = get_tenant_context()
-    session_factory = multi_tenant_manager.get_tenant_session_factory(tenant_id)
-
-    async with session_factory() as session:
-        try:
-            run_repository = TestRunRepository(session)
-            now = datetime.now(timezone.utc)
-            queued_before = now - timedelta(
-                seconds=settings.TEST_RUN_QUEUED_MAX_AGE_SECONDS
-            )
-            running_before = now - timedelta(
-                seconds=settings.TEST_RUN_RUNNING_MAX_AGE_SECONDS
-            )
-            failed = await run_repository.mark_stuck_as_failed(
-                queued_before=queued_before,
-                running_before=running_before,
-                error_message=_STUCK_TEST_RUN_ERROR,
-            )
-            # Repos only flush now; this out-of-band session owns its commit.
-            await session.commit()
-            if failed:
-                logger.warning(
-                    "Reconciled %s stuck evaluation run(s) as failed for tenant %s",
-                    failed,
-                    tenant_id,
-                )
-        except Exception as exc:
-            await session.rollback()
-            logger.error("Error reconciling stuck evaluation runs: %s", exc, exc_info=True)
-        finally:
-            await session.close()
-
-
-async def reconcile_stuck_test_runs_async_with_scope():
-    """Run the stuck-run reconciliation for all tenants."""
-    from app.tasks.base import run_task_with_tenant_support
-
-    return await run_task_with_tenant_support(
-        reconcile_stuck_test_runs_async,
-        "reconcile stuck evaluation runs",
-    )
-
-
-@shared_task
-def reconcile_stuck_test_runs():
-    """Celery beat task to fail evaluation runs orphaned by a worker/pod crash."""
-    try:
-        run_async_in_celery(
-            reconcile_stuck_test_runs_async_with_scope(),
-            timeout=50,
-            task_name="reconcile_stuck_test_runs",
-        )
-    except Exception as exc:
-        logger.error("Error in stuck evaluation-run reconciliation task: %s", exc, exc_info=True)
-        raise

--- a/backend/app/tasks/workflow_schedule_tasks.py
+++ b/backend/app/tasks/workflow_schedule_tasks.py
@@ -9,12 +9,11 @@ task resolves the agent's *current* workflow version and runs it.
 
 import logging
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from uuid import UUID
 
 from celery import shared_task
 
-from app.core.config.settings import settings
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
 from app.core.tenant_scope import get_tenant_context
@@ -353,83 +352,5 @@ def check_scheduled_workflow_runs():
     except Exception as e:
         logger.error(
             f"Error in scheduled workflow check task: {str(e)}", exc_info=True
-        )
-        raise
-
-
-# ==================== Reconciliation (crash recovery) ====================
-#
-# Runs are dispatched with Celery's default early-ack, so a run whose worker/pod
-# dies mid-execution is never redelivered and would otherwise sit in
-# PENDING/RUNNING forever. This sweep marks such runs FAILED once they exceed
-# safe age thresholds so the run history stays truthful. It deliberately does
-# NOT re-dispatch them, to avoid duplicating side effects (a partially-run
-# workflow may already have created tickets, sent messages, etc.). Re-run via
-# "Run now" if needed.
-
-_STUCK_RUN_ERROR = (
-    "Run did not complete — the worker/pod was lost or restarted "
-    "mid-execution and the task was not resumed."
-)
-
-
-async def reconcile_stuck_workflow_runs_async():
-    """Fail runs left stuck by a crashed worker for the current tenant."""
-    tenant_id = get_tenant_context()
-    session_factory = multi_tenant_manager.get_tenant_session_factory(tenant_id)
-
-    async with session_factory() as session:
-        try:
-            run_repository = WorkflowScheduleRunRepository(session)
-            now = datetime.now(timezone.utc)
-            pending_before = now - timedelta(
-                seconds=settings.WORKFLOW_SCHEDULE_PENDING_MAX_AGE_SECONDS
-            )
-            running_before = now - timedelta(
-                seconds=settings.WORKFLOW_SCHEDULE_RUNNING_MAX_AGE_SECONDS
-            )
-            failed = await run_repository.mark_stuck_as_failed(
-                pending_before=pending_before,
-                running_before=running_before,
-                error_message=_STUCK_RUN_ERROR,
-            )
-            # Repos only flush now; this out-of-band session owns its commit.
-            await session.commit()
-            if failed:
-                logger.warning(
-                    f"Reconciled {failed} stuck workflow schedule run(s) as FAILED "
-                    f"for tenant {tenant_id}"
-                )
-        except Exception as e:
-            await session.rollback()
-            logger.error(
-                f"Error reconciling stuck workflow runs: {str(e)}", exc_info=True
-            )
-        finally:
-            await session.close()
-
-
-async def reconcile_stuck_workflow_runs_async_with_scope():
-    """Run the stuck-run reconciliation for all tenants."""
-    from app.tasks.base import run_task_with_tenant_support
-
-    return await run_task_with_tenant_support(
-        reconcile_stuck_workflow_runs_async,
-        "reconcile stuck workflow runs",
-    )
-
-
-@shared_task
-def reconcile_stuck_workflow_runs():
-    """Celery beat task to fail runs orphaned by a worker/pod crash."""
-    try:
-        run_async_in_celery(
-            reconcile_stuck_workflow_runs_async_with_scope(),
-            timeout=50,
-            task_name="reconcile_stuck_workflow_runs",
-        )
-    except Exception as e:
-        logger.error(
-            f"Error in stuck-run reconciliation task: {str(e)}", exc_info=True
         )
         raise

--- a/backend/app/tasks/workflow_schedule_tasks.py
+++ b/backend/app/tasks/workflow_schedule_tasks.py
@@ -25,7 +25,6 @@ from app.core.utils.uuid_utils import coerce_uuid
 from app.db.multi_tenant_session import multi_tenant_manager
 from app.dependencies.injector import injector
 from app.modules.websockets.socket_connection_manager import SocketConnectionManager
-from app.modules.workflow.engine.workflow_engine import WorkflowEngine
 from app.modules.workflow.usage_context import WorkflowUsageContext
 from app.repositories.agent import AgentRepository
 from app.repositories.workflow_schedule import WorkflowScheduleRepository
@@ -139,6 +138,9 @@ async def execute_workflow_run_async(run_id: UUID):
                     "nodes": workflow.nodes or [],
                     "edges": workflow.edges or [],
                 }
+                # Imported lazily so the worker master never loads ML libs before forking
+                from app.modules.workflow.engine.workflow_engine import WorkflowEngine
+
                 workflow_engine = WorkflowEngine(workflow_config)
 
                 state = await workflow_engine.execute_from_node(

--- a/backend/app/tasks/workflow_schedule_tasks.py
+++ b/backend/app/tasks/workflow_schedule_tasks.py
@@ -32,7 +32,7 @@ from app.repositories.agent import AgentRepository
 from app.repositories.workflow_schedule import WorkflowScheduleRepository
 from app.repositories.workflow_schedule_run import WorkflowScheduleRunRepository
 from app.services.realtime_notifications import emit_notification, notification_payload
-from app.tasks.base import run_async_in_celery
+from app.tasks.base import run_async_in_celery, should_execute_run
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +96,8 @@ async def execute_workflow_run_async(run_id: UUID):
                         )
                         return None
                     raise
+                if not should_execute_run("Workflow schedule run", run_id, run.status):
+                    return None
 
                 await run_repository.update_status(
                     run_id, WorkflowScheduleRunStatus.RUNNING

--- a/backend/deploy/k8s/celery-workers.yaml
+++ b/backend/deploy/k8s/celery-workers.yaml
@@ -2,15 +2,17 @@
 # Celery workers — two-pool split for EKS
 #
 # Why two deployments:
-#   * worker-ml      : runs the ML / evaluation / local-fine-tuning tasks on the "ml" queue,
-#                      one child process so evaluations run one at a time.
-#   * worker-default : runs everything else on the "default" queue with two children.
+#   * worker-ml      : runs the ML / evaluation / local-fine-tuning tasks on the "ml" queue
+#                      on the SOLO pool. Workflow Python code nodes execute user code in a
+#                      subprocess, and a prefork child (daemonic) may not start children,
+#                      so this worker cannot run prefork until that executor is adapted.
+#   * worker-default : runs everything else on the "default" queue on the PREFORK pool with
+#                      two children. Prefork is the only pool that enforces task time limits
+#                      and answers `celery inspect ping` during a task.
 #
-# Both use the PREFORK pool. It is the only pool that enforces task time limits and
-# answers `celery inspect ping` during a task (solo does neither). Fork safety: the ML libs
-# (torch/sklearn/transformers) spawn native threads at import and would crash a forked
-# child, so every task module imports them lazily inside the task and the master process
-# stays clean; test_celery_worker_boot_clean.py guards this for both worker configs.
+# Fork safety: the ML libs (torch/sklearn/transformers) spawn native threads at import and
+# would crash a forked child, so every task module imports them lazily inside the task and
+# the master process stays clean; test_celery_worker_boot_clean.py guards this.
 #
 # Routing is configured in app/__init__.py (create_celery): task_default_queue="default",
 # task_routes pins execute_pipeline_run / execute_test_suite_run / execute_workflow_run and
@@ -56,7 +58,7 @@ metadata:
   name: genassist-celery-worker-ml
   labels: { app: genassist, service: celery-worker-ml }
 spec:
-  replicas: 1   # scale ML throughput horizontally (one evaluation per replica)
+  replicas: 1   # scale ML throughput horizontally (solo = one task per process)
   selector:
     matchLabels: { app: genassist, service: celery-worker-ml }
   template:
@@ -66,13 +68,12 @@ spec:
       containers:
         - name: celery-worker-ml
           image: <IMAGE>
-          command: ["python", "/src/run_celery.py", "worker", "--loglevel=info", "--pool=prefork", "-Q", "ml"]
+          command: ["python", "/src/run_celery.py", "worker", "--loglevel=info", "--pool=solo", "-Q", "ml"]
           envFrom:
             - secretRef: { name: genassist-env }
           env:
-            - { name: CELERY_WORKER_POOL,        value: "prefork" }
-            - { name: CELERY_WORKER_CONCURRENCY, value: "1" }
-            - { name: CELERY_INCLUDE_ML_TASKS,   value: "true" }
+            - { name: CELERY_WORKER_POOL,      value: "solo" }
+            - { name: CELERY_INCLUDE_ML_TASKS, value: "true" }
           resources:
             # ML models + torch are memory-hungry; size generously.
             requests: { cpu: "1",  memory: "2Gi" }

--- a/backend/deploy/k8s/celery-workers.yaml
+++ b/backend/deploy/k8s/celery-workers.yaml
@@ -2,24 +2,19 @@
 # Celery workers — two-pool split for EKS
 #
 # Why two deployments:
-#   ML libs (torch/sklearn/transformers) spawn native OpenMP/MKL threads at import.
-#   Celery's prefork pool uses fork(), which copies only the calling thread and leaves
-#   children holding mutexes locked by threads that no longer exist -> SIGSEGV. So:
+#   * worker-ml      : runs the ML / evaluation / local-fine-tuning tasks on the "ml" queue,
+#                      one child process so evaluations run one at a time.
+#   * worker-default : runs everything else on the "default" queue with two children.
 #
-#   * worker-ml      : runs the segfault-prone ML / evaluation / local-fine-tuning tasks
-#                      on the SOLO pool (never forks -> safe). Consumes the "ml" queue.
-#                      Scale throughput by raising `replicas` (each replica is a process).
-#
-#   * worker-default : runs everything else on the PREFORK pool for real in-process
-#                      concurrency. Safe because its image entrypoint (run_celery.py ->
-#                      create_celery(), no HTTP routers) plus CELERY_INCLUDE_ML_TASKS=false
-#                      keep the master process free of ML libs; prefork children may import
-#                      them lazily AFTER fork (e.g. KB ingestion), which is safe.
-#                      Consumes the "default" queue.
+# Both use the PREFORK pool. It is the only pool that enforces task time limits and
+# answers `celery inspect ping` during a task (solo does neither). Fork safety: the ML libs
+# (torch/sklearn/transformers) spawn native threads at import and would crash a forked
+# child, so every task module imports them lazily inside the task and the master process
+# stays clean; test_celery_worker_boot_clean.py guards this for both worker configs.
 #
 # Routing is configured in app/__init__.py (create_celery): task_default_queue="default",
-# task_routes pins execute_pipeline_run / execute_test_suite_run /
-# check_scheduled_pipeline_runs to the "ml" queue.
+# task_routes pins execute_pipeline_run / execute_test_suite_run / execute_workflow_run and
+# the scheduled-run checks to the "ml" queue.
 #
 # This is a reference template — replace <IMAGE>, namespace, env/secret refs and resource
 # requests with your cluster's values. The fields that matter for the split are the
@@ -61,7 +56,7 @@ metadata:
   name: genassist-celery-worker-ml
   labels: { app: genassist, service: celery-worker-ml }
 spec:
-  replicas: 1   # scale ML throughput horizontally (solo = one task per process)
+  replicas: 1   # scale ML throughput horizontally (one evaluation per replica)
   selector:
     matchLabels: { app: genassist, service: celery-worker-ml }
   template:
@@ -71,12 +66,13 @@ spec:
       containers:
         - name: celery-worker-ml
           image: <IMAGE>
-          command: ["python", "/src/run_celery.py", "worker", "--loglevel=info", "--pool=solo", "-Q", "ml"]
+          command: ["python", "/src/run_celery.py", "worker", "--loglevel=info", "--pool=prefork", "-Q", "ml"]
           envFrom:
             - secretRef: { name: genassist-env }
           env:
-            - { name: CELERY_WORKER_POOL,      value: "solo" }
-            - { name: CELERY_INCLUDE_ML_TASKS, value: "true" }
+            - { name: CELERY_WORKER_POOL,        value: "prefork" }
+            - { name: CELERY_WORKER_CONCURRENCY, value: "1" }
+            - { name: CELERY_INCLUDE_ML_TASKS,   value: "true" }
           resources:
             # ML models + torch are memory-hungry; size generously.
             requests: { cpu: "1",  memory: "2Gi" }

--- a/backend/run_celery.py
+++ b/backend/run_celery.py
@@ -5,6 +5,8 @@ import time
 from celery.signals import worker_process_init
 from app import create_celery
 from app.core.config.settings import settings
+# Registers the beat leader lock and tick heartbeat (beat_init signal)
+import app.tasks.beat_leader  # noqa: F401
 
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)
@@ -82,9 +84,8 @@ if __name__ == "__main__":
     import sys
     from celery.__main__ import main as celery_main
 
-    # Only the worker needs a liveness heartbeat (beat/flower are separate
-    # processes with their own concerns). The solo pool runs the worker in this
-    # main process, so a daemon thread here reflects worker liveness directly.
+    # The worker heartbeat thread lives here; beat writes its own heartbeat from
+    # the scheduler loop (see app/tasks/beat_leader.py).
     if "worker" in sys.argv:
         _start_heartbeat_thread()
 

--- a/backend/tests/unit/test_beat_leader.py
+++ b/backend/tests/unit/test_beat_leader.py
@@ -1,0 +1,149 @@
+"""Beat leader lock and scheduler-loop heartbeat."""
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+import redis
+
+from app.tasks import beat_leader
+from app.tasks.beat_leader import BeatLeaderLock, install_tick_heartbeat
+
+
+class FakeRedis:
+    """Just enough of SET NX EX and the compare-and-expire script."""
+
+    def __init__(self):
+        self.store = {}
+
+    def set(self, key, value, nx=False, ex=None):
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        return True
+
+    def eval(self, script, numkeys, key, token, ttl):
+        return 1 if self.store.get(key) == token else 0
+
+    def release(self, key):
+        self.store.pop(key, None)
+
+
+def _lock(client, token="beat-a", **overrides):
+    return BeatLeaderLock(client, token, ttl_seconds=60, sleep=lambda _: None, **overrides)
+
+
+class TestLeaderLock:
+    def test_first_beat_becomes_leader_immediately(self):
+        client = FakeRedis()
+        _lock(client).wait_until_leader()
+        assert client.store[beat_leader.LEADER_KEY] == "beat-a"
+
+    def test_second_beat_stands_by_until_the_lock_is_released(self):
+        client = FakeRedis()
+        _lock(client, "beat-a").wait_until_leader()
+        waits = []
+
+        def sleep(seconds):
+            waits.append(seconds)
+            if len(waits) == 3:
+                client.release(beat_leader.LEADER_KEY)
+
+        BeatLeaderLock(client, "beat-b", ttl_seconds=60, sleep=sleep).wait_until_leader()
+
+        assert len(waits) == 3
+        assert client.store[beat_leader.LEADER_KEY] == "beat-b"
+
+    def test_redis_errors_while_waiting_are_retried(self):
+        client = MagicMock()
+        client.set.side_effect = [redis.ConnectionError("down"), True]
+
+        _lock(client).wait_until_leader()
+
+        assert client.set.call_count == 2
+
+    def test_leader_renews_its_own_lock(self):
+        client = FakeRedis()
+        lock = _lock(client, step_down=MagicMock())
+        lock.wait_until_leader()
+
+        assert lock.renew_once() is True
+        lock._step_down.assert_not_called()
+
+    def test_losing_the_lock_stops_this_scheduler(self):
+        client = FakeRedis()
+        step_down = MagicMock()
+        lock = _lock(client, "beat-a", step_down=step_down)
+        lock.wait_until_leader()
+        client.store[beat_leader.LEADER_KEY] = "beat-b"
+
+        assert lock.renew_once() is False
+        step_down.assert_called_once()
+
+    def test_renewal_survives_a_redis_error(self):
+        client = MagicMock()
+        client.eval.side_effect = redis.ConnectionError("down")
+        step_down = MagicMock()
+
+        assert _lock(client, step_down=step_down).renew_once() is True
+        step_down.assert_not_called()
+
+
+class TestTickHeartbeat:
+    def test_every_tick_refreshes_the_heartbeat_and_still_ticks(self, tmp_path):
+        heartbeat = tmp_path / "beat_heartbeat"
+        scheduler = MagicMock()
+        scheduler.tick.return_value = 5.0
+        install_tick_heartbeat(scheduler, str(heartbeat))
+
+        before = int(time.time())
+        assert scheduler.tick() == 5.0
+
+        assert int(heartbeat.read_text()) >= before
+        assert not (tmp_path / "beat_heartbeat.tmp").exists()
+
+    def test_heartbeat_write_failure_does_not_break_the_tick(self, tmp_path):
+        scheduler = MagicMock()
+        scheduler.tick.return_value = 1.0
+        install_tick_heartbeat(scheduler, str(tmp_path / "missing-dir" / "heartbeat"))
+
+        assert scheduler.tick() == 1.0
+
+
+class TestBeatInitHook:
+    def test_hook_installs_heartbeat_and_waits_for_leadership(self):
+        service = MagicMock()
+        lock = MagicMock()
+        with patch.object(beat_leader, "install_tick_heartbeat") as heartbeat, patch.object(
+            beat_leader, "_redis_client"
+        ), patch.object(beat_leader, "BeatLeaderLock", return_value=lock), patch.object(
+            beat_leader.settings, "CELERY_BEAT_LEADER_LOCK_ENABLED", True
+        ):
+            beat_leader.on_beat_init(sender=service)
+
+        heartbeat.assert_called_once_with(service.scheduler)
+        lock.wait_until_leader.assert_called_once()
+        lock.start_renewal_thread.assert_called_once()
+
+    def test_lock_can_be_disabled_by_setting(self):
+        service = MagicMock()
+        with patch.object(beat_leader, "install_tick_heartbeat"), patch.object(
+            beat_leader, "BeatLeaderLock"
+        ) as lock_cls, patch.object(beat_leader.settings, "CELERY_BEAT_LEADER_LOCK_ENABLED", False):
+            beat_leader.on_beat_init(sender=service)
+
+        lock_cls.assert_not_called()
+
+
+@pytest.mark.parametrize("ttl", [30, 60, 120])
+def test_standby_polls_more_often_than_the_lock_expires(ttl):
+    waits = []
+    client = FakeRedis()
+    client.store[beat_leader.LEADER_KEY] = "someone-else"
+
+    def sleep(seconds):
+        waits.append(seconds)
+        client.release(beat_leader.LEADER_KEY)
+
+    BeatLeaderLock(client, "me", ttl_seconds=ttl, sleep=sleep).wait_until_leader()
+
+    assert waits == [ttl / 6]

--- a/backend/tests/unit/test_beat_leader.py
+++ b/backend/tests/unit/test_beat_leader.py
@@ -22,7 +22,11 @@ class FakeRedis:
         return True
 
     def eval(self, script, numkeys, key, token, ttl):
+        self.renewals = getattr(self, "renewals", 0) + 1
         return 1 if self.store.get(key) == token else 0
+
+    def get(self, key):
+        return self.store.get(key)
 
     def release(self, key):
         self.store.pop(key, None)
@@ -52,6 +56,22 @@ class TestLeaderLock:
 
         assert len(waits) == 3
         assert client.store[beat_leader.LEADER_KEY] == "beat-b"
+
+    def test_standby_keeps_writing_the_heartbeat(self):
+        """A liveness probe on the heartbeat file must not restart a healthy standby."""
+        client = FakeRedis()
+        client.store[beat_leader.LEADER_KEY] = "someone-else"
+        waits = []
+
+        def sleep(seconds):
+            waits.append(seconds)
+            if len(waits) == 2:
+                client.release(beat_leader.LEADER_KEY)
+
+        with patch.object(beat_leader, "write_heartbeat") as heartbeat:
+            BeatLeaderLock(client, "me", ttl_seconds=60, sleep=sleep).wait_until_leader()
+
+        assert heartbeat.call_count == 2
 
     def test_redis_errors_while_waiting_are_retried(self):
         client = MagicMock()
@@ -86,6 +106,52 @@ class TestLeaderLock:
 
         assert _lock(client, step_down=step_down).renew_once() is True
         step_down.assert_not_called()
+
+    def test_a_frozen_loop_stops_renewing_but_keeps_running_while_still_owner(self):
+        """The lock must be allowed to expire so a standby can take over."""
+        client = FakeRedis()
+        step_down = MagicMock()
+        lock = _lock(client, step_down=step_down, loop_is_alive=lambda: False)
+        lock.wait_until_leader()
+
+        assert lock.renew_once() is True
+        assert getattr(client, "renewals", 0) == 0
+        step_down.assert_not_called()
+
+    def test_a_frozen_loop_steps_down_once_the_lock_has_expired(self):
+        client = FakeRedis()
+        step_down = MagicMock()
+        lock = _lock(client, step_down=step_down, loop_is_alive=lambda: False)
+        lock.wait_until_leader()
+        client.release(beat_leader.LEADER_KEY)
+
+        assert lock.renew_once() is False
+        step_down.assert_called_once()
+
+
+class TestTickMonitor:
+    def test_reports_stale_only_after_the_max_age(self):
+        now = [1000.0]
+        monitor = beat_leader.TickMonitor(clock=lambda: now[0])
+
+        now[0] += beat_leader.STALE_SCHEDULER_SECONDS - 1
+        assert monitor.is_alive() is True
+        now[0] += 2
+        assert monitor.is_alive() is False
+
+        monitor.record_tick()
+        assert monitor.is_alive() is True
+
+    def test_installed_heartbeat_records_each_tick(self, tmp_path):
+        now = [50.0]
+        monitor = beat_leader.TickMonitor(clock=lambda: now[0])
+        scheduler = MagicMock()
+        beat_leader.install_tick_heartbeat(scheduler, str(tmp_path / "hb"), monitor)
+
+        now[0] = 900.0
+        scheduler.tick()
+
+        assert monitor.last_tick_at == 900.0
 
 
 class TestTickHeartbeat:

--- a/backend/tests/unit/test_celery_config.py
+++ b/backend/tests/unit/test_celery_config.py
@@ -1,12 +1,18 @@
 """Locks the Celery task, delivery, and beat configuration"""
 
 import importlib
+import math
+import re
+from pathlib import Path
 
 import pytest
 
+import app
 from app import LONG_TASK_TIMEOUTS, create_celery
 from app.core.config.settings import settings
 
+TASK_DECORATOR = re.compile(r"@shared_task(\((.*?)\))?\s*\ndef\s+(\w+)\s*\(", re.S)
+TIMEOUT_LITERAL = re.compile(r"timeout\s*=\s*([0-9][0-9 *+]*)")
 ML_TASK_MODULES = (
     "app.tasks.ml_model_pipeline_tasks",
     "app.tasks.test_suite_tasks",
@@ -38,7 +44,50 @@ def test_no_llm_usage_task_is_scheduled(celery_conf):
 def test_messages_are_acknowledged_only_after_the_task_finishes(celery_conf):
     """A worker killed mid-task must leave its message in the queue for redelivery"""
     assert celery_conf.task_acks_late is True
-    assert celery_conf.task_reject_on_worker_lost is True
+
+
+def test_a_job_that_kills_its_child_process_is_not_requeued(celery_conf):
+    """Requeueing a deterministic crash would jam the queue in an endless loop"""
+    assert celery_conf.task_reject_on_worker_lost is False
+
+
+def _arithmetic(expression: str) -> int:
+    return sum(
+        math.prod(int(factor) for factor in term.split("*"))
+        for term in expression.replace(" ", "").split("+")
+    )
+
+
+def _internal_task_timeouts(included_modules):
+    """(task name, internal asyncio timeout) for every included task module that declares one"""
+    tasks_dir = Path(app.__file__).parent / "tasks"
+    for path in sorted(tasks_dir.glob("*.py")):
+        if f"app.tasks.{path.stem}" not in included_modules:
+            continue
+        source = path.read_text()
+        decorators = list(TASK_DECORATOR.finditer(source))
+        for index, match in enumerate(decorators):
+            decorator_args, function = match.group(2) or "", match.group(3)
+            explicit_name = re.search(r"name\s*=\s*['\"]([^'\"]+)['\"]", decorator_args)
+            name = explicit_name.group(1) if explicit_name else f"app.tasks.{path.stem}.{function}"
+            body_end = decorators[index + 1].start() if index + 1 < len(decorators) else len(source)
+            timeout = TIMEOUT_LITERAL.search(source[match.end():body_end])
+            if timeout:
+                yield name, _arithmetic(timeout.group(1))
+
+
+def test_every_task_with_a_long_internal_timeout_has_its_own_limit(celery_conf):
+    """The table must mirror the task modules, so no long task slips to the global limit"""
+    included_modules = set(celery_conf.include) | set(ML_TASK_MODULES)
+    long_tasks = {
+        name: timeout
+        for name, timeout in _internal_task_timeouts(included_modules)
+        if timeout >= celery_conf.task_soft_time_limit
+    }
+
+    assert long_tasks
+    for name, timeout in long_tasks.items():
+        assert LONG_TASK_TIMEOUTS.get(name) == timeout, name
 
 
 def test_reconcilers_run_on_the_default_queue(celery_conf):

--- a/backend/tests/unit/test_celery_config.py
+++ b/backend/tests/unit/test_celery_config.py
@@ -83,6 +83,19 @@ def test_every_time_limited_task_name_is_a_registered_task(celery_app):
     assert set(LONG_TASK_TIMEOUTS) <= set(celery_app.tasks)
 
 
+def test_frequent_scheduled_ticks_expire_before_the_next_one(celery_conf):
+    """A tick that missed its slot is dropped instead of queuing behind a long ml job"""
+    beat = celery_conf.beat_schedule or {}
+    for name in (
+        "check-scheduled-pipeline-runs",
+        "check-scheduled-workflow-runs",
+        "reconcile-stuck-workflow-runs",
+        "reconcile-stuck-test-runs",
+    ):
+        entry = beat[name]
+        assert entry["options"]["expires"] < entry["schedule"], name
+
+
 def test_redelivery_delay_sits_between_task_timeout_and_reconciler(celery_conf):
     """Redelivery must never duplicate a running 2h job, and must precede the reconciler"""
     two_hours = 2 * 60 * 60

--- a/backend/tests/unit/test_celery_config.py
+++ b/backend/tests/unit/test_celery_config.py
@@ -1,14 +1,28 @@
 """Locks the Celery task, delivery, and beat configuration"""
 
+import importlib
+
 import pytest
 
-from app import create_celery
+from app import LONG_TASK_TIMEOUTS, create_celery
 from app.core.config.settings import settings
+
+ML_TASK_MODULES = (
+    "app.tasks.ml_model_pipeline_tasks",
+    "app.tasks.test_suite_tasks",
+    "app.tasks.workflow_schedule_tasks",
+)
+RUN_TASKS = ("execute_test_suite_run", "execute_workflow_run", "execute_pipeline_run")
 
 
 @pytest.fixture(scope="module")
-def celery_conf():
-    return create_celery().conf
+def celery_app():
+    return create_celery()
+
+
+@pytest.fixture(scope="module")
+def celery_conf(celery_app):
+    return celery_app.conf
 
 
 def test_only_the_backfill_task_module_is_included(celery_conf):
@@ -40,6 +54,33 @@ def test_reconcilers_run_on_the_default_queue(celery_conf):
         "app.tasks.run_reconciliation_tasks.reconcile_stuck_workflow_runs",
         "app.tasks.run_reconciliation_tasks.reconcile_stuck_test_runs",
     ]
+
+
+def test_long_tasks_get_time_limits_above_their_own_timeout(celery_conf):
+    """Under prefork the limits are enforced, so they must never cut a healthy long job"""
+    visibility_timeout = celery_conf.broker_transport_options["visibility_timeout"]
+    annotations = celery_conf.task_annotations
+
+    assert set(annotations) == set(LONG_TASK_TIMEOUTS)
+    for name, timeout in LONG_TASK_TIMEOUTS.items():
+        limits = annotations[name]
+        assert timeout < limits["soft_time_limit"] < limits["time_limit"] < visibility_timeout
+    for run_task in RUN_TASKS:
+        assert LONG_TASK_TIMEOUTS[run_task] == 2 * 60 * 60
+
+
+def test_global_time_limit_covers_every_task_without_its_own(celery_conf):
+    """Every task outside the table has an internal timeout of at most 5 minutes"""
+    assert 5 * 60 < celery_conf.task_soft_time_limit < celery_conf.task_time_limit
+
+
+def test_every_time_limited_task_name_is_a_registered_task(celery_app):
+    """A misspelled name here would silently leave that task on the global limit"""
+    celery_app.loader.import_default_modules()
+    for module in ML_TASK_MODULES:
+        importlib.import_module(module)
+
+    assert set(LONG_TASK_TIMEOUTS) <= set(celery_app.tasks)
 
 
 def test_redelivery_delay_sits_between_task_timeout_and_reconciler(celery_conf):

--- a/backend/tests/unit/test_celery_config.py
+++ b/backend/tests/unit/test_celery_config.py
@@ -27,6 +27,21 @@ def test_messages_are_acknowledged_only_after_the_task_finishes(celery_conf):
     assert celery_conf.task_reject_on_worker_lost is True
 
 
+def test_reconcilers_run_on_the_default_queue(celery_conf):
+    """The cleanup must never queue behind the ml jam it is meant to clear"""
+    assert "app.tasks.run_reconciliation_tasks" in celery_conf.include
+    assert not [name for name in celery_conf.task_routes if "reconcile_stuck" in name]
+
+    beat = celery_conf.beat_schedule or {}
+    reconcile_tasks = [
+        entry["task"] for name, entry in beat.items() if name.startswith("reconcile-stuck")
+    ]
+    assert reconcile_tasks == [
+        "app.tasks.run_reconciliation_tasks.reconcile_stuck_workflow_runs",
+        "app.tasks.run_reconciliation_tasks.reconcile_stuck_test_runs",
+    ]
+
+
 def test_redelivery_delay_sits_between_task_timeout_and_reconciler(celery_conf):
     """Redelivery must never duplicate a running 2h job, and must precede the reconciler"""
     two_hours = 2 * 60 * 60

--- a/backend/tests/unit/test_celery_config.py
+++ b/backend/tests/unit/test_celery_config.py
@@ -1,8 +1,9 @@
-"""Locks the LLM usage slice of the Celery task and beat configuration"""
+"""Locks the Celery task, delivery, and beat configuration"""
 
 import pytest
 
 from app import create_celery
+from app.core.config.settings import settings
 
 
 @pytest.fixture(scope="module")
@@ -18,3 +19,19 @@ def test_no_llm_usage_task_is_scheduled(celery_conf):
     """The backfill is operator-triggered, so nothing in this area runs on a timer"""
     beat = celery_conf.beat_schedule or {}
     assert [name for name, entry in beat.items() if "llm_usage" in str(entry.get("task", ""))] == []
+
+
+def test_messages_are_acknowledged_only_after_the_task_finishes(celery_conf):
+    """A worker killed mid-task must leave its message in the queue for redelivery"""
+    assert celery_conf.task_acks_late is True
+    assert celery_conf.task_reject_on_worker_lost is True
+
+
+def test_redelivery_delay_sits_between_task_timeout_and_reconciler(celery_conf):
+    """Redelivery must never duplicate a running 2h job, and must precede the reconciler"""
+    two_hours = 2 * 60 * 60
+    visibility_timeout = celery_conf.broker_transport_options["visibility_timeout"]
+
+    assert visibility_timeout > two_hours
+    assert visibility_timeout < settings.TEST_RUN_RUNNING_MAX_AGE_SECONDS
+    assert visibility_timeout < settings.WORKFLOW_SCHEDULE_RUNNING_MAX_AGE_SECONDS

--- a/backend/tests/unit/test_celery_worker_boot_clean.py
+++ b/backend/tests/unit/test_celery_worker_boot_clean.py
@@ -1,15 +1,16 @@
-"""Regression guard for the two-pool Celery split.
+"""Regression guard for the prefork Celery workers.
 
-The "default" Celery worker runs the prefork pool, which fork()s child processes. ML
-libraries (torch / sklearn / transformers / sentence_transformers / faiss) spawn native
-OpenMP/MKL threads at import; if they are loaded in the prefork *master* process, fork()
-copies their locked mutexes into children -> SIGSEGV.
+Both Celery workers run the prefork pool, which fork()s child processes. ML libraries
+(torch / sklearn / transformers / sentence_transformers / faiss) spawn native OpenMP/MKL
+threads at import; if they are loaded in the prefork *master* process, fork() copies
+their locked mutexes into children -> SIGSEGV.
 
-So the master must import every task module on the "default" worker WITHOUT loading any of
-those libraries. This test boots the worker app exactly as run_celery.py does
-(create_celery() + import_default_modules()) with CELERY_INCLUDE_ML_TASKS=false, in a
-*subprocess* (a clean interpreter — this test process is already polluted by other tests'
-imports), and asserts none of the heavy ML libs ended up in sys.modules.
+So the master must import every task module WITHOUT loading any of those libraries, on
+the "default" worker (CELERY_INCLUDE_ML_TASKS=false) and on the "ml" worker
+(CELERY_INCLUDE_ML_TASKS=true) alike. This test boots the worker app exactly as
+run_celery.py does (create_celery() + import_default_modules()) in a *subprocess* (a clean
+interpreter — this test process is already polluted by other tests' imports), and asserts
+none of the heavy ML libs ended up in sys.modules.
 
 If this fails, some module reachable from a non-ML task's import graph started importing an
 ML lib at module top level again. Find it with:
@@ -19,12 +20,19 @@ ML lib at module top level again. Find it with:
 "
 and move that import to be lazy (inside the function/method that uses it).
 """
+import os
 import subprocess
 import sys
 import textwrap
 
+import pytest
 
-def test_default_worker_master_imports_no_ml_libs():
+
+@pytest.mark.parametrize(
+    "worker, include_ml_tasks",
+    [("default", "false"), ("ml", "true")],
+)
+def test_worker_master_imports_no_ml_libs(worker, include_ml_tasks):
     script = textwrap.dedent(
         """
         import sys
@@ -42,16 +50,17 @@ def test_default_worker_master_imports_no_ml_libs():
         capture_output=True,
         text=True,
         env={
-            "PATH": __import__("os").environ.get("PATH", ""),
-            "CELERY_INCLUDE_ML_TASKS": "false",
-            "CELERY_WORKER_POOL": "prefork",
+            "PATH": os.environ.get("PATH", ""),
             # Minimal env so settings load; the worker never connects during import.
-            **{k: v for k, v in __import__("os").environ.items()
+            **{k: v for k, v in os.environ.items()
                if k.startswith(("DB_", "REDIS_", "CELERY_", "DATA_", "OPENAI_", "VECTOR_", "CHROMA_"))},
+            # Explicit values last so the host environment cannot override them
+            "CELERY_INCLUDE_ML_TASKS": include_ml_tasks,
+            "CELERY_WORKER_POOL": "prefork",
         },
     )
     loaded = next((l for l in proc.stdout.splitlines() if l.startswith("LOADED:")), "LOADED:?")
     assert proc.returncode == 0, (
-        f"prefork default-worker master loaded ML libs at boot ({loaded}). "
+        f"prefork {worker}-worker master loaded ML libs at boot ({loaded}). "
         f"Move the offending top-level import to be lazy.\nstderr tail:\n{proc.stderr[-2000:]}"
     )

--- a/backend/tests/unit/test_evaluation_run_reliability.py
+++ b/backend/tests/unit/test_evaluation_run_reliability.py
@@ -681,6 +681,18 @@ class TestOrphanRepo:
         db.flush.assert_awaited_once()
 
 
+def _failing_service(run, failure):
+    service = MagicMock()
+    service.run_repo.db = AsyncMock()
+    service.run_repo.get_by_id = AsyncMock(return_value=run)
+    service.run_repo.update = AsyncMock()
+    service.suite_repo.get_by_id = AsyncMock(return_value=SimpleNamespace(id=uuid4()))
+    service.workflow_service.get_by_id = AsyncMock(return_value=MagicMock())
+    service._execute_run = AsyncMock(side_effect=failure)
+    service._fail_run = AsyncMock()
+    return service
+
+
 class TestFailureIsPersisted:
     @pytest.mark.asyncio
     async def test_failed_status_is_committed_when_the_run_raises(self):
@@ -690,13 +702,7 @@ class TestFailureIsPersisted:
         run = SimpleNamespace(
             id=uuid4(), status="running", summary_metrics=None, suite_id=uuid4(), workflow_id=uuid4()
         )
-        service = MagicMock()
-        service.run_repo.db = AsyncMock()
-        service.run_repo.get_by_id = AsyncMock(return_value=run)
-        service.suite_repo.get_by_id = AsyncMock(return_value=SimpleNamespace(id=uuid4()))
-        service.workflow_service.get_by_id = AsyncMock(return_value=MagicMock())
-        service._execute_run = AsyncMock(side_effect=RuntimeError("kaboom"))
-        service._fail_run = AsyncMock()
+        service = _failing_service(run, RuntimeError("kaboom"))
 
         with patch("app.dependencies.injector.injector") as injector:
             injector.get.return_value = service
@@ -705,5 +711,36 @@ class TestFailureIsPersisted:
 
         service.run_repo.db.rollback.assert_awaited_once()
         service.run_repo.db.refresh.assert_awaited_once_with(run)
-        service._fail_run.assert_awaited_once()
+        service._fail_run.assert_awaited_once_with(run, "Run failed unexpectedly: kaboom")
+        service.run_repo.db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_run_the_service_already_failed_is_written_without_a_second_notification(self):
+        from app.tasks.test_suite_tasks import _execute_test_suite_run_async
+
+        run = SimpleNamespace(
+            id=uuid4(), status="running", summary_metrics=None, suite_id=uuid4(), workflow_id=uuid4()
+        )
+
+        async def service_fails_the_run(*_args, **_kwargs):
+            run.status = "failed"
+            run.summary_metrics = {"error": "Run failed unexpectedly: judge down"}
+            raise RuntimeError("judge down")
+
+        service = _failing_service(run, service_fails_the_run)
+
+        async def refresh(instance):
+            instance.status = "running"
+
+        service.run_repo.db.refresh = AsyncMock(side_effect=refresh)
+
+        with patch("app.dependencies.injector.injector") as injector:
+            injector.get.return_value = service
+            with pytest.raises(RuntimeError):
+                await _execute_test_suite_run_async(uuid4(), None, None)
+
+        service._fail_run.assert_not_awaited()
+        service.run_repo.update.assert_awaited_once_with(run)
+        assert run.status == "failed"
+        assert run.summary_metrics == {"error": "Run failed unexpectedly: judge down"}
         service.run_repo.db.commit.assert_awaited_once()

--- a/backend/tests/unit/test_evaluation_run_reliability.py
+++ b/backend/tests/unit/test_evaluation_run_reliability.py
@@ -619,6 +619,45 @@ class TestPausedConversationExecution:
         assert run.summary_metrics["_totals"]["skipped"] == 1
 
 
+class TestRunPickupGuard:
+    """A redelivered message must not re-run a finished run, but must re-run a lost one."""
+
+    @pytest.mark.parametrize("status", ["completed", "failed", "cancelled"])
+    def test_terminal_runs_are_skipped(self, status):
+        from app.tasks.base import should_execute_run
+
+        assert should_execute_run("TestRun", uuid4(), status) is False
+
+    @pytest.mark.parametrize("status", ["queued", "pending", "running"])
+    def test_open_runs_execute(self, status):
+        from app.tasks.base import should_execute_run
+
+        assert should_execute_run("TestRun", uuid4(), status) is True
+
+    def test_enum_statuses_are_understood(self):
+        from app.core.utils.enums.workflow_schedule_enum import WorkflowScheduleRunStatus
+        from app.tasks.base import should_execute_run
+
+        assert should_execute_run("Run", uuid4(), WorkflowScheduleRunStatus.COMPLETED) is False
+        assert should_execute_run("Run", uuid4(), WorkflowScheduleRunStatus.RUNNING) is True
+
+    @pytest.mark.asyncio
+    async def test_redelivered_completed_evaluation_is_not_re_executed(self):
+        from app.tasks.test_suite_tasks import _execute_test_suite_run_async
+
+        service = MagicMock()
+        service.run_repo.get_by_id = AsyncMock(return_value=_run(status="completed"))
+        service.suite_repo.get_by_id = AsyncMock()
+        service._execute_run = AsyncMock()
+
+        with patch("app.dependencies.injector.injector") as injector:
+            injector.get.return_value = service
+            await _execute_test_suite_run_async(uuid4(), None, None)
+
+        service.suite_repo.get_by_id.assert_not_awaited()
+        service._execute_run.assert_not_awaited()
+
+
 class TestWatchdogRepo:
     @pytest.mark.asyncio
     async def test_mark_stuck_as_failed_flushes_and_returns_rowcount(self):

--- a/backend/tests/unit/test_evaluation_run_reliability.py
+++ b/backend/tests/unit/test_evaluation_run_reliability.py
@@ -658,9 +658,10 @@ class TestRunPickupGuard:
         service._execute_run.assert_not_awaited()
 
 
-class TestWatchdogRepo:
+class TestOrphanRepo:
     @pytest.mark.asyncio
-    async def test_mark_stuck_as_failed_flushes_and_returns_rowcount(self):
+    @pytest.mark.parametrize("waiting_ids", [[], [str(uuid4())]])
+    async def test_mark_orphaned_as_failed_flushes_and_returns_rowcount(self, waiting_ids):
         from app.repositories.test_suite import TestRunRepository
 
         db = MagicMock()
@@ -669,9 +670,10 @@ class TestWatchdogRepo:
         db.flush = AsyncMock()
         repo = TestRunRepository(db)
 
-        now = datetime.now(timezone.utc)
-        failed = await repo.mark_stuck_as_failed(
-            queued_before=now, running_before=now, error_message="stuck"
+        failed = await repo.mark_orphaned_as_failed(
+            waiting_ids=waiting_ids,
+            running_before=datetime.now(timezone.utc),
+            error_message="stuck",
         )
 
         assert failed == 3
@@ -679,33 +681,29 @@ class TestWatchdogRepo:
         db.flush.assert_awaited_once()
 
 
-class TestWatchdogTask:
+class TestFailureIsPersisted:
     @pytest.mark.asyncio
-    async def test_reconcile_calls_repo_with_thresholds(self):
-        from app.tasks import test_suite_tasks
+    async def test_failed_status_is_committed_when_the_run_raises(self):
+        """The task wrapper rolls back on raise, so the failed status needs its own commit."""
+        from app.tasks.test_suite_tasks import _execute_test_suite_run_async
 
-        repo = MagicMock()
-        repo.mark_stuck_as_failed = AsyncMock(return_value=2)
+        run = SimpleNamespace(
+            id=uuid4(), status="running", summary_metrics=None, suite_id=uuid4(), workflow_id=uuid4()
+        )
+        service = MagicMock()
+        service.run_repo.db = AsyncMock()
+        service.run_repo.get_by_id = AsyncMock(return_value=run)
+        service.suite_repo.get_by_id = AsyncMock(return_value=SimpleNamespace(id=uuid4()))
+        service.workflow_service.get_by_id = AsyncMock(return_value=MagicMock())
+        service._execute_run = AsyncMock(side_effect=RuntimeError("kaboom"))
+        service._fail_run = AsyncMock()
 
-        session = AsyncMock()
-        session_cm = MagicMock()
-        session_cm.__aenter__ = AsyncMock(return_value=session)
-        session_cm.__aexit__ = AsyncMock(return_value=False)
-        factory = MagicMock(return_value=session_cm)
+        with patch("app.dependencies.injector.injector") as injector:
+            injector.get.return_value = service
+            with pytest.raises(RuntimeError):
+                await _execute_test_suite_run_async(uuid4(), None, None)
 
-        with patch.object(
-            test_suite_tasks.multi_tenant_manager,
-            "get_tenant_session_factory",
-            return_value=factory,
-        ), patch.object(
-            test_suite_tasks, "TestRunRepository", return_value=repo
-        ), patch.object(
-            test_suite_tasks, "get_tenant_context", return_value="tenant_a"
-        ):
-            await test_suite_tasks.reconcile_stuck_test_runs_async()
-
-        repo.mark_stuck_as_failed.assert_awaited_once()
-        kwargs = repo.mark_stuck_as_failed.await_args.kwargs
-        # 15-min queued cutoff is more recent than the 2h10m running cutoff.
-        assert kwargs["queued_before"] > kwargs["running_before"]
-        assert kwargs["error_message"]
+        service.run_repo.db.rollback.assert_awaited_once()
+        service.run_repo.db.refresh.assert_awaited_once_with(run)
+        service._fail_run.assert_awaited_once()
+        service.run_repo.db.commit.assert_awaited_once()

--- a/backend/tests/unit/test_run_async_in_celery.py
+++ b/backend/tests/unit/test_run_async_in_celery.py
@@ -1,0 +1,78 @@
+"""Each Celery task runs on a fresh event loop; pooled async Redis connections must not outlive it."""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.tasks import base
+
+
+def _client(disconnect_error=None):
+    client = MagicMock()
+    client.connection_pool.disconnect = AsyncMock(side_effect=disconnect_error)
+    return client
+
+
+class TestDisconnectAsyncRedisPools:
+    @pytest.mark.asyncio
+    async def test_every_process_wide_client_is_disconnected(self):
+        clients = [_client(), _client(), _client()]
+        with patch.object(base, "_async_redis_clients", return_value=clients):
+            await base.disconnect_async_redis_pools()
+
+        for client in clients:
+            client.connection_pool.disconnect.assert_awaited_once_with(inuse_connections=True)
+
+    @pytest.mark.asyncio
+    async def test_a_failing_client_does_not_stop_the_others_or_the_task(self):
+        broken, healthy = _client(RuntimeError("gone")), _client()
+        with patch.object(base, "_async_redis_clients", return_value=[broken, healthy]):
+            await base.disconnect_async_redis_pools()
+
+        healthy.connection_pool.disconnect.assert_awaited_once()
+
+
+class TestRunAsyncInCelery:
+    def test_pools_are_dropped_after_a_successful_task(self):
+        async def work():
+            return "done"
+
+        with patch.object(base, "disconnect_async_redis_pools", AsyncMock()) as drop:
+            assert base.run_async_in_celery(work()) == "done"
+
+        drop.assert_awaited_once()
+
+    def test_pools_are_dropped_after_a_failing_task(self):
+        async def work():
+            raise ValueError("boom")
+
+        with patch.object(base, "disconnect_async_redis_pools", AsyncMock()) as drop:
+            with pytest.raises(ValueError):
+                base.run_async_in_celery(work())
+
+        drop.assert_awaited_once()
+
+    def test_pools_are_dropped_after_a_timeout(self):
+        async def work():
+            await asyncio.sleep(5)
+
+        with patch.object(base, "disconnect_async_redis_pools", AsyncMock()) as drop:
+            with pytest.raises(asyncio.TimeoutError):
+                base.run_async_in_celery(work(), timeout=0.01)
+
+        drop.assert_awaited_once()
+
+    def test_the_drop_runs_inside_the_task_loop(self):
+        """The disconnect needs the same loop the connections belong to."""
+        seen = {}
+
+        async def record_loop():
+            seen["drop"] = asyncio.get_running_loop()
+
+        async def work():
+            seen["task"] = asyncio.get_running_loop()
+
+        with patch.object(base, "disconnect_async_redis_pools", record_loop):
+            base.run_async_in_celery(work())
+
+        assert seen["drop"] is seen["task"]

--- a/backend/tests/unit/test_run_reconciliation.py
+++ b/backend/tests/unit/test_run_reconciliation.py
@@ -50,6 +50,38 @@ class TestMessageParsing:
             assert await reconciliation.run_ids_in_broker(EVAL_TASK) == {first, second}
 
 
+class TestBrokerScanFailSafe:
+    def _channel(self, waiting, reserved, length):
+        client = MagicMock()
+        client.lrange.return_value = waiting
+        client.hvals.return_value = reserved
+        client.llen.return_value = length
+        channel = MagicMock(client=client, global_keyprefix="{celery}", unacked_key="unacked")
+        connection = MagicMock()
+        connection.__enter__ = MagicMock(return_value=MagicMock(default_channel=channel))
+        connection.__exit__ = MagicMock(return_value=False)
+        return connection
+
+    def test_an_unreadable_non_empty_queue_raises_instead_of_reporting_empty(self):
+        with patch.object(reconciliation, "current_app") as app:
+            app.connection_for_read.return_value = self._channel([], [], 3)
+            with pytest.raises(reconciliation.BrokerScanError):
+                reconciliation._read_broker_messages("ml")
+
+    def test_a_truly_empty_queue_is_fine(self):
+        with patch.object(reconciliation, "current_app") as app:
+            app.connection_for_read.return_value = self._channel([], [], 0)
+            assert reconciliation._read_broker_messages("ml") == []
+
+    @pytest.mark.asyncio
+    async def test_scan_failure_leaves_waiting_runs_alone(self):
+        candidates = [str(uuid4()), str(uuid4())]
+        with patch.object(
+            reconciliation, "run_ids_in_broker", AsyncMock(side_effect=reconciliation.BrokerScanError("x"))
+        ):
+            assert await reconciliation.orphaned_waiting_runs(candidates, EVAL_TASK) == []
+
+
 def _session_factory(session):
     context = MagicMock()
     context.__aenter__ = AsyncMock(return_value=session)

--- a/backend/tests/unit/test_run_reconciliation.py
+++ b/backend/tests/unit/test_run_reconciliation.py
@@ -1,0 +1,146 @@
+"""Queue-aware reconciliation of orphaned evaluation and scheduled workflow runs."""
+import base64
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.config.settings import settings
+from app.tasks import run_reconciliation_tasks as reconciliation
+
+EVAL_TASK = reconciliation.EVALUATION_RUN_TASK
+WORKFLOW_TASK = reconciliation.WORKFLOW_RUN_TASK
+
+
+def _message(task_name: str, run_id: str) -> bytes:
+    body = json.dumps([[run_id, "acme", None, None], {}, {}]).encode()
+    message = {
+        "body": base64.b64encode(body).decode(),
+        "headers": {"task": task_name, "id": str(uuid4())},
+        "properties": {"delivery_info": {"routing_key": "ml"}},
+    }
+    return json.dumps(message).encode()
+
+
+class TestMessageParsing:
+    def test_reads_run_id_of_matching_task(self):
+        run_id = str(uuid4())
+        assert reconciliation.run_id_from_message(_message(EVAL_TASK, run_id), EVAL_TASK) == run_id
+
+    def test_reserved_message_wrapper_is_unwrapped(self):
+        run_id = str(uuid4())
+        wrapped = json.dumps([json.loads(_message(WORKFLOW_TASK, run_id)), "", "ml"]).encode()
+        assert reconciliation.run_id_from_message(wrapped, WORKFLOW_TASK) == run_id
+
+    def test_other_tasks_and_garbage_are_ignored(self):
+        assert reconciliation.run_id_from_message(_message("other_task", str(uuid4())), EVAL_TASK) is None
+        assert reconciliation.run_id_from_message(b"not json", EVAL_TASK) is None
+
+    @pytest.mark.asyncio
+    async def test_run_ids_in_broker_collects_waiting_and_reserved_jobs(self):
+        first, second = str(uuid4()), str(uuid4())
+        messages = [
+            _message(EVAL_TASK, first),
+            _message(EVAL_TASK, second),
+            _message("other_task", str(uuid4())),
+        ]
+        with patch.object(reconciliation, "_read_broker_messages", return_value=messages):
+            assert await reconciliation.run_ids_in_broker(EVAL_TASK) == {first, second}
+
+
+def _session_factory(session):
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=session)
+    context.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=context)
+
+
+def _repository(waiting_ids):
+    repository = MagicMock()
+    repository.get_waiting_ids_older_than = AsyncMock(return_value=waiting_ids)
+    repository.mark_orphaned_as_failed = AsyncMock(return_value=len(waiting_ids))
+    return repository
+
+
+def _patched(repository, repository_name, present_ids):
+    session = AsyncMock()
+    return session, (
+        patch.object(
+            reconciliation.multi_tenant_manager,
+            "get_tenant_session_factory",
+            return_value=_session_factory(session),
+        ),
+        patch.object(reconciliation, repository_name, return_value=repository),
+        patch.object(reconciliation, "get_tenant_context", return_value="tenant_a"),
+        patch.object(reconciliation, "run_ids_in_broker", AsyncMock(return_value=present_ids)),
+    )
+
+
+class TestQueueAwareReconciler:
+    @pytest.mark.asyncio
+    async def test_waiting_runs_still_in_the_queue_are_not_failed(self):
+        """Run all: healthy runs waiting behind others keep their queued status."""
+        waiting = [str(uuid4()) for _ in range(3)]
+        repository = _repository(waiting)
+        session, patches = _patched(repository, "TestRunRepository", set(waiting))
+
+        with patches[0], patches[1], patches[2], patches[3]:
+            await reconciliation.reconcile_stuck_test_runs_async()
+
+        kwargs = repository.mark_orphaned_as_failed.await_args.kwargs
+        assert kwargs["waiting_ids"] == []
+        assert kwargs["running_before"] < datetime.now(timezone.utc)
+        assert kwargs["error_message"]
+        session.commit.assert_awaited_once()
+
+        waiting_before = repository.get_waiting_ids_older_than.await_args.args[0]
+        waited_seconds = (datetime.now(timezone.utc) - waiting_before).total_seconds()
+        assert abs(waited_seconds - settings.TEST_RUN_QUEUED_MAX_AGE_SECONDS) < 5
+
+    @pytest.mark.asyncio
+    async def test_waiting_run_whose_job_left_the_queue_is_failed(self):
+        lost, present = str(uuid4()), str(uuid4())
+        repository = _repository([lost, present])
+        _, patches = _patched(repository, "TestRunRepository", {present})
+
+        with patches[0], patches[1], patches[2], patches[3]:
+            await reconciliation.reconcile_stuck_test_runs_async()
+
+        assert repository.mark_orphaned_as_failed.await_args.kwargs["waiting_ids"] == [lost]
+
+    @pytest.mark.asyncio
+    async def test_broker_is_not_read_when_nothing_is_waiting(self):
+        repository = _repository([])
+        _, patches = _patched(repository, "TestRunRepository", set())
+
+        with patches[0], patches[1], patches[2], patches[3] as broker:
+            await reconciliation.reconcile_stuck_test_runs_async()
+
+        broker.assert_not_awaited()
+        repository.mark_orphaned_as_failed.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_workflow_reconciler_looks_for_its_own_task(self):
+        pending = [str(uuid4())]
+        repository = _repository(pending)
+        _, patches = _patched(repository, "WorkflowScheduleRunRepository", set())
+
+        with patches[0], patches[1], patches[2], patches[3] as broker:
+            await reconciliation.reconcile_stuck_workflow_runs_async()
+
+        broker.assert_awaited_once_with(WORKFLOW_TASK)
+        assert repository.mark_orphaned_as_failed.await_args.kwargs["waiting_ids"] == pending
+
+    @pytest.mark.asyncio
+    async def test_errors_roll_back_and_do_not_raise(self):
+        repository = _repository([str(uuid4())])
+        repository.mark_orphaned_as_failed = AsyncMock(side_effect=RuntimeError("db down"))
+        session, patches = _patched(repository, "TestRunRepository", set())
+
+        with patches[0], patches[1], patches[2], patches[3]:
+            await reconciliation.reconcile_stuck_test_runs_async()
+
+        session.rollback.assert_awaited_once()
+        session.commit.assert_not_awaited()

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -223,12 +223,12 @@ services:
     restart: unless-stopped
 
   # ML Celery worker — ML pipeline / evaluation / local fine-tuning tasks on the "ml"
-  # queue. MUST stay on the solo pool: these tasks import torch/sklearn/transformers,
-  # which are fork-unsafe. Solo never forks. Scale by adding replicas/pods.
+  # queue. Prefork with one child: the task modules import torch/sklearn lazily, so
+  # the master stays fork-safe, and Celery's time limits and health pings work.
   celery_worker_ml:
     image: genassist-app-image
     container_name: genassist-celery-worker-ml-dev
-    command: python /src/run_celery.py worker -l DEBUG --pool=solo -Q ml
+    command: python /src/run_celery.py worker -l DEBUG --pool=prefork -c 1 -Q ml
     env_file:
       - ./backend/.env
     environment:
@@ -237,7 +237,8 @@ services:
       - REDIS_DB=0
       - REDIS_PASSWORD=${REDIS_PASSWORD:-}
       - CELERY_TRACE_APP=1
-      - CELERY_WORKER_POOL=solo
+      - CELERY_WORKER_POOL=prefork
+      - CELERY_WORKER_CONCURRENCY=1
       - CELERY_INCLUDE_ML_TASKS=true
       - WHISPER_TRANSCRIBE_SERVICE=http://whisper:8001/transcribe
       - DB_HOST=db

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -223,12 +223,12 @@ services:
     restart: unless-stopped
 
   # ML Celery worker — ML pipeline / evaluation / local fine-tuning tasks on the "ml"
-  # queue. Prefork with one child: the task modules import torch/sklearn lazily, so
-  # the master stays fork-safe, and Celery's time limits and health pings work.
+  # queue. Stays on the solo pool: workflow Python code nodes run user code in a
+  # subprocess, and a prefork child (daemonic) is not allowed to start children.
   celery_worker_ml:
     image: genassist-app-image
     container_name: genassist-celery-worker-ml-dev
-    command: python /src/run_celery.py worker -l DEBUG --pool=prefork -c 1 -Q ml
+    command: python /src/run_celery.py worker -l DEBUG --pool=solo -Q ml
     env_file:
       - ./backend/.env
     environment:
@@ -237,8 +237,7 @@ services:
       - REDIS_DB=0
       - REDIS_PASSWORD=${REDIS_PASSWORD:-}
       - CELERY_TRACE_APP=1
-      - CELERY_WORKER_POOL=prefork
-      - CELERY_WORKER_CONCURRENCY=1
+      - CELERY_WORKER_POOL=solo
       - CELERY_INCLUDE_ML_TASKS=true
       - WHISPER_TRANSCRIBE_SERVICE=http://whisper:8001/transcribe
       - DB_HOST=db


### PR DESCRIPTION
## Description

Traced background job stuck/crash reports to unbounded Redis waits, early job acknowledgement, and a rescue job that queued behind the jam it was meant to clear. Verified against a month of production logs and local reproductions, with an end-to-end regression against unchanged code.

- Bound Celery's Redis connections with socket timeouts, keepalive, and health checks
- Acknowledge jobs after completion, with a pickup guard so a redelivered job never re-runs a finished one
- Fix failure-status writes for killed jobs, and move stuck-run cleanup to the default queue, made queue-aware
- Make both workers fork-safe (lazy workflow-engine imports), with per-task time limits and a boot-clean test
- Add a beat leader lock, scheduler-loop heartbeat, and expiry on frequent scheduled ticks
- Drop pooled async Redis connections at the end of every task, fixing the chronic "Event loop is closed" errors

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
