### PR TITLE
fix: group id cascades from wf creator to convs

### DIFF
--- a/backend/alembic/versions/00111_backfill_conversations_group_id.py
+++ b/backend/alembic/versions/00111_backfill_conversations_group_id.py
@@ -1,0 +1,36 @@
+"""backfill conversations group id
+
+Revision ID: 454448e85877
+Revises: d37941010920
+Create Date: 2026-09-11 14:06:54.923591
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '454448e85877'
+down_revision: Union[str, None] = 'd37941010920'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+            """
+            UPDATE conversations c
+            SET group_id = u.group_id
+            FROM operators o
+            JOIN agents a ON a.operator_id = o.id AND a.is_deleted = 0
+            JOIN users u ON u.id = a.created_by AND u.is_deleted = 0
+            WHERE c.operator_id = o.id
+            AND c.group_id IS NULL
+            AND u.group_id IS NOT NULL
+            """
+        )
+
+def downgrade() -> None:
+    pass

--- a/backend/app/repositories/conversations.py
+++ b/backend/app/repositories/conversations.py
@@ -70,6 +70,7 @@ class ConversationRepository(DbRepository[ConversationModel]):
             .join(UserModel, UserModel.id == AgentModel.created_by)
             .where(AgentModel.operator_id == operator_id)
             .limit(1)
+            .execution_options(**{GROUP_SCOPE_BYPASS_FLAG: True})
         )
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none()

--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -409,7 +409,9 @@ export const RoutesProvider = () => {
             {
               path: "ai-agents",
               element: (
-                <ProtectedRoute requiredPermissions={["read:llm_analyst"]}>
+                <ProtectedRoute
+                  requiredPermissions={["read:workflow", "read:llm_analyst"]}
+                >
                   <AIAgents />
                 </ProtectedRoute>
               ),
@@ -417,7 +419,9 @@ export const RoutesProvider = () => {
             {
               path: "ai-agents/*",
               element: (
-                <ProtectedRoute requiredPermissions={["read:llm_analyst"]}>
+                <ProtectedRoute
+                  requiredPermissions={["read:workflow", "read:llm_analyst"]}
+                >
                   <AIAgents />
                 </ProtectedRoute>
               ),

--- a/frontend/src/layout/app-sidebar.tsx
+++ b/frontend/src/layout/app-sidebar.tsx
@@ -85,7 +85,7 @@ const navGroups: NavGroup[] = [
         title: "Agent Studio",
         icon: UserRoundCog,
         url: "/ai-agents",
-        permissionsRequired: ["read:llm_analyst"],
+        permissionsRequired: ["read:workflow", "read:llm_analyst"],
       },
       {
         title: "Templates",


### PR DESCRIPTION
## Description

When user creates a workflow, the user's group id is assigned to that workflow. Thus, all conversations of that workflow get the same group id.
Also: permission "read:workflow" sufficient to see workflows.

## Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🏗️ Core implementation (refactoring, architectural changes)
- [ ] 💡 Improvement (enhancement to existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 💬 New release chat plugin
- [ ] 🚀 New platform release

---

**Note**: This PR follows Ritech's contribution guidelines for GenAssist. For questions, refer to [CONTRIBUTING.md](../CONTRIBUTING.md) or contact the Ritech team.
