### PR TITLE
hotfix: avoid circular import from release point #3

### DIFF
--- a/backend/app/services/conversations.py
+++ b/backend/app/services/conversations.py
@@ -24,7 +24,6 @@ from app.cache.redis_cache import clear_conversation_memory_cache
 from app.core.config.settings import settings
 from app.core.exceptions.error_messages import ErrorKey
 from app.core.exceptions.exception_classes import AppException
-from app.core.utils.db_connection_utils import release_db_connection
 from app.core.utils.bi_utils import (
     calculate_duration_from_transcript,
     calculate_incremental_word_counts,
@@ -543,6 +542,11 @@ class ConversationService:
             # Release the pooled connection before the tone-analysis GPT call so it
             # isn't held idle-in-transaction for the duration of the call (see
             # genassist-outage-report-2026-09-03.md, release point #3).
+            # Import kept local: conversations.py loads early in app bootstrap
+            # (injector -> dependency_injection -> services.audio -> here), and
+            # db_connection_utils imports app.dependencies.injector itself, so a
+            # top-level import here is circular.
+            from app.core.utils.db_connection_utils import release_db_connection
             await release_db_connection(context=f"conversation {conversation.id}")
 
             analysis_result = (


### PR DESCRIPTION
conversations.py loads early in app bootstrap (injector -> dependency_injection -> services.audio -> conversations.py), and db_connection_utils itself imports app.dependencies.injector. A top-level `from app.core.utils.db_connection_utils import release_db_connection` in conversations.py therefore created a circular import that crashed the app on startup:

  ImportError: cannot import name 'injector' from partially
  initialized module 'app.dependencies.injector'

Move the import to a local import at the call site inside _analyze_in_progress_tone_and_mark, matching the existing pattern already used elsewhere in this file (see the local injector import a few lines above it) for the same reason.

Verified: app boots cleanly, and a real end-to-end conversation update (start -> update -> tone analysis) completes successfully.

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
