### PR TITLE
hotfix: apply DB_STATEMENT_TIMEOUT to the sync LLM pricing engine

### DIFF
--- a/backend/app/services/llm_pricing_cache.py
+++ b/backend/app/services/llm_pricing_cache.py
@@ -28,11 +28,19 @@ def _session_factory_for_tenant(tenant: str) -> sessionmaker[Any]:
     with _lock:
         if tenant not in _sync_session_factories:
             url = settings.get_tenant_database_url_sync(tenant)
+            connect_args = {}
+            if settings.DB_STATEMENT_TIMEOUT > 0:
+                # psycopg2 equivalent of the asyncpg server_settings timeout in
+                # multi_tenant_session.py; keeps this sync path under the same cap.
+                connect_args["options"] = (
+                    f"-c statement_timeout={settings.DB_STATEMENT_TIMEOUT * 1000}"
+                )
             engine = create_engine(
                 url,
                 pool_pre_ping=True,
                 pool_size=2,
                 max_overflow=2,
+                connect_args=connect_args,
             )
             _sync_session_factories[tenant] = sessionmaker(bind=engine)
         return _sync_session_factories[tenant]


### PR DESCRIPTION
The sync psycopg2 engine in llm_pricing_cache.py wasn't wired to DB_STATEMENT_TIMEOUT, unlike the async pooled engine in multi_tenant_session.py. Mirror the same cap via psycopg2's "-c statement_timeout=..." connect option so setting the env var covers this query path too.

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
