### PR TITLE
hotfix: release DB connection before LLM call to prevent pool exhaustion

### DIFF
--- a/backend/app/modules/workflow/llm/provider.py
+++ b/backend/app/modules/workflow/llm/provider.py
@@ -261,6 +261,22 @@ class LLMProvider:
         )
         await assert_provider_residency(regions, app_settings_service)
 
+        # Release the pooled connection here: this is the last DB read before
+        # the model is handed back to the caller, who then runs the actual
+        # (slow) LLM call on it. get_model()/get_model_with_fallback() are
+        # called from many workflow nodes and services, so fixing it once at
+        # this shared choke point covers all of them.
+        # Import kept local: provider.py loads during injector bootstrap
+        # (dependency_injection.py imports LLMProvider at module top level),
+        # and db_connection_utils imports app.dependencies.injector itself,
+        # so a top-level import here would be circular (see
+        # genassist-outage-report-2026-09-03.md and the release-point-#3 fix
+        # for the same class of bug).
+        from app.core.utils.db_connection_utils import release_db_connection
+        await release_db_connection(
+            context=f"llm provider {getattr(llm_provider, 'id', None)}"
+        )
+
         try:
             # Validate connection data
             validated_data = json.loads(


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

## Changes Made

<!-- Describe the changes in detail -->
- [ ] Change 1
- [ ] Change 2

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

## Ritech Contribution Checklist

- [ ] My code follows GenAssist's style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Multi-tenant considerations addressed (if applicable)

## Related Issues

<!-- Link related issues using keywords (e.g., "Closes #123", "Fixes #456") -->

Closes #<!-- issue number -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
